### PR TITLE
downgrade sphinx to avoid incompatibility of 1.7 with travis-build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - scikit-image
   - scipy
   - setuptools
-  - sphinx
+  - sphinx=1.6
   - sphinx_rtd_theme
   - sphinx-automodapi
   - traitlets


### PR DESCRIPTION
travis-sphinx currently breaks with sphinx 1.7+

So temporarily froze the version of sphinx to 1.6 to avoid this  until it is fixed upstream.