### PR TITLE
more fixes for version.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include CHANGES.rst
+include ctapipe/VERSION
 
 include setup.cfg
 

--- a/ctapipe/_version_cache.py
+++ b/ctapipe/_version_cache.py
@@ -1,0 +1,1 @@
+version='0.3.3.post29+gitea50c1f'

--- a/ctapipe/version.py
+++ b/ctapipe/version.py
@@ -30,7 +30,7 @@ from os import path, name, devnull, environ, listdir
 __all__ = ("get_version",)
 
 CURRENT_DIRECTORY = path.dirname(path.abspath(__file__))
-VERSION_FILE = path.join(CURRENT_DIRECTORY, "VERSION")
+VERSION_FILE = path.join(CURRENT_DIRECTORY, "_version_cache.py")
 
 GIT_COMMAND = "git"
 
@@ -107,8 +107,7 @@ def format_git_describe(git_str, pep440=False):
 def read_release_version():
     """Read version information from VERSION file"""
     try:
-        with open(VERSION_FILE, "r") as infile:
-            version = infile.read().strip()
+        from ._version_cache import version
         if len(version) == 0:
             version = None
         return version
@@ -130,7 +129,7 @@ def update_release_version(pep440=False):
     """
     version = get_version(pep440=pep440)
     with open(VERSION_FILE, "w") as outfile:
-        outfile.write(version)
+        outfile.write("version='{}'".format(version))
         outfile.write("\n")
 
 


### PR DESCRIPTION
- fixes bug that the version does now work when a conda package (or setup.py) package is built since the VERSION file is not included
- made version cache a python file so it is included normally in the
package when built
- use import to read the cached version