### PR TITLE
Updates to EventFileReader

### DIFF
--- a/ctapipe/core/factory.py
+++ b/ctapipe/core/factory.py
@@ -23,9 +23,13 @@ class Factory(Component):
     You must also return the factory name in get_factory_name(), and the
     discriminator in get_product_name() in your custom Factory class.
 
-    To then obtain the product class from the factory, use 'get_class()",
-    which can be used to then initialise the class. The correct traits
-    from the correspoding product are set automatically from the factory.
+    To then obtain the product class from the factory, use 'produce()".
+    The correct traits from the correspoding product are set automatically
+    from the factory.
+
+    To a factory from within a `ctapipe.core.tool.Tool`:
+
+    >>> cls = FactoryChild.produce(config=self.config, tool=self)
 
     .. code:: python
 
@@ -142,4 +146,33 @@ class Factory(Component):
         for key in keys:
             if key not in product.class_trait_names():
                 del c[product.__name__][key]
+        return product
+
+    @classmethod
+    def produce(cls, config, tool, **kwargs):
+        """
+        Produce an instance of the product class
+
+        Parameters
+        ----------
+        config : traitlets.loader.Config
+            Configuration specified by config file or cmdline arguments.
+            Used to set traitlet values.
+            Set to None if no configuration to pass.
+        tool : ctapipe.core.Tool
+            Tool executable that is calling this component.
+            Passes the correct logger to the component.
+            Set to None if no Tool to pass.
+        kwargs
+
+        Returns
+        -------
+        product
+            Instance of the product class that is the purpose of the factory
+            to produce.
+
+        """
+        factory = cls(config=config, tool=tool, **kwargs)
+        class_instance = factory.get_class()
+        product = class_instance(config=config, tool=tool, **kwargs)
         return product

--- a/ctapipe/core/tests/test_factory.py
+++ b/ctapipe/core/tests/test_factory.py
@@ -43,3 +43,11 @@ def test_factory():
     obj = cls(config=factory.config, parent=None)
     assert(obj.__class__.__name__ == 'ExampleComponent2')
     assert(obj.value == 111)
+
+
+def test_factory_produce():
+    obj = ExampleFactory.produce(config=None, tool=None,
+                                 discriminator='ExampleComponent2',
+                                 value=111)
+    assert (obj.__class__.__name__ == 'ExampleComponent2')
+    assert (obj.value == 111)

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -100,6 +100,9 @@ class R0Container(Container):
     Storage of a Merged Raw Data Event
     """
 
+    run_id = Field(-1, "run id number")
+    event_id = Field(-1, "event id number")
+    tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(R0CameraContainer), "map of tel_id to R0CameraContainer")
 
 
@@ -118,6 +121,9 @@ class R1Container(Container):
     Storage of a r1 calibrated Data Event
     """
 
+    run_id = Field(-1, "run id number")
+    event_id = Field(-1, "event id number")
+    tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(R1CameraContainer), "map of tel_id to R1CameraContainer")
 
 
@@ -137,6 +143,9 @@ class DL0Container(Container):
     Storage of a data volume reduced Event
     """
 
+    run_id = Field(-1, "run id number")
+    event_id = Field(-1, "event id number")
+    tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(DL0CameraContainer), "map of tel_id to DL0CameraContainer")
 
 
@@ -315,11 +324,6 @@ class TelescopePointingContainer(Container):
 class DataContainer(Container):
     """ Top-level container for all event information """
 
-    index = Field(0, "number of events processed")
-    event_id = Field(-1, "event id number")
-    run_id = Field(-1, "run id number")
-    tels_with_data = Field([], "list of telescopes with data")
-
     r0 = Field(R0Container(), "Raw Data")
     r1 = Field(R1Container(), "R1 Calibrated Data")
     dl0 = Field(DL0Container(), "DL0 Data Volume Reduced Data")
@@ -328,6 +332,7 @@ class DataContainer(Container):
     mc = Field(MCEventContainer(), "Monte-Carlo data")
     mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
     trig = Field(CentralTriggerContainer(), "central trigger information")
+    count = Field(0, "number of events processed")
     inst = Field(InstrumentContainer(), "instrumental information (deprecated")
     pointing = Field(Map(TelescopePointingContainer), 'Telescope pointing positions')
 

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -100,9 +100,6 @@ class R0Container(Container):
     Storage of a Merged Raw Data Event
     """
 
-    run_id = Field(-1, "run id number")
-    event_id = Field(-1, "event id number")
-    tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(R0CameraContainer), "map of tel_id to R0CameraContainer")
 
 
@@ -121,9 +118,6 @@ class R1Container(Container):
     Storage of a r1 calibrated Data Event
     """
 
-    run_id = Field(-1, "run id number")
-    event_id = Field(-1, "event id number")
-    tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(R1CameraContainer), "map of tel_id to R1CameraContainer")
 
 
@@ -143,9 +137,6 @@ class DL0Container(Container):
     Storage of a data volume reduced Event
     """
 
-    run_id = Field(-1, "run id number")
-    event_id = Field(-1, "event id number")
-    tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(DL0CameraContainer), "map of tel_id to DL0CameraContainer")
 
 
@@ -324,6 +315,11 @@ class TelescopePointingContainer(Container):
 class DataContainer(Container):
     """ Top-level container for all event information """
 
+    index = Field(0, "number of events processed")
+    event_id = Field(-1, "event id number")
+    run_id = Field(-1, "run id number")
+    tels_with_data = Field([], "list of telescopes with data")
+
     r0 = Field(R0Container(), "Raw Data")
     r1 = Field(R1Container(), "R1 Calibrated Data")
     dl0 = Field(DL0Container(), "DL0 Data Volume Reduced Data")
@@ -332,7 +328,6 @@ class DataContainer(Container):
     mc = Field(MCEventContainer(), "Monte-Carlo data")
     mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
     trig = Field(CentralTriggerContainer(), "central trigger information")
-    count = Field(0, "number of events processed")
     inst = Field(InstrumentContainer(), "instrumental information (deprecated")
     pointing = Field(Map(TelescopePointingContainer), 'Telescope pointing positions')
 

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -32,7 +32,7 @@ class EventFileReader(Component):
     to read.
 
     To create an instance of an EventFileReader you must pass the traitlet
-    configuration (containing the input_path) and the
+    configuration (containing the input_url) and the
     `ctapipe.core.tool.Tool`. Therefore from inside a Tool you would do:
 
     >>> reader = EventFileReader(self.config, self)
@@ -42,13 +42,13 @@ class EventFileReader(Component):
     ctapipe/examples/calibration_pipeline.py.
 
     However if you are not inside a Tool, you can still create an instance and
-    supply an input_path via:
+    supply an input_url via:
 
-    >>> reader = EventFileReader(None, None, input_path="/path/to/file")
+    >>> reader = EventFileReader(None, None, input_url="/path/to/file")
 
     To loop through the events in a file:
 
-    >>> reader = EventFileReader(None, None, input_path="/path/to/file")
+    >>> reader = EventFileReader(None, None, input_url="/path/to/file")
     >>> for event in reader:
     >>>    print(event.count)
 
@@ -58,13 +58,13 @@ class EventFileReader(Component):
     Alternatively one can use EventFileReader in a `with` statement to ensure
     the correct cleanups are performed when you are finished with the reader:
 
-    >>> with EventFileReader(None, None, input_path="/path/to/file") as reader:
+    >>> with EventFileReader(None, None, input_url="/path/to/file") as reader:
     >>>    for event in reader:
     >>>       print(event.count)
 
     Attributes
     ----------
-    input_path : str
+    input_url : str
         Path to the input event file.
     max_events : int
         Maximum number of events to loop through in generator
