### PR TITLE
Fixing hmax reconstruction

### DIFF
--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -390,6 +390,7 @@ class HillasReconstructor(Reconstructor):
 
             weights.append(self.hillas_planes[tel_id].weight)
             tels.append(self.hillas_planes[tel_id].pos)
+            cog_direction[1] = - cog_direction[1]
             dirs.append(cog_direction)
 
         # minimising the test function


### PR DESCRIPTION
Hi all,

this is related to https://github.com/cta-observatory/ctapipe/pull/777 and https://github.com/cta-observatory/ctapipe/pull/778. The reconstruction of `h_max` was not working as well. Just like for the core reconstruction it was a sign error in a y-coordinate which I fixed at this point for now.
I guess it could be a problem in the coordinate transformation that lead to the wrong signs for the core and `h_max`  reconstruction.

Just looking at the plot, even with the fixed reconstruction we are underestimating `h_max`.

![image](https://user-images.githubusercontent.com/15632125/45429179-0d11e080-b6a3-11e8-9fb1-29acf13dbf9b.png)
