### PR TITLE
reverted to previous behavior of hessio_event_source

### DIFF
--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -8,6 +8,21 @@ import numpy as np
 __all__ = ['RawData', 'RawCameraData', 'MCShowerData', 'MCEvent', 'MCCamera', 'CalibratedCameraData']
 
 
+class EventContainer(Container):
+    """ Top-level container for all event information """
+    def __init__(self, name="Event"):
+        self.add_item("dl0", RawData())
+        self.add_item("mc", MCEvent())
+        self.add_item("trig", CentralTriggerData())
+        self.add_item("count")
+
+        self.meta.add_item('tel_pos', dict())
+        self.meta.add_item('pixel_pos', dict())
+        self.meta.add_item('optical_foclen', dict())
+        self.meta.add_item('source', "unknown")
+
+
+
 class RawData(Container):
     """
     Storage of a Merged Raw Data Event
@@ -33,7 +48,7 @@ class RawData(Container):
         self.add_item('event_id')
         self.add_item('tels_with_data')
         self.add_item('tel', dict())
-
+        
 
 class MCShowerData(Container):
     def __init__(self, name='MCShowerData'):

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -56,32 +56,18 @@ def hessio_event_source(url, max_events=None, allowed_tels=None):
     eventstream = pyhessio.move_to_next_event()
     if allowed_tels is not None:
         allowed_tels = set(allowed_tels)
-    # container = Container("hessio_container")
-    # container.meta.add_item('hessio__input', url)
-    # container.meta.add_item('hessio__max_events', max_events)
-    # container.meta.add_item('tel_pos', dict())
-    # container.meta.add_item('pixel_pos', dict())
-    # container.meta.add_item('optical_foclen', dict())
-    # container.add_item("dl0", RawData())
-    # container.add_item("mc", MCEvent())
-    # container.add_item("trig", CentralTriggerData())
-    # container.add_item("count")
+    container = Container("hessio_container")
+    container.meta.add_item('hessio__input', url)
+    container.meta.add_item('hessio__max_events', max_events)
+    container.meta.add_item('tel_pos', dict())
+    container.meta.add_item('pixel_pos', dict())
+    container.meta.add_item('optical_foclen', dict())
+    container.add_item("dl0", RawData())
+    container.add_item("mc", MCEvent())
+    container.add_item("trig", CentralTriggerData())
+    container.add_item("count")
     
     for run_id, event_id in eventstream:
-
-        # Re-intialize the container, thereby wiping any extra items added
-        # in the previous event (e.g. dl1)
-        container = Container("hessio_container")
-        container.meta.add_item('source', "hessio")
-        container.meta.add_item('hessio__input', url)
-        container.meta.add_item('hessio__max_events', max_events)
-        container.meta.add_item('tel_pos', dict())
-        container.meta.add_item('pixel_pos', dict())
-        container.meta.add_item('optical_foclen', dict())
-        container.add_item("dl0", RawData())
-        container.add_item("mc", MCEvent())
-        container.add_item("trig", CentralTriggerData())
-        container.add_item("count")
 
         container.dl0.run_id = run_id
         container.dl0.event_id = event_id

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -6,7 +6,7 @@ This requires the hessio python library to be installed
 """
 import logging
 
-from .containers import RawData
+from .containers import EventContainer, RawData
 from .containers import RawCameraData, MCEvent, MCCamera, CentralTriggerData
 from ctapipe.core import Container
 
@@ -52,101 +52,102 @@ def hessio_event_source(url, max_events=None, allowed_tels=None):
         raise RuntimeError("hessio_event_source failed to open '{}'"
                            .format(url))
 
+    # the container is initialized once, and data is replaced within
+    # it after each yield
+
     counter = 0
     eventstream = pyhessio.move_to_next_event()
     if allowed_tels is not None:
         allowed_tels = set(allowed_tels)
-    container = Container("hessio_container")
-    container.meta.add_item('hessio__input', url)
-    container.meta.add_item('hessio__max_events', max_events)
-    container.meta.add_item('tel_pos', dict())
-    container.meta.add_item('pixel_pos', dict())
-    container.meta.add_item('optical_foclen', dict())
-    container.add_item("dl0", RawData())
-    container.add_item("mc", MCEvent())
-    container.add_item("trig", CentralTriggerData())
-    container.add_item("count")
-    
+    event = EventContainer()
+    event.meta.source = "hessio"
+
+    # some hessio_event_source specific parameters
+    event.meta.add_item('hessio__input', url)
+    event.meta.add_item('hessio__max_events', max_events)
+
     for run_id, event_id in eventstream:
 
