### PR TITLE
Implement first methods for muon reconstruction and analysis

### DIFF
--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,7 +1,7 @@
 from .fitting import kundu_chaudhuri_circle_fit
 from .fitting import psf_likelihood_fit
 from .fitting import impact_parameter_chisq_fit
-from .fitting import efficiency_likelihood_fit
+from .fitting import efficiency_fit
 
 from .features import mean_squared_error
 from .features import photon_ratio_inside_ring

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,1 +1,2 @@
 from .fitting import kundu_chaudhuri_circle_fit
+from .fitting import psf_likelihood_fit

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,5 +1,6 @@
 from .fitting import kundu_chaudhuri_circle_fit
 from .fitting import psf_likelihood_fit
+from .fitting import impact_parameter_fit
 
 from .features import mean_squared_error
 from .features import photon_ratio_inside_ring

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,0 +1,1 @@
+from .fitting import kundu_chaudhuri_circle_fit

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -3,3 +3,4 @@ from .fitting import psf_likelihood_fit
 
 from .features import mean_squared_error
 from .features import photon_ratio_inside_ring
+from .features import ring_completeness

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,2 +1,4 @@
 from .fitting import kundu_chaudhuri_circle_fit
 from .fitting import psf_likelihood_fit
+from .fitting import mean_squared_error
+from .fitting import photon_ratio_inside_ring

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,6 +1,7 @@
 from .fitting import kundu_chaudhuri_circle_fit
 from .fitting import psf_likelihood_fit
-from .fitting import impact_parameter_fit
+from .fitting import impact_parameter_chisq_fit
+from .fitting import efficiency_likelihood_fit
 
 from .features import mean_squared_error
 from .features import photon_ratio_inside_ring

--- a/ctapipe/calib/array/muon/__init__.py
+++ b/ctapipe/calib/array/muon/__init__.py
@@ -1,4 +1,5 @@
 from .fitting import kundu_chaudhuri_circle_fit
 from .fitting import psf_likelihood_fit
-from .fitting import mean_squared_error
-from .fitting import photon_ratio_inside_ring
+
+from .features import mean_squared_error
+from .features import photon_ratio_inside_ring

--- a/ctapipe/calib/array/muon/features.py
+++ b/ctapipe/calib/array/muon/features.py
@@ -1,4 +1,7 @@
 import numpy as np
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def mean_squared_error(pixel_x, pixel_y, weights, center_x, center_y, radius):
@@ -38,15 +41,11 @@ def ring_completeness(
         threshold=30,
         bins=30,
         ):
-    angle = np.arctan2(pixel_y - center_y, pixel_x - center_x)
-    hist, edges = np.histogram(angle, bins=bins, range=[-np.pi, np.pi], weights=weights)
 
-    highest_bin = np.argmax(hist)
-    if highest_bin < threshold:
-        return 0
+    angle = np.arctan2(pixel_y - center_y, pixel_x - center_x)
+
+    hist, edges = np.histogram(angle, bins=bins, range=[-np.pi, np.pi], weights=weights)
 
     bins_above_threshold = hist > threshold
 
     return np.sum(bins_above_threshold) / bins
-
-

--- a/ctapipe/calib/array/muon/features.py
+++ b/ctapipe/calib/array/muon/features.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+
+def mean_squared_error(pixel_x, pixel_y, weights, center_x, center_y, radius):
+    ''' calculate the weighted mean squared error for a circle '''
+    r = np.sqrt((center_x - pixel_x)**2 + (center_y - pixel_y)**2)
+    return np.average((r - radius)**2, weights=weights)
+
+
+def photon_ratio_inside_ring(
+        pixel_x, pixel_y, weights, center_x, center_y, radius, width
+        ):
+    '''
+    Calculate the ratio of the photons inside a given ring with
+    coordinates (center_x, center_y), radius and width.
+    '''
+
+    total = np.sum(weights)
+
+    pixel_r = np.sqrt((center_x - pixel_x)**2 + (center_y - pixel_y)**2)
+    mask = np.logical_and(
+        pixel_r >= radius - width,
+        pixel_r <= radius + width
+    )
+
+    inside = np.sum(weights[mask])
+
+    return inside / total
+
+
+

