### PR TITLE
Add role to provenance

### DIFF
--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -50,15 +50,33 @@ class Provenance(metaclass=Singleton):
         self._activities.append(activity)
         log.debug("started activity: {}".format(activity_name))
 
-    def add_input_file(self, filename):
-        """ register an input to the current activity """
-        self.current_activity.register_input(abspath(filename))
+    def add_input_file(self, filename, role=None):
+        """ register an input to the current activity
+
+        Parameters
+        ----------
+        filename: str
+            name or url of file
+        role: str
+            role this input file satisfies (optional)
+        """
+        self.current_activity.register_input(abspath(filename), role=role)
         log.debug("added input entity '{}' to activity: '{}'".format(
             filename, self.current_activity.name))
 
-    def add_output_file(self, filename):
-        """ register an output to the current activity """
-        self.current_activity.register_output(abspath(filename))
+    def add_output_file(self, filename, role=None):
+        """
+        register an output to the current activity
+
+        Parameters
+        ----------
+        filename: str
+            name or url of file
+        role: str
+            role this output file satisfies (optional)
+
+        """
+        self.current_activity.register_output(abspath(filename), role=role)
         log.debug("added output entity '{}' to activity: '{}'".format(
             filename, self.current_activity.name))
 
@@ -152,7 +170,7 @@ class _ActivityProvenance:
         self._prov['start'].update(_sample_cpu_and_memory())
         self._prov['system'].update(_get_system_provenance())
 
-    def register_input(self, url):
+    def register_input(self, url, role=None):
         """
         Add a URL of a file to the list of inputs (can be a filename or full
         url, if no URL specifier is given, assume 'file://')
@@ -161,10 +179,12 @@ class _ActivityProvenance:
         ----------
         url: str
             filename or url of input file
+        role: str
+            role name that this output satisfies
         """
-        self._prov['input'].append(url)
+        self._prov['input'].append(dict(url=url,role=role))
 
-    def register_output(self, url):
+    def register_output(self, url, role=None):
         """
         Add a URL of a file to the list of outputs (can be a filename or full
         url, if no URL specifier is given, assume 'file://')
@@ -173,8 +193,10 @@ class _ActivityProvenance:
         ----------
         url: str
             filename or url of output file
+        role: str
+            role name that this output satisfies
         """
-        self._prov['output'].append(url)
+        self._prov['output'].append(dict(url=url,role=role))
 
     def register_config(self, config):
         """ add a dictionary of configuration parameters to this activity"""

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -181,9 +181,10 @@ class Tool(Application):
             Provenance().finish_activity(activity_name=self.name,
                                          status='interrupted')
         finally:
-            self.log.info("Output: %s",
-                          ' '.join([str(x.output) for x
-                                    in Provenance()._finished_activities]))
+            for activity in Provenance().finished_activities:
+                output_str = ' '.join([x['url'] for x in  activity.output])
+                self.log.info("Output: %s", output_str)
+
             self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
 
     @property

--- a/ctapipe/instrument/atmosphere.py
+++ b/ctapipe/instrument/atmosphere.py
@@ -6,6 +6,7 @@ import numpy as np
 from astropy.table import Table
 from astropy.units import Quantity
 from scipy.interpolate import interp1d
+from ctapipe.core.provenance import Provenance
 
 from ctapipe.utils import get_dataset
 
