### PR TITLE
added a fix to ensure ASTRI images don't have an extra dimension in them

### DIFF
--- a/ctapipe/calib/camera/dl1.py
+++ b/ctapipe/calib/camera/dl1.py
@@ -220,7 +220,7 @@ class CameraDL1Calibrator(Component):
                 n_samples = waveforms.shape[2]
                 if n_samples == 1:
                     # To handle ASTRI and dst
-                    corrected = waveforms
+                    corrected = np.squeeze(waveforms)
                     window = np.ones(waveforms.shape)
                     peakpos = np.zeros(waveforms.shape[0:2])
                     cleaned = waveforms


### PR DESCRIPTION
There may be a better way to fix this, but this was simplest

This fixes #520  with a 1-line change, but perhaps in a somewhat hacky way :) 