### PR TITLE
Fix tests

### DIFF
--- a/ctapipe/utils/json2fits.py
+++ b/ctapipe/utils/json2fits.py
@@ -36,10 +36,17 @@ def traitlets_config_to_fits(config, fits_filename, clobber=True):
     for section, entry in config.items():
         header = fits.Header()
         for key, value in entry.items():
-            if len(key) > 8:
-                warnings.warn('Key "{}" will be truncated to {}'.format(key, key[:8]))
 
-            header[key[:8]] = value
+            # CONTINUE and HIERARCH are incompatible, so we have to decide
+            # to either truncate key or value. I went for the key. @maxnoe
+            if isinstance(value, str):
+                if len(key) > 8 and (len(key) + len(value)) > 70:
+                    warnings.warn(
+                        'Key "{}" will be truncated to {}'.format(key, key[:8])
+                    )
+                    key = key[:8]
+
+            header[key] = value
 
         table_0 = fits.TableHDU(data=None, header=header, name=section)
         hduList.append(table_0)
@@ -87,12 +94,17 @@ def json_to_fits(json_filename, fits_filename, clobber=True):
                             'Malformed json file: fits header cannot contain subobjects'
                         )
 
-                    if len(key) > 8:
-                        warnings.warn('Key "{}" will be truncated to {}'.format(
-                            key, key[:8]
-                        ))
+                    # CONTINUE and HIERARCH are incompatible, so we have to
+                    # decide to either truncate key or value.
+                    # I went for the key. @maxnoe
+                    if isinstance(value, str):
+                        if len(key) > 8 and (len(key) + len(value)) > 70:
+                            warnings.warn(
+                                'Key "{}" will be truncated to {}'.format(key, key[:8])
+                            )
+                            key = key[:8]
 
-                    header[key[:8]] = value
+                    header[key] = value
 
                 # create a new TableHDU with current header and append it to hduList
                 table_0 = fits.TableHDU(data=None, header=header, name=section)

--- a/ctapipe/utils/json2fits.py
+++ b/ctapipe/utils/json2fits.py
@@ -7,8 +7,9 @@ logger = logging.getLogger(__name__)
 
 __all__ = ['traitlets_config_to_fits', 'json_to_fits']
 
+
 def traitlets_config_to_fits(config, fits_filename, clobber=True):
-    """Write a FITS file that represents configuration.
+    '''Write a FITS file that represents configuration.
 
     Parameters
     ----------
@@ -22,16 +23,16 @@ def traitlets_config_to_fits(config, fits_filename, clobber=True):
     Raises
     ------
     OSError : If FITS file containing the traitlets config is not written
-    """
+    '''
 
-    if not isinstance(config,Config):
-        logger.error("traitlets_config_to_fits: config must be an instance of traitlets.config.loader.Config")
-        return False
+    if not isinstance(config, Config):
+        raise TypeError('Config must be an instance of traitlets.config.loader.Config')
+
     # hduList will contain one TableHDU per section
     hduList = fits.HDUList()
     # get all Configuration entries
     # loop over section
-    for section,entry in config.items():
+    for section, entry in config.items():
         header = fits.Header()
         for key,value in entry.items():
             header[key] = value
@@ -44,11 +45,8 @@ def traitlets_config_to_fits(config, fits_filename, clobber=True):
         raise
 
 
-
-
-
 def json_to_fits(json_filename, fits_filename, clobber=True):
-    """Write a FITS file that represents json file for traitlets configuration.
+    '''Write a FITS file that represents json file for traitlets configuration.
 
     Parameters
     ----------
@@ -64,7 +62,7 @@ def json_to_fits(json_filename, fits_filename, clobber=True):
     ------
     OSError : if FITS file containing a copy of json content is not written
     FileNotFoundError : if fits_filename could not be open
