### PR TITLE
fix #248, now have option to do image cleaning where single pixels above pic thresh are removed

### DIFF
--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -46,3 +46,41 @@ def test_dilate():
     # dilate a third row
     dmask = cleaning.dilate(geom, dmask)
     assert dmask.sum() == 1 + 6 + 12 + 18
+
+def test_tailcuts_clean():
+
+    # start with simple 3-pixel camera
+    geom = CameraGeometry.make_rectangular(3, 1, (-1, 1))
+
+    p = 15  #picture value
+    b = 7   # boundary value
+
+    # for no isolated pixels:
+    testcases = {(p, p, 0): [True, True, False],
+                 (p, 0, p): [False, False, False],
+                 (p, b, p): [True, True, True],
+                 (p, b, 0): [True, True, False],
+                 (b, b, 0): [False, False, False],
+                 (0, p ,0): [False, False, False]}
+
+    for image, mask in testcases.items():
+        result = cleaning.tailcuts_clean(geom, np.array(image),
+                                         picture_thresh=15,
+                                         boundary_thresh=5,
+                                         keep_isolated_pixels=False)
+        assert (result == mask).all()
+
+    # allowing isolated pixels
+    testcases = {(p, p, 0): [True, True, False],
+                 (p, 0, p): [True, False, True],
+                 (p, b, p): [True, True, True],
+                 (p, b, 0): [True, True, False],
+                 (b, b, 0): [False, False, False],
+                 (0, p, 0): [False, True, False]}
+
+    for image, mask in testcases.items():
+        result = cleaning.tailcuts_clean(geom, np.array(image),
+                                         picture_thresh=15,
+                                         boundary_thresh=5,
+                                         keep_isolated_pixels=True)
+        assert (result == mask).all()


### PR DESCRIPTION
- `tailcuts_clean` now has a `keep_isolated_pixels` option, which
defaults to False (but can be turned off in the case it is needed,
since there are some use cases where you want to keep them)
- improved tests of tailcuts_clean

Fixes issue #248 