### PR TITLE
Wrong angle in ArrayDisplay. changed phi to psi.

### DIFF
--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -205,7 +205,7 @@ class ArrayDisplay:
         hillas_dict: Dict[int, HillasParametersContainer]
             mapping of tel_id to Hillas parameters
         range: float
-            length of the segments to be plotted (in meters)
+            half of the length of the segments to be plotted (in meters)
         """
 
         # rot_angle_ellipse is psi parameter in HillasParametersContainer
@@ -224,8 +224,8 @@ class ArrayDisplay:
             y = y_0 + m * (x-x_0)
             distance = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2)
             mask = np.ma.masked_where(distance < range, distance).mask
-            self.axes.plot(x[mask], y[mask], color=c[idx])
-            self.axes.scatter(x_0, y_0, color=c[idx], **kwargs)
+            self.axes.plot(x[mask], y[mask], color=c[idx], **kwargs)
+            self.axes.scatter(x_0, y_0, color=c[idx])
 
     def add_labels(self):
         px = self.tel_coords.x.value

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -208,10 +208,6 @@ class ArrayDisplay:
             half of the length of the segments to be plotted (in meters)
         """
 
-        # rot_angle_ellipse is psi parameter in HillasParametersContainer
-
-        rho = np.zeros(self.subarray.num_tels) * u.m
-        rot_angle_ellipse = np.zeros(self.subarray.num_tels) * u.deg
         coords = self.tel_coords
         c = self.tel_colors
 
@@ -219,7 +215,7 @@ class ArrayDisplay:
             idx = self.subarray.tel_indices[tel_id]
             x_0 = coords[idx].x.value
             y_0 = coords[idx].y.value
-            m = np.tan(params.psi)
+            m = np.tan(Angle(params.psi))
             x = x_0 + np.linspace(-range, range, 50)
             y = y_0 + m * (x-x_0)
             distance = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2)

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -194,9 +194,11 @@ class ArrayDisplay:
 
         self.set_vector_rho_phi(rho=rho, phi=rot_angle_ellipse)
 
-    def set_line_hillas(self, hillas_dict, range):
+    def set_line_hillas(self, hillas_dict, range, **kwargs):
         """
-        Function to plot a segment for each telescope from a set of Hillas parameters.
+        Function to plot a segment of length 2*range for each telescope from a set of Hillas parameters.
+        The segment is centered on the telescope position.
+        A point is added at each telescope position for better visualization.
 
         Parameters
         ----------
@@ -218,12 +220,12 @@ class ArrayDisplay:
             x_0 = coords[idx].x.value
             y_0 = coords[idx].y.value
             m = np.tan(params.psi)
-            x = x_0 + np.linspace(-300.0, 300.0, 50)
+            x = x_0 + np.linspace(-range, range, 50)
             y = y_0 + m * (x-x_0)
-            distance = np.sqrt((x-x_0)**2+(y-y_0)**2)
+            distance = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2)
             mask = np.ma.masked_where(distance < range, distance).mask
             self.axes.plot(x[mask], y[mask], color=c[idx])
-
+            self.axes.scatter(x_0, y_0, color=c[idx], **kwargs)
 
     def add_labels(self):
         px = self.tel_coords.x.value

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -183,14 +183,14 @@ class ArrayDisplay:
         """
 
         rho = np.zeros(self.subarray.num_tels) * u.m
-        phi = np.zeros(self.subarray.num_tels) * u.deg
+        psi = np.zeros(self.subarray.num_tels) * u.deg
 
         for tel_id, params in hillas_dict.items():
             idx = self.subarray.tel_indices[tel_id]
             rho[idx] = 1.0 * u.m  # params.length
-            phi[idx] = Angle(params.phi) + Angle(angle_offset)
+            psi[idx] = Angle(params.psi) + Angle(angle_offset)
 
-        self.set_vector_rho_phi(rho=rho, phi=phi)
+        self.set_vector_rho_phi(rho=rho, phi=psi)
 
     def add_labels(self):
         px = self.tel_coords.x.value

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -80,8 +80,8 @@ def test_array_display():
 
     # test using hillas params:
     hillas_dict = {
-        1: HillasParametersContainer(length=1.0 * u.m, phi=90 * u.deg),
-        2: HillasParametersContainer(length=200 * u.cm, phi="95deg"),
+        1: HillasParametersContainer(length=1.0 * u.m, psi=90 * u.deg),
+        2: HillasParametersContainer(length=200 * u.cm, psi="95deg"),
     }
     ad.set_vector_hillas(hillas_dict)
     ad.set_line_hillas(hillas_dict, range=300)

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -84,6 +84,6 @@ def test_array_display():
         2: HillasParametersContainer(length=200 * u.cm, phi="95deg"),
     }
     ad.set_vector_hillas(hillas_dict)
-
+    ad.set_line_hillas(hillas_dict, range=300)
     ad.add_labels()
     ad.remove_labels()


### PR DESCRIPTION
I started to look at the plotting code in ArrayDisplay, since it was not working that well for point gammas and really giving random results for diffuse gammas and protons (as @vuillaut pointed out recently in #721 ).
The results of my investigation is that the angle used for plotting was the wrong one, so i changed the **phi** angle to **psi** angle: these angles are very similar for point sources (that's why the plots for point sources don't look that bad) but very different for other sources.
I'm now working on a simple algorithm for plotting the arrow in the right direction since, as pointed out by @kosack in #723 and #737  sometimes we have a 180° flip.
I analyzed the same file as @vuillaut and this is what I get using his notebook:
![protons](https://user-images.githubusercontent.com/24605557/43473080-72f50e02-94ef-11e8-8aea-2ca601db87c2.png)
