### PR TITLE
Fix tests for Factory and Tool

### DIFF
--- a/ctapipe/core/tests/test_factory.py
+++ b/ctapipe/core/tests/test_factory.py
@@ -3,29 +3,29 @@ from ctapipe.core.component import Component
 from traitlets import Unicode, Int
 
 
-class TestComponentParent(Component):
-    name = 'TestComponentParent'
+class ExampleComponentParent(Component):
+    name = 'ExampleComponentParent'
     value = Int(123, help="").tag(config=True)
 
 
-class TestComponent1(TestComponentParent):
-    name = 'TestComponent1'
+class ExampleComponent1(ExampleComponentParent):
+    name = 'ExampleComponent1'
     value = Int(123111, help="").tag(config=True)
 
 
-class TestComponent2(TestComponentParent):
-    name = 'TestComponent2'
+class ExampleComponent2(ExampleComponentParent):
+    name = 'ExampleComponent2'
     value = Int(123222, help="").tag(config=True)
 
 
-class TestFactory(Factory):
-    name = 'TestFactory'
+class ExampleFactory(Factory):
+    name = 'ExampleFactory'
     description = "Test Factory class"
 
-    subclasses = Factory.child_subclasses(TestComponentParent)
+    subclasses = Factory.child_subclasses(ExampleComponentParent)
     subclass_names = [c.__name__ for c in subclasses]
 
-    discriminator = Unicode('TestComponent1',
+    discriminator = Unicode('ExampleComponent1',
                             help='Product to obtain: {}'
                             .format(subclass_names)).tag(config=True)
 
@@ -40,10 +40,10 @@ class TestFactory(Factory):
 
 
 def test_factory():
-    factory = TestFactory(config=None, tool=None)
-    factory.discriminator = 'TestComponent2'
+    factory = ExampleFactory(config=None, tool=None)
+    factory.discriminator = 'ExampleComponent2'
     factory.value = 111
     cls = factory.get_class()
     obj = cls(config=factory.config, parent=None)
-    assert(obj.name == 'TestComponent2')
+    assert(obj.name == 'ExampleComponent2')
     assert(obj.value == 111)

--- a/ctapipe/core/tests/test_tool.py
+++ b/ctapipe/core/tests/test_tool.py
@@ -21,3 +21,13 @@ def test_tool_simple():
     tool.userparam = 4.0
     with pytest.raises(TraitError):
         tool.userparam = "badvalue"
+
+
+def test_tool_version():
+
+    class MyTool(Tool):
+        description = "test"
+        userparam = Float(5.0, help="parameter").tag(config=True)
+
+    tool = MyTool()
+    assert tool.version_string !=  ""

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -146,7 +146,7 @@ class Tool(Application):
         if self.config_file != '':
             self.log.debug("Loading config from '{}'".format(self.config_file))
             self.load_config_file(self.config_file)
-        self.log.info("version {}".format(self.version_string))
+        self.log.info("ctapipe version {}".format(self.version_string))
         self.setup()
         self.is_setup = True
 
@@ -187,6 +187,4 @@ class Tool(Application):
     @property
     def version_string(self):
         """ a formatted version string with version, release, and git hash"""
-        return "{} [release={}] [githash={}]".format(version,
-                                                     version.split('+')[0],
-                                                     version.split('+')[1][3:])
+        return "{}".format(version)

--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -45,11 +45,11 @@ def info(version=False, tools=False, dependencies=False):
 
 def _info_version():
     """Print version info."""
-    from ctapipe import version
+    import ctapipe
     print('\n*** ctapipe version info ***\n')
-    print('version: {0}'.format(version.version))
-    print('release: {0}'.format(version.release))
-    print('githash: {0}'.format(version.githash))
+    print('version: {0}'.format(ctapipe.__version__))
+    #print('release: {0}'.format(version.release))
+    #print('githash: {0}'.format(version.githash))
     print('')
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ LONG_DESCRIPTION = package.__doc__
 # rename _ to -, and prepend 'ctapipe'
 entry_points = {}
 entry_points['console_scripts'] = [
-    # 'ctapipe-info = ctapipe.tools.info:main',
+    'ctapipe-info = ctapipe.tools.info:main',
     'ctapipe-camdemo = ctapipe.tools.camdemo:main',
     'ctapipe-dump-triggers = ctapipe.tools.dump_triggers:main',
     'ctapipe-flow = ctapipe.flow.flow:main'


### PR DESCRIPTION
- Factory tests had classes with names staring with "Test" which get
collected as pytest tests (even though they are not tests!). Renamed to
"example*"
- add test for version string in tool