### PR TITLE
Refactor optics focal length name

### DIFF
--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -87,7 +87,7 @@ def analyze_muon_event(event, params=None, geom_dict=None):
                                     boundary_thresh=tailcuts[1])
         camera_coord = CameraFrame(
             x=x, y=y,
-            focal_length=teldes.optics.effective_focal_length,
+            focal_length=teldes.optics.equivalent_focal_length,
             rotation=geom.pix_rotation
         )
 

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -411,6 +411,16 @@ class CameraGeometry:
         self.pix_rotation -= Angle(angle)
         self.cam_rotation -= Angle(angle)
 
+    def info(self, printer=print):
+        """ print detailed info about this camera """
+        printer('CameraGeometry: "{}"'.format(self))
+        printer('   - num-pixels: {}'.format(len(self.pix_id)))
+        printer('   - pixel-type: {}'.format(self.pix_type))
+        printer('   - sensitive-area: {}'.format(self.pix_area.sum()))
+        printer('   - pix-rotation: {}'.format(self.pix_rotation))
+        printer('   - cam-rotation: {}'.format(self.cam_rotation))
+
+
 
     @classmethod
     def make_rectangular(cls, npix_x=40, npix_y=40, range_x=(-0.5, 0.5),

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -156,8 +156,8 @@ class SubarrayDescription:
                                             in optics_list]) * u.m**2
             cols['mirror_type'] = [x.mirror_type for x in optics_list]
             cols['num_mirror_tiles'] = [x.num_mirror_tiles for x in optics_list]
