### PR TITLE
remove from .containers import *

### DIFF
--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -1,3 +1,2 @@
 from .camera import *
 from .array import *
-from .containers import *


### PR DESCRIPTION
This line produces an import error in test_container.py (from ctapipe.core import Container)