### PR TITLE
temporarily removed pyzmq version check from ctapipe-info

### DIFF
--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -19,7 +19,7 @@ _dependencies = sorted(['astropy', 'matplotlib',
                         'sklearn', 'scipy', 'numba',
                         'pytest', 'ctapipe_resources', 'iminuit', 'tables'])
 
-_optional_dependencies = sorted(['pytest', 'graphviz', 'pyzmq',
+_optional_dependencies = sorted(['pytest', 'graphviz', #'pyzmq',
                                  'fitsio', 'pyhessio', 'targetio',
                                  'matplotlib'])
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - cta-observatory
   - conda-forge
 dependencies:
-  - zeromq=4.2.2  # frozen since 4.2.3 has packaging problem
+  - zeromq=4.2.2 
   - ctapipe-extra=0.2.*
   - astropy
   - bokeh

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: cta-dev
 channels:
+  - anaconda
   - cta-observatory
   - conda-forge
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - cta-observatory
   - conda-forge
 dependencies:
+  - zeromq=4.2.2  # frozen since 4.2.3 has packaging problem
   - ctapipe-extra=0.2.*
   - astropy
   - bokeh


### PR DESCRIPTION
current version of the package seems to be broken in conda-forge (will look into this later, but for not it's not a required dep, so disabling)