@@ -76,7 +76,7 @@ class EventFileReader(Component):
         * Observation ID
     """
 
-    input_path = Unicode(
+    input_url = Unicode(
         '',
         help='Path to the input file containing events.'
     ).tag(config=True)
@@ -108,15 +108,15 @@ class EventFileReader(Component):
 
         self.metadata = dict(is_simulation=False)
 
-        if not exists(self.input_path):
+        if not exists(self.input_url):
             raise FileNotFoundError("file path does not exist: '{}'"
-                                    .format(self.input_path))
-        self.log.info("INPUT PATH = {}".format(self.input_path))
+                                    .format(self.input_url))
+        self.log.info("INPUT PATH = {}".format(self.input_url))
 
         if self.max_events:
             self.log.info("Max events being read = {}".format(self.max_events))
 
-        Provenance().add_input_file(self.input_path, role='dl0.sub.evt')
+        Provenance().add_input_file(self.input_url, role='dl0.sub.evt')
 
     @staticmethod
     @abstractmethod
@@ -241,7 +241,7 @@ class EventFileReaderFactory(Factory):
 
     # Product classes traits
     # Would be nice to have these automatically set...!
-    input_path = Unicode(
+    input_url = Unicode(
         get_dataset('gamma_test.simtel.gz'),
         help='Path to the input file containing events.'
     ).tag(config=True)
@@ -258,14 +258,14 @@ class EventFileReaderFactory(Factory):
         if self.reader is not None:
             return self.reader
         else:
-            if self.input_path is None:
-                raise ValueError("Please specify an input_path for event file")
+            if self.input_url is None:
+                raise ValueError("Please specify an input_url for event file")
             try:
                 for subclass in self.subclasses:
-                    if subclass.is_compatible(self.input_path):
+                    if subclass.is_compatible(self.input_url):
                         return subclass.__name__
                 raise ValueError
             except ValueError:
                 self.log.exception("Cannot find compatible EventFileReader "
-                                   "for: {}".format(self.input_path))
+                                   "for: {}".format(self.input_url))
                 raise

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -73,6 +73,7 @@ class EventFileReader(Component):
 
         self.source = self._generator()
         self.current_event = None
+        self.getevent_warn = True
 
     @staticmethod
     @abstractmethod
@@ -217,6 +218,9 @@ class EventFileReader(Component):
             The event container filled with the requested event's information
 
         """
+        if self.getevent_warn:
+            self.log.warning("Seeking to event... (long process)")
+            self.getevent_warn = False
         if not use_event_id:
             msg = "Event index {} not found in file".format(ev)
             for event in self.source:
@@ -235,7 +239,7 @@ class EventFileReader(Component):
         # Only need to calculate once
         if not self._num_events:
             self.reset()
-            self.log.info("Obtaining number of events in file...")
+            self.log.warning("Obtaining length of file... (long process)")
             count = 0
             for _ in self:
                 if self.max_events and count >= self.max_events:

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -2,36 +2,32 @@
 Handles reading of different event/waveform containing files
 """
 from abc import abstractmethod
-from os.path import basename, splitext, dirname, join, exists
-import numpy as np
-from traitlets import Unicode, Int, CaselessStrEnum, observe
+from os.path import exists
+from traitlets import Unicode, Int, CaselessStrEnum
 from copy import deepcopy
 from ctapipe.core import Component, Factory
 from ctapipe.utils import get_dataset
-from ctapipe.io.hessio import hessio_event_source, hessio_get_list_event_ids
 
 
 class EventFileReader(Component):
     """
-    Parent class for EventFileReaders of different sources. A new
-    EventFileReader should be created for each type of event file read into
-    ctapipe, e.g. simtelarray files are read by the `HessioFileReader`.
+    Parent class for EventFileReaders of different sources.
+
+    A new EventFileReader should be created for each type of event file read
+    into ctapipe, e.g. sim_telarray files are read by the `HessioFileReader`.
+
+    EventFileReader provides a common high-level interface for accessing data
+    from different data sources. Creating an EventFileReader for a new data
+    source ensures that data can be accessed in a common way, irregardless of
+    the data source.
 
     Attributes
     ----------
     input_path : str
-    directory : str
-        Automatically set from `input_path`.
-    filename : str
-        Name of the file without the extension.
-        Automatically set from `input_path`.
-    extension : str
-        Automatically set from `input_path`.
-    output_directory : str
-        Directory to save outputs for this file
-
+        Path to the input event file.
+    max_events : int
+        Maximum number of events to loop through in generator
     """
-    origin = None
 
     input_path = Unicode(get_dataset('gamma_test.simtel.gz'), allow_none=True,
                          help='Path to the input file containing '
@@ -60,76 +56,21 @@ class EventFileReader(Component):
         """
         super().__init__(config=config, parent=tool, **kwargs)
 
-        if self.origin is None:
-            raise ValueError("Subclass of EventFileReader should specify "
-                             "an origin")
-
         self._num_events = None
-        self._event_id_list = []
 
         if self.input_path is None:
             raise ValueError("Please specify an input_path for event file")
-        self._init_path(self.input_path)
-
-    def _init_path(self, input_path):
-        if not exists(input_path):
+        if not exists(self.input_path):
             raise FileNotFoundError("file path does not exist: '{}'"
-                                    .format(input_path))
+                                    .format(self.input_path))
+        self.log.info("INPUT PATH = {}".format(self.input_path))
 
-        self.input_path = input_path
-        self.directory = dirname(input_path)
-        self.filename = splitext(basename(input_path))[0]
-        self.extension = splitext(input_path)[1]
-        self.output_directory = join(self.directory, self.filename)
-
-        if self.log:
-            self.log.info("INPUT PATH = {}".format(self.input_path))
-
-    @observe('input_path')
-    def on_input_path_changed(self, change):
-        new = change['new']
-        try:
-            self.log.warning("Change: input_path={}".format(new))
-            self._num_events = None
-            self._event_id_list = []
-            self._init_path(new)
-        except AttributeError:
-            pass
-
-    @observe('origin')
-    def on_origin_changed(self, change):
-        new = change['new']
-        try:
-            self.log.warning("Change: origin={}".format(new))
-        except AttributeError:
-            pass
-
-    @observe('max_events')
-    def on_max_events_changed(self, change):
-        new = change['new']
-        try:
-            self.log.warning("Change: max_events={}".format(new))
-            self._num_events = None
-            self._event_id_list = []
-        except AttributeError:
-            pass
-
-    @property
-    @abstractmethod
-    def origin(self):
-        """
-        Abstract property to be defined in child class.
-
-        Get the name for the origin of the file. E.g. 'hessio'.
-
-        Returns
-        -------
-        origin : str
-        """
+        if self.max_events:
+            self.log.info("Max events being read = {}".format(self.max_events))
 
     @staticmethod
     @abstractmethod
-    def check_file_compatibility(file_path):
+    def is_compatible(file_path):
         """
         Abstract method to be defined in child class.
 
@@ -149,214 +90,107 @@ class EventFileReader(Component):
 
     @property
     @abstractmethod
-    def num_events(self):
+    def camera(self):
         """
-        Abstract property to be defined in child class.
+        Name of the camera contained in the file. Read from the file or
+        inferred from the EventFileReader class if the data format is only
+        used by one camera.
 
-        Obtain the number of events from the file, store it inside
-        self._num_events, and return the value.
+        This property is used to choose the correct algorithms to process the
+        waveforms, as some cameras require different algorithms to others
+        (such as with R1 calibration and charge extraction).
 
         Returns
         -------
-        self._num_events : int
+        camera_name : str
         """
 
-    @property
-    @abstractmethod
-    def event_id_list(self):
-        """
-        Abstract property to be defined in child class.
-
-        Obtain the number of events from the file, store it as
-        self._event_id_list, and return the value.
-
-        Returns
-        -------
-        self._event_id_list : list[self._num_events]
-        """
+    def __iter__(self):
+        return self
 
     @abstractmethod
-    def read(self, allowed_tels=None, requested_event=None,
-             use_event_id=False):
+    def __next__(self):
         """
         Abstract method to be defined in child class.
 
-        Read the file using the processes required by the readers file-type.
-
-        Parameters
-        ----------
-        allowed_tels : list[int]
-            select only a subset of telescope, if None, all are read. This can
-            be used for example emulate the final CTA data format, where there
-            would be 1 telescope per file (whereas in current monte-carlo,
-            they are all interleaved into one file)
-        requested_event : int
-            Seek to a paricular event index
-        use_event_id : bool
-            If True ,'requested_event' now seeks for a particular event id
-            instead of index
+        Method where the filling of the `ctapipe.io.containers` occurs.
 
         Returns
         -------
-        source : generator
-            A generator that can be iterated over to obtain events
+        data : ctapipe.io.container
+            The event container filled with the event information
         """
 
-    def get_event(self, requested_event, use_event_id=False):
+    def __getitem__(self, item):
         """
-        Loop through events until the requested event is found
+        Obtain a particular event
 
         Parameters
         ----------
-        requested_event : int
-            Seek to a paricular event index
-        use_event_id : bool
-            If True ,'requested_event' now seeks for a particular event id
-            instead of index
+        item : int or str
+            If `item` is an int, then this is the event_index for the event
+            obtained. If `item` is a str, then this is the event_id for the
+            event obtained.
 
         Returns
         -------
