### PR TITLE
Added small timing test to test_integrators.py, just to compare execu…

### DIFF
--- a/ctapipe/calib/camera/tests/test_integrators.py
+++ b/ctapipe/calib/camera/tests/test_integrators.py
@@ -1,7 +1,6 @@
 from ctapipe.io.hessio import hessio_event_source
 from ctapipe.utils.datasets import get_path
 from ctapipe.io import CameraGeometry
-import time
 import numpy as np
 
 from ..integrators import integrator_switch, full_integration, \
@@ -54,23 +53,13 @@ def test_integrator_switch():
     assert peakpos[0][0] == 14
 
     params['integrator'] = 'local_peak_integration'
-    t1 = time.time()
-    for i in range(10):
-        integration, window, peakpos = integrator_switch(data_ped, geom, params)
-    t2 = time.time()
-#   ^^ simple speed test; can't use timeit to test just the integration part
-    print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
-#   run py.test -s test_integrators.py   to see the print output
+    integration, window, peakpos = integrator_switch(data_ped, geom, params)
     assert integration[0][0] == 76
     assert sum(window[0][0]) == params['integration_window'][0]
     assert peakpos[0][0] == 13
 
     params['integrator'] = 'nb_peak_integration'
-    t1 = time.time()
-    for i in range(10):
-        integration, window, peakpos = integrator_switch(data_ped, geom, params)
-    t2 = time.time()
-    print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
+    integration, window, peakpos = integrator_switch(data_ped, geom, params)
     assert integration[0][0] == -64
     assert sum(window[0][0]) == params['integration_window'][0]
     assert peakpos[0][0] == 20

--- a/ctapipe/calib/camera/tests/test_integrators.py
+++ b/ctapipe/calib/camera/tests/test_integrators.py
@@ -1,6 +1,7 @@
 from ctapipe.io.hessio import hessio_event_source
 from ctapipe.utils.datasets import get_path
 from ctapipe.io import CameraGeometry
+import time
 import numpy as np
 
 from ..integrators import integrator_switch, full_integration, \
@@ -53,13 +54,23 @@ def test_integrator_switch():
     assert peakpos[0][0] == 14
 
     params['integrator'] = 'local_peak_integration'
-    integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t1 = time.time()
+    for i in range(10):
+        integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t2 = time.time()
+#   ^^ simple speed test; can't use timeit to test just the integration part
+    print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
+#   run py.test -s test_integrators.py   to see the print output
     assert integration[0][0] == 76
     assert sum(window[0][0]) == params['integration_window'][0]
     assert peakpos[0][0] == 13
 
     params['integrator'] = 'nb_peak_integration'
-    integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t1 = time.time()
+    for i in range(10):
+        integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t2 = time.time()
+    print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
     assert integration[0][0] == -64
     assert sum(window[0][0]) == params['integration_window'][0]
     assert peakpos[0][0] == 20

--- a/ctapipe/calib/camera/tests/test_integrators.py
+++ b/ctapipe/calib/camera/tests/test_integrators.py
@@ -72,8 +72,6 @@ def test_integrator_switch():
     t2 = time.time()
 #   ^^ simple speed test; can't use timeit to test just the integration part
     print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
-    #
-    integration, window, peakpos = integrator_switch(data_ped, geom, params)
     assert integration[0][0] == -64
     assert sum(window[0][0]) == params['integration_window'][0]
     assert peakpos[0][0] == 20

--- a/ctapipe/calib/camera/tests/test_integrators.py
+++ b/ctapipe/calib/camera/tests/test_integrators.py
@@ -1,6 +1,7 @@
 from ctapipe.io.hessio import hessio_event_source
 from ctapipe.utils.datasets import get_path
 from ctapipe.io import CameraGeometry
+import time
 import numpy as np
 
 from ..integrators import integrator_switch, full_integration, \
@@ -53,12 +54,25 @@ def test_integrator_switch():
     assert peakpos[0][0] == 14
 
     params['integrator'] = 'local_peak_integration'
-    integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t1 = time.time()
+    for i in range(10):
+        integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t2 = time.time()
+#   ^^ simple speed test; can't use timeit to test just the integration part
+    print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
+#   run py.test -s test_integrators.py   to see the print output
     assert integration[0][0] == 76
     assert sum(window[0][0]) == params['integration_window'][0]
     assert peakpos[0][0] == 13
 
     params['integrator'] = 'nb_peak_integration'
+    t1 = time.time()
+    for i in range(10):
+        integration, window, peakpos = integrator_switch(data_ped, geom, params)
+    t2 = time.time()
+#   ^^ simple speed test; can't use timeit to test just the integration part
+    print(params['integrator'], ": wall clock t = {:.3} seconds".format(t2-t1))
+    #
     integration, window, peakpos = integrator_switch(data_ped, geom, params)
     assert integration[0][0] == -64
     assert sum(window[0][0]) == params['integration_window'][0]


### PR DESCRIPTION
Just a small check, not shown by default, of the execution time of "local peak integration" vs. "next-neighbor peak integration" (the latter is currently very slow). The test just uses time.time(), I could not manage to use timeit to test just the integration part, without all the needed preparations like subtracting pedestals or reading in the camera geometry.