-        container.dl0.run_id = run_id
-        container.dl0.event_id = event_id
-        container.dl0.tels_with_data = set(pyhessio.get_teldata_list())
-
+        event.dl0.run_id = run_id
+        event.dl0.event_id = event_id
+        event.dl0.tels_with_data = set(pyhessio.get_teldata_list())
+        
         # handle telescope filtering by taking the intersection of
         # tels_with_data and allowed_tels
         if allowed_tels is not None:
-            selected = container.dl0.tels_with_data & allowed_tels
+            selected = event.dl0.tels_with_data & allowed_tels
             if len(selected) == 0:
                 continue  # skip event
-            container.dl0.tels_with_data = selected
+            event.dl0.tels_with_data = selected
 
-        container.trig.tels_with_trigger \
+        event.trig.tels_with_trigger \
             = pyhessio.get_central_event_teltrg_list()
         time_s, time_ns = pyhessio.get_central_event_gps_time()
-        container.trig.gps_time = Time(time_s * u.s, time_ns * u.ns,
-                                       format='gps', scale='utc')
-        container.mc.energy = pyhessio.get_mc_shower_energy() * u.TeV
-        container.mc.alt = Angle(pyhessio.get_mc_shower_altitude(), u.rad)
-        container.mc.az = Angle(pyhessio.get_mc_shower_azimuth(), u.rad)
-        container.mc.core_x = pyhessio.get_mc_event_xcore() * u.m
-        container.mc.core_y = pyhessio.get_mc_event_ycore() * u.m
-        container.mc.h_first_int = pyhessio.get_mc_shower_h_first_int() * u.m
-        
-        container.count = counter
+        event.trig.gps_time = Time(time_s * u.s, time_ns * u.ns,
+                                   format='gps', scale='utc')
+        event.mc.energy = pyhessio.get_mc_shower_energy() * u.TeV
+        event.mc.alt = Angle(pyhessio.get_mc_shower_altitude(), u.rad)
+        event.mc.az = Angle(pyhessio.get_mc_shower_azimuth(), u.rad)
+        event.mc.core_x = pyhessio.get_mc_event_xcore() * u.m
+        event.mc.core_y = pyhessio.get_mc_event_ycore() * u.m
+        event.mc.h_first_int = pyhessio.get_mc_shower_h_first_int() * u.m
+
+        event.count = counter
 
         # this should be done in a nicer way to not re-allocate the
         # data each time (right now it's just deleted and garbage
         # collected)
 
-        container.dl0.tel = dict()  # clear the previous telescopes
-        container.mc.tel = dict()  # clear the previous telescopes
+        event.dl0.tel = dict()  # clear the previous telescopes
+        event.mc.tel = dict()  # clear the previous telescopes
 
-        for tel_id in container.dl0.tels_with_data:
+        for tel_id in event.dl0.tels_with_data:
 
             # fill pixel position dictionary, if not already done:
-            if tel_id not in container.meta.pixel_pos:
-                container.meta.pixel_pos[tel_id] \
+            if tel_id not in event.meta.pixel_pos:
+                event.meta.pixel_pos[tel_id] \
                     = pyhessio.get_pixel_position(tel_id) * u.m
-                container.meta.optical_foclen[tel_id] = pyhessio.get_optical_foclen(tel_id) * u.m;
+                event.meta.optical_foclen[
+                    tel_id] = pyhessio.get_optical_foclen(tel_id) * u.m
 
             # fill telescope position dictionary, if not already done:
-            if tel_id not in container.meta.tel_pos:
-                container.meta.tel_pos[tel_id] = pyhessio.get_telescope_position(tel_id) * u.m
+            if tel_id not in event.meta.tel_pos:
+                event.meta.tel_pos[
+                    tel_id] = pyhessio.get_telescope_position(tel_id) * u.m
 
             nchans = pyhessio.get_num_channel(tel_id)
             npix = pyhessio.get_num_pixels(tel_id)
             nsamples = pyhessio.get_num_samples(tel_id)