-        event : `ctapipe` event-container
+        data : ctapipe.io.container
+            The event container filled with the requested event's information
 
         """
-        source = self.read(requested_event=requested_event,
-                           use_event_id=use_event_id)
-        event = next(source)
-        return deepcopy(event)
+        use_event_id = False
+        msg = "Event index {} not found in reader".format(item)
+        if isinstance(item, str):
+            item = int(item)
+            use_event_id = True
+            msg = "Event id {} not found in reader".format(item)
 
-    def find_max_true_npe(self, telescopes=None):
-        """
-        Loop through events to find the maximum true npe
-
-        Parameters
-        ----------
-        telescopes : list
-            List of telecopes to include. If None, then all telescopes
-            are included.
-
-        Returns
-        -------
-        max_pe : int
-
-        """
-        # TODO: Find an alternate method so this can be removed
-        self.log.info("Finding maximum true npe inside file...")
-        source = self.read()
-        max_pe = 0
-        for event in source:
-            tels = list(event.dl0.tels_with_data)
-            if telescopes is not None:
-                tels = []
-                for tel in telescopes:
-                    if tel in event.dl0.tels_with_data:
-                        tels.append(tel)
-            if event.count == 0:
-                # Check events have true charge included
-                try:
-                    if np.all(event.mc.tel[tels[0]].photo_electron_image == 0):
-                        raise KeyError
-                except KeyError:
-                    self.log.exception('[chargeres] Source does not contain '
-                                       'true charge')
-                    raise
-            for telid in tels:
-                pe = event.mc.tel[telid].photo_electron_image
-                this_max = np.max(pe)
-                if this_max > max_pe:
-                    max_pe = this_max
-        self.log.info("Maximum true npe inside file = {}".format(max_pe))
-
-        return max_pe
-
-
-class HessioFileReader(EventFileReader):
-    origin = 'hessio'
-
-    @staticmethod
-    def check_file_compatibility(file_path):
-        compatible = True
-        # TODO: Change check to be a try of hessio_event_source?
-        if not file_path.endswith('.gz'):
-            compatible = False
-        return compatible
-
-    @property
-    def num_events(self):
-        self.log.info("Obtaining number of events in file...")
-        if self._num_events:
-            pass
+        if not use_event_id and self.max_events and item >= self.max_events:
+            msg = "Event index {} outside of specified max_events {}"\
+                .format(item, self.max_events)
+        elif not use_event_id:
+            for event in self:
+                if event.index == item:
+                    return deepcopy(event)
         else:
-            self._num_events = len(self.event_id_list)
-        self.log.info("Number of events inside file = {}"
-                      .format(self._num_events))
+            for event in self:
+                if event.id == item:
+                    return deepcopy(event)
+
+        raise KeyError(msg)
+
+    def __len__(self):
+        if not self._num_events:
+            self.log.info("Obtaining number of events in file...")
+            count = 0
+            for _ in self:
+                if count >= self.max_events:
+                    break
+                count += 1
+            self._num_events = count
         return self._num_events
 
-    @property
-    def event_id_list(self):
-        self.log.info("Retrieving list of event ids...")
-        if self._event_id_list:
-            pass
-        else:
-            self.log.info("Building new list of event ids...")
-            ids = hessio_get_list_event_ids(self.input_path,
-                                            max_events=self.max_events)
-            self._event_id_list = ids
-        self.log.info("List of event ids retrieved.")
-        return self._event_id_list
 
-    def read(self, allowed_tels=None, requested_event=None,
-             use_event_id=False):
-        """
-        Read the file using the appropriate method depending on the file origin
-
-        Parameters
-        ----------
-        allowed_tels : list[int]
-            select only a subset of telescope, if None, all are read. This can
-            be used for example emulate the final CTA data format, where there
-            would be 1 telescope per file (whereas in current monte-carlo,
-            they are all interleaved into one file)
-        requested_event : int
-            Seek to a paricular event index
-        use_event_id : bool
-            If True ,'requested_event' now seeks for a particular event id
-            instead of index
-
-        Returns
-        -------
-        source : generator
-            A generator that can be iterated over to obtain events
-        """
-
-        # Obtain relevent source
-        self.log.debug("Reading file...")
-        if self.max_events:
-            self.log.info("Max events being read = {}".format(self.max_events))
-        source = hessio_event_source(self.input_path,
-                                     max_events=self.max_events,
-                                     allowed_tels=allowed_tels,
-                                     requested_event=requested_event,
-                                     use_event_id=use_event_id)
-        self.log.debug("File reading complete")
-        return source
-
-
-# External Children
-try:
-    from targetpipe.io.eventfilereader import TargetioFileReader, \
-        ToyioFileReader
-except ImportError:
-    pass
+# EventFileReader imports so that EventFileReaderFactory can see them
+from ctapipe.io.hessiofilereader import HessioFileReader
 
 
 class EventFileReaderFactory(Factory):
     """
     The `EventFileReader` `ctapipe.core.factory.Factory`. This
     `ctapipe.core.factory.Factory` allows the correct
-    `EventFileReader` to be obtained for the event file being read. This
-    factory tests each EventFileReader by calling
+    `EventFileReader` to be obtained for the event file being read.
+
+    This factory tests each EventFileReader by calling
     `EventFileReader.check_file_compatibility` to see which `EventFileReader`
     is compatible with the file.
+
+    Using `EventFileReaderFactory` in a script allows it to be compatible with
+    any data source that has an `EventFileReader` defined.
+
+    To use within a `ctapipe.core.tool.Tool`:
+
+    >>> reader = EventFileReaderFactory.produce(config=self.config, tool=self)
 
     Parameters
     ----------
@@ -373,7 +207,7 @@ class EventFileReaderFactory(Factory):
     Attributes
     ----------
     reader : traitlets.CaselessStrEnum
-        A string with the `EventFileReader.name` of the reader you want to
+        A string with the `EventFileReader.__name__` of the reader you want to
         use. If left blank, `EventFileReader.check_file_compatibility` will be
         used to find a compatible reader.
     """
@@ -407,7 +241,7 @@ class EventFileReaderFactory(Factory):
                 raise ValueError("Please specify an input_path for event file")
             try:
                 for subclass in self.subclasses:
-                    if subclass.check_file_compatibility(self.input_path):
+                    if subclass.is_compatible(self.input_path):
                         return subclass.__name__
                 raise ValueError
             except ValueError:

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -225,13 +225,13 @@ class EventFileReader(Component):
             msg = "Event index {} not found in file".format(ev)
             for event in self.source:
                 if event.count == ev:
-                    self.current_event = deepcopy(event)
+                    self.current_event = event
                     return deepcopy(event)
         else:
             msg = "Event id {} not found in file".format(ev)
             for event in self:  # Event Ids may not be in order
                 if event.r0.event_id == ev:
-                    self.current_event = deepcopy(event)
+                    self.current_event = event
                     return deepcopy(event)
         raise IndexError(msg)
 

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -62,6 +62,12 @@ class EventFileReader(Component):
     >>>    for event in reader:
     >>>       print(event.count)
 
+    **NOTE**: The "event" that is returned from the generator is a pointer.
+    Any operation that progresses that instance of the generator further will
+    change the data pointed to by "event". If you wish to ensure a particular
+    event is kept, you should perform a `event_copy = copy.deepcopy(event)`.
+
+
     Attributes
     ----------
     input_url : str

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -132,8 +132,6 @@ class EventFileReader(Component):
         self._num_events = None
         self._metadata = dict(is_simulation=False)
 
-        # if self.input_path is None:
-        #     raise ValueError("Please specify an input_path for event file")
         if not exists(self.input_path):
             raise FileNotFoundError("file path does not exist: '{}'"
                                     .format(self.input_path))

--- a/ctapipe/io/eventfilereader.py
+++ b/ctapipe/io/eventfilereader.py
@@ -219,7 +219,7 @@ class EventFileReader(Component):
 
         """
         if self.getevent_warn:
-            self.log.warning("Seeking to event... (long process)")
+            self.log.warning("Seeking to event... (potentially long process)")
             self.getevent_warn = False
         if not use_event_id:
             msg = "Event index {} not found in file".format(ev)
@@ -239,7 +239,8 @@ class EventFileReader(Component):
         # Only need to calculate once
         if not self._num_events:
             self.reset()
-            self.log.warning("Obtaining length of file... (long process)")
+            self.log.warning("Obtaining length of file... "
+                             "(potentially long process)")
             count = 0
             for _ in self:
                 if self.max_events and count >= self.max_events:

--- a/ctapipe/io/eventseeker.py
+++ b/ctapipe/io/eventseeker.py
@@ -1,0 +1,271 @@
+"""
+Handles seeking to a particular event in a
+`ctapipe.io.eventfilereader.EventFileReader`
+"""
+from copy import deepcopy
+from ctapipe.core import Component
+
+
+class EventSeeker(Component):
+    """
+    Provides the functionality to seek through a
+    `ctapipe.io.eventfilereader.EventFileReader` to find a particular event.
+
+    By default, this will loop through events from the start of the file
+    (unless the requested event is the same as the previous requested event,
+    or occurs later in the file). However if the
+    `ctapipe.io.eventfilereader.EventFileReader` has defined a `__getitem__`
+    method itself, then it will use that method, thereby taking advantage of
+    the random event access some file formats provide.
+
+    To create an instance of an EventSeeker you must provide it a sub-class of
+    `ctapipe.io.eventfilereader.EventFileReader` (such as
+    `ctapipe.io.hessiofilereader.HessioFileReader`), which will be used to
+    loop through the file and provide the event container, filled with the
+    event information using the methods defined in the reader for that file
+    format.
+
+    To obtain a particular event in a hessio file:
+
+    >>> from ctapipe.io.hessiofilereader import HessioFileReader
+    >>> reader = HessioFileReader(None, None, input_path="/path/to/file")
+    >>> seeker = EventSeeker(None, None, reader=reader)
+    >>> event = seeker[2]
+    >>> print(event.count)
+
+    To obtain a particular event in a hessio file from its event_id:
+
+    >>> from ctapipe.io.hessiofilereader import HessioFileReader
+    >>> reader = HessioFileReader(None, None, input_path="/path/to/file")
+    >>> seeker = EventSeeker(None, None, reader=reader)
+    >>> event = seeker["101"]
+    >>> print(event.count)
+
+    **NOTE**: Event_index refers to the number associated to the event
+    assigned by ctapipe (`event.count`), based on the order the events are
+    read from the file.
+    Whereas the event_id refers to the ID attatched to the event from the
+    external source of the file (software or camera or CTA array).
+
+    To obtain a slice of events in a hessio file:
+
+    >>> from ctapipe.io.hessiofilereader import HessioFileReader
+    >>> reader = HessioFileReader(None, None, input_path="/path/to/file")
+    >>> seeker = EventSeeker(None, None, reader=reader)
+    >>> event_list = seeker[3:6]
+    >>> print([event.count for event in event_list])
+
+    To obtain a list of events in a hessio file:
+
+    >>> from ctapipe.io.hessiofilereader import HessioFileReader
+    >>> reader = HessioFileReader(None, None, input_path="/path/to/file")
+    >>> seeker = EventSeeker(None, None, reader=reader)
+    >>> event_indicis = [2, 6, 8]
+    >>> event_list = seeker[event_indicis]
+    >>> print([event.count for event in event_list])
+    """
+
+    def __init__(self, config, tool, reader, **kwargs):
+        """
+        Class to handle generic input files. Enables obtaining the "source"
+        generator, regardless of the type of file (either hessio or camera
+        file).
+
+        Parameters
+        ----------
+        config : traitlets.loader.Config
+            Configuration specified by config file or cmdline arguments.
+            Used to set traitlet values.
+            Set to None if no configuration to pass.
+        tool : ctapipe.core.Tool
+            Tool executable that is calling this component.
+            Passes the correct logger to the component.
+            Set to None if no Tool to pass.
+        reader : `ctapipe.io.eventfilereader.EventFileReader`
+            A subclass of `ctapipe.io.eventfilereader.EventFileReader` that
+            defines how the event container is filled for a particular file
+            format
+        kwargs
+        """
+        super().__init__(config=config, parent=tool, **kwargs)
+
+        if reader.is_stream:
+            raise IOError("Reader is not compatible as input to the reader "
+                          "is a stream (seeking not possible)")
+
+        self._reader = reader
+
+        self._num_events = None
+        self._source = self._reader.__iter__()
+        self._current_event = None
+        self._has_fast_seek = False  # By default seeking iterates through
+        self._getevent_warn = True
+
+    def _reset(self):
+        """
+        Recreate the generator so it starts from the beginning
+        """
+        self._source = self._reader.__iter__()
+        self._current_event = None
+
+    def __iter__(self):
+        # Always reset generator when starting a new iteration
+        self._reset()
+        for event in self._source:
+            self._current_event = event
+            yield event
+
+    def __getitem__(self, item):
+        """
+        Obtain a particular event
+
+        Parameters
+        ----------
+        item : int or str
+            If `item` is an int, then this is the event_index for the event
+            obtained. If `item` is a str, then this is the event_id for the
+            event obtained.
+
+        Returns
+        -------
+        event : ctapipe.io.container
+            The event container filled with the requested event's information
+
+        """
+
+        # Handling of different input types (int, string, slice, list)
+        current = None
+        use_event_id = False
+        if isinstance(item, int):
+            if self._current_event:
+                current = self._current_event.count
+            if item < 0:
+                item = len(self) + item
+                if item < 0 or item >= len(self):
+                    msg = ("Event index {} out of range [0, {}]"
+                        .format(item, len(self)))
+                    raise IndexError(msg)
+        elif isinstance(item, str):
+            item = int(item)
+            use_event_id = True
+            if self._current_event:
+                current = self._current_event.r0.event_id
+        elif isinstance(item, slice):
+            it = range(item.start or 0, item.stop or len(self), item.step or 1)
+            events = [self[i] for i in it]
+            return events
+        elif isinstance(item, list):
+            events = [self[i] for i in item]
+            return events
+        else:
+            raise TypeError("{} indexing is not supported".format(type(item)))
+
+        # Return a copy of the current event if we have already reached it
+        if current is not None and item == current:
+            return deepcopy(self._current_event)
+
+        # If requested event is less than the current event position: reset
+        if current is not None and item < current:
+            self._reset()
+
+        # Check we are within max_events range
+        max_events = self._reader.max_events
+        if not use_event_id and max_events and item >= max_events:
+            msg = ("Event index {} outside of specified max_events {}"
+                .format(item, max_events))
+            raise IndexError(msg)
+
+        try:
+            if not use_event_id:
+                event = self._reader.get_event_by_index(item)
+            else:
+                event = self._reader.get_event_by_id(item)
+        except AttributeError:
+            if self._getevent_warn:
+                self.log.warning("Seeking to event by looping through "
+                                 "events... (potentially long process)")
+                self._getevent_warn = False
+            if not use_event_id:
+                event = self._get_event_by_index(item)
+            else:
+                event = self._get_event_by_id(item)
+
+        self._current_event = event
+        return deepcopy(event)
+
+    def _get_event_by_index(self, index):
+        """
+        Method for extracting a particular event by looping through events
+        until it finds the requested event index.
+        If a file format allows random event access, then is can define its
+        own `get_event_by_index` method in its
+        `ctapipe.io.eventfilereader.EventFileReader` to allow this class to
+        utilise that method instead.
+
+        Parameters
+        ----------
+        index : int
+            The event_index to seek.
+
+        Returns
+        -------
+        event : ctapipe.io.container
+            The event container filled with the requested event's information
+
+        """
+        for event in self._source:
+            if event.count == index:
+                return event
+        raise IndexError("Event index {} not found in file".format(index))
+
+    def _get_event_by_id(self, event_id):
+        """
+        Method for extracting a particular event by looping through events
+        until it finds the requested event id.
+        If a file format allows random event access, then is can define its
+        own `get_event_by_index` method in its
+        `ctapipe.io.eventfilereader.EventFileReader` to allow this class to
+        utilise that method instead.
+
+        Parameters
+        ----------
+        event_id : int
+            The event_id to seek.
+
+        Returns
+        -------
+        event : ctapipe.io.container
+            The event container filled with the requested event's information
+
+        """
+        for event in self:  # Event Ids may not be in order
+            if event.r0.event_id == event_id:
+                return event
+        raise IndexError("Event id {} not found in file".format(event_id))
+
+    def __len__(self):
+        """
+        Method for getting number of events in file. By default this is
+        obtained by looping through the file and counting the events. If a
+        file format has a more efficient method of supplying this information,
+        the `ctapipe.io.eventfilereader.EventFileReader` for that file format
+        can define its own `__len__` method, which this class will then
+        use instead.
+
+        Returns
+        -------
+        self._num_events : int
+            Number of events in the file
+        """
+        # Only need to calculate once
+        if not self._num_events:
+            try:
+                count = len(self._reader)
+            except TypeError:
+                self.log.warning("Obtaining length of file by looping through "
+                                 "all events... (potentially long process)")
+                count = 0
+                for _ in self:
+                    count += 1
+            self._num_events = count
+        return self._num_events

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -129,18 +129,25 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
                     counter += 1
                     continue
 
