### PR TITLE
R1 Calibrator Changes

### DIFF
--- a/ctapipe/calib/camera/r1.py
+++ b/ctapipe/calib/camera/r1.py
@@ -188,13 +188,6 @@ class HessioR1Calibrator(CameraR1Calibrator):
                 event.r1.tel[telid].pe_samples = calibrated
 
 
-# External Children
-try:
-    from targetpipe.calib.camera.r1 import TargetioR1Calibrator
-except ImportError:
-    pass
-
-
 class CameraR1CalibratorFactory(Factory):
     """
     The R1 calibrator `ctapipe.core.factory.Factory`. This

--- a/ctapipe/calib/camera/r1.py
+++ b/ctapipe/calib/camera/r1.py
@@ -57,7 +57,6 @@ class CameraR1Calibrator(Component):
         Set to None if no Tool to pass.
     kwargs
     """
-    origin = None
 
     def __init__(self, config=None, tool=None, **kwargs):
         """
@@ -76,10 +75,6 @@ class CameraR1Calibrator(Component):
         kwargs
         """
         super().__init__(config=config, parent=tool, **kwargs)
-        if self.origin is None:
-            raise ValueError("Subclass of CameraR1Calibrator should specify "
-                             "an origin")
-
         self._r0_empty_warn = False
 
     @abstractmethod
@@ -175,8 +170,6 @@ class HessioR1Calibrator(CameraR1Calibrator):
         Set to None if no Tool to pass.
     kwargs
     """
-    origin = 'hessio'
-
     def calibrate(self, event):
         if event.meta['origin'] != 'hessio':
             raise ValueError('Using HessioR1Calibrator to calibrate a '

--- a/ctapipe/calib/camera/r1.py
+++ b/ctapipe/calib/camera/r1.py
@@ -20,7 +20,7 @@ from ctapipe.io import EventSource
 
 __all__ = [
     'NullR1Calibrator',
-    'HessioR1Calibrator',
+    'HESSIOR1Calibrator',
     'CameraR1CalibratorFactory'
 ]
 
@@ -139,7 +139,7 @@ class NullR1Calibrator(CameraR1Calibrator):
                 event.r1.tel[telid].pe_samples = samples.astype('float32')
 
 
-class HessioR1Calibrator(CameraR1Calibrator):
+class HESSIOR1Calibrator(CameraR1Calibrator):
     """
     The R1 calibrator for hessio files. Fills the r1 container.
 
@@ -176,7 +176,7 @@ class HessioR1Calibrator(CameraR1Calibrator):
 
     def calibrate(self, event):
         if event.meta['origin'] != 'hessio':
