### PR TITLE
Fix bad builds by changing channel name (missing pyqt package)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,6 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.githubpages',
               'sphinx.ext.mathjax',
               'sphinx_automodapi.automodapi',
-              'matplotlib.sphinxext.only_directives',
               'matplotlib.sphinxext.plot_directive',
               'numpydoc']
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: cta-dev
 channels:
-  - anaconda
+  - default
   - cta-observatory
   - conda-forge
 dependencies:


### PR DESCRIPTION
changed `anaconda` -> `default` in channel list of `environment.yml`, according to conda docs, since anaconda channel is no longer correct. 

This should fix the broken pyqt package in the tests, according to:
https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/wPB5eRs17J8