--- a/ctapipe/calib/array/muon/features.py
+++ b/ctapipe/calib/array/muon/features.py
@@ -28,4 +28,25 @@ def photon_ratio_inside_ring(
     return inside / total
 
 
+def ring_completeness(
+        pixel_x,
+        pixel_y,
+        weights,
+        center_x,
+        center_y,
+        radius,
+        threshold=30,
+        bins=30,
+        ):
+    angle = np.arctan2(pixel_y - center_y, pixel_x - center_x)
+    hist, edges = np.histogram(angle, bins=bins, range=[-np.pi, np.pi], weights=weights)
+
+    highest_bin = np.argmax(hist)
+    if highest_bin < threshold:
+        return 0
+
+    bins_above_threshold = hist > threshold
+
+    return np.sum(bins_above_threshold) / bins
+
 

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -60,12 +60,12 @@ def photon_ratio_inside_ring(pixel_x, pixel_y, weights, center_x, center_y, radi
     coordinates (center_x, center_y), radius and width.
     '''
 
-    total = np.sum(weight)
+    total = np.sum(weights)
 
     pixel_r = np.sqrt((center_x - pixel_x)**2 + (center_y - pixel_y)**2)
     mask = np.logical_and(
-        pixel_r <= radius - width,
-        pixel_r >= radius + width
+        pixel_r >= radius - width,
+        pixel_r <= radius + width
     )
 
     inside = np.sum(weights[mask])

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -129,6 +129,9 @@ def impact_parameter_chisq_fit(
         bounds=[(0, None), (-np.pi, np.pi), (0, None)],
     )
 
+    if not result.success:
+        result.x = np.full_like(result.x, np.nan)
+
     imp_par, phi_max, scale = result.x
 
     return imp_par, phi_max

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -126,4 +126,6 @@ def impact_parameter_fit(
         method='Powell',
     )
 
-    return result.imp_par
+    imp_par, phi_max = result.x
+
+    return imp_par, phi_max

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+
+def kundu_chaudhuri_circle_fit(x, y, weights):
+    '''
+    Fast, analytic calculation of circle center and radius from
+    x, y and weights. This should be pixel positions and photon equivalents
+
+    Reference:
+    B. B. Chaudhuri und P. Kundu.
+    "Optimum circular fit to weighted data in multi-dimensional space".
+    In: Pattern Recognition Letters 14.1 (1993), S. 1–6
+    '''
+
+
+    mean_x = np.average(x, weights=weights)
+    mean_y = np.average(y, weights=weights)
+
+    a1 = np.sum(weights * (x - mean_x) * x)
+    a2 = np.sum(weights * (y - mean_y) * x)
+
+    b1 = np.sum(weights * (x - mean_x) * y)
+    b2 = np.sum(weights * (y - mean_y) * y)
+
+    c1 = 0.5 * np.sum(weights * (x - mean_x) * (x**2 + y**2))
+    c2 = 0.5 * np.sum(weights * (y - mean_y) * (x**2 + y**2))
+
+    center_x = (b2 * c1 - b1 * c2) / (a1 * b2 - a2 * b1)
+    center_y = (a2 * c1 - a1 * c2) / (a2 * b1 - a1 * b2)
+
+    radius = np.sqrt(np.average(
+        (center_x - x)**2 + (center_y - y)**2,
+        weights=weights,
+    ))
+
+    return radius, center_x, center_y

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -49,30 +49,6 @@ def kundu_chaudhuri_circle_fit(x, y, weights):
     return radius, center_x, center_y
 
 
-def mean_squared_error(pixel_x, pixel_y, weights, center_x, center_y, radius):
-    r = np.sqrt((center_x - pixel_x)**2 + (center_y - pixel_y)**2)
-    return np.average((r - radius)**2, weights=weights)
-
-
-def photon_ratio_inside_ring(pixel_x, pixel_y, weights, center_x, center_y, radius, width):
-    '''
-    Calculate the ratio of the photons inside a given ring with
-    coordinates (center_x, center_y), radius and width.
-    '''
-
-    total = np.sum(weights)
-
-    pixel_r = np.sqrt((center_x - pixel_x)**2 + (center_y - pixel_y)**2)
-    mask = np.logical_and(
-        pixel_r >= radius - width,
-        pixel_r <= radius + width
-    )
-
-    inside = np.sum(weights[mask])
-
-    return inside / total
-
-
 def psf_likelihood_fit(x, y, weights):
     ''' Apply a gaussian likelihood for a muon ring
     '''

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.optimize import minimize
 
 
 def kundu_chaudhuri_circle_fit(x, y, weights):
@@ -11,7 +12,14 @@ def kundu_chaudhuri_circle_fit(x, y, weights):
     "Optimum circular fit to weighted data in multi-dimensional space".
     In: Pattern Recognition Letters 14.1 (1993), S. 1–6
     '''
-
+    # handle astropy units
+    try:
+        unit = x.unit
+        assert x.unit == y.unit
+        x = x.value
+        y = y.value
+    except AttributeError:
+        unit = None
 
     mean_x = np.average(x, weights=weights)
     mean_y = np.average(y, weights=weights)
@@ -33,4 +41,10 @@ def kundu_chaudhuri_circle_fit(x, y, weights):
         weights=weights,
     ))
 