-            raise ValueError('Using HessioR1Calibrator to calibrate a '
+            raise ValueError('Using HESSIOR1Calibrator to calibrate a '
                              'non-hessio event.')
 
         for telid in event.r0.tels_with_data:
@@ -246,5 +246,5 @@ class CameraR1CalibratorFactory(Factory):
         except AttributeError:
             if self.eventsource:
                 if self.eventsource.metadata['is_simulation']:
-                    return 'HessioR1Calibrator'
+                    return 'HESSIOR1Calibrator'
             return 'NullR1Calibrator'

--- a/ctapipe/calib/camera/r1.py
+++ b/ctapipe/calib/camera/r1.py
@@ -23,19 +23,6 @@ __all__ = [
     'CameraR1CalibratorFactory'
 ]
 
-CALIB_SCALE = 1.05
-"""
-CALIB_SCALE is only relevant for MC calibration.
-
-CALIB_SCALE is the factor needed to transform from mean p.e. units to units of
-the single-p.e. peak: Depends on the collection efficiency, the asymmetry of
-the single p.e. amplitude  distribution and the electronic noise added to the
-signals. Default value is for GCT.
-
-To correctly calibrate to number of photoelectron, a fresh SPE calibration
-should be applied using a SPE sim_telarray run with an artificial light source.
-"""
-
 
 class CameraR1Calibrator(Component):
     """
@@ -170,6 +157,22 @@ class HessioR1Calibrator(CameraR1Calibrator):
         Set to None if no Tool to pass.
     kwargs
     """
+
+    calib_scale = 1.05
+    """
+    CALIB_SCALE is only relevant for MC calibration.
+
+    CALIB_SCALE is the factor needed to transform from mean p.e. units to 
+    units of the single-p.e. peak: Depends on the collection efficiency, 
+    the asymmetry of the single p.e. amplitude  distribution and the 
+    electronic noise added to the signals. Default value is for GCT.
+
+    To correctly calibrate to number of photoelectron, a fresh SPE calibration
+    should be applied using a SPE sim_telarray run with an 
+    artificial light source.
+    """
+    # TODO: Handle calib_scale differently per simlated telescope
+
     def calibrate(self, event):
         if event.meta['origin'] != 'hessio':
             raise ValueError('Using HessioR1Calibrator to calibrate a '
@@ -180,7 +183,7 @@ class HessioR1Calibrator(CameraR1Calibrator):
                 samples = event.r0.tel[telid].adc_samples
                 n_samples = samples.shape[2]
                 ped = event.mc.tel[telid].pedestal / n_samples
-                gain = event.mc.tel[telid].dc_to_pe * CALIB_SCALE
+                gain = event.mc.tel[telid].dc_to_pe * self.calib_scale
                 calibrated = (samples - ped[..., None]) * gain[..., None]
                 event.r1.tel[telid].pe_samples = calibrated
 

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -1,16 +1,48 @@
 from copy import deepcopy
-
 from numpy.testing import assert_allclose
-
-from ctapipe.calib.camera import CameraCalibrator
+from ctapipe.calib.camera import (
+    CameraCalibrator,
+    HESSIOR1Calibrator,
+    NullR1Calibrator
+)
+from ctapipe.image.charge_extractors import LocalPeakIntegrator
+from ctapipe.io import HESSIOEventSource
+from ctapipe.utils import get_dataset
 
 
 def test_camera_calibrator(test_event):
     event = deepcopy(test_event) # so we don't modify the test event
     telid = 11
 
-    calibrator = CameraCalibrator()
+    calibrator = CameraCalibrator(r1_product="HESSIOR1Calibrator")
 
     calibrator.calibrate(event)
     image = event.dl1.tel[telid].image
     assert_allclose(image[0, 0], -2.216, 1e-3)
+
+
+def test_manual_r1():
+    calibrator = CameraCalibrator(r1_product="HESSIOR1Calibrator")
+    assert isinstance(calibrator.r1, HESSIOR1Calibrator)
+
+
+def test_manual_extractor():
+    calibrator = CameraCalibrator(extractor_product="LocalPeakIntegrator")
+    assert isinstance(calibrator.dl1.extractor, LocalPeakIntegrator)
+
+
+def test_eventsource_r1():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    eventsource = HESSIOEventSource(input_url=dataset)
+    calibrator = CameraCalibrator(eventsource=eventsource)
+    assert isinstance(calibrator.r1, HESSIOR1Calibrator)
+
+
+def test_eventsource_override_r1():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    eventsource = HESSIOEventSource(input_url=dataset)
+    calibrator = CameraCalibrator(
+        eventsource=eventsource,
+        r1_product="NullR1Calibrator"
+    )
+    assert isinstance(calibrator.r1, NullR1Calibrator)

--- a/ctapipe/calib/camera/tests/test_dl0.py
+++ b/ctapipe/calib/camera/tests/test_dl0.py
@@ -3,11 +3,11 @@ from copy import deepcopy
 from numpy.testing import assert_almost_equal
 
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
-from ctapipe.calib.camera.r1 import HessioR1Calibrator
+from ctapipe.calib.camera.r1 import HESSIOR1Calibrator
 
 
 def previous_calibration(event):
-    r1 = HessioR1Calibrator()
+    r1 = HESSIOR1Calibrator()
     r1.calibrate(event)
 
 

--- a/ctapipe/calib/camera/tests/test_dl1.py
+++ b/ctapipe/calib/camera/tests/test_dl1.py
@@ -5,11 +5,11 @@ from numpy.testing import assert_allclose
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.dl1 import integration_correction, \
     CameraDL1Calibrator
-from ctapipe.calib.camera.r1 import HessioR1Calibrator
+from ctapipe.calib.camera.r1 import HESSIOR1Calibrator
 
 
 def previous_calibration(event):
-    r1 = HessioR1Calibrator()
+    r1 = HESSIOR1Calibrator()
     r1.calibrate(event)
     dl0 = CameraDL0Reducer()
     dl0.reduce(event)

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -1,8 +1,9 @@
-from numpy.testing import assert_almost_equal
-from ctapipe.io.hessio import hessio_event_source
-from ctapipe.utils import get_dataset
-from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory, \
-    HessioR1Calibrator
+from numpy.testing import assert_almost_equal, assert_array_equal
+from ctapipe.calib.camera.r1 import (
+    CameraR1CalibratorFactory,
+    HessioR1Calibrator,
+    NullR1Calibrator
+)
 from copy import deepcopy
 
 def test_hessio_r1_calibrator(test_event):
@@ -12,6 +13,16 @@ def test_hessio_r1_calibrator(test_event):
     calibrator.calibrate(event)
     r1 = event.r1.tel[telid].pe_samples
     assert_almost_equal(r1[0, 0, 0], -0.091, 3)
+
+
+def test_null_r1_calibrator(test_event):
+    telid = 11
+    event = deepcopy(test_event)
+    calibrator = NullR1Calibrator()
+    calibrator.calibrate(event)
+    r0 = event.r0.tel[telid].adc_samples
+    r1 = event.r1.tel[telid].pe_samples
+    assert_array_equal(r0, r1)
 
 
 def test_check_r0_exists(test_event):

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -1,7 +1,7 @@
 from numpy.testing import assert_almost_equal, assert_array_equal
 from ctapipe.calib.camera.r1 import (
     CameraR1CalibratorFactory,
-    HessioR1Calibrator,
+    HESSIOR1Calibrator,
     NullR1Calibrator
 )
 from ctapipe.io.hessioeventsource import HESSIOEventSource
@@ -13,7 +13,7 @@ from copy import deepcopy
 def test_hessio_r1_calibrator(test_event):
     telid = 11
     event = deepcopy(test_event)
-    calibrator = HessioR1Calibrator()
+    calibrator = HESSIOR1Calibrator()
     calibrator.calibrate(event)
     r1 = event.r1.tel[telid].pe_samples
     assert_almost_equal(r1[0, 0, 0], -0.091, 3)
@@ -32,7 +32,7 @@ def test_null_r1_calibrator(test_event):
 def test_check_r0_exists(test_event):
     telid = 11
     event = deepcopy(test_event)
-    calibrator = HessioR1Calibrator()
+    calibrator = HESSIOR1Calibrator()
     assert(calibrator.check_r0_exists(event, telid) is True)
     event.r0.tel[telid].adc_samples = None
     assert(calibrator.check_r0_exists(event, telid) is False)
@@ -44,9 +44,9 @@ def test_factory_from_product():
     )
     assert isinstance(calibrator, NullR1Calibrator)
     calibrator = CameraR1CalibratorFactory.produce(
-        product="HessioR1Calibrator"
+        product="HESSIOR1Calibrator"
     )
-    assert isinstance(calibrator, HessioR1Calibrator)
+    assert isinstance(calibrator, HESSIOR1Calibrator)
 
 
 def test_factory_default():
@@ -58,7 +58,7 @@ def test_factory_from_eventsource():
     dataset = get_dataset("gamma_test.simtel.gz")
     eventsource = HESSIOEventSource(input_url=dataset)
     calibrator = CameraR1CalibratorFactory.produce(eventsource=eventsource)
-    assert isinstance(calibrator, HessioR1Calibrator)
+    assert isinstance(calibrator, HESSIOR1Calibrator)
 
 
 class UnknownEventSource(EventSource):

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -4,6 +4,9 @@ from ctapipe.calib.camera.r1 import (
     HessioR1Calibrator,
     NullR1Calibrator
 )
+from ctapipe.io.hessioeventsource import HESSIOEventSource
+from ctapipe.io.eventsource import EventSource
+from ctapipe.utils import get_dataset
 from copy import deepcopy
 
 
@@ -35,11 +38,44 @@ def test_check_r0_exists(test_event):
     assert(calibrator.check_r0_exists(event, telid) is False)
 
 
-def test_factory(test_event):
-    calibrator = CameraR1CalibratorFactory.produce()
+def test_factory_from_product():
+    calibrator = CameraR1CalibratorFactory.produce(
+        product="NullR1Calibrator"
+    )
+    assert isinstance(calibrator, NullR1Calibrator)
+    calibrator = CameraR1CalibratorFactory.produce(
+        product="HessioR1Calibrator"
+    )
+    assert isinstance(calibrator, HessioR1Calibrator)
 
-    telid = 11
-    event = deepcopy(test_event)
-    calibrator.calibrate(event)
-    r1 = event.r1.tel[telid].pe_samples
-    assert_almost_equal(r1[0, 0, 0], -0.091, 3)
+
+def test_factory_default():
+    calibrator = CameraR1CalibratorFactory.produce()
+    assert isinstance(calibrator, NullR1Calibrator)
+
+
+def test_factory_from_eventsource():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    eventsource = HESSIOEventSource(input_url=dataset)
+    calibrator = CameraR1CalibratorFactory.produce(eventsource=eventsource)
+    assert isinstance(calibrator, HessioR1Calibrator)
+
+
+class UnknownEventSource(EventSource):
+    """
+    Simple working EventSource
+    """
+
+    def _generator(self):
+        return range(len(self.input_url))
+
+    @staticmethod
+    def is_compatible(file_path):
+        return False
+
+
+def test_factory_from_unknown_eventsource():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    eventsource = UnknownEventSource(input_url=dataset)
+    calibrator = CameraR1CalibratorFactory.produce(eventsource=eventsource)
+    assert isinstance(calibrator, NullR1Calibrator)

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -6,6 +6,7 @@ from ctapipe.calib.camera.r1 import (
 )
 from copy import deepcopy
 
+
 def test_hessio_r1_calibrator(test_event):
     telid = 11
     event = deepcopy(test_event)

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -61,6 +61,16 @@ def test_factory_from_eventsource():
     assert isinstance(calibrator, HESSIOR1Calibrator)
 
 
+def test_factory_from_eventsource_override():
+    dataset = get_dataset("gamma_test.simtel.gz")
+    eventsource = HESSIOEventSource(input_url=dataset)
+    calibrator = CameraR1CalibratorFactory.produce(
+        eventsource=eventsource,
+        product="NullR1Calibrator"
+    )
+    assert isinstance(calibrator, NullR1Calibrator)
+
+
 class UnknownEventSource(EventSource):
     """
     Simple working EventSource

--- a/ctapipe/plotting/tests/test_array.py
+++ b/ctapipe/plotting/tests/test_array.py
@@ -5,7 +5,7 @@ from astropy.coordinates import SkyCoord, AltAz
 
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.dl1 import CameraDL1Calibrator
-from ctapipe.calib.camera.r1 import HessioR1Calibrator
+from ctapipe.calib.camera.r1 import HESSIOR1Calibrator
 from ctapipe.coordinates import NominalFrame, CameraFrame
 from ctapipe.image.cleaning import tailcuts_clean
 from ctapipe.image.hillas import hillas_parameters, HillasParameterizationError
@@ -21,7 +21,7 @@ def test_array_draw():
     cam_geom = {}
 
     source = hessio_event_source(filename, max_events=2)
-    r1 = HessioR1Calibrator()
+    r1 = HESSIOR1Calibrator()
     dl0 = CameraDL0Reducer()
 
     calibrator = CameraDL1Calibrator()

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -11,7 +11,7 @@ from traitlets import Dict, List, Int, Unicode
 from ctapipe.analysis.camera.chargeresolution import ChargeResolutionCalculator
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.dl1 import CameraDL1Calibrator
-from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory
+from ctapipe.calib.camera.r1 import HESSIOR1Calibrator
 from ctapipe.core import Tool
 from ctapipe.image.charge_extractors import ChargeExtractorFactory
 from ctapipe.io.hessioeventsource import HESSIOEventSource
@@ -26,12 +26,12 @@ class ChargeResolutionGenerator(Tool):
                       help='Telescopes to include from the event file. '
                            'Default = All telescopes').tag(config=True)
     output_name = Unicode('charge_resolution',
-                          help='Name of the output charge resolution pickle '
+                          help='Name of the output charge resolution hdf5 '
                                'file').tag(config=True)
 
-    aliases = Dict(dict(f='HESSIOEventSource.input_path',
+    aliases = Dict(dict(f='HESSIOEventSource.input_url',
                         max_events='HESSIOEventSource.max_events',
-                        extractor='ChargeExtractorFactory.extractor',
+                        extractor='ChargeExtractorFactory.product',
                         window_width='ChargeExtractorFactory.window_width',
                         t0='ChargeExtractorFactory.t0',
                         window_shift='ChargeExtractorFactory.window_shift',
@@ -52,7 +52,7 @@ class ChargeResolutionGenerator(Tool):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.file_reader = None
+        self.eventsource = None
         self.r1 = None
         self.dl0 = None
         self.dl1 = None
@@ -62,16 +62,11 @@ class ChargeResolutionGenerator(Tool):
         self.log_format = "%(levelname)s: %(message)s [%(name)s.%(funcName)s]"
         kwargs = dict(config=self.config, tool=self)
 
-        self.file_reader = HESSIOEventSource(**kwargs)
+        self.eventsource = HESSIOEventSource(**kwargs)
 
-        extractor_factory = ChargeExtractorFactory(**kwargs)
-        extractor_class = extractor_factory.get_class()
-        extractor = extractor_class(**kwargs)
+        extractor = ChargeExtractorFactory.produce(**kwargs)
 
-        r1_factory = CameraR1CalibratorFactory(origin=self.file_reader.origin,
-                                               **kwargs)
-        r1_class = r1_factory.get_class()
-        self.r1 = r1_class(**kwargs)
+        self.r1 = HESSIOR1Calibrator(**kwargs)
 
         self.dl0 = CameraDL0Reducer(**kwargs)
 
@@ -81,8 +76,7 @@ class ChargeResolutionGenerator(Tool):
 
     def start(self):
         desc = "Filling Charge Resolution"
-        source = self.file_reader.read()
-        for event in tqdm(source, desc=desc):
+        for event in tqdm(self.eventsource, desc=desc):
             tels = list(event.dl0.tels_with_data)
 
             # Check events have true charge included
@@ -112,9 +106,15 @@ class ChargeResolutionGenerator(Tool):
                 self.calculator.add_charges(true_charge, measured_charge)
 
     def finish(self):
-        directory = self.file_reader.output_directory
+        input_url = self.eventsource.input_url
+        input_directory = os.path.dirname(input_url)
+        input_name = os.path.splitext(os.path.basename(input_url))[0]
+        output_directory = os.path.join(input_directory, input_name)
+        if not os.path.exists(output_directory):
+            self.log.info("Creating directory: {}".format(output_directory))
+            os.makedirs(output_directory)
         name = "{}.h5".format(self.output_name)
-        ouput_path = os.path.join(directory, name)
+        ouput_path = os.path.join(output_directory, name)
         self.calculator.save(ouput_path)
 
 

--- a/ctapipe/tools/plot_charge_resolution.py
+++ b/ctapipe/tools/plot_charge_resolution.py
@@ -203,5 +203,6 @@ def main():
     exe = ChargeResolutionViewer()
     exe.run()
 
+
 if __name__ == '__main__':
     main()

--- a/ctapipe/tools/plot_charge_resolution_variation_hist.py
+++ b/ctapipe/tools/plot_charge_resolution_variation_hist.py
@@ -65,8 +65,7 @@ class ChargeResolutionVariationPlotter(Component):
         x = np.power(10, x)
         y = np.power(10, y)
         hist_mask = np.ma.masked_where(np.isnan(hist), hist)
-        im = ax.pcolormesh(x, y, hist_mask, norm=LogNorm(),
-                           cmap=plt.cm.viridis)
+        im = ax.pcolormesh(x, y, hist_mask, norm=LogNorm())
         cb = plt.colorbar(im)
         ax.set_aspect('equal')
         ax.grid()
@@ -145,6 +144,7 @@ class ChargeResolutionVariationViewer(Tool):
 def main():
     exe = ChargeResolutionVariationViewer()
     exe.run()
+
 
 if __name__ == '__main__':
     main()

--- a/examples/display_events_single_tel.py
+++ b/examples/display_events_single_tel.py
@@ -63,10 +63,17 @@ class SingleTelEventDisplay(Tool):
 
     def setup(self):
 
-        self.event_source = EventSourceFactory.produce(None, self)
+        self.event_source = EventSourceFactory.produce(
+            config=self.config,
+            tool=self
+        )
         self.event_source.allowed_tels = [self.tel, ]
 
-        self.calibrator = CameraCalibrator(config=None, tool=self)
+        self.calibrator = CameraCalibrator(
+            config=self.config,
+            tool=self,
+            eventsource=self.event_source
+        )
 
         self.log.info('SELECTING EVENTS FROM TELESCOPE {}'.format(self.tel))
 

--- a/examples/display_integrator.py
+++ b/examples/display_integrator.py
@@ -8,11 +8,11 @@ image, and a calibrated camera image
 
 import numpy as np
 from matplotlib import pyplot as plt
-from traitlets import Dict, List, Int, Bool, Unicode, Enum
+from traitlets import Dict, List, Int, Bool, Enum
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.dl1 import CameraDL1Calibrator
 from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory
-from ctapipe.core import Tool, Component
+from ctapipe.core import Tool
 from ctapipe.image.charge_extractors import ChargeExtractorFactory
 from ctapipe.io.eventsourcefactory import EventSourceFactory
 from ctapipe.io.eventseeker import EventSeeker

--- a/examples/display_integrator.py
+++ b/examples/display_integrator.py
@@ -6,275 +6,215 @@ neighbour, the camera image for the max charge timeslice, the true pe camera
 image, and a calibrated camera image
 """
 
-import os
-
 import numpy as np
 from matplotlib import pyplot as plt
 from traitlets import Dict, List, Int, Bool, Unicode, Enum
-
 from ctapipe.calib.camera.dl0 import CameraDL0Reducer
 from ctapipe.calib.camera.dl1 import CameraDL1Calibrator
 from ctapipe.calib.camera.r1 import CameraR1CalibratorFactory
 from ctapipe.core import Tool, Component
 from ctapipe.image.charge_extractors import ChargeExtractorFactory
-from ctapipe.instrument import CameraGeometry
 from ctapipe.io.eventsourcefactory import EventSourceFactory
+from ctapipe.io.eventseeker import EventSeeker
 from ctapipe.visualization import CameraDisplay
 
 
-class IntegratorPlotter(Component):
-    output_dir = Unicode(None, allow_none=True,
-                         help='Output path to the directory where the plots '
-                              'will be saved. If None, a directory is created '
-                              'in the location of the '
-                              'input file.').tag(config=True)
+def plot(event, telid, chan, extractor_name):
+    # Extract required images
+    dl0 = event.dl0.tel[telid].pe_samples[chan]
 
-    def __init__(self, config=None, tool=None, **kwargs):
-        """
-        Plotter for camera images.
+    t_pe = event.mc.tel[telid].photo_electron_image
+    dl1 = event.dl1.tel[telid].image[chan]
+    max_time = np.unravel_index(np.argmax(dl0), dl0.shape)[1]
+    max_charges = np.max(dl0, axis=1)
+    max_pix = int(np.argmax(max_charges))
+    min_pix = int(np.argmin(max_charges))
 
-        Parameters
-        ----------
-        config : traitlets.loader.Config
-            Configuration specified by config file or cmdline arguments.
-            Used to set traitlet values.
-            Set to None if no configuration to pass.
-        tool : ctapipe.core.Tool
-            Tool executable that is calling this component.
-            Passes the correct logger to the component.
-            Set to None if no Tool to pass.
-        kwargs
-        """
-        super().__init__(config=config, parent=tool, **kwargs)
-        self._init_figure()
+    geom = event.inst.subarray.tel[telid].camera
+    nei = geom.neighbors
 
-    def _init_figure(self):
-        self.fig = plt.figure(figsize=(16, 7))
-        self.ax_intensity = self.fig.add_subplot(1, 2, 1)
-        self.ax_peakpos = self.fig.add_subplot(1, 2, 2)
+    # Get Neighbours
+    max_pixel_nei = nei[max_pix]
+    min_pixel_nei = nei[min_pix]
 
-    def plot(self, input_file, event, telid, chan, extractor_name):
-        # Extract required images
-        dl0 = event.dl0.tel[telid].pe_samples[chan]
+    # Get Windows
+    windows = event.dl1.tel[telid].extracted_samples[chan]
+    length = np.sum(windows, axis=1)
+    start = np.argmax(windows, axis=1)
+    end = start + length - 1
 
-        t_pe = event.mc.tel[telid].photo_electron_image
-        dl1 = event.dl1.tel[telid].image[chan]
-        max_time = np.unravel_index(np.argmax(dl0), dl0.shape)[1]
-        max_charges = np.max(dl0, axis=1)
-        max_pix = int(np.argmax(max_charges))
-        min_pix = int(np.argmin(max_charges))
+    # Draw figures
+    ax_max_nei = {}
+    ax_min_nei = {}
+    fig_waveforms = plt.figure(figsize=(18, 9))
+    fig_waveforms.subplots_adjust(hspace=.5)
+    fig_camera = plt.figure(figsize=(15, 12))
 
-        geom = event.inst.subarray.tel[telid].camera
-        nei = geom.neighbors
+    ax_max_pix = fig_waveforms.add_subplot(4, 2, 1)
+    ax_min_pix = fig_waveforms.add_subplot(4, 2, 2)
+    ax_max_nei[0] = fig_waveforms.add_subplot(4, 2, 3)
+    ax_min_nei[0] = fig_waveforms.add_subplot(4, 2, 4)
+    ax_max_nei[1] = fig_waveforms.add_subplot(4, 2, 5)
+    ax_min_nei[1] = fig_waveforms.add_subplot(4, 2, 6)
+    ax_max_nei[2] = fig_waveforms.add_subplot(4, 2, 7)
+    ax_min_nei[2] = fig_waveforms.add_subplot(4, 2, 8)
 
-        # Get Neighbours
-        max_pixel_nei = nei[max_pix]
-        min_pixel_nei = nei[min_pix]
+    ax_img_nei = fig_camera.add_subplot(2, 2, 1)
+    ax_img_max = fig_camera.add_subplot(2, 2, 2)
+    ax_img_true = fig_camera.add_subplot(2, 2, 3)
+    ax_img_cal = fig_camera.add_subplot(2, 2, 4)
 
-        # Get Windows
-        windows = event.dl1.tel[telid].extracted_samples[chan]
-        length = np.sum(windows, axis=1)
-        start = np.argmax(windows, axis=1)
-        end = start + length - 1
+    # Draw max pixel traces
+    ax_max_pix.plot(dl0[max_pix])
+    ax_max_pix.set_xlabel("Time (ns)")
+    ax_max_pix.set_ylabel("DL0 Samples (ADC)")
+    ax_max_pix.set_title("(Max) Pixel: {}, True: {}, Measured = {:.3f}"
+                         .format(max_pix, t_pe[max_pix], dl1[max_pix]))
+    max_ylim = ax_max_pix.get_ylim()
+    ax_max_pix.plot([start[max_pix], start[max_pix]],
+                    ax_max_pix.get_ylim(), color='r', alpha=1)
+    ax_max_pix.plot([end[max_pix], end[max_pix]],
+                    ax_max_pix.get_ylim(), color='r', alpha=1)
+    for i, ax in ax_max_nei.items():
+        if len(max_pixel_nei) > i:
+            pix = max_pixel_nei[i]
+            ax.plot(dl0[pix])
+            ax.set_xlabel("Time (ns)")
+            ax.set_ylabel("DL0 Samples (ADC)")
+            ax.set_title("(Max Nei) Pixel: {}, True: {}, Measured = {:.3f}"
+                         .format(pix, t_pe[pix], dl1[pix]))
+            ax.set_ylim(max_ylim)
+            ax.plot([start[pix], start[pix]],
+                    ax.get_ylim(), color='r', alpha=1)
+            ax.plot([end[pix], end[pix]],
+                    ax.get_ylim(), color='r', alpha=1)
 
-        # Draw figures
-        ax_max_nei = {}
-        ax_min_nei = {}
-        fig_waveforms = plt.figure(figsize=(18, 9))
-        fig_waveforms.subplots_adjust(hspace=.5)
-        fig_camera = plt.figure(figsize=(15, 12))
+    # Draw min pixel traces
+    ax_min_pix.plot(dl0[min_pix])
+    ax_min_pix.set_xlabel("Time (ns)")
+    ax_min_pix.set_ylabel("DL0 Samples (ADC)")
+    ax_min_pix.set_title("(Min) Pixel: {}, True: {}, Measured = {:.3f}"
+                         .format(min_pix, t_pe[min_pix], dl1[min_pix]))
+    ax_min_pix.set_ylim(max_ylim)
+    ax_min_pix.plot([start[min_pix], start[min_pix]],
+                    ax_min_pix.get_ylim(), color='r', alpha=1)
+    ax_min_pix.plot([end[min_pix], end[min_pix]],
+                    ax_min_pix.get_ylim(), color='r', alpha=1)
+    for i, ax in ax_min_nei.items():
+        if len(min_pixel_nei) > i:
+            pix = min_pixel_nei[i]
+            ax.plot(dl0[pix])
+            ax.set_xlabel("Time (ns)")
+            ax.set_ylabel("DL0 Samples (ADC)")
+            ax.set_title("(Min Nei) Pixel: {}, True: {}, Measured = {:.3f}"
+                         .format(pix, t_pe[pix], dl1[pix]))
+            ax.set_ylim(max_ylim)
+            ax.plot([start[pix], start[pix]],
+                    ax.get_ylim(), color='r', alpha=1)
+            ax.plot([end[pix], end[pix]],
+                    ax.get_ylim(), color='r', alpha=1)
 
-        ax_max_pix = fig_waveforms.add_subplot(4, 2, 1)
-        ax_min_pix = fig_waveforms.add_subplot(4, 2, 2)
-        ax_max_nei[0] = fig_waveforms.add_subplot(4, 2, 3)
-        ax_min_nei[0] = fig_waveforms.add_subplot(4, 2, 4)
-        ax_max_nei[1] = fig_waveforms.add_subplot(4, 2, 5)
-        ax_min_nei[1] = fig_waveforms.add_subplot(4, 2, 6)
-        ax_max_nei[2] = fig_waveforms.add_subplot(4, 2, 7)
-        ax_min_nei[2] = fig_waveforms.add_subplot(4, 2, 8)
+    # Draw cameras
+    nei_camera = np.zeros_like(max_charges, dtype=np.int)
+    nei_camera[min_pixel_nei] = 2
+    nei_camera[min_pix] = 1
+    nei_camera[max_pixel_nei] = 3
+    nei_camera[max_pix] = 4
+    camera = CameraDisplay(geom, ax=ax_img_nei)
+    camera.image = nei_camera
+    ax_img_nei.set_title("Neighbour Map")
+    ax_img_nei.annotate("Pixel: {}".format(max_pix),
+                        xy=(geom.pix_x.value[max_pix],
+                            geom.pix_y.value[max_pix]),
+                        xycoords='data', xytext=(0.05, 0.98),
+                        textcoords='axes fraction',
+                        arrowprops=dict(facecolor='red', width=2,
+                                        alpha=0.4),
+                        horizontalalignment='left',
+                        verticalalignment='top')
+    ax_img_nei.annotate("Pixel: {}".format(min_pix),
+                        xy=(geom.pix_x.value[min_pix],
+                            geom.pix_y.value[min_pix]),
+                        xycoords='data', xytext=(0.05, 0.94),
+                        textcoords='axes fraction',
+                        arrowprops=dict(facecolor='orange', width=2,
+                                        alpha=0.4),
+                        horizontalalignment='left',
+                        verticalalignment='top')
+    camera = CameraDisplay(geom, ax=ax_img_max)
+    camera.image = dl0[:, max_time]
+    camera.add_colorbar(ax=ax_img_max, label="DL0 Samples (ADC)")
+    ax_img_max.set_title("Max Timeslice (T = {})".format(max_time))
+    ax_img_max.annotate("Pixel: {}".format(max_pix),
+                        xy=(geom.pix_x.value[max_pix],
+                            geom.pix_y.value[max_pix]),
+                        xycoords='data', xytext=(0.05, 0.98),
+                        textcoords='axes fraction',
+                        arrowprops=dict(facecolor='red', width=2,
+                                        alpha=0.4),
+                        horizontalalignment='left',
+                        verticalalignment='top')
+    ax_img_max.annotate("Pixel: {}".format(min_pix),
+                        xy=(geom.pix_x.value[min_pix],
+                            geom.pix_y.value[min_pix]),
+                        xycoords='data', xytext=(0.05, 0.94),
+                        textcoords='axes fraction',
+                        arrowprops=dict(facecolor='orange', width=2,
+                                        alpha=0.4),
+                        horizontalalignment='left',
+                        verticalalignment='top')
 
-        ax_img_nei = fig_camera.add_subplot(2, 2, 1)
-        ax_img_max = fig_camera.add_subplot(2, 2, 2)
-        ax_img_true = fig_camera.add_subplot(2, 2, 3)
-        ax_img_cal = fig_camera.add_subplot(2, 2, 4)
+    camera = CameraDisplay(geom, ax=ax_img_true)
+    camera.image = t_pe
+    camera.add_colorbar(ax=ax_img_true, label="True Charge (p.e.)")
+    ax_img_true.set_title("True Charge")
+    ax_img_true.annotate("Pixel: {}".format(max_pix),
+                         xy=(geom.pix_x.value[max_pix],
+                             geom.pix_y.value[max_pix]),
+                         xycoords='data', xytext=(0.05, 0.98),
+                         textcoords='axes fraction',
+                         arrowprops=dict(facecolor='red', width=2,
+                                         alpha=0.4),
+                         horizontalalignment='left',
+                         verticalalignment='top')
+    ax_img_true.annotate("Pixel: {}".format(min_pix),
+                         xy=(geom.pix_x.value[min_pix],
+                             geom.pix_y.value[min_pix]),
+                         xycoords='data', xytext=(0.05, 0.94),
+                         textcoords='axes fraction',
+                         arrowprops=dict(facecolor='orange', width=2,
+                                         alpha=0.4),
+                         horizontalalignment='left',
+                         verticalalignment='top')
 
-        # Draw max pixel traces
-        ax_max_pix.plot(dl0[max_pix])
-        ax_max_pix.set_xlabel("Time (ns)")
-        ax_max_pix.set_ylabel("DL0 Samples (ADC)")
-        ax_max_pix.set_title("(Max) Pixel: {}, True: {}, Measured = {:.3f}"
-                             .format(max_pix, t_pe[max_pix], dl1[max_pix]))
-        max_ylim = ax_max_pix.get_ylim()
-        ax_max_pix.plot([start[max_pix], start[max_pix]],
-                        ax_max_pix.get_ylim(), color='r', alpha=1)
-        ax_max_pix.plot([end[max_pix], end[max_pix]],
-                        ax_max_pix.get_ylim(), color='r', alpha=1)
-        for i, ax in ax_max_nei.items():
-            if len(max_pixel_nei) > i:
-                pix = max_pixel_nei[i]
-                ax.plot(dl0[pix])
-                ax.set_xlabel("Time (ns)")
-                ax.set_ylabel("DL0 Samples (ADC)")
-                ax.set_title("(Max Nei) Pixel: {}, True: {}, Measured = {:.3f}"
-                             .format(pix, t_pe[pix], dl1[pix]))
-                ax.set_ylim(max_ylim)
-                ax.plot([start[pix], start[pix]],
-                        ax.get_ylim(), color='r', alpha=1)
-                ax.plot([end[pix], end[pix]],
-                        ax.get_ylim(), color='r', alpha=1)
+    camera = CameraDisplay(geom, ax=ax_img_cal)
+    camera.image = dl1
+    camera.add_colorbar(ax=ax_img_cal,
+                        label="Calib Charge (Photo-electrons)")
+    ax_img_cal.set_title("Charge (integrator={})".format(extractor_name))
+    ax_img_cal.annotate("Pixel: {}".format(max_pix),
+                        xy=(geom.pix_x.value[max_pix],
+                            geom.pix_y.value[max_pix]),
+                        xycoords='data', xytext=(0.05, 0.98),
+                        textcoords='axes fraction',
+                        arrowprops=dict(facecolor='red', width=2,
+                                        alpha=0.4),
+                        horizontalalignment='left',
+                        verticalalignment='top')
+    ax_img_cal.annotate("Pixel: {}".format(min_pix),
+                        xy=(geom.pix_x.value[min_pix],
+                            geom.pix_y.value[min_pix]),
+                        xycoords='data', xytext=(0.05, 0.94),
+                        textcoords='axes fraction',
+                        arrowprops=dict(facecolor='orange', width=2,
+                                        alpha=0.4),
+                        horizontalalignment='left',
+                        verticalalignment='top')
 
-        # Draw min pixel traces
-        ax_min_pix.plot(dl0[min_pix])
-        ax_min_pix.set_xlabel("Time (ns)")
-        ax_min_pix.set_ylabel("DL0 Samples (ADC)")
-        ax_min_pix.set_title("(Min) Pixel: {}, True: {}, Measured = {:.3f}"
-                             .format(min_pix, t_pe[min_pix], dl1[min_pix]))
-        ax_min_pix.set_ylim(max_ylim)
-        ax_min_pix.plot([start[min_pix], start[min_pix]],
-                        ax_min_pix.get_ylim(), color='r', alpha=1)
-        ax_min_pix.plot([end[min_pix], end[min_pix]],
-                        ax_min_pix.get_ylim(), color='r', alpha=1)
-        for i, ax in ax_min_nei.items():
-            if len(min_pixel_nei) > i:
-                pix = min_pixel_nei[i]
-                ax.plot(dl0[pix])
-                ax.set_xlabel("Time (ns)")
-                ax.set_ylabel("DL0 Samples (ADC)")
-                ax.set_title("(Min Nei) Pixel: {}, True: {}, Measured = {:.3f}"
-                             .format(pix, t_pe[pix], dl1[pix]))
-                ax.set_ylim(max_ylim)
-                ax.plot([start[pix], start[pix]],
-                        ax.get_ylim(), color='r', alpha=1)
-                ax.plot([end[pix], end[pix]],
-                        ax.get_ylim(), color='r', alpha=1)
+    fig_waveforms.suptitle("Integrator = {}".format(extractor_name))
+    fig_camera.suptitle("Camera = {}".format(geom.cam_id))
 
-        # Draw cameras
-        nei_camera = np.zeros_like(max_charges, dtype=np.int)
-        nei_camera[min_pixel_nei] = 2
-        nei_camera[min_pix] = 1
-        nei_camera[max_pixel_nei] = 3
-        nei_camera[max_pix] = 4
-        camera = CameraDisplay(geom, ax=ax_img_nei)
-        camera.image = nei_camera
-        camera.cmap = plt.cm.viridis
-        ax_img_nei.set_title("Neighbour Map")
-        ax_img_nei.annotate("Pixel: {}".format(max_pix),
-                            xy=(geom.pix_x.value[max_pix],
-                                geom.pix_y.value[max_pix]),
-                            xycoords='data', xytext=(0.05, 0.98),
-                            textcoords='axes fraction',
-                            arrowprops=dict(facecolor='red', width=2,
-                                            alpha=0.4),
-                            horizontalalignment='left',
-                            verticalalignment='top')
-        ax_img_nei.annotate("Pixel: {}".format(min_pix),
-                            xy=(geom.pix_x.value[min_pix],
-                                geom.pix_y.value[min_pix]),
-                            xycoords='data', xytext=(0.05, 0.94),
-                            textcoords='axes fraction',
-                            arrowprops=dict(facecolor='orange', width=2,
-                                            alpha=0.4),
-                            horizontalalignment='left',
-                            verticalalignment='top')
-        camera = CameraDisplay(geom, ax=ax_img_max)
-        camera.image = dl0[:, max_time]
-        camera.cmap = plt.cm.viridis
-        camera.add_colorbar(ax=ax_img_max, label="DL0 Samples (ADC)")
-        ax_img_max.set_title("Max Timeslice (T = {})".format(max_time))
-        ax_img_max.annotate("Pixel: {}".format(max_pix),
-                            xy=(geom.pix_x.value[max_pix],
-                                geom.pix_y.value[max_pix]),
-                            xycoords='data', xytext=(0.05, 0.98),
-                            textcoords='axes fraction',
-                            arrowprops=dict(facecolor='red', width=2,
-                                            alpha=0.4),
-                            horizontalalignment='left',
-                            verticalalignment='top')
-        ax_img_max.annotate("Pixel: {}".format(min_pix),
-                            xy=(geom.pix_x.value[min_pix],
-                                geom.pix_y.value[min_pix]),
-                            xycoords='data', xytext=(0.05, 0.94),
-                            textcoords='axes fraction',
-                            arrowprops=dict(facecolor='orange', width=2,
-                                            alpha=0.4),
-                            horizontalalignment='left',
-                            verticalalignment='top')
-
-        camera = CameraDisplay(geom, ax=ax_img_true)
-        camera.image = t_pe
-        camera.cmap = plt.cm.viridis
-        camera.add_colorbar(ax=ax_img_true, label="True Charge (p.e.)")
-        ax_img_true.set_title("True Charge")
-        ax_img_true.annotate("Pixel: {}".format(max_pix),
-                             xy=(geom.pix_x.value[max_pix],
-                                 geom.pix_y.value[max_pix]),
-                             xycoords='data', xytext=(0.05, 0.98),
-                             textcoords='axes fraction',
-                             arrowprops=dict(facecolor='red', width=2,
-                                             alpha=0.4),
-                             horizontalalignment='left',
-                             verticalalignment='top')
-        ax_img_true.annotate("Pixel: {}".format(min_pix),
-                             xy=(geom.pix_x.value[min_pix],
-                                 geom.pix_y.value[min_pix]),
-                             xycoords='data', xytext=(0.05, 0.94),
-                             textcoords='axes fraction',
-                             arrowprops=dict(facecolor='orange', width=2,
-                                             alpha=0.4),
-                             horizontalalignment='left',
-                             verticalalignment='top')
-
-        camera = CameraDisplay(geom, ax=ax_img_cal)
-        camera.image = dl1
-        camera.cmap = plt.cm.viridis
-        camera.add_colorbar(ax=ax_img_cal,
-                            label="Calib Charge (Photo-electrons)")
-        ax_img_cal.set_title("Charge (integrator={})".format(extractor_name))
-        ax_img_cal.annotate("Pixel: {}".format(max_pix),
-                            xy=(geom.pix_x.value[max_pix],
-                                geom.pix_y.value[max_pix]),
-                            xycoords='data', xytext=(0.05, 0.98),
-                            textcoords='axes fraction',
-                            arrowprops=dict(facecolor='red', width=2,
-                                            alpha=0.4),
-                            horizontalalignment='left',
-                            verticalalignment='top')
-        ax_img_cal.annotate("Pixel: {}".format(min_pix),
-                            xy=(geom.pix_x.value[min_pix],
-                                geom.pix_y.value[min_pix]),
-                            xycoords='data', xytext=(0.05, 0.94),
-                            textcoords='axes fraction',
-                            arrowprops=dict(facecolor='orange', width=2,
-                                            alpha=0.4),
-                            horizontalalignment='left',
-                            verticalalignment='top')
-
-        fig_waveforms.suptitle("Integrator = {}".format(extractor_name))
-        fig_camera.suptitle("Camera = {}".format(geom.cam_id))
-
-        waveform_output_name = "e{}_t{}_c{}_extractor{}_waveform.pdf"\
-            .format(event.count, telid, chan, extractor_name)
-        camera_output_name = "e{}_t{}_c{}_extractor{}_camera.pdf"\
-            .format(event.count, telid, chan, extractor_name)
-
-        output_dir = self.output_dir
-        if output_dir is None:
-            output_dir = input_file.output_directory
-        output_dir = os.path.join(output_dir, self.name)
-        if not os.path.exists(output_dir):
-            self.log.info("Creating directory: {}".format(output_dir))
-            os.makedirs(output_dir)
-
-        waveform_output_path = os.path.join(output_dir, waveform_output_name)
-        self.log.info("Saving: {}".format(waveform_output_path))
-        fig_waveforms.savefig(waveform_output_path, format='pdf',
-                              bbox_inches='tight')
-
-        camera_output_path = os.path.join(output_dir, camera_output_name)
-        self.log.info("Saving: {}".format(camera_output_path))
-        fig_camera.savefig(camera_output_path, format='pdf',
-                           bbox_inches='tight')
-        return geom
+    plt.show()
 
 
 class DisplayIntegrator(Tool):
@@ -293,10 +233,10 @@ class DisplayIntegrator(Tool):
                          'telescope with data.').tag(config=True)
     channel = Enum([0, 1], 0, help='Channel to view').tag(config=True)
 
