### PR TITLE
Fix info bug

### DIFF
--- a/ctapipe/tools/__init__.py
+++ b/ctapipe/tools/__init__.py
@@ -1,4 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """ctapipe command line tools.
 """
-from .info import *
+

--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -1,24 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """ print information about ctapipe and its command-line tools. """
-import sys
-import logging
 import importlib
-from .utils import get_parser
-from ctapipe.utils import datasets
+import logging
 import os
+import sys
+
 import ctapipe_resources
 
-__all__ = ['info']
+from ..utils import datasets
+from ..core import Provenance
+from .utils import get_parser
 
+__all__ = ['info']
 
 # TODO: this list should be global (or generated at install time)
 _dependencies = sorted(['astropy', 'matplotlib',
                         'numpy', 'traitlets',
-                        'sklearn', 'scipy',
-                        'pytest', 'ctapipe_resources'])
+                        'sklearn', 'scipy', 'numba',
+                        'pytest', 'ctapipe_resources', 'iminuit', 'tables'])
 
-_optional_dependencies = sorted(['pytest', 'graphviz', 'pyzmq', 'iminuit',
-                                 'fitsio', 'pyhessio', 'targetio'])
+_optional_dependencies = sorted(['pytest', 'graphviz', 'pyzmq',
+                                 'fitsio', 'pyhessio', 'targetio',
+                                 'matplotlib'])
 
 
 def main(args=None):
@@ -31,6 +34,8 @@ def main(args=None):
                         help='Print available versions of dependencies')
     parser.add_argument('--resources', action='store_true',
                         help='Print available versions of dependencies')
+    parser.add_argument('--system', action='store_true',
+                        help='Print system info')
     parser.add_argument('--all', action='store_true',
                         help='show all info')
     args = parser.parse_args(args)
@@ -43,7 +48,7 @@ def main(args=None):
 
 
 def info(version=False, tools=False, dependencies=False,
-         resources=False, all=False):
+         resources=False, system=False, all=False):
     """Print various info to the console.
 
     TODO: explain.
@@ -63,14 +68,17 @@ def info(version=False, tools=False, dependencies=False,
     if resources or all:
         _info_resources()
 
+    if system or all:
+        _info_system()
+
 
 def _info_version():
     """Print version info."""
     import ctapipe
     print('\n*** ctapipe version info ***\n')
     print('version: {0}'.format(ctapipe.__version__))
-    #print('release: {0}'.format(version.release))
-    #print('githash: {0}'.format(version.githash))
+    # print('release: {0}'.format(version.release))
+    # print('githash: {0}'.format(version.githash))
     print('')
 
 
@@ -91,11 +99,10 @@ def _info_tools():
 
     scripts = get_all_descriptions()
     for name, desc in sorted(scripts.items()):
-        text = "{:<30s}  - {}".format(name, desc) 
+        text = "{:<30s}  - {}".format(name, desc)
         print(wrapper.fill(text))
         print('')
     print('')
-
 
 
 def _info_dependencies():
@@ -157,3 +164,19 @@ def _info_resources():
         loc = loc.replace(home, "~")
         print(fmt.format(name=name, loc=loc))
 
+
+def _info_system():
+    # collect system info using the ctapipe provenance system :
+
+    print('\n*** ctapipe system environment ***\n')
+
+    prov = Provenance()
+    system_prov = prov.current_activity.provenance['system']
+
+    for section in ['platform','python']:
+
+        print('\n====== ',section," ======== \n")
+        sysinfo = system_prov[section]
+
+        for name, val in sysinfo.items():
+            print("{:>20.20s} -- {:<60.60s}".format(name, str(val)))


### PR DESCRIPTION
- fixes problem where ctapipe-info didn't work when installed as a conda package
- adds `--system` option, which prints out the system info from core.provenance, useful for debugging problems