### PR TITLE
fix package name for yaml (should be pyyaml)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - traitlets
   - wheel
   - xz
-  - yaml
+  - pyyaml
   - zlib
   - iminuit
   - pytables


### PR DESCRIPTION
the yaml module is provided by the package `pyyaml` (whereas the package `yaml` only provides the underlying C-library for yaml parsing).  This is fixed here and also in the conda package def in cta-conda-packages