### PR TITLE
fix errordef > 0.

### DIFF
--- a/ctapipe/image/muon/muon_integrator.py
+++ b/ctapipe/image/muon/muon_integrator.py
@@ -420,7 +420,7 @@ class MuonLineIntegrate:
             **init_params,
             **init_errs,
             **init_constrain,
-            errordef=0.,
+            errordef=0.1,
             print_level=0,
             pedantic=False
         )


### PR DESCRIPTION
iminuit gives an error if errordef is defined as 0. (or < 0)