### PR TITLE
add interesting environment vars to provenance

### DIFF
--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -25,6 +25,21 @@ log = logging.getLogger(__name__)
 
 __all__ = ['Provenance']
 
+_interesting_env_vars = [
+    'CONDA_DEFAULT_ENV',
+    'CONDA_PREFIX'           
+    'CONDA_PYTHON_EXE',
+    'CONDA_EXE',
+    'CONDA_PROMPT_MODIFIER',
+    'CONDA_SHLVL',
+    'PATH',
+    'LD_LIBRARY_PATH',
+    'DYLD_LIBRARY_PATH',
+    'USER',
+    'HOME',
+    'SHELL'
+]
+
 
 class Provenance(metaclass=Singleton):
     """
@@ -263,10 +278,16 @@ def _get_system_provenance():
             compiler=platform.python_compiler(),
             implementation=platform.python_implementation(),
         ),
+        environment=_get_env_vars(),
         arguments=sys.argv,
         start_time_utc=Time.now().isot,
     )
 
+def _get_env_vars():
+    envvars = {}
+    for var in _interesting_env_vars:
+        envvars[var] = os.getenv(var, None)
+    return envvars
 
 def _sample_cpu_and_memory():
     # times = np.asarray(psutil.cpu_times(percpu=True))

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -283,11 +283,13 @@ def _get_system_provenance():
         start_time_utc=Time.now().isot,
     )
 
+
 def _get_env_vars():
     envvars = {}
     for var in _interesting_env_vars:
         envvars[var] = os.getenv(var, None)
     return envvars
+
 
 def _sample_cpu_and_memory():
     # times = np.asarray(psutil.cpu_times(percpu=True))

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -27,7 +27,7 @@ __all__ = ['Provenance']
 
 _interesting_env_vars = [
     'CONDA_DEFAULT_ENV',
-    'CONDA_PREFIX'           
+    'CONDA_PREFIX',
     'CONDA_PYTHON_EXE',
     'CONDA_EXE',
     'CONDA_PROMPT_MODIFIER',
@@ -37,7 +37,7 @@ _interesting_env_vars = [
     'DYLD_LIBRARY_PATH',
     'USER',
     'HOME',
-    'SHELL'
+    'SHELL',
 ]
 
 


### PR DESCRIPTION
small PR to add a set of useful ENVVARs to the provenence info. E.g.:

```json
        "environment": {
            "CONDA_DEFAULT_ENV": null,
            "CONDA_PYTHON_EXE": null,
            "CONDA_EXE": null,
            "CONDA_PROMPT_MODIFIER": null,
            "CONDA_SHLVL": "0",
            "PATH": "/Users/kosack/anaconda/bin:/Users/kosack/anaconda/bin:/usr/local/bin:/usr/local/opt/coreutils/libexec/gnubin:/usr/local/bin:/usr/local/texlive/2017/bin/x86_64-darwin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/texbin:/Users/kosack/bin:/Users/kosack/.local/bin:.:/Users/kosack/bin:/Users/kosack/.local/bin:/usr/local/sbin:.",
            "LD_LIBRARY_PATH": ":/usr/local/lib:/usr/local/lib",
            "DYLD_LIBRARY_PATH": null,
            "USER": "kosack",
            "HOME": "/Users/kosack",
            "SHELL": "/bin/zsh"
         },
```