### PR TITLE
Bug Correction. Now ctapipe-flow default mode value is set to sequential

### DIFF
--- a/ctapipe/flow/flow.py
+++ b/ctapipe/flow/flow.py
@@ -106,7 +106,7 @@ class Flow(Tool):
     description = 'run stages in multiprocess Flow based framework'
     gui = Bool(False, help='send status to GUI').tag(config=True)
     gui_address = Unicode('localhost:5565', help='GUI adress and port').tag(config=True)
-    mode = Enum(['sequential', 'multiprocess'], default_vallue='sequential',
+    mode = Enum(['sequential', 'multiprocess'], default_value='sequential',
                 help='Flow mode', allow_none=True).tag(config=True)
     producer_conf = Dict(help='producer description: name , module, class',
                          allow_none=False).tag(config=True)


### PR DESCRIPTION
- ctapipe/flow/flow.py default_vallue change to default_value