### PR TITLE
ctapipe.image.cleaning.tailcuts_clean speed up factor ~10

### DIFF
--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -100,3 +100,80 @@ def dilate(geom, mask):
         input mask (array of booleans) to be dilated
     """
     return mask | (mask & geom.neighbor_matrix).any(axis=1)
+
+
+def tailcuts_clean_fast(
+    geom,
+    image,
+    picture_thresh=7,
+    boundary_thresh=5,
+    keep_isolated_pixels=False,
+    min_number_picture_neighbors=0
+):
+
+    """Clean an image by selection pixels that pass a two-threshold
+    tail-cuts procedure.  The picture and boundary thresholds are
+    defined with respect to the pedestal dispersion. All pixels that
+    have a signal higher than the picture threshold will be retained,
+    along with all those above the boundary threshold that are
+    neighbors of a picture pixel.
+
+    To include extra neighbor rows of pixels beyond what are accepted, use the
+    `ctapipe.image.dilate` function.
+
+    Parameters
+    ----------
+    geom: `ctapipe.instrument.CameraGeometry`
+        Camera geometry information
+    image: array
+        pixel values
+    picture_thresh: float or array
+        threshold above which all pixels are retained
+    boundary_thresh: float or array
+        threshold above which pixels are retained if they have a neighbor
+        already above the picture_thresh
+    keep_isolated_pixels: bool
+        If True, pixels above the picture threshold will be included always,
+        if not they are only included if a neighbor is in the picture or
+        boundary
+    min_number_picture_neighbors: int
+        A picture pixel survives cleaning only if it has at least this number
+        of picture neighbors. This has no effect in case keep_isolated_pixels is True
+
+    Returns
+    -------
+
+    A boolean mask of *clean* pixels.  To get a zero-suppressed image and pixel
+    list, use `image[mask], geom.pix_id[mask]`, or to keep the same
+    image size and just set unclean pixels to 0 or similar, use
+    `image[~mask] = 0`
+
+    """
+    # core_pixels: I call pixels, which are above the so called "picture_thresh"
+    # edge_pixels: I call pixels, which are above the so called "boundary_thresh"
+
+
+    core_pixels = image >= picture_thresh
+
+    if keep_isolated_pixels or min_number_picture_neighbors == 0:
+        pixels_in_picture = core_pixels
+    else:
+        # Require at least min_number_picture_neighbors. Otherwise, the pixel
+        #  is not selected
+        number_of_core_neighbors = geom.neighbor_matrix_sparse.dot(core_pixels)
+        enough_core_neighbors = number_of_core_neighbors >= min_number_picture_neighbors
+        pixels_in_picture = core_pixels & enough_core_neighbors
+
+    # by broadcasting together pixels_in_picture (1d) with the neighbor
+    # matrix (2d), we find all pixels that are above the boundary threshold
+    # AND have any neighbor that is in the picture
+    edge_pixels = image >= boundary_thresh
+    pixels_with_picture_neighbors = geom.neighbor_matrix_sparse.dot(pixels_in_picture)
+    if keep_isolated_pixels:
+        return (edge_pixels
+                & pixels_with_picture_neighbors) | pixels_in_picture
+    else:
+        pixels_with_boundary_neighbors = geom.neighbor_matrix_sparse.dot(edge_pixels)
+
+        return ((edge_pixels & pixels_with_picture_neighbors) |
+                (pixels_in_picture & pixels_with_boundary_neighbors))

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -97,7 +97,7 @@ def test_tailcuts_clean_min_neighbors_1():
 
 
 def test_tailcuts_clean_min_neighbors_2():
-    """ requiring that picture pixels have at least two neighbors above 
+    """ requiring that picture pixels have at least two neighbors above
     picture_thresh"""
 
     # start with simple 3-pixel camera
@@ -142,3 +142,48 @@ def test_tailcuts_clean_with_isolated_pixels():
                                          boundary_thresh=5,
                                          keep_isolated_pixels=True)
         assert (result == mask).all()
+
+
+def test_tailcuts_fast_equal_to_normal():
+    geom = CameraGeometry.from_name("LSTCam")
+    np.random.seed(0)
+    image = np.random.normal(loc=3, scale=2.5, size=geom.pix_id.shape)
+
+    mask1 = cleaning.tailcuts_clean(geom, image, keep_isolated_pixels=False)
+    mask2 = cleaning.tailcuts_clean_fast(geom, image, keep_isolated_pixels=False)
+    assert (mask1 == mask2).all()
+    # when the mast is totally empty, this test is useless,
+    # we want to avoid that... the number is basically made up
+    assert mask1.sum() > 30
+
+    mask1 = cleaning.tailcuts_clean(geom, image, keep_isolated_pixels=True)
+    mask2 = cleaning.tailcuts_clean_fast(geom, image, keep_isolated_pixels=True)
+    assert (mask1 == mask2).all()
+    assert mask1.sum() > 30
+
+    mask1 = cleaning.tailcuts_clean(
+        geom, image,
+        keep_isolated_pixels=False, min_number_picture_neighbors=1)
+    mask2 = cleaning.tailcuts_clean_fast(
+        geom, image,
+        keep_isolated_pixels=False, min_number_picture_neighbors=1)
+    assert (mask1 == mask2).all()
+    assert mask1.sum() > 30
+
+
+def test_1000_tailcuts():
+    geom = CameraGeometry.from_name("LSTCam")
+    np.random.seed(0)
+    image = np.random.normal(loc=3, scale=2.5, size=geom.pix_id.shape)
+    for i in range(1000):
+        cleaning.tailcuts_clean(geom, image)
+        cleaning.tailcuts_clean(geom, image, keep_isolated_pixels=True)
+
+
+def test_1000_tailcuts_fast():
+    geom = CameraGeometry.from_name("LSTCam")
+    np.random.seed(0)
+    image = np.random.normal(loc=3, scale=2.5, size=geom.pix_id.shape)
+    for i in range(1000):
+        cleaning.tailcuts_clean_fast(geom, image)
+        cleaning.tailcuts_clean_fast(geom, image, keep_isolated_pixels=True)

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -10,6 +10,7 @@ from astropy.coordinates import Angle
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from scipy.spatial import cKDTree as KDTree
+from scipy.sparse import csr_matrix
 
 from ctapipe.utils import get_table_dataset, find_all_matching_datasets
 from ctapipe.utils.linalg import rotation_matrix_2d
