### PR TITLE
Changes in camera geometry reading from simtelarray files

### DIFF
--- a/ctapipe/io/camera.py
+++ b/ctapipe/io/camera.py
@@ -23,9 +23,9 @@ __all__ = ['CameraGeometry',
 _npix_to_type = {
     (2048, 2.3):   ('SST', 'GATE', 'rectangular', 0 * u.degree, 0 * u.degree),
     (2048, 36.0):  ('LST', 'HESSII', 'hexagonal', 0 * u.degree, 0 * u.degree),
-    (1855, 16.0):  ('MST', 'NectarCam', 'hexagonal', 0 * u.degree, 169.1 * u.degree),
-    (1855, 28.0):  ('LST', 'LSTCam', 'hexagonal', 0. * u.degree, 79.1 * u.degree),
-    (1296, None):   ('SST', 'SST-1m', 'hexagonal', 30 * u.degree, 0 * u.degree),
+    (1855, 16.0):  ('MST', 'NectarCam', 'hexagonal', 0 * u.degree, -100.893 * u.degree),
+    (1855, 28.0):  ('LST', 'LSTCam', 'hexagonal', 0. * u.degree, -100.893 * u.degree),
+    (1296, None):  ('SST', 'SST-1m', 'hexagonal', 30 * u.degree, 0 * u.degree),
     (1764, None):  ('MST', 'FlashCam', 'hexagonal', 30 * u.degree, 0 * u.degree),
     (2368, None):  ('SST', 'ASTRI', 'rectangular', 0 * u.degree, 0 * u.degree),
     (11328, None): ('SCT', 'SCTCam', 'rectangular', 0 * u.degree, 0 * u.degree),
@@ -79,6 +79,7 @@ class CameraGeometry:
         self.pix_rotation = Angle(pix_rotation)
         self.cam_rotation = Angle(cam_rotation)
         self.rotate(cam_rotation)
+
 
     @classmethod
     def guess(cls, pix_x, pix_y, optical_foclen):
@@ -333,6 +334,7 @@ def _load_camera_geometry_from_hessio_file(tel_id, filename):
     next(events)  # load at least one event to get all the headers
     pix_x, pix_y = hessio.get_pixel_position(tel_id)
     optical_foclen = hessio.get_optical_foclen(tel_id)
+
     hessio.close_file()
     return CameraGeometry.guess(pix_x * u.m, pix_y * u.m, optical_foclen)
 

--- a/ctapipe/io/camera.py
+++ b/ctapipe/io/camera.py
@@ -77,7 +77,6 @@ class CameraGeometry:
         self.neighbors = neighbors
         self.pix_type = pix_type
         self.pix_rotation = Angle(pix_rotation)
-        self.cam_rotation = Angle(cam_rotation)
         self.rotate(cam_rotation)
 
 

--- a/ctapipe/io/camera.py
+++ b/ctapipe/io/camera.py
@@ -18,17 +18,17 @@ __all__ = ['CameraGeometry',
 
 # dictionary to convert number of pixels to camera type for use in
 # guess_camera_geometry.
-# Key = (npix, pix_seperation_m)
-# Value = (type, subtype, pixtype)
+# Key = (npix, pix_separation_m)
+# Value = (type, subtype, pixtype, pixrotation, camrotation)
 _npix_to_type = {
-    (2048, 0.006): ('SST', 'GATE', 'rectangular', 0 * u.degree),
-    (2048, 0.042): ('LST', 'HESSII', 'hexagonal', 0 * u.degree),
-    (1141, None):  ('MST', 'NectarCam', 'hexagonal', 0 * u.degree),
-    (1855, None):  ('LST', 'LSTCam', 'hexagonal', 0 * u.degree),
-    (1296, 0.041): ('SST', 'SST-1m', 'hexagonal', 30 * u.degree),
-    (1764, 0.050): ('MST', 'FlashCam', 'hexagonal', 30 * u.degree),
-    (2368, 0.007): ('SST', 'ASTRI', 'rectangular', 0 * u.degree),
-    (11328, None): ('SCT', 'SCTCam', 'rectangular', 0 * u.degree),
+    (2048, 2.3):   ('SST', 'GATE', 'rectangular', 0 * u.degree, 0 * u.degree),
+    (2048, 28.0):  ('LST', 'HESSII', 'hexagonal', 0 * u.degree, 0 * u.degree),
+    (1855, 16.0):  ('MST', 'NectarCam', 'hexagonal', 0 * u.degree, 169.1 * u.degree),
+    (1855, 28.0):  ('LST', 'LSTCam', 'hexagonal', 0. * u.degree, 79.1 * u.degree),
+    (1296, None):   ('SST', 'SST-1m', 'hexagonal', 30 * u.degree, 0 * u.degree),
+    (1764, None):  ('MST', 'FlashCam', 'hexagonal', 30 * u.degree, 0 * u.degree),
+    (2368, None):  ('SST', 'ASTRI', 'rectangular', 0 * u.degree, 0 * u.degree),
+    (11328, None): ('SCT', 'SCTCam', 'rectangular', 0 * u.degree, 0 * u.degree),
 }
 
 
@@ -44,7 +44,7 @@ class CameraGeometry:
     """
 
     def __init__(self, cam_id, pix_id, pix_x, pix_y,
-                 pix_area, neighbors, pix_type, pix_rotation=0 * u.degree):
+                 pix_area, neighbors, pix_type, pix_rotation=0 * u.degree, cam_rotation=0 * u.degree):
         """
         Parameters
         ----------
@@ -66,6 +66,8 @@ class CameraGeometry:
             either 'rectangular' or 'hexagonal'
         pix_rotation: value convertable to an `astropy.coordinates.Angle`
             rotation angle with unit (e.g. 12 * u.deg), or "12d"
+        cam_rotation: overall camera rotation with units
+
         """
         self.cam_id = cam_id
         self.pix_id = pix_id
@@ -75,14 +77,16 @@ class CameraGeometry:
         self.neighbors = neighbors
         self.pix_type = pix_type
         self.pix_rotation = Angle(pix_rotation)
+        self.cam_rotation = Angle(cam_rotation)
+        self.rotate(cam_rotation)
 
     @classmethod
-    def guess(cls, pix_x, pix_y):
+    def guess(cls, pix_x, pix_y, optical_foclen):
         """
         Construct a `CameraGeometry` by guessing the appropriate quantities
         from a list of pixel positions.
         """
-        return guess_camera_geometry(pix_x, pix_y)
+        return guess_camera_geometry(pix_x, pix_y, optical_foclen)
 
     @classmethod
     def from_name(cls, name, tel_id):
@@ -139,7 +143,8 @@ class CameraGeometry:
         rotated = np.dot(rotmat.T, [self.pix_x.value, self.pix_y.value])
         self.pix_x = rotated[0] * self.pix_x.unit
         self.pix_y = rotated[1] * self.pix_x.unit
-        self.pix_rotation += angle
+        self.pix_rotation -= angle
+
 
 # ======================================================================
 # utility functions:
@@ -176,30 +181,38 @@ def find_neighbor_pixels(pix_x, pix_y, rad):
     return neighbors
 
 
-def _guess_camera_type(npix, pix_sep):
+def _guess_camera_type(npix, optical_foclen):
     global _npix_to_type
+
     try:
         return _npix_to_type[(npix, None)]
     except KeyError:
-        return _npix_to_type.get((npix, np.round(pix_sep, 3)),
-                                 ('unknown', 'unknown', 'hexagonal'))
+        return _npix_to_type.get((npix, round(optical_foclen.value, 1)),
+                                 ('unknown', 'unknown', 'hexagonal', 0 * u.degree, 0 * u.degree))
 
 
 @u.quantity_input
-def guess_camera_geometry(pix_x: u.m, pix_y: u.m):
+def guess_camera_geometry(pix_x: u.m, pix_y: u.m, optical_foclen: u.m):
     """ returns a CameraGeometry filled in from just the x,y positions
 
     Assumes:
     --------
     - the pixels are square or hexagonal
-    - the first two pixels are adjacent
     """
 
-    dx = pix_x[1] - pix_x[0]
-    dy = pix_y[1] - pix_y[0]
-    dist = np.sqrt(dx ** 2 + dy ** 2)  # dist between two pixels
-    tel_type, cam_id, pix_type, pix_rotation = _guess_camera_type(
-        len(pix_x), u.Quantity(dist, "m").value
+#    dx = pix_x[1] - pix_x[0]    <=== Not adjacent for DC-SSTs!!
+#    dy = pix_y[1] - pix_y[0]
+
+    pixsep = []
+    for ipix in range(1, len(pix_x)):
+        dx = pix_x[ipix] - pix_x[0]
+        dy = pix_y[ipix] - pix_y[0]        
+        pixsep.append (np.sqrt(dx ** 2 + dy ** 2))  # dist between pixels 0 and ipix
+        
+    dist = min(pixsep)
+        
+    tel_type, cam_id, pix_type, pix_rotation, cam_rotation = _guess_camera_type(
+        len(pix_x), optical_foclen
     )
 
     if pix_type.startswith('hex'):
@@ -223,6 +236,7 @@ def guess_camera_geometry(pix_x: u.m, pix_y: u.m):
         ),
         pix_type=pix_type,
         pix_rotation=pix_rotation,
+        cam_rotation=cam_rotation,
     )
 
 
@@ -318,8 +332,9 @@ def _load_camera_geometry_from_hessio_file(tel_id, filename):
     events = hessio.move_to_next_event()
     next(events)  # load at least one event to get all the headers
     pix_x, pix_y = hessio.get_pixel_position(tel_id)
+    optical_foclen = hessio.get_optical_foclen(tel_id)
     hessio.close_file()
-    return CameraGeometry.guess(pix_x * u.m, pix_y * u.m)
+    return CameraGeometry.guess(pix_x * u.m, pix_y * u.m, optical_foclen)
 
 
 def make_rectangular_camera_geometry(npix_x=40, npix_y=40,

--- a/ctapipe/io/camera.py
+++ b/ctapipe/io/camera.py
@@ -22,7 +22,7 @@ __all__ = ['CameraGeometry',
 # Value = (type, subtype, pixtype, pixrotation, camrotation)
 _npix_to_type = {
     (2048, 2.3):   ('SST', 'GATE', 'rectangular', 0 * u.degree, 0 * u.degree),
-    (2048, 28.0):  ('LST', 'HESSII', 'hexagonal', 0 * u.degree, 0 * u.degree),
+    (2048, 36.0):  ('LST', 'HESSII', 'hexagonal', 0 * u.degree, 0 * u.degree),
     (1855, 16.0):  ('MST', 'NectarCam', 'hexagonal', 0 * u.degree, 169.1 * u.degree),
     (1855, 28.0):  ('LST', 'LSTCam', 'hexagonal', 0. * u.degree, 79.1 * u.degree),
     (1296, None):   ('SST', 'SST-1m', 'hexagonal', 30 * u.degree, 0 * u.degree),

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -60,6 +60,7 @@ def hessio_event_source(url, max_events=None, allowed_tels=None):
     container.meta.add_item('hessio__input', url)
     container.meta.add_item('hessio__max_events', max_events)
     container.meta.add_item('pixel_pos', dict())
+    container.meta.add_item('optical_foclen', dict())
     container.add_item("dl0", RawData())
     container.add_item("mc", MCShowerData())
     container.add_item("trig", CentralTriggerData())
@@ -104,6 +105,7 @@ def hessio_event_source(url, max_events=None, allowed_tels=None):
             if tel_id not in container.meta.pixel_pos:
                 container.meta.pixel_pos[tel_id] \
                     = pyhessio.get_pixel_position(tel_id) * u.m
+                container.meta.optical_foclen[tel_id] = pyhessio.get_optical_foclen(tel_id) * u.m;
 
             nchans = pyhessio.get_num_channel(tel_id)
             container.dl0.tel[tel_id] = RawCameraData(tel_id)

--- a/examples/read_hessio.py
+++ b/examples/read_hessio.py
@@ -44,7 +44,7 @@ def display_event(event):
         ax = plt.subplot(nn, nn, ii + 1)
 
         x, y = event.meta.pixel_pos[tel_id]
-        geom = io.CameraGeometry.guess(x, y)
+        geom = io.CameraGeometry.guess(x, y, event.meta.optical_foclen[tel_id])
         disp = visualization.CameraDisplay(geom, ax=ax,
                                            title="CT{0}".format(tel_id))
         disp.pixels.set_antialiaseds(False)

--- a/examples/read_hessio_single_tel.py
+++ b/examples/read_hessio_single_tel.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 
         if disp is None:
             x, y = event.meta.pixel_pos[args.tel]
-            geom = io.CameraGeometry.guess(x, y)
+            geom = io.CameraGeometry.guess(x, y, event.meta.optical_foclen[args.tel])
             disp = visualization.CameraDisplay(geom, title='CT%d' % args.tel)
             disp.enable_pixel_picker()
             disp.add_colorbar()

--- a/examples/read_hessio_single_tel.py
+++ b/examples/read_hessio_single_tel.py
@@ -40,7 +40,8 @@ def apply_mc_calibration(adcs, tel_id):
     apply basic calibration
     """
     peds, gains = get_mc_calibration_coeffs(tel_id)
-    return (adcs - peds) * gains
+    return adcs
+#    return (adcs - peds) * gains     => DISABLED!! DOES NOT WORK
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Attempt at getting correct camera geometries from simtelarray files.

Focal length is used to distinguish cameras which have the same number of pixels.

No assumption on positions of pixels 0 and 1 is made now.

Rotated LST & Nectar cameras to have consistent coordinates with all other cameras.  Camera coordinate systems are the same as in simtelarray (in order to get camera "as viewed from mirror in park position" the conversion x => -y   y => -x  would be needed).

De-activated buggy camera calibration in read_hessio.py and read_hessio_single_tel.py.

All of this should of course change when done through the instrument description classes, so this is just a temporary fix, but possibly useful to develop e.g. the event display  gui.

