### PR TITLE
replace deprecated astropy broadcast

### DIFF
--- a/ctapipe/coordinates/representation.py
+++ b/ctapipe/coordinates/representation.py
@@ -5,7 +5,7 @@ This module defines any reference systems which may be needed in addition
 from astropy.coordinates import BaseRepresentation, CartesianRepresentation
 import astropy.units as u
 from collections import OrderedDict
-from astropy.utils.compat.numpy import broadcast_arrays
+from numpy import broadcast_arrays
 
 
 class PlanarRepresentation(BaseRepresentation):


### PR DESCRIPTION
Replace astropy broadcast method and use equivalent numpy function. This gets rid of deprecation warnings.