@@ -283,7 +284,7 @@ class CameraGeometry:
 
     def __repr__(self):
         return (
-            "CameraGeometry(cam_id='{cam_id}', pix_type='{pix_type}', " 
+            "CameraGeometry(cam_id='{cam_id}', pix_type='{pix_type}', "
             "npix={npix}, cam_rot={camrot}, pix_rot={pixrot})"
         ).format(
             cam_id=self.cam_id,
@@ -320,6 +321,12 @@ class CameraGeometry:
     @lazyproperty
     def neighbor_matrix(self):
         return _neighbor_list_to_matrix(self.neighbors)
+
+
+    @lazyproperty
+    def neighbor_matrix_sparse(self):
+        return csr_matrix(self.neighbor_matrix)
+
 
     @lazyproperty
     def neighbor_matrix_where(self):


### PR DESCRIPTION
We have a kind of default analysis in digicampipe, which uses `ctapipe.image.cleaning.tailcuts_clean`. I realized this part takes ~13% of the total runtime of the analysis, while it is not operating on the waveforms (n_pixel, n_samples) but on the image, which is a factor of 50x smaller than the waveforms. 

Typically runtime scales somehow with N ... so I was surprised this was so slow. I started digging and saw that tailcut_clean performs basically dot-products with the neighbor matrix. They are not really written as `numpy.dot`-products, but they essentially are dot-products.

Since the neighbor-matrix is sparse by design these dots products can be sped by using that fact.
sparsity of neighbor matrices:
```
Name - fraction of non-zero entries:
---------------------------------------------
ASTRICam 0.16%
HESS-II 0.28%
Whipple490 0.89%
Whipple109 4.85%
CHEC 0.19%
FlashCam 0.33%
Whipple151 3.58%
Whipple331 1.70%
DigiCam 0.45%
HESS-I 0.60%
LSTCam 0.31%
VERITAS 1.14%
NectarCam 0.31%
SCTCam 0.03%
FACT 0.40%
```

In this PR I have just made a fast version of `tailcut_clean` alongside the normal version and implemented a few tests showing that both versions give still the same results and that the version, which claims to be faster is indeed faster.

I found this call to show it quite nicely:
```
 pytest ctapipe/image/tests/test_cleaning.py --durations=10
```

The result on my machine is:
```
dneise@lair:~/cta/ctapipe$ pytest ctapipe/image/tests/test_cleaning.py --durations=10
================================================= test session starts =================================================
platform linux -- Python 3.6.3, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/dneise/anaconda3/bin/python
cachedir: .cache
benchmark: 3.1.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/dneise/cta/ctapipe, inifile: setup.cfg
plugins: profiling-1.2.11, benchmark-3.1.1
collected 9 items                                                                                                     

ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_simple PASSED                                         [ 11%]
ctapipe/image/tests/test_cleaning.py::test_dilate PASSED                                                        [ 22%]
ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean PASSED                                                [ 33%]
ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_min_neighbors_1 PASSED                                [ 44%]
ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_min_neighbors_2 PASSED                                [ 55%]
ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_with_isolated_pixels PASSED                           [ 66%]
ctapipe/image/tests/test_cleaning.py::test_tailcuts_fast_equal_to_normal PASSED                                 [ 77%]
ctapipe/image/tests/test_cleaning.py::test_1000_tailcuts PASSED                                                 [ 88%]
ctapipe/image/tests/test_cleaning.py::test_1000_tailcuts_fast PASSED                                            [100%]

============================================== slowest 10 test durations ==============================================
2.09s call     ctapipe/image/tests/test_cleaning.py::test_1000_tailcuts
0.14s call     ctapipe/image/tests/test_cleaning.py::test_1000_tailcuts_fast
0.05s call     ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_simple
0.04s call     ctapipe/image/tests/test_cleaning.py::test_tailcuts_fast_equal_to_normal
0.03s call     ctapipe/image/tests/test_cleaning.py::test_dilate
0.03s call     ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean
0.00s call     ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_min_neighbors_1
0.00s call     ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_min_neighbors_2
0.00s call     ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_with_isolated_pixels
0.00s setup    ctapipe/image/tests/test_cleaning.py::test_tailcuts_clean_simple
============================================== 9 passed in 2.63 seconds ===============================================
```

## Things, I think are still to do:

-----

### Undo variable renaming:

Please note, I also renamed a couple of variable before I started to work, since I could not wrap my head around the meaning ... in hindsight this was stupid and I should rework this PR without the renaming. 

### Remove the duplication ...
... of `tailcuts_clean_fast` and `tailcuts_clean` there should be only one version in the end. 

### Remove the tests...
... showing that the fast version is indeed faster, since in the end there will probably be only the faster version.


----

Generally I am interested to hear your opinion about performance improving PRs like this one? 
Are they already wanted? Or is this premature?

And how do you like this style, where for a certain time both versions co-exist to test and compare them against each other and then after some time we decide to drop one version... is this the right way to go?

Looking forward to your reviews.