### PR TITLE
fixed units of hillas return parameters

### DIFF
--- a/ctapipe/image/hillas.py
+++ b/ctapipe/image/hillas.py
@@ -258,15 +258,15 @@ def hillas_parameters_1(pix_x, pix_y, image, recalculate_pixels=True):
     # azwidth = np.sqrt(azwidth_2)
 
     return MomentParameters(size=size,
-                             cen_x=mean_x,
-                             cen_y=mean_y,
-                             length=length,
-                             width=width,
-                             r=r,
-                             phi=Angle(phi*u.rad),
-                             psi=Angle(delta*u.rad),
-                             miss=miss,
-                             skewness=skewness,
+                            cen_x=mean_x*u.m,
+                            cen_y=mean_y*u.m,
+                            length=length*u.m,
+                            width=width*u.m,
+                            r=r*u.m,
+                            phi=Angle(phi*u.rad),
+                            psi=Angle(delta*u.rad),
+                            miss=miss,
+                            skewness=skewness,
                             kurtosis=kurtosis)
 
 def static_pix(pix_x, pix_y, recalculate_pixels):
@@ -391,7 +391,7 @@ def hillas_parameters_2(pix_x, pix_y, image, recalculate_pixels=True):
     # polar coordinates of centroid
 
     rr = np.sqrt(xm2 + ym2)  # could use hypot(xm, ym), but already have squares
-    phi = np.arctan2(ym, xm)
+    phi = np.arctan2(ym, xm)*u.rad
 
     # common factors:
 
@@ -457,13 +457,14 @@ def hillas_parameters_2(pix_x, pix_y, image, recalculate_pixels=True):
                     vy4 * spsi2 * spsi2)
         kurtosis = kurt / (length*length*length*length)
     else:  # Skip Higher Moments
-        psi = 0.0
+        psi = 0.0*u.rad
         skewness = 0.0
         kurtosis = 0.0
+        asym = 0.0
 
     return MomentParameters(size=size, cen_x=xm*unit, cen_y=ym*unit,
-                            length=length*unit, width=width, r=rr*unit,
-                            phi=Angle(phi*u.rad), psi=Angle(psi),
+                            length=length*unit, width=width*unit, r=rr*unit,
+                            phi=Angle(phi), psi=Angle(psi),
                             miss=miss*unit, skewness=skewness,
                             kurtosis=kurtosis)
 
@@ -492,8 +493,8 @@ def hillas_parameters_3(pix_x, pix_y, image, recalculate_pixels=True):
     """
 
     if type(pix_x)==Quantity:
-        unit = pix_x.unit()
-        assert pix_x.unit() == pix_y.unit()
+        unit = pix_x.unit
+        assert pix_x.unit == pix_y.unit
     else:
         unit = 1.0
 
@@ -672,6 +673,7 @@ def static_xy(pix_x, pix_y, recalculate_pixels):
         static_xy.pix_xy3 = pix_x * static_xy.pix_y3
         static_xy.pix_y4 = static_xy.pix_y3 * pix_y
 
+
 def hillas_parameters_4(pix_x, pix_y, image, recalculate_pixels=True):
     """Compute Hillas parameters for a given shower image.
 
@@ -699,8 +701,8 @@ def hillas_parameters_4(pix_x, pix_y, image, recalculate_pixels=True):
 
 
     if type(pix_x)==Quantity:
-        unit = pix_x.unit()
-        assert pix_x.unit() == pix_y.unit()
+        unit = pix_x.unit
+        assert pix_x.unit == pix_y.unit
     else:
         unit = 1.0
     # MP: Actually, I don't know why we need to strip the units... shouldn' the calculations all work with them?

--- a/ctapipe/io/camera.py
+++ b/ctapipe/io/camera.py
@@ -27,7 +27,7 @@ _npix_to_type = {
     (1855, 28.0):  ('LST', 'LSTCam', 'hexagonal', 0. * u.degree, -100.893 * u.degree),
     (1296, None):  ('SST', 'SST-1m', 'hexagonal', 30 * u.degree, 0 * u.degree),
     (1764, None):  ('MST', 'FlashCam', 'hexagonal', 30 * u.degree, 0 * u.degree),
-    (2368, None):  ('SST', 'ASTRI', 'rectangular', 0 * u.degree, 90 * u.degree),
+    (2368, None):  ('SST', 'ASTRI', 'rectangular', 0 * u.degree, 0 * u.degree),
     (11328, None): ('SCT', 'SCTCam', 'rectangular', 0 * u.degree, 0 * u.degree),
 }
 

