### PR TITLE
Cleanup: Some pep8, typos in docu, one duplicate test

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -61,7 +61,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         parent: Tool or Component
             Tool or component that is the Parent of this one
         kwargs: type
-            other paremeters
+            other parameters
 
         """
 

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -15,7 +15,7 @@ class AbstractConfigurableMeta(type(Configurable), ABCMeta):
 
 class Component(Configurable, metaclass=AbstractConfigurableMeta):
     """Base class of all Components (sometimes called
-    workers, makers, etc).  Components are are classes that do some sort
+    workers, makers, etc).  Components are classes that do some sort
     of processing and contain user-configurable parameters, which are
     implemented using `traitlets`.
 

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -180,7 +180,7 @@ class _ActivityProvenance:
         url: str
             filename or url of input file
         role: str
-            role name that this output satisfies
+            role name that this input satisfies
         """
         self._prov['input'].append(dict(url=url,role=role))
 

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -196,7 +196,7 @@ class _ActivityProvenance:
         role: str
             role name that this output satisfies
         """
-        self._prov['output'].append(dict(url=url,role=role))
+        self._prov['output'].append(dict(url=url, role=role))
 
     def register_config(self, config):
         """ add a dictionary of configuration parameters to this activity"""

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -147,7 +147,7 @@ class Provenance(metaclass=Singleton):
 class _ActivityProvenance:
     """
     Low-level helper class to collect provenance information for a given
-    *activity*.  Users should use `Provenance` as a top-level API, 
+    *activity*.  Users should use `Provenance` as a top-level API,
     not this class directly.
     """
 

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -182,7 +182,7 @@ class _ActivityProvenance:
         role: str
             role name that this input satisfies
         """
-        self._prov['input'].append(dict(url=url,role=role))
+        self._prov['input'].append(dict(url=url, role=role))
 
     def register_output(self, url, role=None):
         """

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -113,7 +113,7 @@ class Tool(Application):
             self.aliases['config'] = 'Tool.config_file'
 
         super().__init__(**kwargs)
