### PR TITLE
Add Processor, a Component-like function

### DIFF
--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from .component import Component
+from .processor import Processor
 from .container import Container
 from .tool import Tool
 
-__all__ = ['Component', 'Container', 'Tool']
+__all__ = ['Component', 'Container', 'Tool', 'Processor']

--- a/ctapipe/core/processor.py
+++ b/ctapipe/core/processor.py
@@ -1,0 +1,19 @@
+from abc import abstractmethod
+from .component import Component
+
+
+class Processor(Component):
+    '''
+    A processor is a traitlets configurable class that acts like a function
+
+    This should be the baseclass for everything that would normally be just a function
+    if it would not need a log and the configurability.
+    '''
+
+    @abstractmethod
+    def __call__(self):
+        '''
+        The __call__ method must be overriden by every base class to implement
+        what the Processor is meant to do
+        '''
+        pass

--- a/ctapipe/core/tests/test_processor.py
+++ b/ctapipe/core/tests/test_processor.py
@@ -1,0 +1,19 @@
+from ctapipe.core import Processor
+from pytest import raises
+
+
+def test_abstract():
+
+    with raises(TypeError):
+        Processor()
+
+
+def test_callable():
+
+    class MyProcessor(Processor):
+
+        def __call__(self, a, b):
+            return a + b
+
+    p = MyProcessor()
+    p(1, 2)


### PR DESCRIPTION
I observed how much functionality now is put into differently named methods of classes inheriting from `Component` which normally would just be simple functions.

Thinking about the pipeline, I think we should have a common interface for function-like `Component`. 
For that I created the `Processor` class which has the abstract method `__call__`. 

So for example something like the `FitGammaHillas` from #233 would have to override `__call__` instead of having a method `predict`. Or the RingFitter would also override `__call__` instead of having a method `fit`.