-            data.index = counter
-            data.id = event_id
-            data.run_id = pyhessio.get_run_number()
-            data.tels_with_data = set(pyhessio.get_teldata_list())
+            data.r0.run_id = pyhessio.get_run_number()
+            data.r0.event_id = event_id
+            data.r0.tels_with_data = set(pyhessio.get_teldata_list())
+            data.r1.run_id = pyhessio.get_run_number()
+            data.r1.event_id = event_id
+            data.r1.tels_with_data = set(pyhessio.get_teldata_list())
+            data.dl0.run_id = pyhessio.get_run_number()
+            data.dl0.event_id = event_id
+            data.dl0.tels_with_data = set(pyhessio.get_teldata_list())
 
             # handle telescope filtering by taking the intersection of
             # tels_with_data and allowed_tels
             if allowed_tels is not None:
-                selected = data.tels_with_data & allowed_tels
+                selected = data.r0.tels_with_data & allowed_tels
                 if len(selected) == 0:
                     continue  # skip event
-                data.tels_with_data = selected
+                data.r0.tels_with_data = selected
+                data.r1.tels_with_data = selected
+                data.dl0.tels_with_data = selected
 
             data.trig.tels_with_trigger \
                 = pyhessio.get_central_event_teltrg_list()
@@ -160,6 +167,8 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
             # mc run header data
             data.mcheader.run_array_direction = \
                 pyhessio.get_mc_run_array_direction()
+
+            data.count = counter
 
             # this should be done in a nicer way to not re-allocate the
             # data each time (right now it's just deleted and garbage

--- a/ctapipe/io/hessio.py
+++ b/ctapipe/io/hessio.py
@@ -5,7 +5,7 @@ Components to read HESSIO data.
 This requires the hessio python library to be installed
 """
 import logging
-
+import warnings
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.time import Time
@@ -93,6 +93,11 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
         of index
     """
 
+    warnings.warn("hessio_event_source has been deprecated. "
+                  "Please trasition to using "
+                  "ctapipe.io.hessiofilereader.HessioFileReader",
+                  DeprecationWarning)
+
     with open_hessio(url) as pyhessio:
         # the container is initialized once, and data is replaced within
         # it after each yield
@@ -124,25 +129,18 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
                     counter += 1
                     continue
 
-            data.r0.run_id = pyhessio.get_run_number()
-            data.r0.event_id = event_id
-            data.r0.tels_with_data = set(pyhessio.get_teldata_list())
-            data.r1.run_id = pyhessio.get_run_number()
-            data.r1.event_id = event_id
-            data.r1.tels_with_data = set(pyhessio.get_teldata_list())
-            data.dl0.run_id = pyhessio.get_run_number()
-            data.dl0.event_id = event_id
-            data.dl0.tels_with_data = set(pyhessio.get_teldata_list())
+            data.index = counter
+            data.id = event_id
+            data.run_id = pyhessio.get_run_number()
+            data.tels_with_data = set(pyhessio.get_teldata_list())
 
             # handle telescope filtering by taking the intersection of
             # tels_with_data and allowed_tels
             if allowed_tels is not None:
-                selected = data.r0.tels_with_data & allowed_tels
+                selected = data.tels_with_data & allowed_tels
                 if len(selected) == 0:
                     continue  # skip event
-                data.r0.tels_with_data = selected
-                data.r1.tels_with_data = selected
-                data.dl0.tels_with_data = selected
+                data.tels_with_data = selected
 
             data.trig.tels_with_trigger \
                 = pyhessio.get_central_event_teltrg_list()
