### PR TITLE
Improve containers to use __slots__

### DIFF
--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -136,7 +136,7 @@ class Container(metaclass=ContainerMeta):
 
     def items(self):
         """Generator over (key, value) pairs for the items"""
-        return ((k, getattr(self, k)) for k in self.__slots__)
+        return ((k, getattr(self, k)) for k in self._items.keys())
 
     def as_dict(self, recursive=False, flatten=False):
         """
@@ -204,7 +204,9 @@ class Container(metaclass=ContainerMeta):
         return "\n".join(text)
 
     def __getstate__(self):
-        return dict(self.items())
+        state = dict(self.items())
+        state['meta'] = getattr(self, 'meta')
+        return state
 
     def __setstate__(self, state):
         for k, v in state.items():

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -1,208 +1,8 @@
 from collections import defaultdict
-from copy import copy
+from copy import deepcopy
 from pprint import pformat
 from textwrap import wrap
 
-
-class Container:
-    """Generic class that can hold and accumulate data to be passed
-    between Components.
-
-    The purpose of this class is to provide a flexible data structure
-    that works a bit like a dict or blank Python class, but prevents
-    the user from accessing members that have not been defined a
-    priori (more like a C struct), and also keeps metdata information
-    such as a description, defaults, and units for each item in the
-    container.
-
-    Containers can transform the data into a `dict` using the `
-    Container.as_dict()` method.  This allows them to be written to an
-    output table for example, where each Item defines a column. The
-    `dict` conversion can be made recursively and even flattened so
-    that a nested set of `Containers` can be translated into a set of
-    columns in a flat table without naming conflicts (the name of the
-    parent Item is pre-pended).
-
-    To use this class, all members must be defined as `Item`s with
-    default values specified.  For hierarchical data structures, Items
-    can use `Container` subclasses or a `Map` as the default value.
-
-    You should not make class hierarchies of Containers and only ever
-    subclass the Container base class
-
-    >>>    class MyContainer(Container):
-    >>>        x = Item(100,"The X value")
-    >>>        energy = Item(-1, "Energy measurement", unit=u.TeV)
-    >>>
-    >>>    cont = MyContainer()
-    >>>    print(cont.x)
-    100
-    >>>    # metdata will become header keywords in an output file:
-    >>>    cont.meta['KEY'] = value  
-
-    `Items` inside `Containers` can contain instances of other
-    `Containers`, to allow for a hierarchy of containers, and can also
-    contain a `Map` for the case where one wants e.g. a set of
-    sub-classes indexed by a value like the `telescope_id`. Examples
-    of this can be found in `ctapipe.io.containers`
-
-    `Containers` work by shadowing all class variables (which must be
-    instances of `Item`) with instance variables of the same name the
-    hold the value expected. If `Container.reset()` is called, all
-    instance variables are reset to their default values as defined in
-    the class.
-
-    Finally, `Containers` can have associated metadata via their
-    `meta` attribute, which is a `dict` of keywords to values.
-
-    """
-
-    def __init__(self, **values):
-        object.__setattr__(self, "_metadata", dict())
-        self.reset()
-        for key in values:
-            self[key] = values[key]
-
-    def __setattr__(self, name, value):
-        """Prevent new attributes that aren't in the class definition"""
-        if hasattr(self.__class__, name):
-            object.__setattr__(self, name, value)
-        else:
-            raise AttributeError(
-                "{} has no attribute '{}'".format(self.__class__, name))
-
-    def __getitem__(self, item):
-        return self.__dict__[item]
-
-    def __setitem__(self, key, value):
-        if hasattr(self.__class__, key):
-            self.__dict__[key] = value
-        else:
-            raise AttributeError("{} has no attribute '{}'"
-                .format(self.__class__,key))
-
-    @property
-    def meta(self):
-        """metadata key/values associated with this Container.
-
-        When written to an output file, these will become headers, so
-        should represent data that does not change after the
-        `Container` is constructed.
-        """
-        return self._metadata
-
-    @property
-    def attributes(self):
-        """
-        a dict of the Item metadata of each attribute.
-        """
-        return {key: val for key, val in self.__class__.__dict__.items()
-                if isinstance(val, Item)}
-
-    def items(self):
-        """dict-like access, but skip any hidden items like _metadata"""
-        return ( (k,v) for k,v in self.__dict__.items()
-                 if not k.startswith('_') )
-
-    def as_dict(self, recursive=False, flatten=False):
-        """
-        convert the `Container` into a dictionary
-
-        Parameters
-        ----------
-        recursive: bool
-            sub-Containers should also be converted to dicts
-        flatten: type
-            return a flat dictionary, with any sub-item keys generated
-            by appending the sub-Container name.
-        """
-        if not recursive:
-            return dict(self.items())
-        else:
-            d = dict()
-            for key, val in self.items():
-                if key.startswith("_"): continue
-                if isinstance(val, Container) or isinstance(val, Map):
-                    if flatten:
-                        d.update({"{}_{}".format(key, k): v
-                                  for k, v in val.as_dict(recursive).items()})
-                    else:
-                        d[key] = val.as_dict(recursive=recursive,
-                                             flatten=flatten)
-                    continue
-                d[key] = val
-            return d
-
-    @classmethod
-    def disable_attribute_check(cls):
-        """
-        Globally turn off attribute checking for all Containers,
-        which provides a ~5-10x speed up for setting attributes.
-        This may be used e.g. after code is tested to speed up operation.
-        """
-        cls.__setattr__ = object.__setattr__
-
-    def reset(self, recursive=True):
-        """ set all values back to their default values"""
-        for name, value in self.__class__.__dict__.items():
-            if isinstance(value, Item):
-                self.__dict__[name] = copy(value.default)
-            if recursive and isinstance(value, Container):
-                value.reset()
-
-    def update(self, **values):
-        """
-        update more than one parameter at once (e.g. `update(x=3,y=4)`
-        or `update(**dict_of_values)`)
-        """
-        for key in values:
-            self[key] = values[key]
-
-
-    def __str__(self):
-        return pformat(self.as_dict(recursive=True))
-
-    def __repr__(self):
-        text = ["{}.{}:".format(type(self).__module__,type(self).__name__),]
-        for name, item in self.attributes.items():
-            extra = ""
-            if isinstance(self.__dict__[name], Container):
-                extra = ".*"
-            if isinstance(self.__dict__[name], Map):
-                extra = "[*]"
-            desc = "{:>30s}: {}".format(name+extra, repr(item))
-            lines = wrap(desc, 80, subsequent_indent=' '*32)
-            text.extend(lines)
-        return  "\n".join(text)
-
-
-class Map(defaultdict):
-    """A dictionary of sub-containers that can be added to a Container. This
-    may be used e.g. to store a set of identical sub-Containers (e.g. indexed
-    by `tel_id` or algorithm name).
-    """
-
-    def as_dict(self, recursive=False, flatten=False):
-        if not recursive:
-            return dict(self.items())
-        else:
-            d = dict()
-            for key, val in self.items():
-                if isinstance(val, Container) or isinstance(val, Map):
-                    if flatten:
-                        d.update({"{}_{}".format(key, k): v
-                                  for k, v in val.as_dict(recursive).items()})
-                    else:
-                        d[key] = val.as_dict(recursive=recursive,
-                                             flatten=flatten)
-                    continue
-                d[key] = val
-            return d
-
-    def reset(self, recursive=True):
-        for key, val in self.items():
-            if isinstance(val, Container):
-                val.reset(recursive=True)
 
 
 class Item:
@@ -233,3 +33,195 @@ class Item:
             desc += ' [{}]'.format(self.unit)
         return desc
 
+
+
+class ContainerMeta(type):
+    '''
+    The MetaClass for the Containers
+
+    It reserves __slots__ for every class variable,
+    that is of instance items and sets all other class variables
+    as read-only for the instances.
+
+    This makes sure, that the metadata is immutable,
+    and no new fields can be added to a container by accident.
+    '''
+    def __new__(cls, name, bases, dct):
+        items = [
+            k for k, v in dct.items()
+            if isinstance(v, Item)
+        ]
+        dct['__slots__'] = tuple(items + ['meta'])
+        dct['_items'] = {}
+
+        for k in items:
+            dct['_items'][k] = dct.pop(k)
+
+        return type.__new__(cls, name, bases, dct)
+
+
+class Container(metaclass=ContainerMeta):
+    """Generic class that can hold and accumulate data to be passed
+    between Components.
+
+    The purpose of this class is to provide a flexible data structure
+    that works a bit like a dict or blank Python class, but prevents
+    the user from accessing members that have not been defined a
+    priori (more like a C struct), and also keeps metadata information
+    such as a description, defaults, and units for each item in the
+    container.
+
+    Containers can transform the data into a `dict` using the `
+    Container.as_dict()` method.  This allows them to be written to an
+    output table for example, where each Item defines a column. The
+    `dict` conversion can be made recursively and even flattened so
+    that a nested set of `Containers` can be translated into a set of
+    columns in a flat table without naming conflicts (the name of the
+    parent Item is pre-pended).
+
+    To only members of instance `Item` will be used as output.
+    For hierarchical data structures, Items can use `Container`
+    subclasses or a `Map` as the default value.
+
+    You should not make class hierarchies of Containers and only ever
+    subclass the Container base class
+
+    >>>    class MyContainer(Container):
+    >>>        x = Item(100,"The X value")
+    >>>        energy = Item(-1, "Energy measurement", unit=u.TeV)
+    >>>
+    >>>    cont = MyContainer()
+    >>>    print(cont.x)
+    100
+    >>>    # metsdata will become header keywords in an output file:
+    >>>    cont.meta['KEY'] = value
+
+    `Items` inside `Containers` can contain instances of other
+    `Containers`, to allow for a hierarchy of containers, and can also
+    contain a `Map` for the case where one wants e.g. a set of
+    sub-classes indexed by a value like the `telescope_id`. Examples
+    of this can be found in `ctapipe.io.containers`
+
+    Finally, `Containers` can have associated metadata via their
+    `meta` attribute, which is a `dict` of keywords to values.
+
+    """
+
+    def __init__(self, **items):
+
+        self.meta = {}
+        for k, v in self._items.items():
+            setattr(self, k, v.default)
+            self.meta[k] = v
+
+        for k, v in items.items():
+            setattr(self, k, v)
+
+    def __getitem__(self, item):
+        if item in self.__slots__:
+            return getattr(self, item)
+        else:
+            raise KeyError('No such Item: "{}"'.format(item))
+
+    @property
+    def attributes(self):
+        """
+        a dict of the Item metadata of each attribute.
+        """
+        return self.meta
+
+    def items(self):
+        """Generator over (key, value) pairs for the items"""
+        return ((k, getattr(self, k)) for k in self.__slots__)
+
+    def as_dict(self, recursive=False, flatten=False):
+        """
+        convert the `Container` into a dictionary
+
+        Parameters
+        ----------
+        recursive: bool
+            sub-Containers should also be converted to dicts
+        flatten: type
+            return a flat dictionary, with any sub-item keys generated
+            by appending the sub-Container name.
+        """
+        if not recursive:
+            return dict(self.items())
+        else:
+            d = dict()
+            for key, val in self.items():
+                if key.startswith("_"):
+                    continue
+                if isinstance(val, Container) or isinstance(val, Map):
+                    if flatten:
+                        d.update({
+                            "{}_{}".format(key, k): v
+                            for k, v in val.as_dict(recursive).items()
+                        })
+                    else:
+                        d[key] = val.as_dict(recursive=recursive,
+                                             flatten=flatten)
+                    continue
+                d[key] = val
+            return d
+
+    def reset(self, recursive=True):
+        """ set all values back to their default values"""
+        for name, value in self.meta.items():
+            setattr(self, name, deepcopy(value.default))
+            if recursive and isinstance(value, Container):
+                value.reset()
+
+    def update(self, **values):
+        """
+        update more than one parameter at once (e.g. `update(x=3,y=4)`
+        or `update(**dict_of_values)`)
+        """
+        for key in values:
+            self[key] = values[key]
+
+    def __str__(self):
+        return pformat(self.as_dict(recursive=True))
+
+    def __repr__(self):
+        text = ["{}.{}:".format(type(self).__module__, type(self).__name__)]
+        for name, item in self.attributes.items():
+            extra = ""
+            if isinstance(self.__dict__[name], Container):
+                extra = ".*"
+            if isinstance(self.__dict__[name], Map):
+                extra = "[*]"
+            desc = "{:>30s}: {}".format(name+extra, repr(item))
+            lines = wrap(desc, 80, subsequent_indent=' '*32)
+            text.extend(lines)
+        return "\n".join(text)
+
+
+class Map(defaultdict):
+    """A dictionary of sub-containers that can be added to a Container. This
+    may be used e.g. to store a set of identical sub-Containers (e.g. indexed
+    by `tel_id` or algorithm name).
+    """
+
+    def as_dict(self, recursive=False, flatten=False):
+        if not recursive:
+            return dict(self.items())
+        else:
+            d = dict()
+            for key, val in self.items():
+                if isinstance(val, Container) or isinstance(val, Map):
+                    if flatten:
+                        d.update({"{}_{}".format(key, k): v
+                                  for k, v in val.as_dict(recursive).items()})
+                    else:
+                        d[key] = val.as_dict(recursive=recursive,
+                                             flatten=flatten)
+                    continue
+                d[key] = val
+            return d
+
+    def reset(self, recursive=True):
+        for key, val in self.items():
+            if isinstance(val, Container):
+                val.reset(recursive=True)

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -91,7 +91,7 @@ class Container(metaclass=ContainerMeta):
     >>>    cont = MyContainer()
     >>>    print(cont.x)
     100
