### PR TITLE
WIP: Implement first version of typed fields

### DIFF
--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -1,10 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from .component import Component
-from .container import Container, Field, Map
+from .container import Container, Map
 from .factory import Factory
 from .provenance import Provenance
 from .tool import Tool, ToolConfigurationError
+from .field import Field, QuantityField, ArrayField
 
-__all__ = ['Component', 'Container', 'Tool', 'Field', 'Map', 'Factory',
-           'Provenance', 'ToolConfigurationError']
+
+__all__ = [
+    'Component',
+    'Container',
+    'Tool',
+    'Map',
+    'Factory',
+    'Provenance',
+    'ToolConfigurationError',
+    'Field',
+    'ArrayField',
+    'QuantityField',
+]

--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -5,7 +5,7 @@ from .container import Container, Map
 from .factory import Factory
 from .provenance import Provenance
 from .tool import Tool, ToolConfigurationError
-from .field import Field, QuantityField, ArrayField
+from .field import Field, QuantityField, ArrayField, TimeField
 
 
 __all__ = [
@@ -19,4 +19,5 @@ __all__ = [
     'Field',
     'ArrayField',
     'QuantityField',
+    'TimeField',
 ]

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -97,7 +97,6 @@ class Container(metaclass=ContainerMeta):
             setattr(self, k, v)
 
     def __setattr__(self, name, value):
-        print(name, value)
         if name in self.fields:
             try:
                 value = self.fields[name].coerce(value)

--- a/ctapipe/core/field.py
+++ b/ctapipe/core/field.py
@@ -1,0 +1,161 @@
+import numpy as np
+from astropy.units.core import UnitBase
+
+
+class Field:
+    '''
+    Class for storing an arbitrary python object in a `Container`.
+
+    Parameters
+    ----------
+    description: str
+        Help text associated with the item
+    default:
+        default value of the item (this will be set when the `Container`
+        is constructed, as well as when  `Container.reset()` is called
+    allow_none: bool
+        If true, the field is allowed to contain `None`
+    ucd: str
+        universal content descriptor (see Virtual Observatory standards)
+    '''
+
+    def __init__(
+        self,
+        description,
+        default=None,
+        allow_none=False,
+        ucd=None
+    ):
+        self.allow_none = allow_none
+        self.default = default
+        self.description = description
+        self.ucd = ucd
+
+    def __repr__(self):
+        desc = '{}'.format(self.description)
+        return desc
+
+    def coerce(self, value):
+        if value is None and not self.allow_none:
+            raise ValueError('Value must not be None')
+
+        return value
+
+
+class ArrayField(Field):
+    '''
+    Class for storing a numpy array in a `Container`.
+
+    Parameters
+    ----------
+    description: str
+        Help text associated with the item
+    default:
+        default value of the item (this will be set when the `Container`
+        is constructed, as well as when  `Container.reset()` is called
+    shape: tuple
+        The shape of the field
+    dtype: numpy.dtype or None
+        If given, coerce values to this dtype
+    allow_none: bool
+        If true, the field is allowed to contain `None`
+    ucd: str
+        universal content descriptor (see Virtual Observatory standards)
+    '''
+
+    def __init__(
+        self,
+        description,
+        default=None,
+        shape=None,
+        dtype=None,
+        allow_none=False,
+        ucd=None
+    ):
+        super().__init__(
+            description=description,
+            default=default,
+            allow_none=allow_none,
+            ucd=ucd,
+        )
+        self.shape = shape
+        self.dtype = dtype
+
+    def coerce(self, value):
+
+        if value is None:
+            if self.allow_none:
+                return value
+            else:
+                raise ValueError('Value must not be None')
+
+        value = np.asanyarray(value)
+
+        if self.shape is not None and self.shape != value.shape:
+            raise ValueError('New Value has wrong shape')
+
+        if self.dtype is not None:
+            value = value.astype(self.dtype)
+
+        return value
+
+
+class QuantityField(ArrayField):
+    '''
+    Class for storing an astropy quantity in a `Container`.
+
+    Parameters
+    ----------
+    description: str
+        Help text associated with the item
+    unit: astropy.units.Unit
+        The unit of the Field
+    default:
+        default value of the item (this will be set when the `Container`
+        is constructed, as well as when  `Container.reset()` is called
+    shape: tuple
+        The shape of the field
+    dtype: numpy.dtype or None
+        If given, coerce values to this dtype
+    allow_none: bool
+        If true, the field is allowed to contain `None`
+    ucd: str
+        universal content descriptor (see Virtual Observatory standards)
+    '''
+
+    def __init__(
+        self,
+        description,
+        unit,
+        default=None,
+        shape=None,
+        dtype=None,
+        allow_none=False,
+        ucd=None
+    ):
+        super().__init__(
+            description=description,
+            default=default,
+            allow_none=allow_none,
+            ucd=ucd,
+            shape=shape,
+            dtype=dtype,
+        )
+        if not isinstance(unit, UnitBase):
+            raise ValueError('Unit must be an astropy unit')
+        self.unit = unit
+
+    def coerce(self, value):
+
+        value = super().coerce(value)
+
+        if not self.unit.is_equivalent(value.unit):
+            raise ValueError('New value has wrong unit')
+
+        return value
+
+    def __repr__(self):
+        desc = '{}'.format(self.description)
+        if self.unit is not None:
+            desc += ' [{}]'.format(self.unit)
+        return desc

--- a/ctapipe/core/field.py
+++ b/ctapipe/core/field.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy.units.core import UnitBase
+from astropy.time import Time
 
 
 class Field:
@@ -159,3 +160,11 @@ class QuantityField(ArrayField):
         if self.unit is not None:
             desc += ' [{}]'.format(self.unit)
         return desc
+
+
+class TimeField(Field):
+
+    def coerce(self, value):
+        super().coerce(value)
+
+        return Time(value)

--- a/ctapipe/core/tests/test_field.py
+++ b/ctapipe/core/tests/test_field.py
@@ -81,3 +81,17 @@ def test_quantity():
     with raises(ValueError):
         t = TestContainer(x=[1, 2, 3] * u.m)
 
+
+def test_time():
+    from ctapipe.core import Container, TimeField
+    from astropy.time import Time
+
+    class TestContainer(Container):
+        time = TimeField('observation time')
+
+    t = TestContainer(time=Time.now())
+
+    t.time = '2017-01-01 20:00'
+
+    with raises(ValueError):
+        t.time = 5

--- a/ctapipe/core/tests/test_field.py
+++ b/ctapipe/core/tests/test_field.py
@@ -1,0 +1,83 @@
+from pytest import raises
+
+
+def test_none():
+    from ctapipe.core import Container, Field
+
+    class TestContainer(Container):
+        test = Field('test')
+
+
+    TestContainer(test=5)
+
+    with raises(ValueError):
+        TestContainer()
+
+    class TestContainer(Container):
+        test = Field('test', allow_none=True)
+
+    TestContainer()
+
+
+def test_none_existent():
+    from ctapipe.core import Container, Field
+
+    class TestContainer(Container):
+        test = Field('test', allow_none=True)
+
+    t = TestContainer()
+
+    with raises(AttributeError):
+        t.x = 10
+
+
+def test_array():
+    from ctapipe.core import Container, ArrayField
+    import numpy as np
+
+    class TestContainer(Container):
+        x = ArrayField('x')
+
+    t = TestContainer(x=np.zeros(5))
+
+    t.x = 5
+
+    assert t.x == np.array(5)
+
+    class TestContainer(Container):
+        x = ArrayField('x', dtype=int, shape=(2, ))
+
+    t = TestContainer(x=[1.0, 2.4])
+
+    assert t.x.dtype == np.dtype(int)
+    assert np.all(t.x == np.array([1, 2]))
+
+    with raises(ValueError):
+        t.x = [1, 2, 3]
+
+
+def test_quantity():
+    from ctapipe.core import Container, QuantityField
+    import astropy.units as u
+    import numpy as np
+
+    class TestContainer(Container):
+        x = QuantityField('x', default=5 * u.m, unit=u.m)
+
+    t = TestContainer()
+
+    t.x = 4 * u.cm
+
+    with raises(ValueError):
+        t.x = 5 * u.A
+
+    class TestContainer(Container):
+        x = QuantityField('x', dtype=int, shape=(2, ), unit=u.m)
+
+    t = TestContainer(x=[1, 2] * u.m)
+
+    assert t.x.dtype == np.dtype(int)
+
+    with raises(ValueError):
+        t = TestContainer(x=[1, 2, 3] * u.m)
+


### PR DESCRIPTION
Do not merge, this is WIP but I want to get Feedback early.

This is something that was already talked about. I started to implement typed fields, inspired by orm models for the containers.

Right now there is
* `Field` for arbitrary python objects
* `ArrayField` for numpy arrays
* `QuantityField` for astropy quantities
* `TimeField` for astropy.time.Time

There need to be more Field types, name any you deem useful.

I plan to rewrite `Map` so map is a `Map` of `Fields` and there should be a `SubContainerField` to have strictly typed `Map → Subcontainer` relations.

This will result in mostly statically typed Containers, which should make serialisation a lot easier.