@@ -162,8 +160,6 @@ def hessio_event_source(url, max_events=None, allowed_tels=None,
             # mc run header data
             data.mcheader.run_array_direction = \
                 pyhessio.get_mc_run_array_direction()
-
-            data.count = counter
 
             # this should be done in a nicer way to not re-allocate the
             # data each time (right now it's just deleted and garbage

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -28,6 +28,11 @@ class HessioFileReader(EventFileReader):
         self.HessioGeneralError = HessioGeneralError
 
         self.allowed_tels = None
+        self.pyhessio = None
+
+    def __del__(self):
+        if self.pyhessio:
+            self.pyhessio.close_file()
 
     @staticmethod
     def is_compatible(file_path):
@@ -39,6 +44,7 @@ class HessioFileReader(EventFileReader):
 
     def _generator(self):
         with self.open_hessio(self.input_path) as pyhessio:
+            self.pyhessio = pyhessio
             # the container is initialized once, and data is replaced within
             # it after each yield
             Provenance().add_input_file(self.input_path, role='dl0.sub.evt')
@@ -157,10 +163,9 @@ class HessioFileReader(EventFileReader):
                 counter += 1
 
                 if self.max_events and counter >= self.max_events:
-                    pyhessio.close_file()
                     self.reset()
                     raise StopIteration
-        pyhessio.close_file()
+        self.pyhessio = None
         self.reset()
         raise StopIteration
 

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -20,9 +20,10 @@ class HessioFileReader(EventFileReader):
     """
     _count = 0
 
-    input_path = Unicode(get_dataset('gamma_test.simtel.gz'), allow_none=False,
-                         help='Path to the input file containing '
-                              'events.').tag(config=True)
+    input_path = Unicode(
+        get_dataset('gamma_test.simtel.gz'),
+        help='Path to the input file containing events.'
+    ).tag(config=True)
 
     def __init__(self, config, tool, **kwargs):
         super().__init__(config=config, tool=tool, **kwargs)
@@ -44,7 +45,7 @@ class HessioFileReader(EventFileReader):
             self.pyhessio.close_file()
         HessioFileReader._count += 1
 
-        self._metadata['is_simulation'] = True
+        self.metadata['is_simulation'] = True
 
     @staticmethod
     def is_compatible(file_path):

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -37,7 +37,7 @@ class HessioFileReader(EventFileReader):
     def camera(self):
         return 'hessio'
 
-    def _generator(self):
+    def __iter__(self):
         with self.open_hessio(self.input_path) as pyhessio:
             self.pyhessio = pyhessio
             # the container is initialized once, and data is replaced within
@@ -158,10 +158,8 @@ class HessioFileReader(EventFileReader):
                 counter += 1
 
                 if self.max_events and counter >= self.max_events:
-                    self.reset()
-                    raise StopIteration
-        self.reset()
-        raise StopIteration
+                    return
+        return
 
     def _build_subarray_info(self, pyhessio):
         """

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -20,7 +20,7 @@ class HessioFileReader(EventFileReader):
     """
     _count = 0
 
-    input_path = Unicode(
+    input_url = Unicode(
         get_dataset('gamma_test.simtel.gz'),
         help='Path to the input file containing events.'
     ).tag(config=True)
@@ -64,7 +64,7 @@ class HessioFileReader(EventFileReader):
         self.pyhessio.close_file()
 
     def _generator(self):
-        with self.pyhessio.open_hessio(self.input_path) as file:
+        with self.pyhessio.open_hessio(self.input_url) as file:
             # the container is initialized once, and data is replaced within
             # it after each yield
             Provenance().add_input_file(self.input_path, role='dl0.sub.evt')
@@ -76,7 +76,7 @@ class HessioFileReader(EventFileReader):
             data.meta['origin'] = "hessio"
 
             # some hessio_event_source specific parameters
-            data.meta['input_url'] = self.input_path
+            data.meta['input_url'] = self.input_url
             data.meta['max_events'] = self.max_events
 
             for event_id in eventstream:

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -1,0 +1,190 @@
+from astropy import units as u
+from astropy.coordinates import Angle
+from astropy.time import Time
+from ctapipe.core import Provenance
+from ctapipe.io.eventfilereader import EventFileReader
+from ctapipe.io.containers import DataContainer
+from ctapipe.instrument import TelescopeDescription, SubarrayDescription
+
+
+class HessioFileReader(EventFileReader):
+
+    def __init__(self, config, tool, **kwargs):
+        super().__init__(config=config, tool=tool, **kwargs)
+
+        try:
+            from pyhessio import open_hessio
+            from pyhessio import HessioError
+            from pyhessio import HessioTelescopeIndexError
+            from pyhessio import HessioGeneralError
+        except ImportError:
+            msg = "The `pyhessio` python module is required to access MC data"
+            self.log.error(msg)
+            raise
+
+        self.open_hessio = open_hessio
+        self.HessioError = HessioError
+        self.HessioTelescopeIndexError = HessioTelescopeIndexError
+        self.HessioGeneralError = HessioGeneralError
+
+        self.allowed_tels = None
+
+    @staticmethod
+    def is_compatible(file_path):
+        return file_path.endswith('.gz')
+
+    @property
+    def camera(self):
+        return 'hessio'
+
+    def __next__(self):
+        with self.open_hessio(self.input_path) as pyhessio:
+            # the container is initialized once, and data is replaced within
+            # it after each yield
+            Provenance().add_input_file(self.input_path, role='dl0.sub.evt')
+            counter = 0
+            eventstream = pyhessio.move_to_next_event()
+            if self.allowed_tels is not None:
+                self.allowed_tels = set(self.allowed_tels)
+            data = DataContainer()
+            data.meta['origin'] = "hessio"
+
+            # some hessio_event_source specific parameters
+            data.meta['input'] = self.input_path
+            data.meta['max_events'] = self.max_events
+
+            for event_id in eventstream:
+
+                if counter == 0:
+                    # subarray info is only available when an event is loaded,
+                    # so load it on the first event.
+                    data.inst.subarray = self._build_subarray_info(pyhessio)
+
+                data.index = counter
+                data.id = event_id
+                data.run_id = pyhessio.get_run_number()
+                data.tels_with_data = set(pyhessio.get_teldata_list())
+
+                # handle telescope filtering by taking the intersection of
+                # tels_with_data and allowed_tels
+                if self.allowed_tels is not None:
+                    selected = data.tels_with_data & self.allowed_tels
+                    if len(selected) == 0:
+                        continue  # skip event
+                    data.tels_with_data = selected
+
+                data.trig.tels_with_trigger \
+                    = pyhessio.get_central_event_teltrg_list()
+                time_s, time_ns = pyhessio.get_central_event_gps_time()
+                data.trig.gps_time = Time(time_s * u.s, time_ns * u.ns,
+                                          format='unix', scale='utc')
+                data.mc.energy = pyhessio.get_mc_shower_energy() * u.TeV
+                data.mc.alt = Angle(pyhessio.get_mc_shower_altitude(), u.rad)
+                data.mc.az = Angle(pyhessio.get_mc_shower_azimuth(), u.rad)
+                data.mc.core_x = pyhessio.get_mc_event_xcore() * u.m
+                data.mc.core_y = pyhessio.get_mc_event_ycore() * u.m
+                first_int = pyhessio.get_mc_shower_h_first_int() * u.m
+                data.mc.h_first_int = first_int
+                data.mc.shower_primary_id = \
+                    pyhessio.get_mc_shower_primary_id()
+
+                # mc run header data
+                data.mcheader.run_array_direction = \
+                    pyhessio.get_mc_run_array_direction()
+
+                # this should be done in a nicer way to not re-allocate the
+                # data each time (right now it's just deleted and garbage
+                # collected)
+
+                data.r0.tel.clear()
+                data.r1.tel.clear()
+                data.dl0.tel.clear()
+                data.dl1.tel.clear()
+                data.mc.tel.clear()  # clear the previous telescopes
+
+                for tel_id in data.r0.tels_with_data:
+
+                    # event.mc.tel[tel_id] = MCCameraContainer()
+
+                    data.mc.tel[tel_id].dc_to_pe \
+                        = pyhessio.get_calibration(tel_id)
+                    data.mc.tel[tel_id].pedestal \
+                        = pyhessio.get_pedestal(tel_id)
+
+                    data.r0.tel[tel_id].adc_samples = \
+                        pyhessio.get_adc_sample(tel_id)
+                    if data.r0.tel[tel_id].adc_samples.size == 0:
+                        # To handle ASTRI and dst files
+                        data.r0.tel[tel_id].adc_samples = \
+                            pyhessio.get_adc_sum(tel_id)[..., None]
+                    data.r0.tel[tel_id].adc_sums = \
+                        pyhessio.get_adc_sum(tel_id)
+                    data.mc.tel[tel_id].reference_pulse_shape = \
+                        pyhessio.get_ref_shapes(tel_id)
+
+                    nsamples = pyhessio.get_event_num_samples(tel_id)
+                    if nsamples <= 0:
+                        nsamples = 1
+                    data.r0.tel[tel_id].num_samples = nsamples
+
+                    # load the data per telescope/pixel
+                    hessio_mc_npe = pyhessio.get_mc_number_photon_electron
+                    data.mc.tel[tel_id].photo_electron_image \
+                        = hessio_mc_npe(telescope_id=tel_id)
+                    data.mc.tel[tel_id].meta['refstep'] = \
+                        pyhessio.get_ref_step(tel_id)
+                    data.mc.tel[tel_id].time_slice = \
+                        pyhessio.get_time_slice(tel_id)
+                    data.mc.tel[tel_id].azimuth_raw = \
+                        pyhessio.get_azimuth_raw(tel_id)
+                    data.mc.tel[tel_id].altitude_raw = \
+                        pyhessio.get_altitude_raw(tel_id)
+                    data.mc.tel[tel_id].azimuth_cor = \
+                        pyhessio.get_azimuth_cor(tel_id)
+                    data.mc.tel[tel_id].altitude_cor = \
+                        pyhessio.get_altitude_cor(tel_id)
+                yield data
+                counter += 1
+
+                if self.max_events and counter >= self.max_events:
+                    pyhessio.close_file()
+                    raise StopIteration
+        raise StopIteration
+
+    def _build_subarray_info(self, pyhessio):
+        """
+        constructs a SubarrayDescription object from the info in an
+        EventIO/HESSSIO file
+
+        Parameters
+        ----------
+        pyhessio: HessioFile
+            The open pyhessio file
+
+        Returns
+        -------
+        SubarrayDescription :
+            instrumental information
+        """
+        telescope_ids = list(pyhessio.get_telescope_ids())
+        subarray = SubarrayDescription("MonteCarloArray")
+
+        for tel_id in telescope_ids:
+            try:
+
+                pix_pos = pyhessio.get_pixel_position(tel_id) * u.m
+                foclen = pyhessio.get_optical_foclen(tel_id) * u.m
+                mirror_area = pyhessio.get_mirror_area(tel_id) * u.m ** 2
+                num_tiles = pyhessio.get_mirror_number(tel_id)
+                tel_pos = pyhessio.get_telescope_position(tel_id) * u.m
+
+                tel = TelescopeDescription.guess(*pix_pos, foclen)
+                tel.optics.mirror_area = mirror_area
+                tel.optics.num_mirror_tiles = num_tiles
+                subarray.tels[tel_id] = tel
+                subarray.positions[tel_id] = tel_pos
+
+            except self.HessioGeneralError:
+                pass
+
+        return subarray

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -22,6 +22,7 @@ class HessioFileReader(EventFileReader):
         try:
             from pyhessio import open_hessio
             from pyhessio import close_file
+            from pyhessio import HessioGeneralError
         except ImportError:
             msg = "The `pyhessio` python module is required to access MC data"
             self.log.error(msg)
@@ -29,6 +30,7 @@ class HessioFileReader(EventFileReader):
 
         self.open_hessio = open_hessio
         self.close_hessio = close_file
+        self.HessioGeneralError = HessioGeneralError
 
         self.allowed_tels = None
 

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -28,11 +28,6 @@ class HessioFileReader(EventFileReader):
         self.HessioGeneralError = HessioGeneralError
 
         self.allowed_tels = None
-        self.pyhessio = None
-
-    def __del__(self):
-        if self.pyhessio:
-            self.pyhessio.close_file()
 
     @staticmethod
     def is_compatible(file_path):
@@ -165,7 +160,6 @@ class HessioFileReader(EventFileReader):
                 if self.max_events and counter >= self.max_events:
                     self.reset()
                     raise StopIteration
-        self.pyhessio = None
         self.reset()
         raise StopIteration
 

--- a/ctapipe/io/hessiofilereader.py
+++ b/ctapipe/io/hessiofilereader.py
@@ -67,7 +67,6 @@ class HessioFileReader(EventFileReader):
         with self.pyhessio.open_hessio(self.input_url) as file:
             # the container is initialized once, and data is replaced within
             # it after each yield
-            Provenance().add_input_file(self.input_path, role='dl0.sub.evt')
             counter = 0
             eventstream = file.move_to_next_event()
             if self.allowed_tels is not None:

--- a/ctapipe/io/tests/test_eventfilereader.py
+++ b/ctapipe/io/tests/test_eventfilereader.py
@@ -1,7 +1,7 @@
 from os.path import join, dirname
 from ctapipe.utils import get_dataset
 from ctapipe.io.eventfilereader import EventFileReader, \
-    EventFileReaderFactory, HessioFileReader
+    EventFileReaderFactory
 
 
 def test_event_file_reader():
@@ -13,44 +13,10 @@ def test_event_file_reader():
                     "instantiated due to its abstract methods")
 
 
-def test_hessio_file_reader():
-    dataset = get_dataset("gamma_test.simtel.gz")
-    file = HessioFileReader(None, None, input_path=dataset)
-    assert file.directory == dirname(dataset)
-    assert file.extension == ".gz"
-    assert file.filename == "gamma_test.simtel"
-    source = file.read()
-    event = next(source)
-    assert event.r0.tels_with_data == {38, 47}
-
-
-def test_get_event():
-    dataset = get_dataset("gamma_test.simtel.gz")
-    file = HessioFileReader(None, None, input_path=dataset)
-    event = file.get_event(2)
-    assert event.count == 2
-    assert event.r0.event_id == 803
-    event = file.get_event(803, True)
-    assert event.count == 2
-    assert event.r0.event_id == 803
-
-
-def test_get_num_events():
-    dataset = get_dataset("gamma_test.simtel.gz")
-    file = HessioFileReader(None, None, input_path=dataset)
-    num_events = file.num_events
-    assert(num_events == 9)
-
-    file.max_events = 2
-    num_events = file.num_events
-    assert (num_events == 2)
-
-
 def test_event_file_reader_factory():
     dataset = get_dataset("gamma_test.simtel.gz")
     factory = EventFileReaderFactory(None, None)
     factory.input_path = dataset
     cls = factory.get_class()
-    file = cls(None, None)
-    num_events = file.num_events
-    assert(num_events == 9)
+    reader = cls(None, None)
+    assert(len(reader) == 9)

--- a/ctapipe/io/tests/test_eventfilereader.py
+++ b/ctapipe/io/tests/test_eventfilereader.py
@@ -13,6 +13,29 @@ def test_event_file_reader():
                     "instantiated due to its abstract methods")
 
 
+class TestReader(EventFileReader):
+    """
+    Simple working EventFileReader
+    """
+    def _generator(self):
+        return range(len(self.input_path))
+
+    def is_compatible(self, path):
+        return False
+
+
+def test_can_be_implemented():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    test_reader = TestReader(None, None, input_path=dataset)
+
+
+def test_is_iterable():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    test_reader = TestReader(None, None, input_path=dataset)
+    for _ in test_reader:
+        pass
+
+
 def test_event_file_reader_factory():
     dataset = get_dataset("gamma_test.simtel.gz")
     factory = EventFileReaderFactory(None, None)

--- a/ctapipe/io/tests/test_eventfilereader.py
+++ b/ctapipe/io/tests/test_eventfilereader.py
@@ -18,7 +18,7 @@ class TestReader(EventFileReader):
     Simple working EventFileReader
     """
     def _generator(self):
-        return range(len(self.input_path))
+        return range(len(self.input_url))
 
     def is_compatible(self, path):
         return False
@@ -26,12 +26,12 @@ class TestReader(EventFileReader):
 
 def test_can_be_implemented():
     dataset = get_dataset("gamma_test.simtel.gz")
-    test_reader = TestReader(None, None, input_path=dataset)
+    test_reader = TestReader(None, None, input_url=dataset)
 
 
 def test_is_iterable():
     dataset = get_dataset("gamma_test.simtel.gz")
-    test_reader = TestReader(None, None, input_path=dataset)
+    test_reader = TestReader(None, None, input_url=dataset)
     for _ in test_reader:
         pass
 
@@ -39,7 +39,7 @@ def test_is_iterable():
 def test_event_file_reader_factory():
     dataset = get_dataset("gamma_test.simtel.gz")
     factory = EventFileReaderFactory(None, None)
-    factory.input_path = dataset
+    factory.input_url = dataset
     cls = factory.get_class()
     reader = cls(None, None)
     assert reader.__class__.__name__ == "HessioFileReader"

--- a/ctapipe/io/tests/test_eventfilereader.py
+++ b/ctapipe/io/tests/test_eventfilereader.py
@@ -19,4 +19,4 @@ def test_event_file_reader_factory():
     factory.input_path = dataset
     cls = factory.get_class()
     reader = cls(None, None)
-    assert(len(reader) == 9)
+    assert reader.__class__.__name__ == "HessioFileReader"

--- a/ctapipe/io/tests/test_eventseeker.py
+++ b/ctapipe/io/tests/test_eventseeker.py
@@ -6,7 +6,7 @@ import pytest
 
 def test_eventseeker():
     dataset = get_dataset("gamma_test.simtel.gz")
-    kwargs = dict(config=None, tool=None, input_path=dataset)
+    kwargs = dict(config=None, tool=None, input_url=dataset)
     with HessioFileReader(**kwargs) as reader:
         seeker = EventSeeker(None, None, reader=reader)
         event = seeker[1]

--- a/ctapipe/io/tests/test_eventseeker.py
+++ b/ctapipe/io/tests/test_eventseeker.py
@@ -38,3 +38,10 @@ def test_eventseeker():
         seeker = EventSeeker(None, None, reader=reader)
         with pytest.raises(IndexError):
             event = seeker[5]
+
+    class StreamFileReader(HessioFileReader):
+        def is_stream(self):
+            return True
+    with StreamFileReader(**kwargs) as reader:
+        with pytest.raises(IOError):
+            seeker = EventSeeker(None, None, reader=reader)

--- a/ctapipe/io/tests/test_eventseeker.py
+++ b/ctapipe/io/tests/test_eventseeker.py
@@ -1,0 +1,40 @@
+from ctapipe.utils import get_dataset
+from ctapipe.io.hessiofilereader import HessioFileReader
+from ctapipe.io.eventseeker import EventSeeker
+import pytest
+
+
+def test_eventseeker():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    kwargs = dict(config=None, tool=None, input_path=dataset)
+    with HessioFileReader(**kwargs) as reader:
+        seeker = EventSeeker(None, None, reader=reader)
+        event = seeker[1]
+        assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
+        event = seeker[0]
+        assert event.r0.tels_with_data == {38, 47}
+        event = seeker['409']
+        assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
+        tel_list = [{38, 47}, {11, 21, 24, 26, 61, 63, 118, 119}]
+        events = seeker[0:2]
+        events_tels = [e.r0.tels_with_data for e in events]
+        assert events_tels == tel_list
+        events = seeker[[0, 1]]
+        events_tels = [e.r0.tels_with_data for e in events]
+        assert events_tels == tel_list
+        events = seeker[['408', '409']]
+        events_tels = [e.r0.tels_with_data for e in events]
+        assert events_tels == tel_list
+        assert len(seeker) == 9
+
+        with pytest.raises(IndexError):
+            event = seeker[200]
+        with pytest.raises(ValueError):
+            event = seeker['t']
+        with pytest.raises(TypeError):
+            event = seeker[dict()]
+
+    with HessioFileReader(**kwargs, max_events=5) as reader:
+        seeker = EventSeeker(None, None, reader=reader)
+        with pytest.raises(IndexError):
+            event = seeker[5]

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -4,7 +4,7 @@ from ctapipe.io.hessiofilereader import HessioFileReader
 
 def test_hessio_file_reader():
     dataset = get_dataset("gamma_test.simtel.gz")
-    kwargs = dict(config=None, tool=None, input_path=dataset)
+    kwargs = dict(config=None, tool=None, input_url=dataset)
     with HessioFileReader(**kwargs) as reader:
         assert reader.is_compatible(dataset)
         assert not reader.is_stream

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -1,0 +1,21 @@
+from os.path import join, dirname
+from ctapipe.utils import get_dataset
+from ctapipe.io.hessiofilereader import HessioFileReader
+
+
+def test_hessio_file_reader():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    reader = HessioFileReader(None, None, input_path=dataset)
+    assert reader.is_compatible(dataset)
+    assert reader.camera == 'hessio'
+    assert len(reader) == 9
+    event = next(reader)
+    assert event.r0.tels_with_data == {38, 47}
+    event = next(reader)
+    assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
+    event = reader[0]
+    assert event.r0.tels_with_data == {38, 47}
+    for event in reader:
+        pass
+    event = next(reader)
+    assert event.r0.tels_with_data == {38, 47}

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -13,10 +13,9 @@ def test_hessio_file_reader():
     assert event.r0.tels_with_data == {38, 47}
     event = next(reader)
     assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
-    event = reader[0]
-    assert event.r0.tels_with_data == {38, 47}
     for event in reader:
         pass
     event = next(reader)
     assert event.r0.tels_with_data == {38, 47}
-    reader.__del__()
+    event = reader[0]
+    assert event.r0.tels_with_data == {38, 47}

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -7,7 +7,6 @@ def test_hessio_file_reader():
     kwargs = dict(config=None, tool=None, input_path=dataset)
     with HessioFileReader(**kwargs) as reader:
         assert reader.is_compatible(dataset)
-        assert reader.camera == 'hessio'
         assert len(reader) == 9
         for event in reader:
             if event.count == 0:

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -19,3 +19,5 @@ def test_hessio_file_reader():
     assert event.r0.tels_with_data == {38, 47}
     event = reader[0]
     assert event.r0.tels_with_data == {38, 47}
+    event = reader['409']
+    assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -4,29 +4,31 @@ from ctapipe.io.hessiofilereader import HessioFileReader
 
 def test_hessio_file_reader():
     dataset = get_dataset("gamma_test.simtel.gz")
-    reader = HessioFileReader(None, None, input_path=dataset)
-    assert reader.is_compatible(dataset)
-    assert reader.camera == 'hessio'
-    assert len(reader) == 9
-    for event in reader:
-        if event.count == 0:
-            assert event.r0.tels_with_data == {38, 47}
-        if event.count == 1:
-            assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118,
-                                               119}
-    event = reader[0]
-    assert event.r0.tels_with_data == {38, 47}
-    event = reader['409']
-    assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
-    tel_list = [{38, 47}, {11, 21, 24, 26, 61, 63, 118, 119}]
-    events = reader[0:2]
-    events_tels = [e.r0.tels_with_data for e in events]
-    assert events_tels == tel_list
-    events = reader[[0, 1]]
-    events_tels = [e.r0.tels_with_data for e in events]
-    assert events_tels == tel_list
-    events = reader[['408', '409']]
-    events_tels = [e.r0.tels_with_data for e in events]
-    assert events_tels == tel_list
-    reader = HessioFileReader(None, None, input_path=dataset, max_events=5)
-    assert len(reader) == 5
+    kwargs = dict(config=None, tool=None, input_path=dataset)
+    with HessioFileReader(**kwargs) as reader:
+        assert reader.is_compatible(dataset)
+        assert reader.camera == 'hessio'
+        assert len(reader) == 9
+        for event in reader:
+            if event.count == 0:
+                assert event.r0.tels_with_data == {38, 47}
+            if event.count == 1:
+                assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118,
+                                                   119}
+        event = reader[0]
+        assert event.r0.tels_with_data == {38, 47}
+        event = reader['409']
+        assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
+        tel_list = [{38, 47}, {11, 21, 24, 26, 61, 63, 118, 119}]
+        events = reader[0:2]
+        events_tels = [e.r0.tels_with_data for e in events]
+        assert events_tels == tel_list
+        events = reader[[0, 1]]
+        events_tels = [e.r0.tels_with_data for e in events]
+        assert events_tels == tel_list
+        events = reader[['408', '409']]
+        events_tels = [e.r0.tels_with_data for e in events]
+        assert events_tels == tel_list
+    with HessioFileReader(**kwargs, max_events=5) as reader:
+        reader = HessioFileReader(None, None, input_path=dataset, max_events=5)
+        assert len(reader) == 5

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -1,4 +1,3 @@
-from os.path import join, dirname
 from ctapipe.utils import get_dataset
 from ctapipe.io.hessiofilereader import HessioFileReader
 
