### PR TITLE
Modify some names in the MuonParameter container

### DIFF
--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -193,34 +193,36 @@ class MuonParameter(Container):
         run number
     event_id : int
         event number
-    center_x, center_y, radius: float
+    ring_center_x, ring_center_y, ring_radius:
         center position and radius of the fitted ring
-    chi2_ring_fit:
+    ring_chi2_fit:
         chi squared of the ring fit
-    Cov_ring:
+    ring_cov_matrix:
         covariance matrix of ring parameters
     impact_parameter: float
         reconstructed impact parameter
-    chi2_impact_parameter:
+    impact_parameter_chi2:
         chi squared impact parameter
-    Cov_intensity:
+    intensity_cov_matrix:
         Covariance matrix of impact parameters or alternatively:
         full 5x5 covariance matrix for the complete fit (ring + impact)
-    mirror_pos_x, mirror_pos_y:
+    impact_parameter_pos_x, impact_parameter_pos_y:
         position on the mirror of the muon impact
     ring_completeness:
         completeness of the ring
-    num_pixel: int
+    ring_num_pixel: int
         Number of pixels composing the ring
-    size:
+    ring_size:
         ring size
-    off_size:
+    off_ring_size:
         size outside of the ring
-    COG:
+    COG_x, COG_y:
         center of gravity
-    width:
+    optical_efficiency_muon:
+        optical muon efficiency from intensity fit
+    ring_width:
         ring width
-    time_std:
+    ring_time_width:
         standard deviation of the photons time arrival
     """
 
@@ -228,24 +230,25 @@ class MuonParameter(Container):
         super().__init__(name)
         self.add_item('run_id')
         self.add_item('event_id')
-        self.add_item('center_x')
-        self.add_item('center_y')
-        self.add_item('radius')
-        self.add_item('chi2_ring_fit')
-        self.add_item('Cov_ring')
+        self.add_item('ring_center_x')
+        self.add_item('ring_center_y')
+        self.add_item('ring_radius')
+        self.add_item('ring_chi2_fit')
+        self.add_item('ring_cov_matrix')
         self.add_item('impact_parameter')
-        self.add_item('chi2_impact_parameter')
-        self.add_item('Cov_intensity')
-        self.add_item('mirror_pos_x')
-        self.add_item('mirror_pos_y')
+        self.add_item('impact_parameter_chi2')
+        self.add_item('intensity_cov_matrix')
+        self.add_item('impact_parameter_pos_x')
+        self.add_item('impact_parameter_pos_y')
         self.add_item('ring_completeness')
-        self.add_item('num_pixel')
-        self.add_item('size')
-        self.add_item('off_size')
-        self.add_item('COG')
-        self.add_item('efficiency')
-        self.add_item('width')
-        self.add_item('time_std')
+        self.add_item('ring_num_pixel')
+        self.add_item('ring_size')
+        self.add_item('off_ring_size')
+        self.add_item('COG_x')
+        self.add_item('COG_y')
+        self.add_item('optical_efficiency_muon')
+        self.add_item('ring_width')
+        self.add_item('ring_time_width')
         self.meta.add_item('ring_fit_method')
         self.meta.add_item('intensity_fit_method')
         self.meta.add_item('inputfile')

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -22,7 +22,6 @@ class EventContainer(Container):
         self.meta.add_item('source', "unknown")
 
 
-
 class RawData(Container):
     """
     Storage of a Merged Raw Data Event
@@ -182,7 +181,7 @@ class CalibratedCameraData(Container):
         self.add_item('calibration_parameters', dict())
 
 
