### PR TITLE
True charge array

### DIFF
--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -69,7 +69,7 @@ class MCEvent(MCShowerData):
     def __str__(self):
         return_string = super().__str__()+"\n"
         npix = np.sum([np.sum(t.photo_electrons > 0) for t in self.tel.values()])
-        return_string += "hit pixels: {}".format( npix )
+        return_string += "total photo_electrons: {}".format( npix )
         return return_string
 
 

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -2,6 +2,7 @@
 """
 
 from ctapipe.core import Container
+import numpy as np
 
 
 __all__ = ['RawData', 'RawCameraData', 'MCShowerData', 'MCEvent', 'MCCamera', 'CalibratedCameraData']
@@ -67,12 +68,8 @@ class MCEvent(MCShowerData):
         self.add_item('tel',dict())
     def __str__(self):
         return_string = super().__str__()+"\n"
-        NPix=0
-        for t in self.tel.values():
-            for pix in t.photo_electrons:
-                if pix > 0:
-                    NPix += 1
-        return_string += "hit pixels: {}".format( NPix )
+        npix = np.sum([np.sum(t.photo_electrons > 0) for t in self.tel.values()])
+        return_string += "hit pixels: {}".format( npix )
         return return_string
 
 

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -4,7 +4,7 @@
 from ctapipe.core import Container
 
 
-__all__ = ['RawData', 'RawCameraData', 'MCShowerData', 'MCEvent', 'CalibratedCameraData']
+__all__ = ['RawData', 'RawCameraData', 'MCShowerData', 'MCEvent', 'MCCamera', 'CalibratedCameraData']
 
 
 class RawData(Container):
@@ -52,14 +52,24 @@ class MCShowerData(Container):
         return return_string
 
 class MCEvent(MCShowerData):
+    """
+    Storage of MC event data
+
+    Parameters
+    ----------
+
+    tel : dict of `RawCameraData` by tel_id
+        dictionary of the data for each telescope
+
+    """
     def __init__(self, name='MCEvent'):
         super().__init__(name)
-        self.add_item('photo_electrons',dict())
+        self.add_item('tel',dict())
     def __str__(self):
         return_string = super().__str__()+"\n"
         NPix=0
-        for tel in self.photo_electrons.values():
-            for pix in tel.values():
+        for t in self.tel.values():
+            for pix in t.photo_electrons:
                 if pix > 0:
                     NPix += 1
         return_string += "hit pixels: {}".format( NPix )
@@ -71,6 +81,22 @@ class CentralTriggerData(Container):
         super().__init__(name)
         self.add_item('gps_time')
         self.add_item('tels_with_trigger')
+
+
+class MCCamera(Container):
+    """
+    Storage of mc data used for a single telescope
+
+    Parameters
+    ----------
+
+    pe_count : dict by channel
+        (masked) arrays of true (mc) pe count in each pixel (n_pixels)
+
+    """
+    def __init__(self, tel_id):
+        super().__init__("CT{:03d}".format(tel_id))
+        self.add_item('photo_electrons', dict())
 
 
 class RawCameraData(Container):


### PR DESCRIPTION
Commits to update compatibility with cta-observatory/pyhessio@63ec30b67e805ade7f9e0b073a24bfc2fe12506f, and is therefore stored directly into event.mc.tel[#].photo_electrons as a numpy array.

@tino-michael I understand this changes the implementation you created for photo_electrons. I figured it might make more sense to have it accessed in a similar way to event.dl0.tel[#].adc_samples. Let me know if you have issue with this.