### PR TITLE
fixed bug in calling io.CameraGeometry.from_name: updated to new func…

### DIFF
--- a/examples/camera_display_multi.py
+++ b/examples/camera_display_multi.py
@@ -50,7 +50,7 @@ def draw_several_cams(geom, ncams=4):
 
 if __name__ == '__main__':
 
-    hexgeom = io.get_camera_geometry("hess", 1)
+    hexgeom = io.CameraGeometry.from_name("hess", 1)
     recgeom = io.make_rectangular_camera_geometry()
 
     draw_several_cams(recgeom)


### PR DESCRIPTION
This is a tiny bug fix in the example camera_display_multi.py, so that it actually works.
(this is more a test if I understand as a git newcomer the work flow)

This was the full error:

> python camera_display_multi.py 
Traceback (most recent call last):
  File "camera_display_multi.py", line 53, in <module>
    hexgeom = io.get_camera_geometry("hess", 1)
AttributeError: 'module' object has no attribute 'get_camera_geometry'