### PR TITLE
added to methods to EventClassifier

### DIFF
--- a/ctapipe/reco/event_classifier.py
+++ b/ctapipe/reco/event_classifier.py
@@ -1,12 +1,11 @@
 import numpy as np
 import pandas as pd
-
+import logging
 from astropy import units as u
 
 from sklearn.ensemble import RandomForestClassifier
 
 from .regressor_classifier_base import RegressorClassifierBase
-
 
 def proba_drifting(x):
     """
@@ -105,3 +104,126 @@ class EventClassifier(RegressorClassifierBase):
         Q[:] = Q[::-1].copy()
 
         return Q, bins[1:]  # , eps_g[::-1], eps_h[::-1]
+
+    def _hyperBinning(self, x, featsToGroupBy: list):
+        """
+        This function is for hyper binning with pandas.
+        It is intended to be used here in order to level number of events before training the classifier;
+        for more general purposes, it is the Histogram in utils/fitshistogram.py to be used.
+
+        This outputs the input array grouped in as many bins as present in the featsToGroupBy list.
+        This is a list of dictionaries, each dictionary is related to a feature (array column) to be binned.
+
+        Beware of bins generation: since np.linspace is used, if you want log bins
+        you have to make log of the input array column and pass log(max and min)!
+
+        Parameters
+        ----------
+        x: input array to be binned
+
+        featsToGroupBy: list(dictionary)
+              list of dictionaries (see Examples for dict keys)
+
+        Output
+        ----------
+        A pandas.core.groupby.DataFrameGroupBy object
+
+
+        Examples
+        --------
+
+        >>> featsToGroupBy = [{'feat': 'feat0', 'maxf': max(x[:, 0]), 'minf': min(x[:, 0]), 'col': 0, 'nbins': 10},
+        ... {'feat': 'feat1', 'maxf': max(x[:, 1]), 'minf': min(x[:, 1]), 'col': 1, 'nbins': 5}]
+
+        where
+
+        'feat' is feature name (optional);
+        'maxf' and 'minf' are the range where to bin in
+        'col' is feature column number in the input array
+        'nbins' is the number of requested bins
+        """
+        dfx = pd.DataFrame(x)
+        binning_list = []
+
+        for i in range(len(featsToGroupBy)):
+            feat_dict = featsToGroupBy[i]
+            bins = np.linspace(feat_dict['minf'], feat_dict['maxf'], feat_dict['nbins']+1)
+            binning_list.append(pd.cut(dfx[feat_dict['col']], bins))
+
+        groups = dfx.groupby(binning_list)
+
+        return groups
+
+    def level_populations(self, group_gamma, group_hadron, gamma_evts, hadron_evts):
+        """Equalize number of entries in each bin.
+        When doing gamma hadron separation, it is common to wrangle input data equalizing
+        the number of entries for gammas and hadron in all the requested hyper-bins,
+        before training the classifier.
+        This is different from the sklearn train_test_split in the sense that this level
+        the two populations based upon a previous binning over any feature requested.
+
+        Parameters
+        ----------
+        group_gamma: (multi dimension) histogram of gammas population in pandas groups format
+
+        group_hadron: (multi dimension) histogram of hadrons population in pandas groups format
+
+        gamma_evts: array of gamma events, to be equalized
+
+        hadron_evts: array of hadron events, to be equalized
+
+
+        Output
+        -----------
+        array of gammas and array of hadrons now of the same size
+
+        """
+        logger = logging.getLogger('level_population')
+        logging.basicConfig(level=logging.DEBUG)
+
+        try:
+            type(group_gamma) is pd.core.groupby.DataFrameGroupBy
+        except TypeError:
+            raise TypeError("This function wants pandas DataFrameGroupBy objects as group_* inputs")
+        try:
+            type(group_hadron) is pd.core.groupby.DataFrameGroupBy
+        except TypeError:
+            raise TypeError("This function wants pandas DataFrameGroupBy objects as group_* inputs")
+
+        # convert to pandas to use .drop()
+        dfg = pd.DataFrame(gamma_evts)
+        dfh = pd.DataFrame(hadron_evts)
+
+        # have a unique set of keys in the histograms
+        s = set(group_gamma.indices)
+        s.update(group_hadron.indices)
+
+        for key in s:
+            if key in group_gamma.indices and key in group_hadron.indices:
+                # count exceeding records
+                exceeding = len(group_hadron.indices[key]) - len(group_gamma.indices[key])
+
+                # drop records from dataset picking exceeding number of indices
+                # among those in group.indices[key]
+                if exceeding > 0:
+                    logger.debug('bin: {} - g: {}\th: {}\t - '
+                                 'Removing {} protons'.format(key, len(group_gamma.indices[key]),
+                                                                   len(group_hadron.indices[key]),
+                                                                   np.abs(exceeding)))
+                    r_ind_list = list(np.random.choice(group_hadron.indices[key], size=exceeding, replace=False))
+                    dfh.drop(r_ind_list, inplace=True)
+                elif exceeding < 0:
+                    logger.debug('bin: {} - g: {}\th: {}\t - '
+                                 'Removing {} gammas'.format(key, len(group_gamma.indices[key]),
+                                                                  len(group_hadron.indices[key]),
+                                                                  np.abs(exceeding)))
+                    r_ind_list = list(np.random.choice(group_gamma.indices[key], size=-exceeding, replace=False))
+                    dfg.drop(r_ind_list, inplace=True)
+
+            elif key in group_hadron.indices and key not in group_gamma.indices:
+                dfh.drop(group_hadron.indices[key], inplace=True)
+
+            elif key in group_gamma.indices and key not in group_hadron.indices:
+                dfg.drop(group_gamma.indices[key], inplace=True)
+
+        return np.array(dfg), np.array(dfh)

--- a/ctapipe/reco/tests/test_event_classifier.py
+++ b/ctapipe/reco/tests/test_event_classifier.py
@@ -143,3 +143,59 @@ def test_Qfactor():
 
     assert Q.size != 0
     assert Q.size == gammaness.size
+
+def test_hyperBinning():
+    clf = EventClassifier(cam_id_list=None)
+    x = np.array([[26, 70, 53],
+                  [97, 20, 56],
+                  [35, 38, 81],
+                  [48, 60, 40],
+                  [73, 68, 63],
+                  [96, 86, 63],
+                  [73, 67,  6],
+                  [48, 66, 60],
+                  [47, 82, 87],
+                  [60, 52, 74]])
+
+    dum_l = [{'maxf': max(x[:, 0]), 'minf': min(x[:, 0]), 'col': 0, 'nbins': 4},
+             {'maxf': max(x[:, 1]), 'minf': min(x[:, 1]), 'col': 1, 'nbins': 2}]
+
+    dum_g = clf._hyperBinning(x, dum_l)
+
+    assert np.all(dum_g.size() == (1, 1, 3, 2, 1))
+
+def test_level_populations():
+    clf = EventClassifier(cam_id_list=None)
+    g = np.array([[26, 70, 53],
+                  [97, 20, 56],
+                  [35, 38, 81],
+                  [48, 60, 40],
+                  [73, 68, 63],
+                  [96, 86, 63],
+                  [73, 67, 6],
+                  [48, 66, 60],
+                  [47, 82, 87],
+                  [60, 52, 74]])
+
+    h = np.array([[18, 31, 47],
+                  [15, 81, 72],
+                  [75, 93, 45],
+                  [57, 50,  3],
+                  [12, 80,  3],
+                  [82, 49, 31],
+                  [ 1, 21,  0],
+                  [79, 12, 29],
+                  [19, 52, 42],
+                  [86, 49, 15]])
+
+    dum_l = [{'maxf': 100, 'minf': 0, 'col': 0, 'nbins': 4},
+             {'maxf': 100, 'minf': 0, 'col': 1, 'nbins': 2}]
+
+    group_g = clf._hyperBinning(g, dum_l)
+    group_h = clf._hyperBinning(h, dum_l)
+
+    cleaned_g, cleaned_h = clf.level_populations(group_g, group_h, g, h)
+
+    assert cleaned_g.shape == cleaned_h.shape
+
+


### PR DESCRIPTION
* a hyperBinning method that output pandas groups
* a level_populations method to equalize gamma and hadrons based upon
binning

When doing gamma hadron separation, it is common to wrangle input data equalising the number of entries for gammas and hadron in all the requested hyper-bins, before training the classifier.
This is different from the sklearn train_test_split in the sense that this levels the two populations based upon a previous binning over any requested feature.