-class MuonParameter(Container):
+class MuonRingParameter(Container):
     """
     Storage of a Output of muon reconstruction Event
 
@@ -199,34 +198,9 @@ class MuonParameter(Container):
         chi squared of the ring fit
     ring_cov_matrix:
         covariance matrix of ring parameters
-    impact_parameter: float
-        reconstructed impact parameter
-    impact_parameter_chi2:
-        chi squared impact parameter
-    intensity_cov_matrix:
-        Covariance matrix of impact parameters or alternatively:
-        full 5x5 covariance matrix for the complete fit (ring + impact)
-    impact_parameter_pos_x, impact_parameter_pos_y:
-        position on the mirror of the muon impact
-    ring_completeness:
-        completeness of the ring
-    ring_num_pixel: int
-        Number of pixels composing the ring
-    ring_size:
-        ring size
-    off_ring_size:
-        size outside of the ring
-    COG_x, COG_y:
-        center of gravity
-    optical_efficiency_muon:
-        optical muon efficiency from intensity fit
-    ring_width:
-        ring width
-    ring_time_width:
-        standard deviation of the photons time arrival
     """
 
-    def __init__(self, name="MuonParameter"):
+    def __init__(self, name="MuonRingParameter"):
         super().__init__(name)
         self.add_item('run_id')
         self.add_item('event_id')
@@ -235,20 +209,64 @@ class MuonParameter(Container):
         self.add_item('ring_radius')
         self.add_item('ring_chi2_fit')
         self.add_item('ring_cov_matrix')
-        self.add_item('impact_parameter')
-        self.add_item('impact_parameter_chi2')
-        self.add_item('intensity_cov_matrix')
-        self.add_item('impact_parameter_pos_x')
-        self.add_item('impact_parameter_pos_y')
-        self.add_item('ring_completeness')
-        self.add_item('ring_num_pixel')
-        self.add_item('ring_size')
-        self.add_item('off_ring_size')
-        self.add_item('COG_x')
-        self.add_item('COG_y')
-        self.add_item('optical_efficiency_muon')
-        self.add_item('ring_width')
-        self.add_item('ring_time_width')
         self.meta.add_item('ring_fit_method')
-        self.meta.add_item('intensity_fit_method')
         self.meta.add_item('inputfile')
+
+class MuonIntensityParameter(Container):
+        """
+        Storage of a Output of muon reconstruction Event
+
+        Parameters
+        ----------
+
+        run_id : int
+            run number
+        event_id : int
+            event number
+        impact_parameter: float
+            reconstructed impact parameter
+        impact_parameter_chi2:
+            chi squared impact parameter
+        intensity_cov_matrix:
+            Covariance matrix of impact parameters or alternatively:
+            full 5x5 covariance matrix for the complete fit (ring + impact)
+        impact_parameter_pos_x, impact_parameter_pos_y:
+            position on the mirror of the muon impact
+        COG_x, COG_y:
+            center of gravity
+        optical_efficiency_muon:
+            optical muon efficiency from intensity fit
+        ring_completeness:
+            completeness of the ring
+        ring_num_pixel: int
+            Number of pixels composing the ring
+        ring_size:
+            ring size
+        off_ring_size:
+            size outside of the ring
+        ring_width:
+            ring width
+        ring_time_width:
+            standard deviation of the photons time arrival
+        """
+
+        def __init__(self, name="MuonIntensityParameter"):
+            super().__init__(name)
+            self.add_item('run_id')
+            self.add_item('event_id')
+            self.add_item('ring_completeness')
+            self.add_item('ring_num_pixel')
+            self.add_item('ring_size')
+            self.add_item('off_ring_size')
+            self.add_item('ring_width')
+            self.add_item('ring_time_width')
+            self.add_item('impact_parameter')
+            self.add_item('impact_parameter_chi2')
+            self.add_item('intensity_cov_matrix')
+            self.add_item('impact_parameter_pos_x')
+            self.add_item('impact_parameter_pos_y')
+            self.add_item('COG_x')
+            self.add_item('COG_y')
+            self.add_item('optical_efficiency_muon')
+            self.meta.add_item('intensity_fit_method')
+            self.meta.add_item('inputfile')


### PR DESCRIPTION
In ctapipe/io/containers.py, changes made with @mgaug :
- I modified some of the names in the MuonParameter container to make them more intuitive (e.g. center_x ->ring_center_x)
- Changed Center of Gravity (COG) in COG_x and COG_y for the two different coordinates