### PR TITLE
remove channels for astropy, openastronomy and replace with conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,7 @@
 name: ctadev
 channels:
   - cta-observatory
-  - openastronomy
-  - astropy
+  - conda-forge
 dependencies:
   - ctapipe-extra=0.2.11
   - astropy

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - astropy
   - bokeh
   - cython
-  - fitsio
   - gammapy
   - graphviz
   - iminuit


### PR DESCRIPTION
conda-forge seems to be the way to keep external (non-anaconda) packages up-to-date, so this simplifies the number of channels needed, perhaps.