### PR TITLE
Use fully qualified name for logger if no parent was given

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -71,4 +71,6 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         if self.parent:
             self.log = self.parent.log.getChild(self.__class__.__name__)
         else:
-            self.log = getLogger(self.__class__.__name__)
+            self.log = getLogger(
+                self.__class__.__module__ + '.' + self.__class__.__name__
+            )


### PR DESCRIPTION
Before, the logger was not a child of ctapipe, it was just the components name.