-            container.dl0.tel[tel_id] = RawCameraData(tel_id)
-            container.dl0.tel[tel_id].num_channels = nchans
-            container.dl0.tel[tel_id].num_pixels = npix
-            container.dl0.tel[tel_id].num_samples = nsamples
-            container.mc.tel[tel_id] = MCCamera(tel_id)
+            event.dl0.tel[tel_id] = RawCameraData(tel_id)
+            event.dl0.tel[tel_id].num_channels = nchans
+            event.dl0.tel[tel_id].num_pixels = npix
+            event.dl0.tel[tel_id].num_samples = nsamples
+            event.mc.tel[tel_id] = MCCamera(tel_id)
 
-            container.dl0.tel[tel_id].calibration \
+            event.dl0.tel[tel_id].calibration \
                 = pyhessio.get_calibration(tel_id)
-            container.dl0.tel[tel_id].pedestal \
+            event.dl0.tel[tel_id].pedestal \
                 = pyhessio.get_pedestal(tel_id)
 
             # load the data per telescope/chan
             for chan in range(nchans):
-                container.dl0.tel[tel_id].adc_samples[chan] \
+                event.dl0.tel[tel_id].adc_samples[chan] \
                     = pyhessio.get_adc_sample(channel=chan,
                                               telescope_id=tel_id)
-                container.dl0.tel[tel_id].adc_sums[chan] \
+                event.dl0.tel[tel_id].adc_sums[chan] \
                     = pyhessio.get_adc_sum(channel=chan,
                                            telescope_id=tel_id)
-                container.mc.tel[tel_id].refshapes[chan] = \
+                event.mc.tel[tel_id].refshapes[chan] = \
                     pyhessio.get_ref_shapes(tel_id, chan)
 
             # load the data per telescope/pixel
-            container.mc.tel[tel_id].photo_electrons \
+            event.mc.tel[tel_id].photo_electrons \
                 = pyhessio.get_mc_number_photon_electron(telescope_id=tel_id)
-            container.mc.tel[tel_id].refstep = pyhessio.get_ref_step(tel_id)
-            container.mc.tel[tel_id].lrefshape = pyhessio.get_lrefshape(tel_id)
-            container.mc.tel[tel_id].time_slice = \
+            event.mc.tel[tel_id].refstep = pyhessio.get_ref_step(tel_id)
+            event.mc.tel[tel_id].lrefshape = pyhessio.get_lrefshape(tel_id)
+            event.mc.tel[tel_id].time_slice = \
                 pyhessio.get_time_slice(tel_id)
-        yield container
+        yield event
         counter += 1
 
         if max_events is not None and counter >= max_events:

--- a/ctapipe/io/mock.py
+++ b/ctapipe/io/mock.py
@@ -13,14 +13,7 @@ from scipy.stats import norm
 logger = logging.getLogger(__name__)
 
 
-def mock_event_source(
-        geoms,
-        events=100,
-        single_tel=False,
-        n_channels=1,
-        n_samples=25,
-        p_trigger=0.3,
-        ):
+def mock_event_source(geoms, events=100, single_tel=False, n_channels=1, n_samples=25,  p_trigger=0.3):
     """
     An event source that produces array
     Parameters
@@ -37,11 +30,9 @@ def mock_event_source(
         mean trigger probability for the telescopes
     """
     n_telescopes = len(geoms)
-    container = Container("mock_container")
+    container = EventContainer()
     container.meta.add_item('mock__max_events', events)
-    container.meta.add_item('pixel_pos', dict())
-    container.add_item("dl0", RawData())
-    container.add_item("count")
+    container.meta.source = "mock"
     tel_ids = np.arange(n_telescopes)
 
     for event_id in range(events):


### PR DESCRIPTION
- reverted to old behavior where the return value is a pointer to a
Container, and each subsequent access only  updates data in the
container, without creating a new one (this was intentionally for speed
and memory use)
- the "new event" behavior can be achieved by simply wrapping with a
deepcopy version of the generator `uniquesource = (deepcopy(event) for event in source)`
- Created a top-level EventContainer that sets up all items (no more adding items in the event source code, which is not easy to enforce)