### PR TITLE
Add unit to h_max in HillasReconstructor

### DIFF
--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -313,7 +313,7 @@ class HillasReconstructor(Reconstructor):
         positions = [plane.pos for plane in self.hillas_planes.values()]
 
         # not sure if its better to return the length of the vector of the z component
-        return np.linalg.norm(line_line_intersection_3d(uvw_vectors, positions))
+        return np.linalg.norm(line_line_intersection_3d(uvw_vectors, positions)) * u.m
 
 
 class HillasPlane:


### PR DESCRIPTION
Hi @mackaiver , @kosack ,
This short PR add a unit (meter) to the height of the shower mawimum computed by `estimate_h_max` (for consistency with other methods).

Don't you want also to rename the python file: HillasReconstructor.py to hillas_reconstructor.py for consistency with the other files?