@@ -27,7 +28,10 @@ def get_atmosphere_profile_table(atmosphere_name='paranal'):
     'altitude' (m), and 'thickness' (g cm-2) as well as others.
 
     """
-    return Table.read(get_dataset('{}.atmprof.fits.gz'.format(atmosphere_name)))
+    filename = '{}.atmprof.fits.gz'.format(atmosphere_name)
+    table = Table.read(get_dataset(filename))
+    Provenance().add_input_file(filename, role='dl0.arr.svc.atmosphere')
+    return table
 
 
 def get_atmosphere_profile_functions(atmosphere_name="paranal",

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -232,7 +232,7 @@ class CameraGeometry:
 
         filename = get_dataset("{camera_id}{verstr}.camgeom.fits.gz"
                                .format(camera_id=camera_id, verstr=verstr))
-        Provenance().add_input_file(filename)
+        Provenance().add_input_file(filename, role='dl0.tel.svc.camera')
         return CameraGeometry.from_table(filename)
 
     def to_table(self):

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -54,7 +54,7 @@ def hessio_get_list_event_ids(url, max_events=None):
     logger.warning("This method is slow. Need to find faster method.")
     try:
         with open_hessio(url) as pyhessio:
-            Provenance().add_input_file(url)
+            Provenance().add_input_file(url, role='r0.sub.evt')
             counter = 0
             event_id_list = []
             eventstream = pyhessio.move_to_next_event()
@@ -96,7 +96,7 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
     with open_hessio(url) as pyhessio:
         # the container is initialized once, and data is replaced within
         # it after each yield
-        Provenance().add_input_file(url)
+        Provenance().add_input_file(url, role='dl0.sub.evt')
         counter = 0
         eventstream = pyhessio.move_to_next_event()
         if allowed_tels is not None:

--- a/ctapipe/tools/dump_instrument.py
+++ b/ctapipe/tools/dump_instrument.py
@@ -93,7 +93,7 @@ class DumpInstrumentTool(Tool):
 
             try:
                 table.write(filename, **args)
-                Provenance().add_output_file(filename)
+                Provenance().add_output_file(filename, 'dl0.tel.svc.camera')
             except IOError as err:
                 self.log.warn("couldn't write camera definition '%s' because: "
                               "%s", filename, err)
@@ -107,7 +107,7 @@ class DumpInstrumentTool(Tool):
         filename = '{}.optics.{}'.format(sub.name, ext)
         try:
             tab.write(filename, **args)
-            Provenance().add_output_file(filename)
+            Provenance().add_output_file(filename, 'dl0.sub.svc.optics')
         except IOError as err:
             self.log.warn("couldn't write optics description '%s' because: "
                           "%s", filename, err)
@@ -121,7 +121,7 @@ class DumpInstrumentTool(Tool):
         filename = '{}.subarray.{}'.format(sub.name, ext)
         try:
             tab.write(filename, **args)
-            Provenance().add_output_file(filename)
+            Provenance().add_output_file(filename, 'dl0.sub.svc.subarray')
         except IOError as err:
             self.log.warn("couldn't write subarray description '%s' because: "
                           "%s", filename, err)

--- a/ctapipe/tools/dump_triggers.py
+++ b/ctapipe/tools/dump_triggers.py
@@ -128,7 +128,7 @@ class DumpTriggersTool(Tool):
 
             Provenance().add_output_file(self.outfile)
         except IOError as err:
-            self.log.warn("Couldn't write output (%s)", self.outfile, err)
+            self.log.warn("Couldn't write output (%s)", err)
 
         self.log.info('\n %s', self.events)
 


### PR DESCRIPTION
add_input_file() and add_output_file() now take an optional role
attribute, which is set to the CTA data name when possible

For example the input/output entity list in the provenance looks like the following for `ctapipe-dump-instrument`:

```
     },
      "input": [
         {
            "url": "/Users/kosack/Data/CTA/Prod3/gamma.simtel.gz",
            "role": "dl0.sub.evt"
         }
      ],
      "output": [
         {
            "url": "/Users/kosack/Data/CTA/Prod3/LSTCam.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/FlashCam.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/NectarCam.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/ASTRICam.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/CHEC.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/DigiCam.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/SCTCam.camgeom.fits.gz",
            "role": "dl0.tel.svc.camera"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/MonteCarloArray.optics.fits.gz",
            "role": "dl0.sub.svc.optics"
         },
         {
            "url": "/Users/kosack/Data/CTA/Prod3/MonteCarloArray.subarray.fits.gz",
            "role": "dl0.sub.svc.subarray"
         }
      ],

```