### PR TITLE
Do not share `connexions` member variable among instances

### DIFF
--- a/ctapipe/flow/flow.py
+++ b/ctapipe/flow/flow.py
@@ -45,7 +45,7 @@ class PipeStep():
         Maximum number of element the router can queue
 '''
     def __init__(self, name,
-                 next_steps_name=list(),
+                 next_steps_name=None,
                  port_in=None,
                  main_connection_name=None,
                  nb_processes=1, level=0,
@@ -53,7 +53,7 @@ class PipeStep():
 
         self.name = name
         self.port_in = port_in
-        self.next_steps_name = next_steps_name
+        self.next_steps_name = next_steps_name or []
         self.nb_process = nb_processes
         self.level = level
         self.connections = dict()

--- a/ctapipe/flow/multiprocess/connections.py
+++ b/ctapipe/flow/multiprocess/connections.py
@@ -5,7 +5,7 @@ class Connections():
     """
     implements ZMQ connections between process for PRODUCER and STAGER and CONSUMER
     """
-    def __init__(self, main_connection_name, connections=dict()):
+    def __init__(self, main_connection_name, connections=None):
         """
         Parameters
         ----------
@@ -13,7 +13,7 @@ class Connections():
         main_connection_name : str
             Default next step name. Used to send data when destination is not provided
         """
-        self.connections = connections
+        self.connections = connections or {}
         self.sockets=dict()
         self.context = zmq.Context()
         self.main_out_socket = None

--- a/ctapipe/flow/multiprocess/producer_zmq.py
+++ b/ctapipe/flow/multiprocess/producer_zmq.py
@@ -16,7 +16,7 @@ class ProducerZmq(Process, Component, Connections):
     init() method is call by run method.
     """
     def __init__(self, coroutine, name, main_connection_name,
-                 connections=dict()):
+                 connections=None):
         """
         Parameters
         ----------

--- a/ctapipe/flow/multiprocess/router_queue_zmq.py
+++ b/ctapipe/flow/multiprocess/router_queue_zmq.py
@@ -25,7 +25,7 @@ class RouterQueue(Process, Component):
     later.
     """
     def __init__(
-        self, connections=dict(), gui_address=None):
+        self, connections=None, gui_address=None):
         """
         Parameters
         ----------
@@ -48,7 +48,7 @@ class RouterQueue(Process, Component):
         self.router_sockets = dict()
         self.dealer_sockets = dict()
         self.queue_limit = dict()
-        self.connections = connections
+        self.connections = connections or {}
         self.done = False
         self._stop = Value('i',0)
         self._total_queue_size = Value('i',0)

--- a/ctapipe/flow/multiprocess/stager_zmq.py
+++ b/ctapipe/flow/multiprocess/stager_zmq.py
@@ -25,7 +25,7 @@ class StagerZmq(Component, Process, Connections):
     """
     def __init__(
             self, coroutine, sock_job_for_me_port,
-            name=None, connections=dict(),main_connection_name=None):
+            name=None, connections=None, main_connection_name=None):
         """
         Parameters
         ----------

--- a/ctapipe/flow/sequential/producer_sequential.py
+++ b/ctapipe/flow/sequential/producer_sequential.py
@@ -7,7 +7,7 @@ class ProducerSequential():
     """
 
     def __init__(
-            self, coroutine, name=None, connections=list(),main_connection_name=None):
+            self, coroutine, name=None, connections=None, main_connection_name=None):
         """
         Parameters
         ----------
@@ -18,7 +18,7 @@ class ProducerSequential():
         self.name = name
         self.coroutine = coroutine
         self.main_connection_name = main_connection_name
-        self.connections = connections
+        self.connections = connections or []
         self.running = 0
         self.nb_job_done = 0
 

--- a/ctapipe/flow/sequential/stager_sequential.py
+++ b/ctapipe/flow/sequential/stager_sequential.py
@@ -9,7 +9,7 @@ class StagerSequential():
     """
 
     def __init__(
-            self, coroutine, name=None, connections=list(), main_connection_name=None):
+            self, coroutine, name=None, connections=None, main_connection_name=None):
         """
         Parameters
         ----------
@@ -20,7 +20,7 @@ class StagerSequential():
         self.name = name
         self.coroutine = coroutine
         self.main_connection_name = main_connection_name
-        self.connections = connections
+        self.connections = connections or []
         self.running = 0
         self.nb_job_done = 0
 

--- a/ctapipe/flow/stager_rep.py
+++ b/ctapipe/flow/stager_rep.py
@@ -13,11 +13,11 @@ class StagerRep():
     PRODUCER = 2
     CONSUMER = 3
 
-    def __init__(self,name,next_steps=list(),running=0,
+    def __init__(self,name,next_steps=None,running=0,
                 nb_job_done=0, queue_length = 0, nb_process = 1, step_type=STAGER):
         self.type = step_type
         self.name = name
-        self.next_steps = next_steps
+        self.next_steps = next_steps or []
         self.running = running
         self.nb_job_done = nb_job_done
         self.queue_length = queue_length


### PR DESCRIPTION
Default arguments should be not mutable.