-    >>>    # metsdata will become header keywords in an output file:
+    >>>    # metadata will become header keywords in an output file:
     >>>    cont.meta['KEY'] = value
 
     `Items` inside `Containers` can contain instances of other

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -121,6 +121,12 @@ class Container(metaclass=ContainerMeta):
         else:
             raise KeyError('No such Item: "{}"'.format(item))
 
+    def __setitem__(self, item, value):
+        if item in self.__slots__:
+            return setattr(self, item, value)
+        else:
+            raise KeyError('No such Item: "{}"'.format(item))
+
     @property
     def attributes(self):
         """

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -38,7 +38,7 @@ class ContainerMeta(type):
     The MetaClass for the Containers
 
     It reserves __slots__ for every class variable,
-    that is of instance items and sets all other class variables
+    that is of instance `Item` and sets all other class variables
     as read-only for the instances.
 
     This makes sure, that the metadata is immutable,

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -116,16 +116,10 @@ class Container(metaclass=ContainerMeta):
             setattr(self, k, v)
 
     def __getitem__(self, item):
-        if item in self.__slots__:
-            return getattr(self, item)
-        else:
-            raise KeyError('No such Item: "{}"'.format(item))
+        return getattr(self, item)
 
     def __setitem__(self, item, value):
-        if item in self.__slots__:
-            return setattr(self, item, value)
-        else:
-            raise KeyError('No such Item: "{}"'.format(item))
+        return setattr(self, item, value)
 
     @property
     def attributes(self):

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -77,7 +77,7 @@ class Container(metaclass=ContainerMeta):
     columns in a flat table without naming conflicts (the name of the
     parent Item is pre-pended).
 
-    To only members of instance `Item` will be used as output.
+    Only members of instance `Item` will be used as output.
     For hierarchical data structures, Items can use `Container`
     subclasses or a `Map` as the default value.
 

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -46,6 +46,7 @@ def test_child_containers():
     cont = ParentContainer()
     assert cont.child.z == 1
 
+
 def test_map_containers():
 
     class ChildContainer(Container):

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -6,8 +6,8 @@ from ctapipe.core import Container, Item, Map
 def test_container():
 
     class ExampleContainer(Container):
-        x = Item(-1,"x value")
-        y = Item(-1,"y value")
+        x = Item(-1, "x value")
+        y = Item(-1, "y value")
 
     cont = ExampleContainer()
     cont2 = ExampleContainer()
@@ -85,5 +85,14 @@ def test_container_as_dict():
     assert 'child' in the_dict and 'z' in the_dict['child']
 
 
+def test_container_brackets():
 
+    class TestContainer(Container):
+        answer = Item(-1, "The answer to all questions")
 
+    t = TestContainer()
+
+    t['answer'] = 42
+
+    with pytest.raises(AttributeError):
+        t['foo'] = 5

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -217,7 +217,7 @@ class ReconstructedShowerContainer(Container):
                        unit=u.m)
     h_max = Item(0.0, 'reconstructed height of the shower maximum')
     h_max_uncert = Item(0.0, 'uncertainty of h_max')
-    is_valid = (False, ('direction validity flag. True if the shower direction'
+    is_valid = Item(False, ('direction validity flag. True if the shower direction'
                         'was properly reconstructed by the algorithm'))
     tel_ids = Item([], ('list of the telescope ids used in the'
                         ' reconstruction of the shower'))

--- a/ctapipe/io/serializer.py
+++ b/ctapipe/io/serializer.py
@@ -9,7 +9,6 @@ from pickle import dump
 import numpy as np
 from astropy import log
 from astropy.table import Table, Column
-from traitlets import Unicode
 
 from ctapipe.core import Container
 
@@ -95,7 +94,6 @@ class Serializer:
         Add a container to serializer
         """
         self._writer.add_container(container)
