### PR TITLE
Methods to convert Container to astropy.Table and to write it

### DIFF
--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -1,6 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from pprint import pformat
+from astropy.table import Table
+from astropy.units import Quantity
+from ctapipe.io.files import get_file_type
+import numpy as np
+import logging
 
 __all__ = [
     'component',
@@ -88,7 +93,7 @@ class Container:
         return self.__dict__[name]
 
     def __str__(self, ):
-        # string represnetation (e.g. `print(cont)`)
+        # string representation (e.g. `print(cont)`)
         return pformat(self.__dict__)
 
     def __repr__(self):
@@ -102,8 +107,54 @@ class Container:
         # allow iterating over item names
         return (k for k in self.__dict__.keys() if not k.startswith("_"))
 
+    def as_dict(self):
+        '''Creates a dictionary of Container items unrolling recursively
+        nested containers.'''
+        d = dict()
+        for k, v in self.items():
+            if isinstance(v, Container):
+                d[k] = v.as_dict()
+                continue
+            d[k] = v
+        return d
+
     def items(self):
         '''Iterate over pairs of key, value. Just like the dictionary method'''
         # allow iterating over item names
         return ((k, v) for k, v in self.__dict__.items()
                 if not k.startswith('_'))
+
+    def to_table(self):
+        '''Create Table from Container'''
+        # Scalar `Quantity` objects do not have __len__ method which is
+        # needed by Table.write. We artificially change their shape
+        # With chunking this should not be an issue
+        for _, val in self.items():
+            if isinstance(val, Quantity) and val.isscalar:
+                val.shape = 1
+
+        names = [i.upper() for i in self]
+        dtype = [v.dtype for _, v in self.items()]
+        data = [v for _, v in self.items()]
+        # data = [v for _, v.chunk in self.items()] # It depends on
+                                                    # chunking syntax
+
+        return Table(data=data,
+                     names=names,
+                     dtype=dtype,
+                     meta=self.meta.as_dict())
+
+    def write(self, *args, **kwargs):
+        '''Write table using astropy.table write method'''
+        # if self._meta is None:
+        #     logging.error("Metadata should be present before writing data")
+        #     return
+
+        table = self.to_table()
+        # Write HDU name
+        if get_file_type(args[0]) == "fits":
+            table.meta["EXTNAME"] = self._name
+
+        table.write(*args, **kwargs)
+
+        return table


### PR DESCRIPTION
First try of `Container` serialization (just playing with it). It is achieved by converting a Container to an astropy.Table and writing it. The resulting astropy.Table has necessarily one row because of how the current `Container` class behaves.

As said, serialization implementation depends a lot on how data collection and chunking is implemented (#70, #71).