### PR TITLE
Update example in fitshistogram.py

### DIFF
--- a/ctapipe/utils/fitshistogram.py
+++ b/ctapipe/utils/fitshistogram.py
@@ -171,7 +171,7 @@ class Histogram:
         Examples
         --------
 
-        >>> myhist.to_fits().writeto("outputfile.fits.gz", clobber=True)
+        >>> myhist.to_fits().writeto("outputfile.fits.gz", overwrite=True)
 
         """
         ohdu = fits.ImageHDU(data=self.data.transpose())


### PR DESCRIPTION
This changes the astropy.io.fits writeto call from clobber to overwrite.
That's a change made in Astropy a few years ago, overwrite is used consistently there now.