### PR TITLE
Unify camera geom by name

### DIFF
--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -51,7 +51,7 @@ def test_ChaudhuriKunduRingFitterHline():
 
 def test_ChaudhuriKunduRingFitter():
 
-    geom = CameraGeometry.from_name(name='hess',tel_id=1)
+    geom = CameraGeometry.from_name('HESSI', array_id='HESS')
 
     ring_rad = np.deg2rad(1.*u.deg) * 15.  # make sure this is in camera coordinates
     ring_width = np.deg2rad(0.05*u.deg) * 15.

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -6,7 +6,7 @@ from ctapipe.instrument import CameraGeometry
 
 def test_tailcuts_clean():
 
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     image = np.zeros_like(geom.pix_id, dtype=np.float)
     pedvar = np.ones_like(geom.pix_id, dtype=np.float)
 
@@ -29,7 +29,7 @@ def test_tailcuts_clean():
 
 def test_dilate():
 
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     mask = np.zeros_like(geom.pix_id, dtype=bool)
 
     mask[100] = True  # a single pixel far from a border is true.

--- a/ctapipe/image/tests/test_hillas.py
+++ b/ctapipe/image/tests/test_hillas.py
@@ -12,7 +12,7 @@ def create_sample_image(psi='-30d'):
 
     # set up the sample image using a HESS camera geometry (since it's easy
     # to load)
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
 
     # make a toymodel shower model
     model = toymodel.generate_2d_shower_model(centroid=(0.2, 0.3),

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 
 import numpy as np
 import logging
+from pkg_resources import resource_listdir
+import re
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.table import Table
@@ -160,6 +162,31 @@ class CameraGeometry:
 
         CameraGeometry._geometry_cache[identifier] = instance
         return instance
+
+    @classmethod
+    def get_known_camera_names(cls, array_id='CTA'):
+        """
+        Returns a list of camera_ids that are registered in 
+        `ctapipe_resources`. These are all the camera-ids that can be 
+        instantiated by the `from_name` method
+     
+        Parameters
+        ----------
+        array_id: str 
+            which array to search (default CTA)
+
+        Returns
+        -------
+        list(str)
+        """
+        names = []
+        pattern = "{}-(.*)\.camgeom.fits".format(array_id)
+        for resource in resource_listdir('ctapipe_resources', '/'):
+            match = re.match(pattern, resource)
+            if match:
+                names.append(match[1])
+        return names
+
 
     @classmethod
     def from_name(cls, camera_id='NectarCam', array_id='CTA', version=None):

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -15,6 +15,7 @@ from ctapipe.io.files import get_file_type
 from ctapipe.utils.datasets import get_dataset
 from ctapipe.utils.linalg import rotation_matrix_2d
 from scipy.spatial import cKDTree as KDTree
+from ctapipe.utils.datasets import get_dataset
 
 __all__ = ['CameraGeometry',
            'get_camera_types',
@@ -161,23 +162,38 @@ class CameraGeometry:
         return instance
 
     @classmethod
-    def from_name(cls, name, tel_id):
+    def from_name(cls, camera_id='NectarCam', array_id='CTA', version=None):
         """
-        Construct a `CameraGeometry` from the name of the instrument and
-        telescope id, if it can be found in a standard database.
-        """
-        return get_camera_geometry(name, tel_id)
+        Construct a CameraGeometry using the name of the camera and array.
+        
+        This expects that there is a resource in the `ctapipe_resources` module
+        called "[array]-[camera].camgeom.fits.gz" or "[array]-[camera]-[
+        version].camgeom.fits.gz"
+        
+        Parameters
+        ----------
+        camera_id: str
+           name of camera (e.g. 'NectarCam', 'LSTCam', 'GCT', 'SST-1M')
+        array_id: str
+           array identifier (e.g. 'CTA', 'HESS')
+        version:
+           camera version id (currently unused)
 
-    @classmethod
-    def from_file(cls, filename, tel_id):
+        Returns
+        -------
+        new CameraGeometry
         """
-        Construct a `CameraGeometry` from the a data file
-        """
-        filetype = get_file_type(filename)
-        if filetype == 'simtel':
-            return _load_camera_geometry_from_hessio_file(tel_id, filename)
+
+        if version is None:
+            verstr = ''
         else:
-            raise TypeError("File type {} not supported".format(filetype))
+            verstr = "-{:03d}".format(version)
+
+        filename = get_dataset("{array_id}-{camera_id}{verstr}.camgeom.fits.gz"
+                               .format(array_id=array_id, camera_id=camera_id,
+                                       verstr=verstr))
+        return CameraGeometry.from_table(filename)
+
 
     def to_table(self):
         """ convert this to an `astropy.table.Table` """
@@ -401,106 +417,6 @@ def _guess_camera_type(npix, optical_foclen):
                                           ('unknown', 'unknown', 'hexagonal',
                                   0 * u.degree, 0 * u.degree))
 
