### PR TITLE
rename hessio_event_source to simtelarray_event_source?

### DIFF
--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -1,13 +1,13 @@
 from ctapipe.calib.camera import CameraCalibrator
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from numpy.testing import assert_allclose
 
 
 def get_test_event():
     filename = get_dataset('gamma_test.simtel.gz')
-    source = hessio_event_source(filename, requested_event=409,
-                                 use_event_id=True)
+    source = simtelarray_event_source(filename, requested_event=409,
+                                      use_event_id=True)
     event = next(source)
     return event
 

--- a/ctapipe/calib/camera/tests/test_dl0.py
+++ b/ctapipe/calib/camera/tests/test_dl0.py
@@ -1,14 +1,14 @@
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.r1 import HessioR1Calibrator
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from numpy.testing import assert_almost_equal
 
 
 def get_test_event():
     filename = get_dataset('gamma_test.simtel.gz')
-    source = hessio_event_source(filename, requested_event=409,
-                                 use_event_id=True)
+    source = simtelarray_event_source(filename, requested_event=409,
+                                      use_event_id=True)
     event = next(source)
     return event
 

--- a/ctapipe/calib/camera/tests/test_dl1.py
+++ b/ctapipe/calib/camera/tests/test_dl1.py
@@ -2,15 +2,15 @@ from ctapipe.calib.camera.dl1 import integration_correction, \
     CameraDL1Calibrator
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.r1 import HessioR1Calibrator
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from numpy.testing import assert_allclose
 
 
 def get_test_event():
     filename = get_dataset('gamma_test.simtel.gz')
-    source = hessio_event_source(filename, requested_event=409,
-                                 use_event_id=True)
+    source = simtelarray_event_source(filename, requested_event=409,
+                                      use_event_id=True)
     event = next(source)
     return event
 

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -1,5 +1,5 @@
 from numpy.testing import assert_almost_equal
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory, \
     HessioR1Calibrator
@@ -7,8 +7,8 @@ from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory, \
 
 def get_test_event():
     filename = get_dataset('gamma_test.simtel.gz')
-    source = hessio_event_source(filename, requested_event=409,
-                                 use_event_id=True)
+    source = simtelarray_event_source(filename, requested_event=409,
+                                      use_event_id=True)
     event = next(source)
     return event
 

--- a/ctapipe/flow/algorithms/simtelarray_reader.py
+++ b/ctapipe/flow/algorithms/simtelarray_reader.py
@@ -1,5 +1,5 @@
 from ctapipe.utils import get_dataset
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.core import Component
 from traitlets import Unicode
 
@@ -17,7 +17,7 @@ class SimTelArrayReader(Component):
         self.log.debug("--- SimTelArrayReader init {}---".format(self.filename))
         try:
             in_file = get_dataset(self.filename)
-            self.source = hessio_event_source(in_file,max_events=3)
+            self.source = simtelarray_event_source(in_file, max_events=3)
             self.log.debug('{} successfully opened {}'.format(self.filename,self.source))
         except:
             self.log.error('could not open ' + in_file)

--- a/ctapipe/image/tests/test_charge_extraction.py
+++ b/ctapipe/image/tests/test_charge_extraction.py
@@ -1,4 +1,4 @@
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from ctapipe.instrument import CameraGeometry
 import numpy as np
@@ -11,8 +11,8 @@ from ctapipe.image.charge_extractors import FullIntegrator, \
 
 def get_test_event():
     filename = get_dataset('gamma_test.simtel.gz')
-    source = hessio_event_source(filename, requested_event=409,
-                                 use_event_id=True)
+    source = simtelarray_event_source(filename, requested_event=409,
+                                      use_event_id=True)
     event = next(source)
     return event
 

--- a/ctapipe/image/tests/test_geometry_converter.py
+++ b/ctapipe/image/tests/test_geometry_converter.py
@@ -3,7 +3,7 @@ from matplotlib import pyplot as plt
 
 from ctapipe.utils import get_dataset
 
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 
 from ctapipe.image.geometry_converter import CameraGeometry, \
                                              convert_geometry_1d_to_2d, \
@@ -31,7 +31,7 @@ def test_convert_geometry():
 
     cam_geom = {}
 
