### PR TITLE
improvements to muon example

### DIFF
--- a/ctapipe/image/muon/muon_integrator.py
+++ b/ctapipe/image/muon/muon_integrator.py
@@ -12,10 +12,14 @@ from scipy.ndimage.filters import correlate1d
 from iminuit import Minuit
 from astropy import units as u
 from astropy.constants import alpha
-from ctapipe.io.containers import MuonIntensityParameter
+from ...io.containers import MuonIntensityParameter
 from scipy.stats import norm
 
+import logging
+
 __all__ = ['MuonLineIntegrate']
+
+logger = logging.getLogger(__name__)
 
 
 class MuonLineIntegrate:
@@ -402,7 +406,7 @@ class MuonLineIntegrate:
         init_constrain['limit_ring_width'] = (0., 1.)
         init_constrain['limit_optical_efficiency_muon'] = (0., 1.)
 
-        print("radius =", radius, " pre migrad")
+        logger.debug("radius = %3.3f pre migrad", radius)
 
         # Create Minuit object with first guesses at parameters
         # strip away the units as Minuit doesnt like them

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -9,13 +9,13 @@ from astropy.table import Table
 from tqdm import tqdm
 
 from ctapipe.calib import CameraCalibrator
+from ctapipe.core import Provenance
 from ctapipe.core import Tool
 from ctapipe.core import traits as t
 from ctapipe.image.muon.muon_diagnostic_plots import plot_muon_event
 from ctapipe.image.muon.muon_reco_functions import analyze_muon_event
 from ctapipe.io import event_source
 from ctapipe.utils import get_dataset_path
-from ctapipe.core import Provenance
 
 warnings.filterwarnings("ignore")  # Supresses iminuit warnings
 

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -77,7 +77,7 @@ class MuonDisplayerTool(Tool):
 
         numev = 0
         self.num_muons_found = defaultdict(int)
-        
+
         for event in tqdm(self.source, desc='detecting muons'):
 
             self.calib.calibrate(event)

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -103,7 +103,6 @@ class MuonDisplayerTool(Tool):
 
                     if intens_params is not None:
                         ring_params = muon_evt['MuonRingParams'][idx]
-                        assert ring_params is not None
                         cam_id = str(event.inst.subarray.tel[tel_id].camera)
                         self.num_muons_found[cam_id] += 1
                         self.log.debug("INTENSITY: %s", intens_params)

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -18,9 +18,8 @@ from ctapipe.core import Tool, ToolConfigurationError
 from ctapipe.core import traits as t
 from ctapipe.image.muon.muon_diagnostic_plots import plot_muon_event
 from ctapipe.image.muon.muon_reco_functions import analyze_muon_event
-from ctapipe.io import HDF5TableWriter
 from ctapipe.io import EventSourceFactory
-from ctapipe.utils import get_dataset_path
+from ctapipe.io import HDF5TableWriter
 
 warnings.filterwarnings("ignore")  # Supresses iminuit warnings
 
@@ -43,7 +42,7 @@ class MuonDisplayerTool(Tool):
     description = t.Unicode(__doc__)
 
     events = t.Unicode("",
-                      help="input event data file").tag(config=True)
+                       help="input event data file").tag(config=True)
 
     outfile = t.Unicode("muons.hdf5", help='HDF5 output file name').tag(
         config=True)

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -77,8 +77,7 @@ class MuonDisplayerTool(Tool):
 
         numev = 0
         self.num_muons_found = defaultdict(int)
-        table_name = "all"
-
+        
         for event in tqdm(self.source, desc='detecting muons'):
 
             self.calib.calibrate(event)

--- a/examples/muon_reconstruction.py
+++ b/examples/muon_reconstruction.py
@@ -8,9 +8,9 @@ The resulting output can be read e.g. using `pandas.read_hdf(filename,
 """
 
 import warnings
+from collections import defaultdict
 
 from tqdm import tqdm
-from collections import defaultdict
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Provenance
@@ -23,6 +23,7 @@ from ctapipe.io import event_source
 from ctapipe.utils import get_dataset_path
 
 warnings.filterwarnings("ignore")  # Supresses iminuit warnings
+
 
 def _exclude_some_columns(subarray, writer):
     """ a hack to exclude some columns of all output tables"""

--- a/examples/simple_pipeline.py
+++ b/examples/simple_pipeline.py
@@ -16,11 +16,12 @@ if __name__ == '__main__':
 
     cal = CameraCalibrator(r1_product="HESSIOR1Calibrator")
 
-    for data in source:
+    for ii, event in enumerate(source):
 
         print(
-            "EVENT: {}, ENERGY: {:.2f}, TELS:{}".format(
-                data.r0.event_id, data.mc.energy, len(data.dl0.tels_with_data)
+            "{} EVENT_ID: {}, ENERGY: {:.2f}, NTELS:{}".format(
+                ii,
+                event.r0.event_id, event.mc.energy, len(event.dl0.tels_with_data)
             )
         )
 


### PR DESCRIPTION
A few changes in some examples for things that bugged me while playing with data. 

- in muon code, removed a print -> use logger
- in muon_reconstruction: make sure output file is still written if cancelled by ctrl-c (use finish() function)
- in muon_reconstruction: write out to HDF5 file, with all muon ring and intensity parameters 
- in simple_pipeline add a max_events option


You can now for example read the `muon_reconstruction.py` output table using *Pandas*:

```py3
import pandas as pd

muons = pd.read_hdf("muons.hdf5", 'muons/LSTCam')
muons.hist()
```

![image](https://user-images.githubusercontent.com/11677812/38681715-a7607e24-3e69-11e8-9e78-1bebd8c9b7e4.png)
