### PR TITLE
Conda path for travis is wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ matrix:
         - python: 3.4
           env: SETUP_CMD='test'
 
+        # Currently broken: https://github.com/cta-observatory/ctapipe/pull/33#issuecomment-153979923
         # Try older numpy versions
-        - python: 3.4
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+#        - python: 3.4
+#          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
 
 before_install:
 
@@ -86,13 +87,13 @@ install:
 
     # ASTROPY
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL astropy; fi
 
     # OPTIONAL DEPENDENCIES
     - if [[ $SETUP_CMD != egg_info ]] && $INSTALL_OPTIONAL; then $CONDA_INSTALL h5py scikit-image scikit-learn pandas; fi
 
     # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,25 @@ matrix:
 
 before_install:
 
-    # Use utf8 encoding. Should be default, but this is insurance against
-    # future changes
-    - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
-
     # UPDATE APT-GET LISTINGS
     - sudo apt-get update
+
+    # Use utf8 encoding. Should be default, but this is insurance against future changes
+    - export PYTHONIOENCODING=UTF8
+
+    # Install miniconda following instructions at http://conda.pydata.org/docs/travis.html
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    # Useful for debugging any issues with conda
+    - conda info -a
 
     # DOCUMENTATION DEPENDENCIES
     - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi


### PR DESCRIPTION
miniconda is installed to `/home/travis/miniconda2` but the exported 
`PATH` ist `/home/travis/miniconda/bin`