-    source = hessio_event_source(filename)
+    source = simtelarray_event_source(filename)
 
     # testing a few images just for the sake of being thorough
     counter = 5

--- a/ctapipe/image/tests/test_waveform_cleaning.py
+++ b/ctapipe/image/tests/test_waveform_cleaning.py
@@ -3,14 +3,14 @@ from numpy.testing import assert_almost_equal
 
 from ctapipe.image.waveform_cleaning import NullWaveformCleaner, \
     CHECMWaveformCleaner
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 
 
 def get_test_event():
     filename = get_dataset('gamma_test.simtel.gz')
-    source = hessio_event_source(filename, requested_event=409,
-                                 use_event_id=True)
+    source = simtelarray_event_source(filename, requested_event=409,
+                                      use_event_id=True)
     event = next(source)
     return event
 

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -8,7 +8,7 @@ from traitlets import Unicode, Int, CaselessStrEnum, observe
 from copy import deepcopy
 from ctapipe.core import Component, Factory
 from ctapipe.utils import get_dataset
-from ctapipe.io.hessio import hessio_event_source, hessio_get_list_event_ids
+from ctapipe.io.hessio import simtelarray_event_source, build_event_id_list
 
 
 class EventFileReader(Component):
@@ -268,7 +268,7 @@ class EventFileReader(Component):
         return max_pe
 
 
-class HessioFileReader(EventFileReader):
+class SimTelArrayFileReader(EventFileReader):
     name = 'HessioFileReader'
     origin = 'hessio'
 
@@ -298,8 +298,8 @@ class HessioFileReader(EventFileReader):
             pass
         else:
             self.log.info("Building new list of event ids...")
-            ids = hessio_get_list_event_ids(self.input_path,
-                                            max_events=self.max_events)
+            ids = build_event_id_list(self.input_path,
+                                      max_events=self.max_events)
             self._event_id_list = ids
         self.log.info("List of event ids retrieved.")
         return self._event_id_list
@@ -332,11 +332,11 @@ class HessioFileReader(EventFileReader):
         self.log.debug("Reading file...")
         if self.max_events:
             self.log.info("Max events being read = {}".format(self.max_events))
-        source = hessio_event_source(self.input_path,
-                                     max_events=self.max_events,
-                                     allowed_tels=allowed_tels,
-                                     requested_event=requested_event,
-                                     use_event_id=use_event_id)
+        source = simtelarray_event_source(self.input_path,
+                                          max_events=self.max_events,
+                                          allowed_tels=allowed_tels,
+                                          requested_event=requested_event,
+                                          use_event_id=use_event_id)
         self.log.debug("File reading complete")
         return source
 

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -12,6 +12,7 @@ from ..core import Provenance
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.time import Time
+from astropy.utils.decorators import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,12 @@ def build_event_id_list(url, max_events=None):
         raise RuntimeError("hessio_event_source failed to open '{}'"
                            .format(url))
 
+
+@deprecated(since='v0.5', alternative='simtelarray_event_source')
+def hessio_event_source(url, max_events=None, allowed_tels=None,
+                             requested_event=None, use_event_id=False):
+    return simtelarray_event_source(url, max_events, allowed_tels,
+                                    requested_event, use_event_id)
 
 def simtelarray_event_source(url, max_events=None, allowed_tels=None,
                              requested_event=None, use_event_id=False):

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -27,11 +27,11 @@ except ImportError as err:
     raise err
 
 __all__ = [
-    'hessio_event_source',
+    'simtelarray_event_source',
 ]
 
 
-def hessio_get_list_event_ids(url, max_events=None):
+def build_event_id_list(url, max_events=None):
     """
     Faster method to get a list of all the event ids in the hessio file.
     This list can also be used to find out the number of events that exist
@@ -69,8 +69,8 @@ def hessio_get_list_event_ids(url, max_events=None):
                            .format(url))
 
 
-def hessio_event_source(url, max_events=None, allowed_tels=None,
-                        requested_event=None, use_event_id=False):
+def simtelarray_event_source(url, max_events=None, allowed_tels=None,
+                             requested_event=None, use_event_id=False):
     """A generator that streams data from an EventIO/HESSIO MC data file
     (e.g. a standard CTA data file.)
 
