### PR TITLE
remove the "v" from git tags when determining the version

### DIFF
--- a/ctapipe/version.py
+++ b/ctapipe/version.py
@@ -89,6 +89,8 @@ def format_git_describe(git_str, pep440=False):
     if git_str is None:
         return None
     if "-" not in git_str:  # currently at a tag
+        if git_str.startswith('v'):
+            return git_str[1:]
         return git_str
     else:
         # formatted as version-N-githash


### PR DESCRIPTION
python version strings should not start with 'v', but git tags have to
(since they cannot start with a numeric character)

This removes the warnings like: `UserWarning: Normalizing 'v0.3.2' to
'0.3.2'
0.3.2`