-        self.log_format = ('%(levelname)8s [%(name)s] '                           
+        self.log_format = ('%(levelname)8s [%(name)s] '
                            '(%(module)s/%(funcName)s): %(message)s')
         self.log_level = 20  # default to INFO and above
         self.is_setup = False
@@ -153,7 +153,7 @@ class Tool(Application):
         ----------
 
         argv: list(str)
-            command-line arguments, or None to get them 
+            command-line arguments, or None to get them
             from sys.argv automatically
         """
         try:

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -115,7 +115,7 @@ class Tool(Application):
         super().__init__(**kwargs)
         self.log_format = ('%(levelname)8s [%(name)s] '
                            '(%(module)s/%(funcName)s): %(message)s')
-        self.log_level = 20  # default to INFO and above
+        self.log_level = logging.INFO
         self.is_setup = False
 
     def initialize(self, argv=None):

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -4,11 +4,11 @@ from abc import abstractmethod
 from traitlets import Unicode
 from traitlets.config import Application
 
-logging.basicConfig(level=logging.WARNING)
-
 from ctapipe import __version__ as version
 from .logging import ColoredFormatter
 from . import Provenance
+
+logging.basicConfig(level=logging.WARNING)
 
 
 class ToolConfigurationError(Exception):

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -182,7 +182,7 @@ class Tool(Application):
                                          status='interrupted')
         finally:
             for activity in Provenance().finished_activities:
-                output_str = ' '.join([x['url'] for x in  activity.output])
+                output_str = ' '.join([x['url'] for x in activity.output])
                 self.log.info("Output: %s", output_str)
 
             self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))

--- a/ctapipe/flow/flow.py
+++ b/ctapipe/flow/flow.py
@@ -73,14 +73,15 @@ class PipeStep():
     def __repr__(self):
         '''standard representation
         '''
-        return ('Name[ ' + str(self.name)
-                + '], next_steps_name[' + str(self.next_steps_name)
-                + '], port in[ ' + str(self.port_in)
-                + '], main connection name  [ ' + str(self.main_connection_name) + ' ]'
-                + '], port in[ ' + str(self.port_in)
-                + '], nb process[ ' + str(self.nb_process)
-                + '], level[ ' + str(self.level)
-                + '], queue_limit[ ' + str(self.queue_limit) + ']')
+        return (
+            'Name[{self.name}], '
+            'next_steps_name[{self.next_steps_name}], '
+            'port in[{self.port_in}], '
+            'main connection name  [{self.main_connection_name} ], '
+            'nb_process [{self.nb_process}], '
+            'level [{self.level}]'
+            'queue_limit [{self.queue_limit}]'
+        ).format(self=self)
 
 
 class FlowError(Exception):

--- a/ctapipe/flow/flow.py
+++ b/ctapipe/flow/flow.py
@@ -31,7 +31,7 @@ class PipeStep():
 
     '''
     PipeStep represents a Flow step. One or several processes can be attach
-    to this step.    
+    to this step.
     Parameters
     ----------
     name : str
@@ -269,11 +269,11 @@ class Flow(Tool):
         return True
 
     def configure_stagers(self, router_names):
-        """ Creates Processes with users's coroutines for all stages        
+        """ Creates Processes with users's coroutines for all stages
         Parameters
         ----------
         router_names: List
-            List to fill with routers name        
+            List to fill with routers name
         Returns
         -------
         True if every instantiation is correct
@@ -310,7 +310,7 @@ class Flow(Tool):
 
 
     def configure_consumer(self):
-        """ Creates consumer Processes with users's coroutines        
+        """ Creates consumer Processes with users's coroutines
         Returns
         -------
         True if every instantiation is correct
@@ -329,7 +329,7 @@ class Flow(Tool):
 
     def add_consumer_to_router(self):
         """ Create router_names dictionary and
-        Add consumer router ports        
+        Add consumer router ports
         Returns
         -------
         The new router_names dictionary
@@ -344,7 +344,7 @@ class Flow(Tool):
         return router_names
 
     def configure_producer(self):
-        """ Creates producer Process with users's coroutines        
+        """ Creates producer Process with users's coroutines
         Returns
         -------
         True if every instatiation is correct
@@ -365,7 +365,7 @@ class Flow(Tool):
         return True
 
     def connect_gui(self):
-        """ Connect ZMQ socket to send information to GUI        
+        """ Connect ZMQ socket to send information to GUI
         Returns
         -------
         True if everything correct
@@ -402,7 +402,7 @@ class Flow(Tool):
 
     def configure_ports(self):
         """
-        Configures producer, stagers and consumer ZMQ ports        
+        Configures producer, stagers and consumer ZMQ ports
         Returns
         -------
         True if everything correct
@@ -444,11 +444,11 @@ class Flow(Tool):
 
     def get_step_by_name(self, name):
         ''' Find a PipeStep in self.producer_step or  self.stager_steps or
-        self.consumer_step        
+        self.consumer_step
         Parameters
         ----------
         name : str
-            step name            
+            step name
         Returns
         -------
         PipeStep if found, otherwise None
@@ -461,7 +461,7 @@ class Flow(Tool):
     def instantiation(self, name, stage_type, process_name=None, port_in=None,
                       connections=None, main_connection_name=None, config=None):
         '''
-        Instantiate on Python object from name found in configuration        
+        Instantiate on Python object from name found in configuration
         Parameters
         ----------
         name : str
@@ -504,13 +504,13 @@ class Flow(Tool):
 
     def get_pipe_steps(self, role):
         '''
-        Create a list of Flow based framework steps from configuration and 
-        filter by role        
+        Create a list of Flow based framework steps from configuration and
+        filter by role
         Parameters
         ----------
         role: str
                 filter with role for step to be add in result list
-                Accepted values: self.PRODUCER - self.STAGER  - self.CONSUMER                
+                Accepted values: self.PRODUCER - self.STAGER  - self.CONSUMER
         Returns
         -------
         PRODUCER,CONSUMER: a step name filter by specific role (PRODUCER,CONSUMER)
@@ -557,7 +557,7 @@ class Flow(Tool):
             return None
 
     def def_step_for_gui(self):
-        ''' 
+        '''
         Create a list (levels_for_gui) containing all steps
 
         Returns
@@ -586,7 +586,7 @@ class Flow(Tool):
                 for process in step.process:
                     nb_job_done += process.nb_job_done
                     running += process.running
-                levels_for_gui.append(StagerRep(process.name, step.next_steps_name, 
+                levels_for_gui.append(StagerRep(process.name, step.next_steps_name,
                                       nb_job_done=nb_job_done,
                                       running=running,
                                       nb_process=len(step.process)))
@@ -680,12 +680,12 @@ class Flow(Tool):
 
     def run_generator(self, destination, msg):
         """ Get step for destination. Create a genetor from its run method.
-        re-enter in run_generator until Generator send values        
+        re-enter in run_generator until Generator send values
         Parameters
         ----------
         destination: str
             Next step name
-        msg: a Pickle dumped msg        
+        msg: a Pickle dumped msg
         Returns
         -------
         Next destination and msg
@@ -769,7 +769,7 @@ class Flow(Tool):
 
     def wait_all_stagers(self, mintime):
         """ Verify id all steps (stage + consumers) are finished their
-        jobs and waiting        
+        jobs and waiting
         Returns
         -------
         True if all stages queue are empty and all Processes
@@ -789,9 +789,9 @@ class Flow(Tool):
 
     def wait_and_send_levels(self, processes_to_wait):
         '''
-        Wait for a process to join and regularly send Flow based framework 
+        Wait for a process to join and regularly send Flow based framework
         state to GUI
-        in case of a GUI will connect later        
+        in case of a GUI will connect later
         Parameters
         ----------
         processes_to_wait : process
@@ -811,7 +811,7 @@ class Flow(Tool):
     def get_step_conf(self, name):
         '''
         Search step by its name in self.stage_conf list,
-        self.producer_conf and self.consumer_conf        
+        self.producer_conf and self.consumer_conf
         Parameters
         ----------
         name : str
@@ -832,11 +832,11 @@ class Flow(Tool):
 
     def get_stager_indice(self, name):
         '''
-        Search step by its name in self.stage_conf list        
+        Search step by its name in self.stage_conf list
         Parameters
         ----------
         name : str
-                stage name                
+                stage name
         Returns
         -------
         indice in list, -1 if not found

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -8,18 +8,22 @@ import pytest
 
 cam_ids = CameraGeometry.get_known_camera_names()
 
-def test_load_by_name():
 
+def test_known_cameras():
+    cams = CameraGeometry.get_known_camera_names()
+    assert len(cams) > 3
+    assert 'FlashCam' in cams
+
+
+def test_load_by_name():
     cams = CameraGeometry.get_known_camera_names()
     assert len(cams) > 4
     assert 'FlashCam' in cams
     assert 'NectarCam' in cams
-    
 
     for cam in cams:
         geom = CameraGeometry.from_name(cam)
         geom.info()
-
 
 
 def test_make_rectangular_camera_geometry():
@@ -102,10 +106,6 @@ def test_write_read(tmpdir):
     assert (geom.pix_area == geom2.pix_area).all()
     assert geom.pix_type == geom2.pix_type
 
-def test_known_cameras():
-    cams = CameraGeometry.get_known_camera_names()
-    assert 'FlashCam' in cams
-    assert len(cams) > 3
 
 
 def test_precal_neighbors():

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -32,7 +32,7 @@ def test_load_hess_camera():
 def test_guess_camera():
     px = np.linspace(-10, 10, 11328) * u.m
     py = np.linspace(-10, 10, 11328) * u.m
-    geom = CameraGeometry.guess(px, py,0 * u.m)
+    geom = CameraGeometry.guess(px, py, 0 * u.m)
     assert geom.pix_type.startswith('rect')
 
 

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -72,7 +72,6 @@ def test_neighbor_pixels(cam_id):
     assert n_neighbors.count(1) == 0  # no pixel should have a single neighbor
 
 
-
 def test_to_and_from_table():
     geom = CameraGeometry.from_name("LSTCam")
     tab = geom.to_table()

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -105,10 +105,12 @@ def test_precal_neighbors():
                           pix_x=np.arange(3)*u.deg,
                           pix_y=np.arange(3)*u.deg,
                           pix_area=np.ones(3)*u.deg**2,
-                          neighbors=[[1,],[0,2],[1,]],
+                          neighbors=[
+                            [1, ], [0, 2], [1, ]
+                          ],
                           pix_type='rectangular',
                           pix_rotation="0deg",
-                          cam_rotation="0deg" )
+                          cam_rotation="0deg")
 
     neigh = geom.neighbors
     assert len(neigh) == len(geom.pix_x)

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -3,7 +3,6 @@ from astropy import units as u
 from ctapipe.instrument import CameraGeometry
 from ctapipe.instrument.camera import _find_neighbor_pixels, \
     _get_min_pixel_seperation
-from numpy import median
 import pytest
 
 cam_ids = CameraGeometry.get_known_camera_names()

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -99,7 +99,6 @@ def test_write_read(tmpdir):
     assert geom.pix_type == geom2.pix_type
 
 
-
 def test_precal_neighbors():
     geom = CameraGeometry(cam_id="TestCam",
                           pix_id=np.arange(3),
@@ -116,7 +115,6 @@ def test_precal_neighbors():
 
     nmat = geom.neighbor_matrix
     assert nmat.shape == (len(geom.pix_x), len(geom.pix_x))
-
 
 
 def test_slicing():

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -128,7 +128,7 @@ def test_slicing():
     assert len(sliced1.pix_area) == 100
     assert len(sliced1.pix_id) == 100
 
-    sliced2 = geom[[5,7,8,9,10]]
+    sliced2 = geom[[5, 7, 8, 9, 10]]
     assert sliced2.pix_id[0] == 5
     assert sliced2.pix_id[1] == 7
     assert len(sliced2.pix_x) == 5

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -9,13 +9,7 @@ import pytest
 cam_ids = CameraGeometry.get_known_camera_names()
 
 
-def test_known_cameras():
-    cams = CameraGeometry.get_known_camera_names()
-    assert len(cams) > 3
-    assert 'FlashCam' in cams
-
-
-def test_load_by_name():
+def test_known_camera_names():
     cams = CameraGeometry.get_known_camera_names()
     assert len(cams) > 4
     assert 'FlashCam' in cams

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -1,6 +1,7 @@
-from ctapipe.instrument.optics import  OpticsDescription
+from ctapipe.instrument.optics import OpticsDescription
 from astropy import units as u
 import pytest
+
 
 def test_guess_optics():
 
@@ -12,6 +13,4 @@ def test_guess_optics():
     assert od.mirror_type == 'DC'
 
     with pytest.raises(KeyError):
-        od2 = OpticsDescription.guess(0*u.m)
-
-
+        OpticsDescription.guess(0*u.m)

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -1,6 +1,10 @@
-from ctapipe.instrument import SubarrayDescription, TelescopeDescription, CameraGeometry
+from ctapipe.instrument import (
+    SubarrayDescription,
+    TelescopeDescription,
+)
 import numpy as np
 from astropy import units as u
+
 
 def test_subarray_description():
 
@@ -15,8 +19,6 @@ def test_subarray_description():
         tel[ii] = TelescopeDescription.guess(pix_x, pix_y, foclen)
         pos[ii] = (np.random.uniform(200, size=2)-100) * u.m
 
-
-
     sub = SubarrayDescription("test array",
                               tel_positions=pos,
                               tel_descriptions=tel)
@@ -27,6 +29,6 @@ def test_subarray_description():
     assert sub.tel[0].camera is not None
     assert len(sub.to_table()) == 10
 
-    subsub = sub.select_subarray("newsub", [1,2,3,4])
+    subsub = sub.select_subarray("newsub", [1, 2, 3, 4])
     assert subsub.num_tels == 4
-    assert set(subsub.tels.keys()) == {1,2,3,4}
+    assert set(subsub.tels.keys()) == {1, 2, 3, 4}

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -15,9 +15,8 @@ def test_subarray_description():
     pix_y = np.arange(1764, dtype=np.float) * u.m
 
     for ii in range(10):
-
         tel[ii] = TelescopeDescription.guess(pix_x, pix_y, foclen)
-        pos[ii] = (np.random.uniform(200, size=2)-100) * u.m
+        pos[ii] = np.random.uniform(-100, 100, size=2) * u.m
 
     sub = SubarrayDescription("test array",
                               tel_positions=pos,

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -2,6 +2,7 @@ from ctapipe.instrument import TelescopeDescription
 from astropy import units as u
 import numpy as np
 
+
 def test_telescope_description():
 
     # setup a dummy telescope that look like an MST with FlashCam


### PR DESCRIPTION
I am just starting in CTA and was reading the code of ctapipe on the weekend in order to learn what it does. 

I stumbled over a few minor style issues, typos in doc-strings and found one duplicate unit test.
I'm used to fix these while I read code (I call this "active reading") and I wondered if you might like to merge these modifications upstream. I was happy to read, you're following PEP8 here:
https://cta-observatory.github.io/ctapipe/development/style-guide.html#coding-style

But I must admit, there might be different interpretations sometimes and I hope, I did not accidentally misinterpret something, for example: `flake8` does not complain about "trailing spaces" while `pylint` does.

I many cases I removed trailing spaces, and I hope it did not step on anyones toes doing this.

----

I know reviewing PRs, which modify many files in many places is annoying, so I immediately opened the PR when I was back in the office, to keep it as small as possible.

The test are of course still pass, though there is one test less, since I removed one duplicate test.