@@ -19,5 +18,15 @@ def test_hessio_file_reader():
     assert event.r0.tels_with_data == {38, 47}
     event = reader['409']
     assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
+    tel_list = [{38, 47}, {11, 21, 24, 26, 61, 63, 118, 119}]
+    events = reader[0:2]
+    events_tels = [e.r0.tels_with_data for e in events]
+    assert events_tels == tel_list
+    events = reader[[0, 1]]
+    events_tels = [e.r0.tels_with_data for e in events]
+    assert events_tels == tel_list
+    events = reader[['408', '409']]
+    events_tels = [e.r0.tels_with_data for e in events]
+    assert events_tels == tel_list
     reader = HessioFileReader(None, None, input_path=dataset, max_events=5)
     assert len(reader) == 5

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -19,3 +19,4 @@ def test_hessio_file_reader():
         pass
     event = next(reader)
     assert event.r0.tels_with_data == {38, 47}
+    reader.__del__()

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -9,14 +9,12 @@ def test_hessio_file_reader():
     assert reader.is_compatible(dataset)
     assert reader.camera == 'hessio'
     assert len(reader) == 9
-    event = next(reader)
-    assert event.r0.tels_with_data == {38, 47}
-    event = next(reader)
-    assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
     for event in reader:
-        pass
-    event = next(reader)
-    assert event.r0.tels_with_data == {38, 47}
+        if event.count == 0:
+            assert event.r0.tels_with_data == {38, 47}
+        if event.count == 1:
+            assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118,
+                                               119}
     event = reader[0]
     assert event.r0.tels_with_data == {38, 47}
     event = reader['409']

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -7,27 +7,23 @@ def test_hessio_file_reader():
     kwargs = dict(config=None, tool=None, input_path=dataset)
     with HessioFileReader(**kwargs) as reader:
         assert reader.is_compatible(dataset)
