### PR TITLE
better error handling for OpticsDescription

### DIFF
--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -5,6 +5,7 @@ Classes and functions related to telescope Optics
 import logging
 from ..utils import get_table_dataset
 import numpy as np
+import astropy.units as u
 
 logger = logging.getLogger(__name__)
 
@@ -43,14 +44,23 @@ class OpticsDescription:
     equivalent_focal_length: Quantity(float)
         effective focal-length of telescope, independent of which type of
         optics (as in the Monte-Carlo)
+
+    Raises
+    ------
+    ValueError:
+        if tel_type or mirror_type are not one of the accepted values
     """
 
+    @u.quantity_input
     def __init__(self, mirror_type, tel_type,
-                 tel_subtype, equivalent_focal_length,
-                 mirror_area=None, num_mirror_tiles=None):
+                 tel_subtype, equivalent_focal_length : u.m,
+                 mirror_area : u.m**2=None, num_mirror_tiles=None):
 
         if tel_type not in ['LST', 'MST', 'SST']:
             raise ValueError("Unknown tel_type %s", tel_type)
+
+        if mirror_type not in ['SC', 'DC']:
+            raise ValueError("Unknown mirror_type: %s", mirror_type)
 
         self.mirror_type = mirror_type
         self.tel_type = tel_type
@@ -60,7 +70,8 @@ class OpticsDescription:
         self.num_mirror_tiles = num_mirror_tiles
 
     @classmethod
-    def guess(cls, equivalent_focal_length):
+    @u.quantity_input
+    def guess(cls, equivalent_focal_length : u.m):
         """
         Construct an OpticsDescription by guessing from metadata (e.g. when
         using a simulation where the exact type is not known)
@@ -70,15 +81,14 @@ class OpticsDescription:
         equivalent_focal_length: Quantity('m')
             effective optical focal-length in meters
 
+        Raises
+        ------
+        KeyError:
+            on unknown focal length
         """
 
         tel_type, tel_subtype, mir_type = \
             telescope_info_from_metadata(equivalent_focal_length)
-
-        if tel_type == "unknown":
-            logger.warning(("No OpticsDescription found for focal-length "
-                            "%s, setting to 'unknown'"),
-                           equivalent_focal_length)
 
         return cls(mirror_type=mir_type,
                    tel_type=tel_type,

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -44,11 +44,17 @@ class OpticsDescription:
     equivalent_focal_length: Quantity(float)
         effective focal-length of telescope, independent of which type of
         optics (as in the Monte-Carlo)
+    mirror_area: u.Quantity('m')
+        total reflective surface area of the optical system
+    num_mirror_tiles: int
+        number of mirror facets
 
     Raises
     ------
     ValueError:
         if tel_type or mirror_type are not one of the accepted values
+    TypeError, astropy.units.UnitsError:
+        if the units of one of the inputs are missing or incompatible
     """
 
     @u.quantity_input

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -8,6 +8,16 @@ import pytest
 cam_ids = CameraGeometry.get_known_camera_names()
 
 
+def test_construct():
+    x = np.linspace(-10, 10, 100)
+    y = np.linspace(-10, 10, 100)
+    geom = CameraGeometry(cam_id=0, pix_id=np.arange(100),
+                          pix_x=x*u.m, pix_y=y*u.m ,
+                          pix_area=x*u.m**2,
+                          pix_type='rectangular',
+                          pix_rotation = "10d",
+                          cam_rotation = "12d")
+
 def test_known_camera_names():
     cams = CameraGeometry.get_known_camera_names()
     assert len(cams) > 4

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -13,4 +13,25 @@ def test_guess_optics():
     assert od.mirror_type == 'DC'
 
     with pytest.raises(KeyError):
-        OpticsDescription.guess(0*u.m)
+        OpticsDescription.guess(0*u.m) # unknown tel
+
+
+def test_construct_optics():
+
+    with pytest.raises(ValueError):
+        od = OpticsDescription(mirror_type="DC",
+                               tel_type="bad",  # bad value
+                               tel_subtype="1M",
+                               equivalent_focal_length=10*u.m)
+
+    with pytest.raises(ValueError):
+        od = OpticsDescription(mirror_type="bad", # bad value
+                               tel_type="MST",
+                               tel_subtype="1M",
+                               equivalent_focal_length=10*u.m)
+
+    with pytest.raises(u.UnitsError):
+        od = OpticsDescription.guess(28.0 * u.kg)  # bad unit
+
+    with pytest.raises(TypeError):
+        od = OpticsDescription.guess(28.0)  # not a unit quantity


### PR DESCRIPTION
- guess() now consistently throws either a KeyError (telescope wasn't found) or a ValueError (bad input), no longer "works" on bad key
- added more tests
- fixes #605 