### PR TITLE
Bugfix on some example scripts

### DIFF
--- a/examples/camera_display.py
+++ b/examples/camera_display.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Example of drawing a Camera using a mock shower image
+Example of drawing a Camera using a mock shower image.
 """
 
 import matplotlib.pylab as plt
@@ -11,22 +11,24 @@ from ctapipe.reco import hillas_parameters
 
 
 def draw_neighbors(geom, pixel_index, color='r', **kwargs):
-    """ draw lines between a pixel and its neighbors"""
+    """Draw lines between a pixel and its neighbors"""
+
     neigh = geom.neighbors[pixel_index]  # neighbor indices (not pixel ids)
     x, y = geom.pix_x[pixel_index].value, geom.pix_y[pixel_index].value
     for nn in neigh:
         nx, ny = geom.pix_x[nn].value, geom.pix_y[nn].value
         plt.plot([x, nx], [y, ny], color=color, **kwargs)
 
+
 if __name__ == '__main__':
 
-    # load the camera
+    # Load the camera
     geom = io.CameraGeometry.from_name("hess", 1)
     disp = visualization.CameraDisplay(geom)
     disp.set_limits_minmax(0, 300)
     disp.add_colorbar()
 
-    # create a fake camera image to display:
+    # Create a fake camera image to display:
     model = mock.generate_2d_shower_model(centroid=(0.2, 0.0),
                                           width=0.01,
                                           length=0.1,
@@ -36,20 +38,20 @@ if __name__ == '__main__':
                                                  intensity=50,
                                                  nsb_level_pe=1000)
 
-    # apply really stupid image cleaning (single threshold):
+    # Apply really stupid image cleaning (single threshold):
     clean = image.copy()
     clean[image <= 3.0 * image.mean()] = 0.0
 
-    # calculate image parameters
+    # Calculate image parameters
     hillas = hillas_parameters(geom.pix_x, geom.pix_y, clean)
     print(hillas)
 
-    # show the camera image and overlay Hillas ellipse
+    # Show the camera image and overlay Hillas ellipse
     disp.image = image
     disp.overlay_moments(hillas, color='seagreen', linewidth=3)
 
-    # draw the neighbors of pixel 100 in red, and the
-    # neighbor-neighbors in green
+    # Draw the neighbors of pixel 100 in red, and the neighbor-neighbors in
+    # green
     for ii in geom.neighbors[130]:
         draw_neighbors(geom, ii, color='green')
 

--- a/examples/camera_display.py
+++ b/examples/camera_display.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     clean[image <= 3.0 * image.mean()] = 0.0
 
     # calculate image parameters
-    hillas = hillas_parameters(geom.pix_x.value, geom.pix_y.value, clean)
+    hillas = hillas_parameters(geom.pix_x, geom.pix_y, clean)
     print(hillas)
 
     # show the camera image and overlay Hillas ellipse

--- a/examples/camera_display_multi.py
+++ b/examples/camera_display_multi.py
@@ -42,7 +42,7 @@ def draw_several_cams(geom, ncams=4):
 
         clean = image.copy()
         clean[image <= 3.0 * image.mean()] = 0.0
-        hillas = hillas_parameters(geom.pix_x.value, geom.pix_y.value, clean)
+        hillas = hillas_parameters(geom.pix_x, geom.pix_y, clean)
 
         disp.image = image
         disp.add_colorbar(ax=axs[ii])

--- a/examples/plot_hillas_parameters.py
+++ b/examples/plot_hillas_parameters.py
@@ -1,0 +1,1 @@
+camera_display.py


### PR DESCRIPTION
Bugfix and miscellaneous updates on some example scripts:
- Fix a bug: example/camera_display.py (line 44) gave a numpy array instead an astropy Quantity to ctapipe.reco.hillas_parameters() causing an exception when this script was run ("AttributeError: 'numpy.ndarray' object has no attribute 'unit'");
- Fix a bug: example/camera_display_multi.py gave a numpy array instead an astropy Quantity to ctapipe.reco.hillas_parameters() causing an exception when this script was run ("AttributeError: 'numpy.ndarray' object has no attribute 'unit'");
- example/camera_display.py: miscellaneous updates (on comments);
- example/camera_display.py: add a symbolic link as this example can also be interesting for those who search how to plot Hillas parameters.