-        assert len(reader) == 9
+        assert not reader.is_stream
         for event in reader:
             if event.count == 0:
                 assert event.r0.tels_with_data == {38, 47}
-            if event.count == 1:
+            elif event.count == 1:
                 assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118,
                                                    119}
-        event = reader[0]
-        assert event.r0.tels_with_data == {38, 47}
-        event = reader['409']
-        assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
-        tel_list = [{38, 47}, {11, 21, 24, 26, 61, 63, 118, 119}]
-        events = reader[0:2]
-        events_tels = [e.r0.tels_with_data for e in events]
-        assert events_tels == tel_list
-        events = reader[[0, 1]]
-        events_tels = [e.r0.tels_with_data for e in events]
-        assert events_tels == tel_list
-        events = reader[['408', '409']]
-        events_tels = [e.r0.tels_with_data for e in events]
-        assert events_tels == tel_list
-    with HessioFileReader(**kwargs, max_events=5) as reader:
-        reader = HessioFileReader(None, None, input_path=dataset, max_events=5)
-        assert len(reader) == 5
+            else:
+                break
+        for event in reader:
+            # Check generator has restarted from beginning
+            assert event.count == 0
+            break
+
+    max_events = 5
+    with HessioFileReader(**kwargs, max_events=max_events) as reader:
+        count = 0
+        for _ in reader:
+            count += 1
+        assert count == max_events

--- a/ctapipe/io/tests/test_hessiofilereader.py
+++ b/ctapipe/io/tests/test_hessiofilereader.py
@@ -19,3 +19,5 @@ def test_hessio_file_reader():
     assert event.r0.tels_with_data == {38, 47}
     event = reader['409']
     assert event.r0.tels_with_data == {11, 21, 24, 26, 61, 63, 118, 119}
+    reader = HessioFileReader(None, None, input_path=dataset, max_events=5)
+    assert len(reader) == 5

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -14,7 +14,7 @@ from ctapipe.calib.camera.dl1 import CameraDL1Calibrator
 from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory
 from ctapipe.core import Tool
 from ctapipe.image.charge_extractors import ChargeExtractorFactory
-from ctapipe.io.eventfilereader import HessioFileReader
+from ctapipe.io.hessiofilereader import HessioFileReader
 
 
 class ChargeResolutionGenerator(Tool):


### PR DESCRIPTION
This PR concerns updates to EventFileReader and HessioFileReader discussed in #590 and #610.

* EventFileReader has been cleaned-up (removing stuff like output_directory)
* EventFileReader has been made into a [sequence](https://docs.python.org/3.6/glossary.html#term-sequence) so that is is iterable and supports element access.
* The methods for retrieving events are defined in the base EventFileReader class. Other EventFileReaders can override `__getitem__` if they have a more efficient method instead of looping from the first event.
* The functionality of hessio_event_source has been moved into HessioFileReader._generator
  