-
-def get_camera_geometry(instrument_name, cam_id, recalc_neighbors=True):
-    """Helper function to provide the camera geometry definition for a
-    camera by name.
-
-    Parameters
-    ----------
-    instrument_name : {'hess'}
-        name of instrument
-    cam_id : int
-        identifier of camera, in case of multiple versions
-    recalc_neighbors : bool
-        if True, recalculate the neighbor pixel list, otherwise
-        use what is in the file
-
-    Returns
-    -------
-    a `CameraGeometry` object
-
-    Examples
-    --------
-
-    >>> geom_ct1 = get_camera_geometry( "hess", 1 )
-    >>> neighbors_pix_1 = geom_ct1.pix_id[geom_ct1.neighbors[1]]
-    """
-
-    # let's assume the instrument name is encoded in the
-    # filename
-    name = instrument_name.lower()
-    geomfile = get_dataset('{}_camgeom.fits.gz'.format(name))
-
-    geom = _load_camera_table_from_file(cam_id, geomfile=geomfile)
-    neigh_list = geom['PIX_NEIG'].data
-    neigh = np.ma.masked_array(neigh_list, neigh_list < 0),
-
-    # put them all in units of M (conversions are automatic)
-    xx = u.Quantity(geom['PIX_POSX'], u.m)
-    yy = u.Quantity(geom['PIX_POSY'], u.m)
-    dd = u.Quantity(geom['PIX_DIAM'], u.m)
-    aa = u.Quantity(geom['PIX_AREA'], u.m ** 2)
-
-    if recalc_neighbors is True:
-        neigh = _find_neighbor_pixels(xx.value, yy.value,
-                                      (dd.mean() + 0.01 * u.m).value)
-
-    return CameraGeometry(
-        cam_id="{}:{}".format(instrument_name, cam_id),
-        pix_id=np.array(geom['PIX_ID']),
-        pix_x=xx,
-        pix_y=yy,
-        pix_area=aa,
-        neighbors=neigh,
-        pix_type='hexagonal',
-        cam_rotation=Angle('0deg'),
-        pix_rotation=Angle('0deg'),
-
-    )
-
-
-def _load_camera_table_from_file(cam_id, geomfile='chercam.fits.gz'):
-    filetype = get_file_type(geomfile)
-    if filetype == 'fits':
-        return _load_camera_geometry_from_fits_file(cam_id, geomfile)
-    else:
-        raise NameError("file type not supported")
-
-
-def _load_camera_geometry_from_fits_file(cam_id, geomfile='chercam.fits.gz'):
-    """
-    Read camera geometry from a  FITS file with a ``CHERCAM`` extension.
-
-    Parameters
-    ----------
-
-    cam_id : int
-        ID number of camera in the fits file
-    geomfile : str
-        FITS file containing camera geometry in ``CHERCAM`` extension
-
-    Returns
-    -------
-
-    a `CameraGeometry` object
-
-    """
-    camtable = Table.read(geomfile, hdu="CHERCAM")
-    geom = camtable[camtable['CAM_ID'] == cam_id]
-    return geom
-
-
-def _load_camera_geometry_from_hessio_file(tel_id, filename):
-    import hessio  # warning, non-rentrant!
-    hessio.file_open(filename)
-    events = hessio.move_to_next_event()
-    next(events)  # load at least one event to get all the headers
-    pix_x, pix_y = hessio.get_pixel_position(tel_id)
-    optical_foclen = hessio.get_optical_foclen(tel_id)
-
-    hessio.close_file()
-    return CameraGeometry.guess(pix_x * u.m, pix_y * u.m, optical_foclen)
 
 
 def _neighbor_list_to_matrix(neighbors):

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -7,14 +7,20 @@ from numpy import median
 import pytest
 
 
+def test_load_by_name():
+    for cam in ['NectarCam', 'LSTCam','GCT', 'SST-1M']:
+        geom = CameraGeometry.from_name(cam)
+    geom = CameraGeometry.from_name('HESSI', array_id='HESS')
+
+
 def test_make_rectangular_camera_geometry():
     geom = CameraGeometry.make_rectangular()
     assert(geom.pix_x.shape == geom.pix_y.shape)
 
 
 def test_load_hess_camera():
-    geom = CameraGeometry.from_name("hess", 1)
-    assert len(geom.pix_x) == 960
+    geom = CameraGeometry.from_name("LSTCam")
+    assert len(geom.pix_x) == 1855
 
 
 def test_guess_camera():
@@ -36,7 +42,7 @@ def test_find_neighbor_pixels():
     assert(set(neigh[11]) == set([16, 6, 10, 12]))
 
 def test_neighbor_pixels():
-    hexgeom = CameraGeometry.from_name("HESS", 1)
+    hexgeom = CameraGeometry.from_name("LSTCam")
     recgeom = CameraGeometry.make_rectangular()
 
     # most pixels should have 4 neighbors for rectangular geometry and 6 for
@@ -45,7 +51,7 @@ def test_neighbor_pixels():
     assert int(median(hexgeom.neighbor_matrix.sum(axis=1))) == 6
 
 def test_to_and_from_table():
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     tab = geom.to_table()
     geom2 = geom.from_table(tab)
 