-            cols['effective_focal_length'] = [
-                x.effective_focal_length.to('m').value
+            cols['equivalent_focal_length'] = [
+                x.equivalent_focal_length.to('m').value
                 for x in optics_list
             ] * u.m
 

--- a/ctapipe/instrument/telescope.py
+++ b/ctapipe/instrument/telescope.py
@@ -57,7 +57,7 @@ class TelescopeDescription:
         return self._camera
 
     @classmethod
-    def guess(cls, pix_x, pix_y, effective_focal_length):
+    def guess(cls, pix_x, pix_y, equivalent_focal_length):
         """
         Construct a TelescopeDescription from metadata, filling in the
         missing information using a lookup table.
@@ -68,11 +68,11 @@ class TelescopeDescription:
            array of pixel x-positions with units
         pix_y: array
            array of pixel y-positions with units
-        effective_focal_length: float
+        equivalent_focal_length: float
            effective focal length of telescope with units (m)
         """
-        camera = CameraGeometry.guess(pix_x, pix_y, effective_focal_length)
-        optics = OpticsDescription.guess(effective_focal_length)
+        camera = CameraGeometry.guess(pix_x, pix_y, equivalent_focal_length)
+        optics = OpticsDescription.guess(equivalent_focal_length)
         return cls(optics=optics, camera=camera)
 
     @classmethod

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -18,6 +18,7 @@ def test_load_by_name():
 
     for cam in cams:
         geom = CameraGeometry.from_name(cam)
+        geom.info()
 
 
 
@@ -139,5 +140,6 @@ def test_slicing():
     assert sliced2.pix_id[0] == 5
     assert sliced2.pix_id[1] == 7
     assert len(sliced2.pix_x) == 5
+    
 if __name__ == '__main__':
     pass

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -140,6 +140,6 @@ def test_slicing():
     assert sliced2.pix_id[0] == 5
     assert sliced2.pix_id[1] == 7
     assert len(sliced2.pix_x) == 5
-    
+
 if __name__ == '__main__':
     pass

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -6,6 +6,7 @@ from ctapipe.instrument.camera import _find_neighbor_pixels, \
 from numpy import median
 import pytest
 
+cam_ids = CameraGeometry.get_known_camera_names()
 
 def test_load_by_name():
 
@@ -48,14 +49,31 @@ def test_find_neighbor_pixels():
     neigh = _find_neighbor_pixels(x.ravel(), y.ravel(), rad=3.1)
     assert(set(neigh[11]) == set([16, 6, 10, 12]))
 
-def test_neighbor_pixels():
-    hexgeom = CameraGeometry.from_name("LSTCam")
-    recgeom = CameraGeometry.make_rectangular()
 
-    # most pixels should have 4 neighbors for rectangular geometry and 6 for
-    # hexagonal
-    assert int(median(recgeom.neighbor_matrix.sum(axis=1))) == 4
-    assert int(median(hexgeom.neighbor_matrix.sum(axis=1))) == 6
+@pytest.mark.parametrize("cam_id", cam_ids)
+def test_neighbor_pixels(cam_id):
+    """
+    test if each camera has a reasonable number of neighbor pixels (4 for
+    rectangular, and 6 for hexagonal.  Other than edge pixels, the majority
+    should have the same value
+    """
+
+    geom = CameraGeometry.from_name(cam_id)
+    n_pix = len(geom.pix_id)
+    n_neighbors = [len(x) for x in geom.neighbors]
+
+    if geom.pix_type.startswith('hex'):
+        assert n_neighbors.count(6) > 0.5 * n_pix
+        assert n_neighbors.count(6) > n_neighbors.count(4)
+
+    if geom.pix_type.startswith('rect'):
+        assert n_neighbors.count(4) > 0.5 * n_pix
+        assert n_neighbors.count(5) == 0
+        assert n_neighbors.count(6) == 0
+
+    assert n_neighbors.count(1) == 0  # no pixel should have a single neighbor
+
+
 
 def test_to_and_from_table():
     geom = CameraGeometry.from_name("LSTCam")

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -5,6 +5,7 @@ import pytest
 def test_guess_optics():
 
     od = OpticsDescription.guess(28.0*u.m)
+    od.info()
 
     assert od.tel_type == 'LST'
     assert od.tel_subtype == ''
@@ -12,4 +13,5 @@ def test_guess_optics():
 
     with pytest.raises(KeyError):
         od2 = OpticsDescription.guess(0*u.m)
+
 

--- a/ctapipe/plotting/tests/test_array.py
+++ b/ctapipe/plotting/tests/test_array.py
@@ -45,7 +45,7 @@ def test_array_draw():
 
             pmt_signal = event.dl1.tel[tel_id].image[0]
             geom = deepcopy(event.inst.subarray.tel[tel_id].camera)
-            fl = event.inst.subarray.tel[tel_id].optics.effective_focal_length
+            fl = event.inst.subarray.tel[tel_id].optics.equivalent_focal_length
 
             # Transform the pixels positions into nominal coordinates
             camera_coord = CameraFrame(x=geom.pix_x, y=geom.pix_y,

--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -285,7 +285,7 @@ class HillasReconstructor(Reconstructor):
             # NOTE this is correct: +cos(psi) ; +sin(psi)
             p2_x = moments.cen_x + moments.length * np.cos(moments.psi)
             p2_y = moments.cen_y + moments.length * np.sin(moments.psi)
-            foclen = subarray.tel[tel_id].optics.effective_focal_length
+            foclen = subarray.tel[tel_id].optics.equivalent_focal_length
 
             circle = GreatCircle(
                 guess_pix_direction(
@@ -530,7 +530,7 @@ class HillasReconstructor(Reconstructor):
         tels = []
         dirs = []
         for tel_id, hillas in hillas_dict.items():
-            foclen = subarray.tel[tel_id].optics.effective_focal_length
+            foclen = subarray.tel[tel_id].optics.equivalent_focal_length
             max_dir, = guess_pix_direction(
                 np.array([hillas.cen_x / u.m]) * u.m,
                 np.array([hillas.cen_y / u.m]) * u.m,

--- a/ctapipe/tools/camdemo.py
+++ b/ctapipe/tools/camdemo.py
@@ -78,14 +78,14 @@ class CameraDemo(Tool):
 
         # poor-man's coordinate transform from telscope to camera frame (it's
         # better to use ctapipe.coordiantes when they are stable)
-        scale = tel.optics.effective_focal_length.to(geom.pix_x.unit).value
+        scale = tel.optics.equivalent_focal_length.to(geom.pix_x.unit).value
         fov = np.deg2rad(4.0)
         maxwid = np.deg2rad(0.01)
         maxlen = np.deg2rad(0.03)
 
         disp = CameraDisplay(geom, ax=ax, autoupdate=True,
                              title="{}, f={}".format(tel,
-                             tel.optics.effective_focal_length))
+                             tel.optics.equivalent_focal_length))
         disp.cmap = plt.cm.terrain
 
         def update(frame):

--- a/examples/camera_animation.py
+++ b/examples/camera_animation.py
@@ -23,12 +23,12 @@ if __name__ == '__main__':
 
     # load the camera
     tel = TelescopeDescription.from_name("SST-1M","DigiCam")
-    print(tel, tel.optics.effective_focal_length)
+    print(tel, tel.optics.equivalent_focal_length)
     geom = tel.camera
 
     # poor-man's coordinate transform from telscope to camera frame (it's
     # better to use ctapipe.coordiantes when they are stable)
-    scale = tel.optics.effective_focal_length.to(geom.pix_x.unit).value
+    scale = tel.optics.equivalent_focal_length.to(geom.pix_x.unit).value
     fov = np.deg2rad(4.0)
     maxwid = np.deg2rad(0.01)
     maxlen = np.deg2rad(0.03)

--- a/examples/notebooks/InstrumentDescription.ipynb
+++ b/examples/notebooks/InstrumentDescription.ipynb
@@ -167,7 +167,7 @@
       "text/html": [
        "&lt;Table length=4&gt;\n",
        "<table id=\"table9202131968\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>tel_type</th><th>tel_subtype</th><th>mirror_area</th><th>mirror_type</th><th>num_mirror_tiles</th><th>effective_focal_length</th></tr></thead>\n",
+       "<thead><tr><th>tel_type</th><th>tel_subtype</th><th>mirror_area</th><th>mirror_type</th><th>num_mirror_tiles</th><th>equivalent_focal_length</th></tr></thead>\n",
        "<thead><tr><th></th><th></th><th>m2</th><th></th><th></th><th>m</th></tr></thead>\n",
        "<thead><tr><th>str3</th><th>str5</th><th>float64</th><th>str2</th><th>int64</th><th>float64</th></tr></thead>\n",
        "<tr><td>MST</td><td>SCT</td><td>73.3475723267</td><td>SC</td><td>2</td><td>5.58629989624</td></tr>\n",
@@ -178,7 +178,7 @@
       ],
       "text/plain": [
        "<Table length=4>\n",
-       "tel_type tel_subtype  mirror_area  ... num_mirror_tiles effective_focal_length\n",
+       "tel_type tel_subtype  mirror_area  ... num_mirror_tiles equivalent_focal_length\n",
        "                           m2      ...                            m           \n",
        "  str3       str5       float64    ...      int64              float64        \n",
        "-------- ----------- ------------- ... ---------------- ----------------------\n",
@@ -356,7 +356,7 @@
     }
    ],
    "source": [
-    "tel.optics.effective_focal_length"
+    "tel.optics.equivalent_focal_length"
    ]
   },
   {

--- a/examples/obsolete/muon_reco.py
+++ b/examples/obsolete/muon_reco.py
@@ -169,7 +169,7 @@ if __name__ == '__main__':
 
             camera_coord = CameraFrame(x=x, y=y, z=np.zeros(x.shape) * u.m)
             optics = event.inst.subarray.tel[tel_id].optics
-            foclen = optics.effective_focal_length
+            foclen = optics.equivalent_focal_length
             frame = NominalFrame(array_direction=[container.mc.alt,
                                                   container.mc.az],
                                  pointing_direction=[container.mc.alt,


### PR DESCRIPTION
- changed `effective_focal_length` to `equivalent_focal_length`,  fixes #515 
- added `.info()` functions to `OpticsDescription` and `CameraGeometry` for convenience
- added a better test for camera pixel neighbors (testing all cameras)

This change implies also a change to the `optics.ecsv.txt` table in *ctapipe-extra*, which has been updated (though the old format where the column name is still "effective" is still readable, with a warning emitted)