-    """
+    '''
     try:
         f = open(json_filename, 'r')
         # hduList will contain one TableHDU per section
@@ -72,9 +70,9 @@ def json_to_fits(json_filename, fits_filename, clobber=True):
         json_object = load(f)
         # Create a global header for key/value that not depend of a section
         global_header = fits.Header()
-        #loop over json entries (corresponding to Python class or general purpose)
-        for section,entry in json_object.items():
-            #create a new header for this section
+
+        # loop over json entries (corresponding to Python class or general purpose)
+        for section, entry in json_object.items():
             header = fits.Header()
             if  isinstance(entry, dict):
                 #loop over key/value entries
@@ -87,13 +85,14 @@ def json_to_fits(json_filename, fits_filename, clobber=True):
                 # create a new TableHDU with current header and append it to hduList
                 table_0 = fits.TableHDU(data=None, header=header, name=section)
                 hduList.append(table_0)
+
             else:
                 # entry is not a dictionary of key value but a simple value.
                 # That means last section is not a section but a general purpose entry
                 global_header[section] = entry
 
         # create a new TableHDU for global_header and append it to hduList
-        table_0 = fits.TableHDU(data=None, header=global_header, name="GLOBAL")
+        table_0 = fits.TableHDU(data=None, header=global_header, name='GLOBAL')
         hduList.append(table_0)
         # write hduList to FITS file
         try:
@@ -101,7 +100,7 @@ def json_to_fits(json_filename, fits_filename, clobber=True):
         except OSError as e:
             logging.exception('Could not do save {}'.format(fits_filename))
             raise
-        return True
+
     except FileNotFoundError:
         logging.exception('Could not open  {}'.format(fits_filename))
         raise

--- a/ctapipe/utils/tests/test_json_2_fits.py
+++ b/ctapipe/utils/tests/test_json_2_fits.py
@@ -1,4 +1,4 @@
-"""A simple example of how to use traitlets.config.application.Application.
+'''A simple example of how to use traitlets.config.application.Application.
 
 This should serve as a simple example that shows how the traitlets config
 system works. The main classes are:
@@ -19,68 +19,65 @@ to set the following options:
 
 * ``config``: set to ``True`` to make the attribute configurable.
 * ``shortname``: by default, configurable attributes are set using the syntax
-  "Classname.attributename". At the command line, this is a bit verbose, so
-  we allow "shortnames" to be declared. Setting a shortname is optional, but
+  'Classname.attributename'. At the command line, this is a bit verbose, so
+  we allow 'shortnames' to be declared. Setting a shortname is optional, but
   when you do this, you can set the option at the command line using the
-  syntax: "shortname=value".
+  syntax: 'shortname=value'.
 * ``help``: set the help string to display a help message when the ``-h``
   option is given at the command line. The help string should be valid ReST.
 
 When the config attribute of an Application is updated, it will fire all of
 the trait's events for all of the config=True attributes.
-"""
+'''
 
 from traitlets.config.configurable import Configurable
 from traitlets.config.application import Application
 from traitlets import (
     Bool, Unicode, Int, List, Dict
 )
-from traitlets.config.loader import JSONFileConfigLoader, ConfigFileNotFound
-from traitlets.config.loader import Config
 
 from ctapipe.utils.json2fits import traitlets_config_to_fits, json_to_fits
-import ctapipe.instrument.CameraDescription as CD
 from ctapipe.utils.datasets import get_path
 
-import io
 import sys
 import os
 import json
-import pytest
+
 
 class Foo(Configurable):