-    aliases = Dict(dict(r='EventSourceFactory.event_source',
-                        f='EventSourceFactory.input_path',
+    aliases = Dict(dict(r='EventSourceFactory.product',
+                        f='EventSourceFactory.input_url',
                         max_events='EventSourceFactory.max_events',
-                        extractor='ChargeExtractorFactory.extractor',
+                        extractor='ChargeExtractorFactory.product',
                         window_width='ChargeExtractorFactory.window_width',
                         window_shift='ChargeExtractorFactory.window_shift',
                         sig_amp_cut_HG='ChargeExtractorFactory.sig_amp_cut_HG',
@@ -307,7 +247,6 @@ class DisplayIntegrator(Tool):
                         E='DisplayIntegrator.event_index',
                         T='DisplayIntegrator.telescope',
                         C='DisplayIntegrator.channel',
-                        O='IntegratorPlotter.output_dir'
                         ))
     flags = Dict(dict(id=({'DisplayDL1Calib': {'use_event_index': True}},
                           'event_index will obtain an event using '
@@ -316,41 +255,40 @@ class DisplayIntegrator(Tool):
     classes = List([EventSourceFactory,
                     ChargeExtractorFactory,
                     CameraDL1Calibrator,
-                    IntegratorPlotter
                     ])
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.file_reader = None
+        self.eventseeker = None
         self.r1 = None
         self.dl0 = None
         self.extractor = None
         self.dl1 = None
-        self.plotter = None
 
     def setup(self):
         self.log_format = "%(levelname)s: %(message)s [%(name)s.%(funcName)s]"
         kwargs = dict(config=self.config, tool=self)
 
-        self.file_reader = EventSourceFactory.produce(**kwargs)
+        eventsource = EventSourceFactory.produce(**kwargs)
+        self.eventseeker = EventSeeker(eventsource, **kwargs)
 
-        extractor_factory = ChargeExtractorFactory(**kwargs)
-        extractor_class = extractor_factory.get_class()
-        self.extractor = extractor_class(**kwargs)
+        self.extractor = ChargeExtractorFactory.produce(**kwargs)
 
-        r1_factory = CameraR1CalibratorFactory(origin=self.file_reader.origin,
-                                               **kwargs)
-        r1_class = r1_factory.get_class()
-        self.r1 = r1_class(**kwargs)
+        self.r1 = CameraR1CalibratorFactory.produce(
+            eventsource=eventsource,
+            **kwargs
+        )
 
         self.dl0 = CameraDL0Reducer(**kwargs)
 
         self.dl1 = CameraDL1Calibrator(extractor=self.extractor, **kwargs)
 
-        self.plotter = IntegratorPlotter(**kwargs)
 
     def start(self):
-        event = self.file_reader.get_event(self.event_index, self.use_event_id)
+        event_num = self.event_index
+        if self.use_event_id:
+            event_num = str(event_num)
+        event = self.eventseeker[event_num]
 
         # Calibrate
         self.r1.calibrate(event)
@@ -367,13 +305,13 @@ class DisplayIntegrator(Tool):
                            "telescopes for this event: {}".format(tels))
             exit()
 
-        extractor_name = self.extractor.name
+        extractor_name = self.extractor.__class__.__name__
 
-        self.plotter.plot(self.file_reader, event, telid,
-                          self.channel, extractor_name)
+        plot(event, telid, self.channel, extractor_name)
 
     def finish(self):
         pass
+
 
 if __name__ == '__main__':
     exe = DisplayIntegrator()

--- a/examples/display_summed_images.py
+++ b/examples/display_summed_images.py
@@ -60,7 +60,13 @@ class ImageSumDisplayerTool(Tool):
                       self.telgroup,
                       str(event.inst.subarray.tel[self._selected_tels[0]]))
         self.log.info("SELECTED TELESCOPES:{}".format(self._selected_tels))
-        self.calibrator = CameraCalibrator(config=self.config, tool=self)
+
+        self.calibrator = CameraCalibrator(
+            config=self.config,
+            tool=self,
+            eventsource=self.reader
+        )
+
         self.reader.allowed_tels = self._selected_tels
 
 

--- a/examples/load_one_event.py
+++ b/examples/load_one_event.py
@@ -10,7 +10,7 @@ from ctapipe.calib import CameraCalibrator
 
 if __name__ == '__main__':
 
-    calib = CameraCalibrator()
+    calib = CameraCalibrator(r1_product="HESSIOR1Calibrator")
 
     if len(sys.argv) >= 2:
         filename = sys.argv[1]

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -56,7 +56,11 @@ class MuonDisplayerTool(Tool):
 
 
     def setup(self):
-        self.calib = CameraCalibrator(config=self.config, tool=self)
+        self.calib = CameraCalibrator(
+            config=self.config,
+            tool=self,
+            r1_product="HESSIOR1Calibrator"
+        )
 
     def start(self):
 

--- a/examples/plot_theta_square.py
+++ b/examples/plot_theta_square.py
@@ -33,7 +33,7 @@ point_azimuth = {}
 point_altitude = {}
 
 reco = HillasReconstructor()
-calib = CameraCalibrator()
+calib = CameraCalibrator(r1_product="HESSIOR1Calibrator")
 off_angles = []
 
 for event in source:

--- a/examples/simple_pipeline.py
+++ b/examples/simple_pipeline.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
     source = event_source(filename, max_events=None)
 
-    cal = CameraCalibrator()
+    cal = CameraCalibrator(r1_product="HESSIOR1Calibrator")
 
     for data in source:
 


### PR DESCRIPTION
Some cleanup of the R1 Calibrator code following the recent pull requests:

- Created NullR1Calibrator, which serves as a better default than HessioR1Calibrator, as other file formats would not want that used by default.
- Allowed the passing of eventsource to CameraR1CalibratorFactory. The Factory can then select the correct CameraR1Calibrator to use based on metadata or instrument information, unless overrided by the user.
- Allowed more customisation on the generic CameraCalibrator class
- Moved calib_scale into the HessioR1Calibrator
- Renamed HessioR1Calibrator to HESSIOR1Calibrator