### PR TITLE
WIP: fix missing version number in generated docs

### DIFF
--- a/ctapipe/version.py
+++ b/ctapipe/version.py
@@ -80,7 +80,8 @@ def get_git_describe_version(abbrev=7):
                          "--abbrev=%d" % abbrev]
             return check_output(arguments, cwd=CURRENT_DIRECTORY,
                                 stderr=fnull).decode("ascii").strip()
-    except (OSError, CalledProcessError):
+    except (OSError, CalledProcessError) as err:
+        print("couldn't get version from git repo: {}".format(err))
         return None
 
 


### PR DESCRIPTION
As seen in #705 :

For some reason the docs generated by travis have the version set to "unknown", which means the version number is not being found from the git tags (normally it is taken from `git describe --tags --abbrev=7`).   This used to work correctly, so it needs some debugging...

