### PR TITLE
Revert "Fixing core reconstruction"

### DIFF
--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -327,9 +327,7 @@ class HillasReconstructor(Reconstructor):
             # circle.norm to the ground gives higher weight to planes
             # perpendicular to the ground and less to those that have
             # a steeper angle
-            norm = circle.norm.copy()
-            norm[1] = - norm[1]
-            A[i] = circle.weight * norm[:2]
+            A[i] = circle.weight * circle.norm[:2]
             # since A[i] is used in the dot-product, no need to multiply the
             # weight here
             D[i] = np.dot(A[i], circle.pos[:2])


### PR DESCRIPTION
Reverts cta-observatory/ctapipe#777

This will be fixed in a more comprehensive way later - the problem is in the coordinate transform, not the plotting