@@ -60,7 +66,7 @@ def test_write_read(tmpdir):
 
     filename = str(tmpdir.join('testcamera.fits.gz'))
 
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     geom.to_table().write(filename, overwrite=True)
     geom2 = geom.from_table(filename)
 

--- a/ctapipe/tools/camdemo.py
+++ b/ctapipe/tools/camdemo.py
@@ -50,7 +50,7 @@ class CameraDemo(Tool):
         ax = plt.subplot(111)
 
         # load the camera
-        geom = CameraGeometry.from_name("hess", 1)
+        geom = CameraGeometry.from_name("LSTCam")
         disp = CameraDisplay(geom, ax=ax, autoupdate=True, )
         disp.cmap = plt.cm.terrain
 

--- a/ctapipe/tools/camdemo.py
+++ b/ctapipe/tools/camdemo.py
@@ -28,11 +28,16 @@ class CameraDemo(Tool):
     blit = traits.Bool(False, help='use blit operation to draw on screen ('
                                    'much faster but may cause some draw '
                                    'artifacts)').tag(config=True)
+    camera = traits.Enum(CameraGeometry.get_known_camera_names(),
+                         default_value='LSTCam', help='Name of camera to '
+                                                      'display').tag(
+        config=True)
 
     aliases = traits.Dict({'delay': 'CameraDemo.delay',
                            'cleanframes': 'CameraDemo.cleanframes',
                            'autoscale' : 'CameraDemo.autoscale',
-                           'blit': 'CameraDemo.blit'})
+                           'blit': 'CameraDemo.blit',
+                           'camera': 'CameraDemo.camera'})
 
 
     def __init__(self):
@@ -50,7 +55,7 @@ class CameraDemo(Tool):
         ax = plt.subplot(111)
 
         # load the camera
-        geom = CameraGeometry.from_name("LSTCam")
+        geom = CameraGeometry.from_name(self.camera)
         disp = CameraDisplay(geom, ax=ax, autoupdate=True, )
         disp.cmap = plt.cm.terrain
 

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -10,7 +10,7 @@ def test_camera_display_single():
     """ test CameraDisplay functionality """
     from ..mpl import CameraDisplay
 
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     disp = CameraDisplay(geom)
     image = ones(len(geom.pix_x), dtype=float)
     disp.image = image
@@ -24,7 +24,7 @@ def test_camera_display_multiple():
     """ create a figure with 2 subplots, each with a CameraDisplay """
     from ..mpl import CameraDisplay
     
-    geom = CameraGeometry.from_name("HESS", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     fig, ax = plt.subplots(2, 1)
 
     d1 = CameraDisplay(geom, ax=ax[0])

--- a/docs/instrument/camerageometry_example.py
+++ b/docs/instrument/camerageometry_example.py
@@ -1,7 +1,7 @@
 from ctapipe.instrument import CameraGeometry
 from matplotlib import pyplot as plt
 
-geom = CameraGeometry.from_name("HESS", 1)
+geom = CameraGeometry.from_name("LSTCam")
 
 plt.figure(figsize=(8, 3))
 plt.subplot(1, 2, 1)

--- a/examples/camera_animation.py
+++ b/examples/camera_animation.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     fig, ax = plt.subplots()
 
     # load the camera
-    geom = CameraGeometry.from_name("hess", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     disp = CameraDisplay(geom, ax=ax)
     disp.cmap = plt.cm.terrain
     disp.add_colorbar(ax=ax)

--- a/examples/camera_display.py
+++ b/examples/camera_display.py
@@ -23,7 +23,7 @@ def draw_neighbors(geom, pixel_index, color='r', **kwargs):
 if __name__ == '__main__':
 
     # Load the camera
-    geom = CameraGeometry.from_name("hess", 1)
+    geom = CameraGeometry.from_name("LSTCam")
     disp = CameraDisplay(geom)
     disp.set_limits_minmax(0, 300)
     disp.add_colorbar()

--- a/examples/camera_display_multi.py
+++ b/examples/camera_display_multi.py
@@ -54,7 +54,7 @@ def draw_several_cams(geom, ncams=4):
 
 if __name__ == '__main__':
 
-    hexgeom = CameraGeometry.from_name("hess", 1)
+    hexgeom = CameraGeometry.from_name("LSTCam")
     recgeom = CameraGeometry.make_rectangular()
 
     draw_several_cams(recgeom)

--- a/examples/camera_norms.py
+++ b/examples/camera_norms.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     use('ggplot')
     # load the camera
     fig, axs = plt.subplots(1, 3, figsize=(15, 5))
-    geom = CameraGeometry.from_name("hess", 1)
+    geom = CameraGeometry.from_name("LSTCam")
 
     titles = 'Linear Scale', 'Log-Scale', 'PowerNorm(gamma=2)'
 


### PR DESCRIPTION
- CameraGeometry.from_name now supports all CTA cameras
- CameraGeometry.get_known_camera_types() will list them
- all cameras loaded from ctapipe_resources by the table method
- removed all other IO methods

example:
```python
geom = CameraGeometry.from_name("LSTCam")
geom = CameraGeometry.from_name("HESSI", array_id='HESS')
```
