### PR TITLE
Revert ax._sci but make add_colorbar more usefull

### DIFF
--- a/ctapipe/visualization/mpl.py
+++ b/ctapipe/visualization/mpl.py
@@ -196,8 +196,6 @@ class CameraDisplay:
             )
 
         self.pixels.set_array(image)
-        self.axes._sci(self.pixels)
-
         self.update()
 
     def set_image(self, image):

--- a/ctapipe/visualization/mpl.py
+++ b/ctapipe/visualization/mpl.py
@@ -204,15 +204,20 @@ class CameraDisplay:
         logger.warn("set_image(x) is deprecated:"
                     " use CameraDisplay.image = x instead")
         self.image = image
-        
+
     def update(self):
         """ signal a redraw if necessary """
         if self.autoupdate:
             plt.draw()
 
-    def add_colorbar(self):
-        """ add a colobar to the camera plot """
-        self.axes.figure.colorbar(self.pixels)
+    def add_colorbar(self, **kwargs):
+        """
+        add a colobar to the camera plot
+        kwargs are passed to figure.colorbar(self.pixels, **kwargs)
+        See matplotlib documentation for the supported kwargs:
+        http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure.colorbar
+        """
+        self.axes.figure.colorbar(self.pixels, **kwargs)
 
     def add_ellipse(self, centroid, length, width, angle, asymmetry=0.0,
                     **kwargs):
@@ -318,7 +323,7 @@ class ArrayDisplay:
     @property
     def intensities(self):
         return self.telescopes.get_array()
-        
+
     @intensities.setter
     def intensities(self, intensities):
         """ set the telescope colors to display  """

--- a/examples/camera_display_multi.py
+++ b/examples/camera_display_multi.py
@@ -1,7 +1,7 @@
 """
 Demo to show multiple shower images on a single figure using
 `CameraDisplay` and really simple mock shower images (not
-simulations). Also shows how to change the color palette. 
+simulations). Also shows how to change the color palette.
 """
 
 import matplotlib.pylab as plt
@@ -11,32 +11,39 @@ from ctapipe.reco.hillas import hillas_parameters_2 as hillas_parameters
 from astropy import units as u
 
 
-def draw_several_cams(geom):
+def draw_several_cams(geom, ncams=4):
 
-    ncams = 4
-    cmaps = [plt.cm.jet, plt.cm.afmhot, plt.cm.terrain, plt.cm.autumn]
-    fig, ax = plt.subplots(1, ncams, figsize=(15, 4), sharey=True, sharex=True)
+    cmaps = ['jet', 'afmhot', 'terrain', 'autumn']
+    fig, axs = plt.subplots(1, ncams, figsize=(15, 4), sharey=True, sharex=True)
 
     for ii in range(ncams):
-        disp = visualization.CameraDisplay(geom, ax=ax[ii],
-                                           title="CT{}".format(ii + 1))
+        disp = visualization.CameraDisplay(
+            geom,
+            ax=axs[ii],
+            title="CT{}".format(ii + 1),
+        )
         disp.cmap = cmaps[ii]
 
-        model = mock.generate_2d_shower_model(centroid=(0.2 - ii * 0.1,
-                                                        -ii * 0.05),
-                                              width=0.005 + 0.001 * ii,
-                                              length=0.1 + 0.05 * ii,
-                                              psi=ii * 20 * u.deg)
+        model = mock.generate_2d_shower_model(
+            centroid=(0.2 - ii * 0.1, -ii * 0.05),
+            width=0.005 + 0.001 * ii,
+            length=0.1 + 0.05 * ii,
+            psi=ii * 20 * u.deg,
+        )
 
-        image, sig, bg = mock.make_mock_shower_image(geom, model.pdf,
-                                                     intensity=50,
-                                                     nsb_level_pe=1000)
+        image, sig, bg = mock.make_mock_shower_image(
+            geom,
+            model.pdf,
+            intensity=50,
+            nsb_level_pe=1000,
+        )
 
         clean = image.copy()
         clean[image <= 3.0 * image.mean()] = 0.0
         hillas = hillas_parameters(geom.pix_x.value, geom.pix_y.value, clean)
 
         disp.image = image
+        disp.add_colorbar(ax=axs[ii])
         disp.set_limits_percent(95)
         disp.overlay_moments(hillas, linewidth=3, color='blue')
 


### PR DESCRIPTION
Adding `**kwargs` to the `add_colorbar` method should eliminate the need for calling
other colorbar functions like `plt.colorbar()`.