### PR TITLE
ctapipe.image.cleaning.tailcuts_clean speed up factor ~10

### DIFF
--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -30,11 +30,11 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
     picture_thresh: float or array
         threshold above which all pixels are retained
     boundary_thresh: float or array
-        threshold above which pixels are retained if they have a neighbor 
+        threshold above which pixels are retained if they have a neighbor
         already above the picture_thresh
     keep_isolated_pixels: bool
-        If True, pixels above the picture threshold will be included always, 
-        if not they are only included if a neighbor is in the picture or 
+        If True, pixels above the picture threshold will be included always,
+        if not they are only included if a neighbor is in the picture or
         boundary
     min_number_picture_neighbors: int
         A picture pixel survives cleaning only if it has at least this number
@@ -56,8 +56,8 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
     else:
         # Require at least min_number_picture_neighbors. Otherwise, the pixel
         #  is not selected
-        number_of_neighbors_above_picture = np.sum(pixels_above_picture &
-                                                   geom.neighbor_matrix, axis=1)
+        number_of_neighbors_above_picture = geom.neighbor_matrix_sparse.dot(
+            pixels_above_picture)
         pixels_in_picture = pixels_above_picture & (
             number_of_neighbors_above_picture >= min_number_picture_neighbors
         )
@@ -66,23 +66,21 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
     # matrix (2d), we find all pixels that are above the boundary threshold
     # AND have any neighbor that is in the picture
     pixels_above_boundary = image >= boundary_thresh
-    pixels_with_picture_neighbors = (pixels_in_picture &
-                                     geom.neighbor_matrix).any(axis=1)
-
+    pixels_with_picture_neighbors = geom.neighbor_matrix_sparse.dot(
+        pixels_in_picture)
     if keep_isolated_pixels:
         return (pixels_above_boundary
                 & pixels_with_picture_neighbors) | pixels_in_picture
     else:
-        pixels_with_boundary_neighbors = (pixels_above_boundary &
-                                          geom.neighbor_matrix).any(axis=1)
-
+        pixels_with_boundary_neighbors = geom.neighbor_matrix_sparse.dot(
+            pixels_above_boundary)
         return ((pixels_above_boundary & pixels_with_picture_neighbors) |
                 (pixels_in_picture & pixels_with_boundary_neighbors))
 
 
 def dilate(geom, mask):
     """
-    Add one row of neighbors to the True values of a pixel mask and return 
+    Add one row of neighbors to the True values of a pixel mask and return
     the new mask.
     This can be used to include extra rows of pixels in a mask that was
     pre-computed, e.g. via `tailcuts_clean`.
@@ -91,7 +89,7 @@ def dilate(geom, mask):
     ----------
     geom: `~ctapipe.instrument.CameraGeometry`
         Camera geometry information
-    mask: ndarray 
+    mask: ndarray
         input mask (array of booleans) to be dilated
     """
     return mask | (mask & geom.neighbor_matrix).any(axis=1)

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -92,4 +92,4 @@ def dilate(geom, mask):
     mask: ndarray
         input mask (array of booleans) to be dilated
     """
-    return mask | (mask & geom.neighbor_matrix).any(axis=1)
+    return mask | geom.neighbor_matrix_sparse.dot(mask)

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -57,7 +57,7 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
         # Require at least min_number_picture_neighbors. Otherwise, the pixel
         #  is not selected
         number_of_neighbors_above_picture = geom.neighbor_matrix_sparse.dot(
-            pixels_above_picture)
+            pixels_above_picture.view(np.byte))
         pixels_in_picture = pixels_above_picture & (
             number_of_neighbors_above_picture >= min_number_picture_neighbors
         )

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -10,6 +10,7 @@ from astropy.coordinates import Angle
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from scipy.spatial import cKDTree as KDTree
+from scipy.sparse import csr_matrix
 
 from ctapipe.utils import get_table_dataset, find_all_matching_datasets
 from ctapipe.utils.linalg import rotation_matrix_2d
@@ -283,7 +284,7 @@ class CameraGeometry:
 
     def __repr__(self):
         return (
-            "CameraGeometry(cam_id='{cam_id}', pix_type='{pix_type}', " 
+            "CameraGeometry(cam_id='{cam_id}', pix_type='{pix_type}', "
             "npix={npix}, cam_rot={camrot}, pix_rot={pixrot})"
         ).format(
             cam_id=self.cam_id,
@@ -320,6 +321,10 @@ class CameraGeometry:
     @lazyproperty
     def neighbor_matrix(self):
         return _neighbor_list_to_matrix(self.neighbors)
+
+    @lazyproperty
+    def neighbor_matrix_sparse(self):
+        return csr_matrix(self.neighbor_matrix)
 
     @lazyproperty
     def neighbor_matrix_where(self):


### PR DESCRIPTION
Same as #665, but this time doing only the smallest possible diff to reach the result.

No additional tests, so no proof that this is faster than the previous version. Proof was shown in #665 

Regarding readability vs speed, I think some people might even like matrix notation better than the previous version, but who knows.

One peculiar thing is this:

Before:
```
boolean_vector = (Matrix & Vector).any(axis=1)
integer_vector = (Matrix & Vector).sum(axis=1)
```
Now:
```
boolean_vector = Matrix.dot(Vector)
integer_vector = Matrix.dot(Vector.view(np.byte))
```

This might actually confuse the readers ... "Why is this view needed here?? WTF?"
The point is obvious for us when I write it down here ... but a month from now I might have forgotten it ... see this code and remove the view, since I think it is superfluous. 

Luckily there is a test, that immediately fails, when this `view(byte)` is removed, so we have a test harness for this peculiar piece of code, which is really good.

Of course instead of `view(byte)` also one could have written `astype(int)` or so ... gives the same result. but view is faster than astype and a numpy boolean array is a char array in the background, so this view was the fasted version I found. It still costs ~430ns which is a lot, given that the view is not actually doing anything, it is just needed so that the result of the later dot-product is not cast 