@@ -208,6 +208,9 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
                     pyhessio.get_altitude_cor(tel_id)
             yield data
             counter += 1
+
+            if requested_event is not None and current == requested_event:
+                return
 
             if max_events is not None and counter >= max_events:
                 pyhessio.close_file()

--- a/ctapipe/io/tests/test_eventfilereader.py
+++ b/ctapipe/io/tests/test_eventfilereader.py
@@ -1,7 +1,7 @@
 from os.path import join
 from ctapipe.utils import get_dataset
 from ctapipe.io.eventfilereader import EventFileReader, \
-    EventFileReaderFactory, HessioFileReader
+    EventFileReaderFactory, SimTelArrayFileReader
 
 
 def test_event_file_reader():
@@ -15,7 +15,7 @@ def test_event_file_reader():
 
 def test_hessio_file_reader():
     dataset = get_dataset("gamma_test.simtel.gz")
-    file = HessioFileReader(None, None, input_path=dataset)
+    file = SimTelArrayFileReader(None, None, input_path=dataset)
     datasets_path = get_dataset("")
     assert file.input_path == join(datasets_path, "gamma_test.simtel.gz")
     assert file.directory == datasets_path
@@ -28,7 +28,7 @@ def test_hessio_file_reader():
 
 def test_get_event():
     dataset = get_dataset("gamma_test.simtel.gz")
-    file = HessioFileReader(None, None, input_path=dataset)
+    file = SimTelArrayFileReader(None, None, input_path=dataset)
     event = file.get_event(2)
     assert event.count == 2
     assert event.r0.event_id == 803
@@ -39,7 +39,7 @@ def test_get_event():
 
 def test_get_num_events():
     dataset = get_dataset("gamma_test.simtel.gz")
-    file = HessioFileReader(None, None, input_path=dataset)
+    file = SimTelArrayFileReader(None, None, input_path=dataset)
     num_events = file.num_events
     assert(num_events == 9)
 

--- a/ctapipe/io/tests/test_hessio.py
+++ b/ctapipe/io/tests/test_hessio.py
@@ -1,11 +1,11 @@
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 
 
 def test_get_run_id():
     filename = get_dataset("gamma_test.simtel.gz")
     print(filename)
-    gen = hessio_event_source(filename)
+    gen = simtelarray_event_source(filename)
     event = next(gen)
     tels = event.dl0.tels_with_data
     print(tels)
@@ -14,12 +14,12 @@ def test_get_run_id():
 
 def test_get_specific_event():
     dataset = get_dataset("gamma_test.simtel.gz")
-    source = hessio_event_source(dataset, requested_event=2)
+    source = simtelarray_event_source(dataset, requested_event=2)
     event = next(source)
     assert event.count == 2
     assert event.dl0.event_id == 803
-    source = hessio_event_source(dataset, requested_event=803,
-                                 use_event_id=True)
+    source = simtelarray_event_source(dataset, requested_event=803,
+                                      use_event_id=True)
     event = next(source)
     assert event.count == 2
     assert event.dl0.event_id == 803

--- a/ctapipe/io/tests/test_serializer.py
+++ b/ctapipe/io/tests/test_serializer.py
@@ -4,7 +4,7 @@ from os import remove
 import pytest
 from astropy.io import fits
 
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.io.serializer import Serializer
 from ctapipe.io.sources import PickleSource
 from ctapipe.utils import get_dataset
@@ -19,7 +19,7 @@ def compare(read_container, source_container):
 def generate_input_containers():
     # Get event from hessio file, append them into input_containers
     input_filename = get_dataset("gamma_test.simtel.gz")
-    gen = hessio_event_source(input_filename, max_events=3)
+    gen = simtelarray_event_source(input_filename, max_events=3)
     input_containers = []
     for event in gen:
         input_containers.append(deepcopy(event))

--- a/ctapipe/plotting/tests/test_array.py
+++ b/ctapipe/plotting/tests/test_array.py
@@ -7,7 +7,7 @@ from ctapipe.reco.HillasReconstructor import HillasReconstructor, GreatCircle
 from ctapipe.image.hillas import hillas_parameters, HillasParameterizationError
 from ctapipe.image.cleaning import tailcuts_clean, dilate
 
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.instrument import CameraGeometry
 from ctapipe.plotting.array import ArrayPlotter, NominalPlotter
 from ctapipe.coordinates import TiltedGroundFrame, NominalFrame, CameraFrame
