### PR TITLE
Fix the drawing of square pixel cameras

### DIFF
--- a/ctapipe/visualization/mpl.py
+++ b/ctapipe/visualization/mpl.py
@@ -118,7 +118,7 @@ class CameraDisplay:
             else:
                 rr = sqrt(aa)
                 poly = Rectangle(
-                    (xx, yy),
+                    (xx-rr/2., yy-rr/2.),
                     width=rr,
                     height=rr,
                     angle=self.geom.pix_rotation.deg,


### PR DESCRIPTION
Corrected the drawing of the rectangles for square pixel cameras so the xy positions of pixels correctly represent the center of the pixels instead of the corners. Therefore the cameras are correctly centered on 0,0.