+    if unit:
+        radius *= unit
+        center_x *= unit
+        center_y *= unit
+
     return radius, center_x, center_y
+

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -211,7 +211,7 @@ def expected_pixel_light_content(
         pixel_fov, mirror_radius, lambda1, lambda2
     )
 
-    result = light * pixel_diameter * norm.pdf(ring_radius, pixel_r, sigma_psf)
+    result = light * pixel_diameter * norm.pdf(pixel_r, ring_radius, sigma_psf)
     return result
 
 

--- a/ctapipe/calib/array/muon/fitting.py
+++ b/ctapipe/calib/array/muon/fitting.py
@@ -100,31 +100,6 @@ def impact_parameter_fit(
         ):
     ''' Impact parameter calculation
     '''
-    def _intensity(phi, phi_max, impact_parameter, telescope_radius):
-        ''' function (6) from G. Vacanti et. al., Astroparticle Physics 2, 1994, 1-11 '''
-        ratio = impact_parameter / telescope_radius
-        radicant = 1 - ratio**2 * np.sin(phi - phi_max)**2
-
-        if impact_parameter > telescope_radius:
-            D = np.empty_like(phi)
-            mask = np.logical_and(
-                phi < np.arcsin(1 / ratio),
-                phi > -np.arcsin(1 / ratio)
-            )
-            D[np.logical_not(mask)] = 0
-            D[mask] = 2 * telescope_radius * np.sqrt(radicant[mask])
-        else:
-            D = telescope_radius * (np.sqrt(radicant) + ratio * np.cos(phi - phi_max))
-
-        return D
-
-    def _impact_parameter_chisq(params,  phi, hist, telescope_radius):
-        ''' function (6) from G. Vacanti et. al., Astroparticle Physics 2, 1994, 1-11 '''
-
-        impact_parameter, phi_max, scale = params
-        theory = _intensity(phi, phi_max, impact_parameter, telescope_radius)
-
-        return np.sum((hist - theory)**2)
 
     phi = np.arctan2(pixel_y - center_y, pixel_x - center_x)
     hist, edges = np.histogram(phi, bins=bins, range=[-np.pi, np.pi], weights=weights)
