### PR TITLE
changed np.count_nonzero() to np.sum() in tailcuts_clean

### DIFF
--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -53,9 +53,13 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
     if keep_isolated_pixels or min_number_picture_neighbors == 0:
        pixels_in_picture = pixels_above_picture
     else:
-        # Require at least min_number_picture_neighbors. Otherwise, the pixel is not selected
-        number_of_neighbors_above_picture = np.count_nonzero(pixels_above_picture & geom.neighbor_matrix, axis=1)
-        pixels_in_picture = pixels_above_picture & (number_of_neighbors_above_picture >= min_number_picture_neighbors)
+        # Require at least min_number_picture_neighbors. Otherwise, the pixel
+        #  is not selected
+        number_of_neighbors_above_picture = np.sum(pixels_above_picture &
+                                                   geom.neighbor_matrix, axis=1)
+        pixels_in_picture = pixels_above_picture & (
+            number_of_neighbors_above_picture >= min_number_picture_neighbors
+        )
 
 
     # by broadcasting together pixels_in_picture (1d) with the neighbor

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -70,7 +70,19 @@ def test_tailcuts_clean():
                                          keep_isolated_pixels=False)
         assert (result == mask).all()
 
-# requiring that picture pixels have at least one neighbor above picture_thres:
+
+def test_tailcuts_clean_min_neighbors_1():
+    """
+    requiring that picture pixels have at least one neighbor above picture_thres:
+    """
+
+    # start with simple 3-pixel camera
+    geom = CameraGeometry.make_rectangular(3, 1, (-1, 1))
+
+    p = 15  # picture value
+    b = 7  # boundary value
+
+
     testcases = {(p, p, 0): [True,  True,  False],
                  (p, 0, p): [False, False, False],
                  (p, b, p): [False, False, False],
@@ -87,7 +99,16 @@ def test_tailcuts_clean():
                                          keep_isolated_pixels=False)
         assert (result == mask).all()
 
-# requiring that picture pixels have at least two neighbors above picture_thres:
+def test_tailcuts_clean_min_neighbors_2():
+    """ requiring that picture pixels have at least two neighbors above 
+    picture_thresh"""
+
+    # start with simple 3-pixel camera
+    geom = CameraGeometry.make_rectangular(3, 1, (-1, 1))
+
+    p = 15  #picture value
+    b = 7   # boundary value
+
     testcases = {(p, p, 0): [False, False, False],
                  (p, 0, p): [False, False, False],
                  (p, b, p): [False, False, False],
@@ -104,7 +125,14 @@ def test_tailcuts_clean():
         assert (result == mask).all()
 
 
-    # allowing isolated pixels
+def test_tailcuts_clean_with_isolated_pixels():
+
+    # start with simple 3-pixel camera
+    geom = CameraGeometry.make_rectangular(3, 1, (-1, 1))
+
+    p = 15  #picture value
+    b = 7   # boundary value
+
     testcases = {(p, p, 0): [True, True, False],
                  (p, 0, p): [True, False, True],
                  (p, b, p): [True, True, True],


### PR DESCRIPTION
for some reason this had different behavior with different versions of
numpy, causing tests to fail in some cases.  Still not sure why, but on my machine (osx with 1.11.3) the test with min neighbors=2 failed for the last test case, while it worked on the travis build.