### PR TITLE
Add optical_foclen to geom = CameraGeometry.guess() in test_guess_cam…

### DIFF
--- a/ctapipe/io/tests/test_camera.py
+++ b/ctapipe/io/tests/test_camera.py
@@ -16,13 +16,14 @@ def test_load_hess_camera():
 
 def test_rotate_camera():
     geom = make_rectangular_camera_geometry(10, 10)
-    geom.rotate('10d')
+    #geom.rotate('10.0d')
+    geom.rotate(10* u.deg)
 
 
 def test_guess_camera():
     px = np.linspace(-10, 10, 11328) * u.m
     py = np.linspace(-10, 10, 11328) * u.m
-    geom = CameraGeometry.guess(px, py)
+    geom = CameraGeometry.guess(px, py,0 * u.m)
     assert geom.pix_type.startswith('rect')
 
 


### PR DESCRIPTION
Warning: geom.rotate('10.0d') should work. I do not understand why is not currently working