-
 
     def close(self):
         """

--- a/ctapipe/io/tests/test_serializer.py
+++ b/ctapipe/io/tests/test_serializer.py
@@ -25,18 +25,20 @@ def generate_input_containers():
         input_containers.append(deepcopy(event))
     return input_containers
 
+
 # Setup
 input_containers = generate_input_containers()
+
 
 @pytest.fixture(scope='session')
 def binary_filename(tmpdir_factory):
     return str(tmpdir_factory.mktemp('data')
                .join('pickle_data.pickle.gz'))
 
+
 @pytest.fixture(scope='session')
 def fits_file_name(tmpdir_factory):
     return str(tmpdir_factory.mktemp('data').join('output.fits'))
-
 
 
 def test_pickle_serializer(binary_filename):
@@ -100,13 +102,12 @@ def test_pickle_iterator(binary_filename):
     remove(binary_filename)
 
 
-
-
-
 def test_fits_dl0(fits_file_name):
     serial = Serializer(filename=fits_file_name, format='fits', mode='w')
+
     for container in input_containers:
         serial.add_container(container.dl0)
+
     serial.close()
     hdu = fits.open(fits_file_name)[1]
     assert hdu.data["event_id"][0] == 408


### PR DESCRIPTION
If I understood the idea correctly, containers should have:

* A number of fixed items, comparable to an ORM Model like peewee for example
* These Items should have read-only metadata and defaults
* It should not possible to create new instance members

This was currently implemented by raising an error in `__setitem__`, if the key was not a class member.
It involved a lot of look ups in the instance and class `__dict__`s.

I think I found a more concise way to do it, using a `metaclass` setting `__slots__`. 
Instances of `Item` will be added to the `__slots__` along with a `meta` dictionary for the metadata.
Every other class variable will become a read only class instance.

This is meant as a proposal and as bases for further discussion ;)
Let me know your ideas on this.

Working further on the Idea that a Container should be like a ORM Model, I think one should start to subclass `Item` to do static typing, which will help in the serialisation. 
So, for instance introduce `FloatItem`, `DoubleItem`, `StringItem`, `DateTimeItem` etc.