### PR TITLE
WIP: put TelescopeDescription input `inst.subarray`

### DIFF
--- a/ctapipe/io/sst1meventsource.py
+++ b/ctapipe/io/sst1meventsource.py
@@ -7,6 +7,7 @@ Needs protozfits v0.44.3 from github.com/cta-sst-1m/protozfitsreader
 import numpy as np
 from .eventsource import EventSource
 from .containers import SST1MDataContainer
+from ..instrument import TelescopeDescription
 
 __all__ = ['SST1MEventSource']
 
@@ -31,6 +32,7 @@ class SST1MEventSource(EventSource):
             data.count = count
             data.sst1m.fill_from_zfile_event(event, self._pixel_sort_ids)
             self.fill_R0Container_from_zfile_event(data.r0, event)
+            data.inst.subarray.tels[0] = TelescopeDescription.from_name('SST-1M', 'DigiCam')
             yield data
 
 


### PR DESCRIPTION
@watsonjj spotted a bug in the SST1MEventSource.

The problem came up in connection with the new bokeh plotter in #714.

As far as I understood, EventSources are supposed to fill also the `inst` Field, which is not done by the SST1MEventSource.

### Unit test still missing