@@ -21,7 +21,7 @@ def test_array_draw():
     filename = get_dataset("gamma_test.simtel.gz")
     cam_geom = {}
 
-    source = hessio_event_source(filename)
+    source = simtelarray_event_source(filename)
     r1 = HessioR1Calibrator(None, None)
     dl0 = CameraDL0Reducer(None, None)
 

--- a/ctapipe/plotting/tests/test_camera.py
+++ b/ctapipe/plotting/tests/test_camera.py
@@ -1,4 +1,4 @@
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from ctapipe.plotting.camera import CameraPlotter
 import numpy as np
@@ -6,7 +6,7 @@ import numpy as np
 
 def test_eventplotter():
     dataset = get_dataset("gamma_test.simtel.gz")
-    source = hessio_event_source(dataset, max_events=1)
+    source = simtelarray_event_source(dataset, max_events=1)
     event = next(source)
     data = event.r0.tel[38].adc_samples[0]
     plotter = CameraPlotter(event)

--- a/ctapipe/reco/tests/test_FitGammaHillas.py
+++ b/ctapipe/reco/tests/test_FitGammaHillas.py
@@ -9,7 +9,7 @@ from ctapipe.reco.HillasReconstructor import HillasReconstructor, GreatCircle
 from ctapipe.image.hillas import hillas_parameters, HillasParameterizationError
 from ctapipe.image.cleaning import tailcuts_clean, dilate
 
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.instrument import CameraGeometry
 
 
@@ -117,7 +117,7 @@ def test_FitGammaHillas():
     tel_phi = {}
     tel_theta = {}
 
-    source = hessio_event_source(filename)
+    source = simtelarray_event_source(filename)
 
     for event in source:
 

--- a/ctapipe/tools/dump_instrument.py
+++ b/ctapipe/tools/dump_instrument.py
@@ -7,7 +7,7 @@ automatically generated.
 
 from ctapipe.core.traits import (Unicode, Dict, Bool, Enum)
 from ctapipe.core import Tool
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.instrument import CameraGeometry, get_camera_types, print_camera_types
 
 
@@ -27,7 +27,7 @@ class DumpInstrumentTool(Tool):
 
 
     def setup(self):
-        source = hessio_event_source(self.infile)
+        source = simtelarray_event_source(self.infile)
         data = next(source)  # get one event, so the instrument table is
                              # filled in
         self.inst = data.inst # keep a pointer to the instrument stuff

--- a/ctapipe/tools/dump_triggers.py
+++ b/ctapipe/tools/dump_triggers.py
@@ -108,7 +108,7 @@ class DumpTriggersTool(Tool):
 
     def start(self):
         """ main event loop """
-        source = hessio.hessio_event_source(self.infile)
+        source = hessio.simtelarray_event_source(self.infile)
 
         for event in source:
             self.add_event_to_table(event)

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -14,7 +14,7 @@ from ctapipe.calib.camera.dl1 import CameraDL1Calibrator
 from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory
 from ctapipe.core import Tool
 from ctapipe.image.charge_extractors import ChargeExtractorFactory
-from ctapipe.io.eventfilereader import HessioFileReader
+from ctapipe.io.eventfilereader import SimTelArrayFileReader
 
 
 class ChargeResolutionGenerator(Tool):
@@ -44,7 +44,7 @@ class ChargeResolutionGenerator(Tool):
                         T='ChargeResolutionGenerator.telescopes',
                         O='ChargeResolutionGenerator.output_name',
                         ))
