### PR TITLE
Make Component abstract

### DIFF
--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -4,4 +4,4 @@ from .component import Component
 from .container import Container
 from .tool import Tool
 
-#__all__ = ['Component', 'Container', 'Tool']
+__all__ = ['Component', 'Container', 'Tool']

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -53,7 +53,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         comp.some_option = 'test' # will fail validation
     """
 
-    def __init__(self, parent, **kwargs):
+    def __init__(self, parent=None, **kwargs):
         """
         Parameters
         ----------

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -1,10 +1,18 @@
 """ Class to handle configuration for algorithms """
 
-from logging import getLogger
 from traitlets.config import Configurable
+from abc import ABCMeta
+from logging import getLogger
 
 
-class Component(Configurable):
+class AbstractConfigurableMeta(type(Configurable), ABCMeta):
+    '''
+    Metaclass to be able to make Component abstract
+    see: http://stackoverflow.com/a/7314847/3838691
+    '''
+
+
+class Component(Configurable, metaclass=AbstractConfigurableMeta):
     """Base class of all Components (sometimes called
     workers, makers, etc).  Components are are classes that do some sort
     of processing and contain user-configurable parameters, which are
@@ -43,7 +51,6 @@ class Component(Configurable):
         comp = MyComponent(None)
         comp.some_option = 6      # ok
         comp.some_option = 'test' # will fail validation
-
     """
 
     def __init__(self, parent, **kwargs):
@@ -64,4 +71,3 @@ class Component(Configurable):
             self.log = self.parent.log.getChild(self.__class__.__name__)
         else:
             self.log = getLogger(self.__class__.__name__)
-

--- a/ctapipe/core/tests/test_component.py
+++ b/ctapipe/core/tests/test_component.py
@@ -1,7 +1,19 @@
 import pytest
 from traitlets import Float, TraitError
 
-from .. import Component
+from ctapipe.core import Component
+from abc import abstractmethod
+
+
+def test_componen_is_abstract():
+
+    class AbstractComponent(Component):
+        @abstractmethod
+        def test(self):
+            pass
+
+    with pytest.raises(TypeError):
+        AbstractComponent()
 
 
 def test_component_simple():

--- a/ctapipe/core/tests/test_component.py
+++ b/ctapipe/core/tests/test_component.py
@@ -5,7 +5,7 @@ from ctapipe.core import Component
 from abc import abstractmethod
 
 
-def test_componen_is_abstract():
+def test_component_is_abstract():
 
     class AbstractComponent(Component):
         @abstractmethod


### PR DESCRIPTION
This makes `ctapipe.core.Component` abstract (as i think it was meant to be a baseclass only).