### PR TITLE
add CutFlow to utils imports (for docs and convenience)

### DIFF
--- a/ctapipe/utils/__init__.py
+++ b/ctapipe/utils/__init__.py
@@ -5,3 +5,4 @@ from .dynamic_class import dynamic_class_from_module
 from .table_interpolator import TableInterpolator
 from .datasets import (find_all_matching_datasets, get_table_dataset, get_dataset,
                        find_in_path)
+from .CutFlow import CutFlow, PureCountingCut, UndefinedCut


### PR DESCRIPTION
make `utils.CutFlow` and related classes appear in the docs, and usable from the `utils` module directly