### PR TITLE
bugfix for grabbing photo electrons from pyhessio

### DIFF
--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -129,10 +129,9 @@ def hessio_event_source(url, max_events=None, allowed_tels=None):
 
             # load the data per telescope/pixel
             for pix in range(pyhessio.get_num_pixels(tel_id)):
-                container.mc.tel[tel_id].photo_electrons \
+                container.mc.tel[tel_id].photo_electrons[pix] \
                     = pyhessio.get_mc_number_photon_electron(pixel_id=pix,
-                                           telescope_id=tel_id)
-
+                                           telescope_id=tel_id)[0]
         yield container
         counter += 1
 


### PR DESCRIPTION
old version would just save the value for the last pixel as an array with only this one element
(pyhessio.get_mc_number_photon_electron always returns an array with one element for each pixel. Is that necessary?)