@@ -132,12 +107,42 @@ def impact_parameter_fit(
 
     result = minimize(
         _impact_parameter_chisq,
-        x0=(telescope_radius / 2, 0, 100),
+        x0=(telescope_radius / 2, bin_centers[np.argmax(hist)], 1),
         args=(bin_centers, hist, telescope_radius),
-        method='Powell',
+        method='L-BFGS-B',
+        bounds=[(0, None), (-np.pi, np.pi), (0, None)],
     )
 
     imp_par, phi_max, scale = result.x
 
     return imp_par, phi_max
+
+
+def _integration_distance(phi, phi_max, impact_parameter, telescope_radius):
+    ''' function (6) from G. Vacanti et. al., Astroparticle Physics 2, 1994, 1-11 '''
+    phi = phi - phi_max
+    ratio = impact_parameter / telescope_radius
+    radicant = 1 - ratio**2 * np.sin(phi)**2
+
+    if impact_parameter > telescope_radius:
+        D = np.empty_like(phi)
+        mask = np.logical_and(
+            phi < np.arcsin(1 / ratio),
+            phi > -np.arcsin(1 / ratio)
+        )
+        D[np.logical_not(mask)] = 0
+        D[mask] = 2 * telescope_radius * np.sqrt(radicant[mask])
+    else:
+        D = 2 * telescope_radius * (np.sqrt(radicant) + ratio * np.cos(phi))
+
+    return D
+
+
+def _impact_parameter_chisq(params,  phi, hist, telescope_radius):
+    ''' function (6) from G. Vacanti et. al., Astroparticle Physics 2, 1994, 1-11 '''
+
+    imp_par, phi_max, scale = params
+    theory = scale * _integration_distance(phi, phi_max, imp_par, telescope_radius)
+
+    return np.sum((hist - theory)**2)
 

--- a/ctapipe/calib/array/muon/test_fitting.py
+++ b/ctapipe/calib/array/muon/test_fitting.py
@@ -1,5 +1,7 @@
-from ctapipe.calib.array.muon import kundu_chaudhuri_circle_fit
 import numpy as np
+import astropy.units as u
+
+from ctapipe.calib.array.muon import kundu_chaudhuri_circle_fit
 
 np.random.seed(0)
 
@@ -25,4 +27,23 @@ def test_kundu_chaudhuri():
         assert np.isclose(fit_x, center_x)
         assert np.isclose(fit_y, center_y)
         assert np.isclose(fit_radius, radius)
+
+
+def test_kundu_chaudhuri_with_units():
+
+    center_x = 0.5 * u.meter
+    center_y = 0.5 * u.meter
+    radius = 1 * u.meter
+
+    phi = np.random.uniform(0, 2 * np.pi, 100)
+    x = center_x + radius * np.cos(phi)
+    y = center_y + radius * np.sin(phi)
+
+    weights = np.ones_like(x)
+
+    fit_radius, fit_x, fit_y = kundu_chaudhuri_circle_fit(x, y, weights)
+
+    assert fit_x.unit == center_x.unit
+    assert fit_y.unit == center_y.unit
+    assert fit_radius.unit == radius.unit
 

--- a/ctapipe/calib/array/muon/test_fitting.py
+++ b/ctapipe/calib/array/muon/test_fitting.py
@@ -1,0 +1,28 @@
+from ctapipe.calib.array.muon import kundu_chaudhuri_circle_fit
+import numpy as np
+
+np.random.seed(0)
+
+
+def test_kundu_chaudhuri():
+
+    num_tests = 10
+    center_xs = np.random.uniform(-1000, 1000, num_tests)
+    center_ys = np.random.uniform(-1000, 1000, num_tests)
+    radii = np.random.uniform(10, 1000, num_tests)
+
+
+    for center_x, center_y, radius in zip(center_xs, center_ys, radii):
+
+        phi = np.random.uniform(0, 2 * np.pi, 100)
+        x = center_x + radius * np.cos(phi)
+        y = center_y + radius * np.sin(phi)
+
+        weights = np.ones_like(x)
+
+        fit_radius, fit_x, fit_y = kundu_chaudhuri_circle_fit(x, y, weights)
+
+        assert np.isclose(fit_x, center_x)
+        assert np.isclose(fit_y, center_y)
+        assert np.isclose(fit_radius, radius)
+


### PR DESCRIPTION
@pcumani and I were working on the muon reconstruction this week and implemented some first methods.

### Implemented stuff
* Reconstruction of ring parameters via gaussian likelihood fit with kundu chaudhuri formula as initial guess
* Estimation of the psf via a gaussian likelihood fit
* Estimation of the impact parameter via a binned χ²-Fit
* Estimation of optical efficiency using all of the above and the theoretical light distribution as described in @AMWMitchell s ICRC proceeding

* Some features for event selection

### Some open questions we have:
* How are units to be handled?
* Do you have ideas for more tests?


### Some first results:
We applied the methods to LST Mono muon monte carlo data.  
The scripts we used are in http://github.com/maxnoe/cta-muons  

* Fits of two well reconstructed muons:
![nice_muon-035](https://cloud.githubusercontent.com/assets/5488440/18996313/18a2e59c-8730-11e6-953d-0f9f80909a92.png)

![nice_muon-049](https://cloud.githubusercontent.com/assets/5488440/18996346/424b4a1a-8730-11e6-989c-1f18bd5b7343.png)

* Distribution of the radius for selected muon events:
![muon_cherenkov_angle](https://cloud.githubusercontent.com/assets/5488440/18996578/1bf570ba-8731-11e6-833d-aceda22a4b40.png)

* PSF (standard deviation of gaussian fit)
![muon_psf](https://cloud.githubusercontent.com/assets/5488440/18996657/7229416e-8731-11e6-94b6-302c7009c610.png)

* Impact Parameter vs. Ring Completeness:
![impact_vs_completeness](https://cloud.githubusercontent.com/assets/5488440/18996873/5aeb44a6-8732-11e6-9a5d-bf383b551ce2.png)

* Optical Efficiency
![optical_efficiency](https://cloud.githubusercontent.com/assets/5488440/18996725/af7d3930-8731-11e6-86ee-c93c40ba52f6.png)