--- a/ctapipe/io/camera.py
+++ b/ctapipe/io/camera.py
@@ -27,7 +27,7 @@ _npix_to_type = {
     (1855, 28.0):  ('LST', 'LSTCam', 'hexagonal', 0. * u.degree, -100.893 * u.degree),
     (1296, None):  ('SST', 'SST-1m', 'hexagonal', 30 * u.degree, 0 * u.degree),
     (1764, None):  ('MST', 'FlashCam', 'hexagonal', 30 * u.degree, 0 * u.degree),
-    (2368, None):  ('SST', 'ASTRI', 'rectangular', 0 * u.degree, 0 * u.degree),
+    (2368, None):  ('SST', 'ASTRI', 'rectangular', 0 * u.degree, 90. * u.degree),
     (11328, None): ('SCT', 'SCTCam', 'rectangular', 0 * u.degree, 0 * u.degree),
 }
 

--- a/ctapipe/reco/FitGammaHillas.py
+++ b/ctapipe/reco/FitGammaHillas.py
@@ -247,10 +247,8 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
         self.circles = {}
         for tel_id, moments in hillas_dict.items():
 
-            p2_x = moments.cen_x + moments.length*np.cos(moments.psi +
-                                                         np.pi/2*u.rad)
-            p2_y = moments.cen_y + moments.length*np.sin(moments.psi +
-                                                         np.pi/2*u.rad)
+            p2_x = moments.cen_x + moments.length*np.cos(moments.psi)
+            p2_y = moments.cen_y + moments.length*np.sin(moments.psi)
 
             circle = GreatCircle(
                 guess_pix_direction(np.array([moments.cen_x/u.m, p2_x/u.m]) * u.m,
@@ -262,6 +260,7 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
             )
             circle.pos = inst.tel_pos[tel_id]
             self.circles[tel_id] = circle
+
 
     def fit_origin_crosses(self):
         '''calculates the origin of the gamma as the weighted average

--- a/ctapipe/reco/FitGammaHillas.py
+++ b/ctapipe/reco/FitGammaHillas.py
@@ -147,11 +147,6 @@ def MEst(origin, circles, weights):
     sin_ang = np.array([linalg.length(np.cross(origin, circ.norm))
                         for circ in circles.values()])
     return -2 * np.sum(weights * np.sqrt((1 + np.square(sin_ang))) - 2)
-    return -np.sum(weights * np.square(sin_ang))
-
-    ang = np.array([linalg.angle(origin, circ.norm)
-                    for circ in circles.values()])
-    return np.sum(weights * np.sqrt(2. + (ang - np.pi / 2.) ** 2))
 
 
 def neg_angle_sum(origin, circles, weights):

--- a/ctapipe/reco/FitGammaHillas.py
+++ b/ctapipe/reco/FitGammaHillas.py
@@ -261,7 +261,6 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
             circle.pos = inst.tel_pos[tel_id]
             self.circles[tel_id] = circle
 
-
     def fit_origin_crosses(self):
         '''calculates the origin of the gamma as the weighted average
         direction of the intersections of all great circles

--- a/ctapipe/reco/FitGammaHillas.py
+++ b/ctapipe/reco/FitGammaHillas.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from scipy.optimize import minimize
 
+
 from astropy import units as u
 u.dimless = u.dimensionless_unscaled
 
@@ -153,7 +154,7 @@ def MEst(origin, circles, weights):
     return np.sum(weights * np.sqrt(2. + (ang - np.pi / 2.) ** 2))
 
 
-def n_angle_sum(origin, circles, weights):
+def neg_angle_sum(origin, circles, weights):
     '''calculates the negative sum of the angle between the fit direction
     and all the normal vectors of the great circles
 
@@ -227,10 +228,10 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
 
         # container class for reconstructed showers '''
         result = ReconstructedShowerContainer()
-        (phi, theta) = linalg.get_phi_theta(dir1)
+        (phi, theta) = linalg.get_phi_theta(dir1).to(u.deg)
 
         # TODO make sure az and phi turn in same direction...
-        result.alt, result.az = theta - 90 * u.deg, phi
+        result.alt, result.az = 90*u.deg - theta, phi
         result.core_x = pos[0]
         result.core_y = pos[1]
 
@@ -256,10 +257,9 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
             p2_y = moments.cen_y + moments.length*np.sin(moments.psi +
                                                          np.pi/2*u.rad)
 
-
             circle = GreatCircle(
-                guess_pix_direction(np.array([moments.cen_x, p2_x]) * u.m,
-                                    np.array([moments.cen_y, p2_y]) * u.m,
+                guess_pix_direction(np.array([moments.cen_x/u.m, p2_x/u.m]) * u.m,
+                                    np.array([moments.cen_y/u.m, p2_y/u.m]) * u.m,
                                     tel_phi[tel_id], tel_theta[tel_id],
                                     inst.optical_foclen[tel_id]
                                     ),
@@ -300,7 +300,7 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
         # averaging over the solutions of all permutations
         return linalg.normalise(np.sum(crossings, axis=0)) * u.dimless, crossings
 
-    def fit_origin_minimise(self, seed=(0, 0, 1), test_function=n_angle_sum):
+    def fit_origin_minimise(self, seed=(0, 0, 1), test_function=neg_angle_sum):
         '''fits the origin of the gamma with a minimisation procedure this
         function expects that get_great_circles has been run already a
         seed should be given otherwise it defaults to "straight up"
@@ -313,9 +313,9 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
         seed : length-3 array
             starting point of the minimisation
         test_function : member function if this class
-            either n_angle_sum or MEst (or own implementation...)
-            defaults to n_angle_sum if none is given
-            n_angle_sum seemingly superior to MEst
+            either neg_angle_sum or MEst (or own implementation...)
+            defaults to neg_angle_sum if none is given
+            neg_angle_sum seemingly superior to MEst
 
         Returns
         -------
@@ -326,7 +326,7 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
         '''
 
         # using the sum of the cosines of each direction with every
-        # otherdirection as weight; don't use the product -- with many
+        # other direction as weight; don't use the product -- with many
         # steep angles, the product will become too small and the
         # weight (and the whole fit) useless
 
@@ -344,7 +344,7 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
 
         return np.array(linalg.normalise(self.fit_result_origin.x)) * u.dimless
 
-    def fit_core(self, seed=(0*u.m, 0*u.m), test_function=dist_to_traces):
+    def fit_core(self, seed=(0, 0), test_function=dist_to_traces):
         '''reconstructs the shower core position from the already set up
         great circles
 
@@ -359,13 +359,19 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
 
         Parameters
         ----------
-        seed : python tuple * astropy quantity, optional
-            shape (2) tuple with optional starting coordinates in
+        seed : tuple, optional (default: (0, 0))
+            shape (2) tuple with optional starting coordinates
+            tuple of floats or astropy.length -- if floats, assume metres
         test_function : function object, optional
             function to be used by the minimiser
             by default uses self._dist_to_traces
 
         '''
+
+        if type(seed) == u.Quantity:
+            unit = seed.unit
+        else:
+            unit = u.m
 
         # the direction of the cross section of the great circle with
         # the horizontal frame is the cross product of the great
@@ -375,16 +381,15 @@ class FitGammaHillas(RecoShowerGeomAlgorithm):
         for circle in self.circles.values():
             circle.trace = linalg.normalise(np.cross(circle.norm, zdir))
 
-        # minimising the test function
-        self.fit_result_core = minimize(test_function, seed[:2] / u.m,
+        # minimising the test function (note: minimize strips seed off its unit)
+        self.fit_result_core = minimize(test_function, seed[:2],
                                         args=(self.circles),
                                         method='BFGS', options={'disp': False})
-        if self.fit_result_core.success:
-            return np.array(self.fit_result_core.x) * u.m
-        else:
-            print("fit no success")
-            return np.array(self.fit_result_core.x) * u.m
-            return np.array([np.nan] * 3) * u.m
+
+        if not self.fit_result_core.success:
+            print("fit_core: fit no success")
+
+        return np.array(self.fit_result_core.x) * unit
 
 
 class GreatCircle:

--- a/ctapipe/reco/tests/test_FitGammaHillas.py
+++ b/ctapipe/reco/tests/test_FitGammaHillas.py
@@ -80,7 +80,7 @@ def test_FitGammaHillas():
                                         event.inst.pixel_pos[tel_id][1],
                                         event.inst.optical_foclen[tel_id])
 
-                tel_phi[tel_id] = 180.*u.deg
+                tel_phi[tel_id] = 0.*u.deg
                 tel_theta[tel_id] = 20.*u.deg
 
             pmt_signal = event.dl0.tel[tel_id].adc_sums[0]


### PR DESCRIPTION
the various functions for the Hillas-parametrisation where highly inconsistent with regards to the units of the return values (even within one and the same function -- length was in metres, width was unitless...)

somewhere, pix_x.unit() was called with parentheses (should be without)

also adapted FitGammaHillas to the now "unificated" parameters