### PR TITLE
Fixing core reconstruction

### DIFF
--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -327,7 +327,9 @@ class HillasReconstructor(Reconstructor):
             # circle.norm to the ground gives higher weight to planes
             # perpendicular to the ground and less to those that have
             # a steeper angle
-            A[i] = circle.weight * circle.norm[:2]
+            norm = circle.norm.copy()
+            norm[1] = - norm[1]
+            A[i] = circle.weight * norm[:2]
             # since A[i] is used in the dot-product, no need to multiply the
             # weight here
             D[i] = np.dot(A[i], circle.pos[:2])


### PR DESCRIPTION
Discussing with @TarekHC, @mackaiver and @moralejo we found that there was a bug in the calculation of the core position. I've tracked this down to being a wrong sign in one component of the norm vector in the HillasPlanes. In order to not break the direction reconstruction I added two lines which only change the y-component's sign of the norm vector in the estimation of the core position and should not affect anything else.

In this plot right here, you can clearly see that the old reconstruction of the position (blue diamond) was nonsense and the fixed estimate in red is clearly getting close to the true position (black).
![attachment](https://user-images.githubusercontent.com/15632125/45228832-88028200-b2c4-11e8-9f99-a2d94db18df3.png)