-    """A class that has configurable, typed attributes.
+    '''A class that has configurable, typed attributes.
 
-    """
+    '''
 
-    i = Int(0, help="The integer i.").tag(config=True)
-    j = Int(1, help="The integer j.").tag(config=True)
-    name = Unicode(u'Brian', help="First name.").tag(config=True)
+    i = Int(0, help='The integer i.').tag(config=True)
+    j = Int(1, help='The integer j.').tag(config=True)
+    name = Unicode(u'Brian', help='First name.').tag(config=True)
 
 
 class Bar(Configurable):
 
-    enabled = Bool(True, help="Enable bar.").tag(config=True)
+    enabled = Bool(True, help='Enable bar.').tag(config=True)
 
 
 class MyApp(Application):
 
-
-    name = Unicode(u'myapp')
+    name = Unicode('myapp')
     running = Bool(False,
-                   help="Is the app running?").tag(config=True)
+                   help='Is the app running?').tag(config=True)
     classes = List([Bar, Foo])
 
+    aliases = Dict(dict(
+        i='Foo.i', j='Foo.j', name='Foo.name', running='MyApp.running',
+        enabled='Bar.enabled', log_level='MyApp.log_level',
+        config_file='MyApp.config_file',
+    ))
 
-    aliases = Dict(dict(i='Foo.i',j='Foo.j',name='Foo.name', running='MyApp.running',
-                        enabled='Bar.enabled', log_level='MyApp.log_level', config_file='MyApp.config_file'))
-
-    flags = Dict(dict(enable=({'Bar': {'enabled' : True}}, "Enable Bar"),
-                  disable=({'Bar': {'enabled' : False}}, "Disable Bar"),
-                  debug=({'MyApp':{'log_level':10}}, "Set loglevel to DEBUG")
-            ))
-    config_file = Unicode(u'',
-                            help="Load this config file").tag(config=True)
+    flags = Dict(dict(
+        enable=({'Bar': {'enabled': True}}, 'Enable Bar'),
+        disable=({'Bar': {'enabled': False}}, 'Disable Bar'),
+        debug=({'MyApp': {'log_level': 10}}, 'Set loglevel to DEBUG')
+    ))
+    config_file = Unicode(u'', help='Load this config file').tag(config=True)
 
     def init_foo(self):
         # Pass config to other classes for them to inherit the config.
@@ -102,11 +99,11 @@ class MyApp(Application):
         pass
 
     def stage_default_config_file(self):
-        """auto generate default config file, and stage it into the profile."""
-        #s = self.generate_config_file()
-        fname = os.path.join( ".", 'foo.json')#self.config_file)
+        '''auto generate default config file, and stage it into the profile.'''
+        # s = self.generate_config_file()
+        fname = os.path.join('.', 'foo.json')  # self.config_file)
         if not os.path.exists(fname):
-            self.log.warn("Generating default config file: %r"%(fname))
+            self.log.warn('Generating default config file: {}'.format(fname))
             with open(fname, 'w') as f:
                 f.write(str(json.dumps(self.config)))
 
@@ -119,7 +116,7 @@ class MyApp(Application):
 def test_traitlets_config_to_fits():
     backup = sys.argv
     full_config_name = get_path('config.json')
-    sys.argv = ['test_json_2_fits.py', '--config_file='+full_config_name]
+    sys.argv = ['test_json_2_fits.py', '--config_file=' + full_config_name]
     app = MyApp()
     app.initialize()
     app.start()
@@ -127,10 +124,11 @@ def test_traitlets_config_to_fits():
     app.traitlets_config_to_fits()
     sys.argv = backup
 
+
 def test_jsonToFits():
     backup = sys.argv
     full_config_name = get_path('config.json')
-    sys.argv = ['test_json_2_fits.py', '--config_file='+full_config_name]
+    sys.argv = ['test_json_2_fits.py', '--config_file=' + full_config_name]
     app = MyApp()
     app.initialize()
     app.start()
@@ -143,5 +141,5 @@ def main():
     test_jsonToFits()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/ctapipe/utils/tests/test_json_2_fits.py
+++ b/ctapipe/utils/tests/test_json_2_fits.py
@@ -76,8 +76,12 @@ class MyApp(Application):
     flags = Dict(dict(
         enable=({'Bar': {'enabled': True}}, 'Enable Bar'),
         disable=({'Bar': {'enabled': False}}, 'Disable Bar'),
-        debug=({'MyApp': {'log_level': 10}}, 'Set loglevel to DEBUG')
+        debug=({'MyApp': {'log_level': 10}}, 'Set loglevel to DEBUG'),
+
     ))
+    key_much_too_long_for_fits = Unicode('value short enough')
+    key_and_value_too_long = Unicode(5 * 'value to long as wellenough')
+    short = Unicode(20 * 'value to long')
     config_file = Unicode(u'', help='Load this config file').tag(config=True)
 
     def init_foo(self):

--- a/ctapipe/utils/tests/test_json_2_fits.py
+++ b/ctapipe/utils/tests/test_json_2_fits.py
@@ -38,6 +38,7 @@ from traitlets import (
 
 from ctapipe.utils.json2fits import traitlets_config_to_fits, json_to_fits
 from ctapipe.utils.datasets import get_path
+import tempfile
 
 import sys
 import os
@@ -107,11 +108,12 @@ class MyApp(Application):
             with open(fname, 'w') as f:
                 f.write(str(json.dumps(self.config)))
 
-    def traitlets_config_to_fits(self):
-        return traitlets_config_to_fits( self.config,'config_to_fits.fits',clobber=True)
+    def traitlets_config_to_fits(self, outputfile):
+        traitlets_config_to_fits(self.config, outputfile, clobber=True)
 
-    def jsonToFits(self):
-        return json_to_fits(self.full_path_configfile, 'json_to_fits.fits', clobber=True)
+    def jsonToFits(self, outputfile):
+        json_to_fits(self.full_path_configfile, outputfile, clobber=True)
+
 
 def test_traitlets_config_to_fits():
     backup = sys.argv
@@ -120,8 +122,9 @@ def test_traitlets_config_to_fits():
     app = MyApp()
     app.initialize()
     app.start()
-    
-    app.traitlets_config_to_fits()
+
+    tmp = tempfile.NamedTemporaryFile()
+    app.traitlets_config_to_fits(tmp.name)
     sys.argv = backup
 
 
@@ -132,7 +135,8 @@ def test_jsonToFits():
     app = MyApp()
     app.initialize()
     app.start()
-    app.jsonToFits()
+    tmp = tempfile.NamedTemporaryFile()
+    app.jsonToFits(tmp)
     sys.argv = backup
 
 


### PR DESCRIPTION
This removes two left over status codes (we missed two returns in the last PR) and truncates keys with more than eight characters.

A warning is raised if a truncation happens.


**Question:** Do we want that an error is raised if a key is to long? Or is it ok to truncate the key?