### PR TITLE
Restore masked array support for hillas

### DIFF
--- a/ctapipe/image/hillas.py
+++ b/ctapipe/image/hillas.py
@@ -548,7 +548,8 @@ def hillas_parameters_4(geom: CameraGeometry, image, container=False):
         raise HillasParameterizationError("no signal to parametrize")
 
     M = geom.pixel_moment_matrix
-    moms = (M @ image)/sumsig
+    # Use a dot matrix approach that still supports masked arrays (@ does not)
+    moms = np.ma.dot(M, image)/sumsig
 
     (xm, ym , x2m, xym, y2m, x3m, x2ym, xy2m, y3m, x4m, x3ym, x2y2m, xy3m,
      y4m) = moms


### PR DESCRIPTION
In a previous commit the hillas parameters were changed to use the “@“ operator to perform dot matrix multiplication.
This does not seem to handle masked arrays correctly, completely ignoring the mask.
Instead I suggest to use the np.ma.dot method, which is applicable to both default numpy arrays and masked arrays.