-    classes = List([HessioFileReader,
+    classes = List([SimTelArrayFileReader,
                     ChargeExtractorFactory,
                     CameraDL1Calibrator,
                     ChargeResolutionCalculator
@@ -62,7 +62,7 @@ class ChargeResolutionGenerator(Tool):
         self.log_format = "%(levelname)s: %(message)s [%(name)s.%(funcName)s]"
         kwargs = dict(config=self.config, tool=self)
 
-        self.file_reader = HessioFileReader(**kwargs)
+        self.file_reader = SimTelArrayFileReader(**kwargs)
 
         extractor_factory = ChargeExtractorFactory(**kwargs)
         extractor_class = extractor_factory.get_class()

--- a/examples/calc_pedestals.py
+++ b/examples/calc_pedestals.py
@@ -2,7 +2,7 @@
 
 import sys
 import matplotlib.pyplot as plt
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from ctapipe.calib import pedestals
 import numpy as np
@@ -37,7 +37,7 @@ if __name__ == '__main__':
 
     # loop over all events, all telescopes and all channels and call
     # the calc_peds function defined above to do some work:
-    for event in hessio_event_source(filename):
+    for event in simtelarray_event_source(filename):
         for telid in event.r0.tels_with_data:
             for chan in range(event.r0.tel[telid].adc_samples.shape[0]):
 

--- a/examples/display_DL0testbed3_withID.py
+++ b/examples/display_DL0testbed3_withID.py
@@ -10,7 +10,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 from ctapipe import visualization
 from ctapipe.instrument import InstrumentDescription as ID
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from ctapipe.instrument import CameraGeometry
 
@@ -119,7 +119,7 @@ if __name__ == '__main__':
 
     tel, cam, opt = ID.load(args.filename)
     # Load the DL0 events into the generator source
-    source = hessio_event_source(args.filename)
+    source = simtelarray_event_source(args.filename)
 
     print(args.tel_id)
     # Display the calibrated results into camera displays

--- a/examples/display_summed_images.py
+++ b/examples/display_summed_images.py
@@ -9,7 +9,7 @@ from astropy.table import Table
 from ctapipe.core import Tool
 from ctapipe.core.traits import *
 from ctapipe.instrument import CameraGeometry
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.visualization import CameraDisplay
 from ctapipe.instrument.camera import _guess_camera_type
 from matplotlib import pyplot as plt
@@ -62,7 +62,7 @@ class ImageSumDisplayerTool(Tool):
         # load up the telescope types table (need to first open a file, a bit of
         # a hack until a proper insturment module exists) and select only the
         # telescopes with the same camera type
-        data = next(hessio_event_source(self.infile, max_events=1))
+        data = next(simtelarray_event_source(self.infile, max_events=1))
         camtypes = get_camera_types(data.inst)
         group = camtypes.groups[self.telgroup]
         self._selected_tels = group['tel_id'].data
@@ -77,9 +77,9 @@ class ImageSumDisplayerTool(Tool):
         imsum = None
         disp = None
 
-        for data in hessio_event_source(self.infile,
-                                        allowed_tels=self._selected_tels,
-                                        max_events=self.max_events):
+        for data in simtelarray_event_source(self.infile,
+                                             allowed_tels=self._selected_tels,
+                                             max_events=self.max_events):
 
             self.calibrator.calibrate(data)
 

--- a/examples/list_simtel_events_per_telescope.py
+++ b/examples/list_simtel_events_per_telescope.py
@@ -6,7 +6,7 @@ Print the list of triggered events per telescope of the given simtel file.
 """
 
 import argparse
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 
 
 def list_simtel_events_per_telescope(simtel_file_path):
@@ -24,7 +24,7 @@ def list_simtel_events_per_telescope(simtel_file_path):
     file (for each item: key=telescope id, value=the list of triggered events).
     """
 
-    source = hessio_event_source(simtel_file_path, allowed_tels=None, max_events=None)
+    source = simtelarray_event_source(simtel_file_path, allowed_tels=None, max_events=None)
 
     events_per_tel_dict = {}   # List of events per telescope
 

--- a/examples/list_simtel_triggered_telescopes_per_event.py
+++ b/examples/list_simtel_triggered_telescopes_per_event.py
@@ -6,7 +6,7 @@ Print the list triggered telescopes per event of the given simtel file.
 """
 
 import argparse
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 
 
 def list_simtel_triggered_telescopes_per_event(simtel_file_path):
@@ -24,7 +24,7 @@ def list_simtel_triggered_telescopes_per_event(simtel_file_path):
     file (for each item: key=event id, value=the list of triggered telescopes).
     """
 
-    source = hessio_event_source(simtel_file_path, allowed_tels=None, max_events=None)
+    source = simtelarray_event_source(simtel_file_path, allowed_tels=None, max_events=None)
 
     tels_per_event_dict = {}   # List of events per telescope
 

--- a/examples/muon_reco.py
+++ b/examples/muon_reco.py
@@ -1,7 +1,7 @@
 #Rough work - please use muon_reconstruction.py instead
 
 from ctapipe.utils.datasets import get_example_simtelarray_file
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.core import Container
 
 from ctapipe.io.containers import RawData
@@ -63,7 +63,7 @@ if __name__ == '__main__':
                         default=get_example_simtelarray_file())
     args = parser.parse_args()
 
-    source = hessio_event_source(args.filename)
+    source = simtelarray_event_source(args.filename)
 
     container = Container("hessio_container")
     container.meta.add_item('pixel_pos', dict())

--- a/examples/muon_reco_rdp.py
+++ b/examples/muon_reco_rdp.py
@@ -1,5 +1,5 @@
 from ctapipe.utils.datasets import get_example_simtelarray_file
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.core import Container
 
 from ctapipe.io.containers import RawData
@@ -58,7 +58,7 @@ if __name__ == '__main__':
                         default=get_example_simtelarray_file())
     args = parser.parse_args()
 
-    source = hessio_event_source(args.filename)
+    source = simtelarray_event_source(args.filename)
 
     container = Container("hessio_container")
     container.meta.add_item('pixel_pos', dict())

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 from astropy import log
 from astropy.table import Table
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 #from calibration_pipeline import display_telescope
 from ctapipe.calib.camera.r1 import HessioR1Calibrator
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
@@ -65,7 +65,7 @@ def main():
     log.debug("[file] Reading file")
     #input_file = InputFile(args.input_path, args.origin)
     #source = input_file.read()
-    source = hessio_event_source(args.input_path)
+    source = simtelarray_event_source(args.input_path)
     
     geom_dict = {}
 

--- a/examples/read_hessio.py
+++ b/examples/read_hessio.py
@@ -8,7 +8,7 @@
 # containing ~10 events
 
 from ctapipe.utils.datasets import get_example_simtelarray_file
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.instrument import CameraGeometry
 from ctapipe.visualization import CameraDisplay
 from matplotlib import pyplot as plt
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     plt.show(block=False)
 
     # loop over events and display menu at each event:
-    source = hessio_event_source(filename)
+    source = simtelarray_event_source(filename)
 
     for event in source:
 

--- a/examples/read_hessio_single_tel.py
+++ b/examples/read_hessio_single_tel.py
@@ -16,7 +16,7 @@ import logging
 
 import numpy as np
 from ctapipe.instrument import CameraGeometry
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 from ctapipe.utils import get_dataset
 from ctapipe.visualization import CameraDisplay
 from matplotlib import pyplot as plt
@@ -67,9 +67,9 @@ if __name__ == '__main__':
                         help='apply calibration coeffs from MC')
     args = parser.parse_args()
 
-    source = hessio_event_source(args.filename,
-                                 allowed_tels=[args.tel, ],
-                                 max_events=args.max_events)
+    source = simtelarray_event_source(args.filename,
+                                      allowed_tels=[args.tel, ],
+                                      max_events=args.max_events)
     disp = None
 
     print('SELECTING EVENTS FROM TELESCOPE {}'.format(args.tel))

--- a/examples/simple_pipeline.py
+++ b/examples/simple_pipeline.py
@@ -8,13 +8,13 @@ import sys
 import numpy as np
 
 from ctapipe.calib import CameraCalibrator
-from ctapipe.io.hessio import hessio_event_source
+from ctapipe.io.hessio import simtelarray_event_source
 
 if __name__ == '__main__':
 
     filename = sys.argv[1]
 
-    source = hessio_event_source(filename, max_events=None)
+    source = simtelarray_event_source(filename, max_events=None)
 
     cal = CameraCalibrator(None,None)
 


### PR DESCRIPTION
More efforts to clarify some of the code:
------------------------------------

- to avoid confusion renamed the event source to be more clear about what data it applies to (not only HESS)
- also changed HessioFileReader → SimTelArrayFileReader
- also fixed small bug where the event source generator doesn't exit if
a single event is requested (causing some tests to fail due to an
unclosed file)