### PR TITLE
Particleid to mceventcontainer

### DIFF
--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -200,7 +200,7 @@ class MCEventContainer(Container):
     core_x = Field(0.0, "MC core position", unit=u.m)
     core_y = Field(0.0, "MC core position", unit=u.m)
     h_first_int = Field(0.0, "Height of first interaction")
-    shower_primary_id = Field(None,"MC shower primary ID 0 (gamma), 1(e-),"
+    shower_primary_id = Field(None, "MC shower primary ID 0 (gamma), 1(e-),"
                               "2(mu-), 100*A+Z for nucleons and nuclei," 
                               "negative for antimatter.")
     tel = Field(

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -200,6 +200,7 @@ class MCEventContainer(Container):
     core_x = Field(0.0, "MC core position", unit=u.m)
     core_y = Field(0.0, "MC core position", unit=u.m)
     h_first_int = Field(0.0, "Height of first interaction")
+    shower_primary_id = Field(None,"MC shower primary ID 0 (gamma), 1(e-), 2(mu-), 100*A+Z for nucleons and nuclei, negative for antimatter.")
     tel = Field(
         Map(MCCameraEventContainer), "map of tel_id to MCCameraEventContainer"
     )

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -200,7 +200,9 @@ class MCEventContainer(Container):
     core_x = Field(0.0, "MC core position", unit=u.m)
     core_y = Field(0.0, "MC core position", unit=u.m)
     h_first_int = Field(0.0, "Height of first interaction")
-    shower_primary_id = Field(None,"MC shower primary ID 0 (gamma), 1(e-), 2(mu-), 100*A+Z for nucleons and nuclei, negative for antimatter.")
+    shower_primary_id = Field(None,"MC shower primary ID 0 (gamma), 1(e-),"
+                              "2(mu-), 100*A+Z for nucleons and nuclei," 
+                              "negative for antimatter.")
     tel = Field(
         Map(MCCameraEventContainer), "map of tel_id to MCCameraEventContainer"
     )

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -151,6 +151,8 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
             data.mc.core_y = pyhessio.get_mc_event_ycore() * u.m
             first_int = pyhessio.get_mc_shower_h_first_int() * u.m
             data.mc.h_first_int = first_int
+            data.mc.shower_primary_id = \
+                pyhessio.get_mc_shower_primary_id()
 
             # mc run header data
             data.mcheader.run_array_direction = \


### PR DESCRIPTION
Very simple PR: I just added the MC particle ID as a new field in MCEventContainer.

Edits have been done to io/containers.py and io/hessio.py.

The main reason for this new feature is to be able to keep track of the particle ID down the analysis road, which may be useful for people working on particle classification (I guess this might be a simple use case?).

No new dependencies are required.

Related to issue [#556](https://github.com/cta-observatory/ctapipe/issues/556).

Cheers,

D.


