### PR TITLE
SPE Fitting

### DIFF
--- a/ctapipe/analysis/camera/spe_fitter/__init__.py
+++ b/ctapipe/analysis/camera/spe_fitter/__init__.py
@@ -1,0 +1,1 @@
+from .base import SPEFitter

--- a/ctapipe/analysis/camera/spe_fitter/base.py
+++ b/ctapipe/analysis/camera/spe_fitter/base.py
@@ -1,0 +1,334 @@
+from abc import abstractmethod
+import iminuit
+import numpy as np
+from scipy.stats.distributions import poisson
+import yaml
+import warnings
+
+
+class SPEFitterMeta(type):
+    def __call__(cls, *args, **kwargs):
+        obj = type.__call__(cls, *args, **kwargs)
+        obj._post_init()
+        return obj
+
+
+class SPEFitter(metaclass=SPEFitterMeta):
+    def __init__(self, n_illuminations, config_path=None):
+        """
+        Base class for fitters of Single-Photoelectron spectra. Built to
+        flexibly handle any number of illuminations simultaneously.
+
+        Parameters
+        ----------
+        n_illuminations : int
+            Number of illuminations to fit simultaneously
+        config_path : str
+            Path to JAML config file
+        """
+        self.hist = None
+        self.edges = None
+        self.between = None
+        self.coeff = None
+        self.errors = None
+        self.p0 = None
+
+        self.nbins = 100
+        self.range = [-10, 100]
+
+        self.coeff_names = []
+        self.multi_coeff = []
+        self.initial = dict()
+        self.limits = dict()
+        self.fix = dict()
+
+        self.n_illuminations = n_illuminations
+        self.config_path = config_path
+
+    def _post_init(self):
+        if self.config_path:
+            self.load_config(self.config_path)
+
+    @property
+    def fit_x(self):
+        """
+        Default X coordinates for the fit
+
+        Returns
+        -------
+        ndarray
+        """
+        return np.linspace(self.edges[0], self.edges[-1], 10*self.edges.size)
+
+    @property
+    def fit(self):
+        """
+        Curve for the current fit result
+
+        Returns
+        -------
+        ndarray
+        """
+        return self.fit_function(x=self.fit_x, **self.coeff)
+
+
+    def add_parameter(self, name, initial, lower, upper,
+                      fix=False, multi=False):
+        """
+        Add a new parameter for this particular fit function
+
+        Parameters
+        ----------
+        name : str
+            Name of the parameter
+        initial : float
+            Initial value for the parameter
+        lower : float
+            Lower limit for the parameter
+        upper : float
+            Upper limit for the parameter
+        fix : bool
+            Specify if the parameter should be fixed
+        multi : bool
+            Specify if the parameter should be duplicated for additional
+            illuminations
+        """
+        if not multi:
+            self.coeff_names.append(name)
+            self.initial[name] = initial
+            self.limits["limit_" + name] = (lower, upper)
+            self.fix["fix_" + name] = fix
+        else:
+            self.multi_coeff.append(name)
+            for i in range(self.n_illuminations):
+                name_i = name + str(i)
+                self.coeff_names.append(name_i)
+                self.initial[name_i] = initial
+                self.limits["limit_" + name_i] = (lower, upper)
+                self.fix["fix_" + name_i] = fix
+        # ds = "minimize_function(" + ", ".join(self.coeff_names) + ")"
+        # self._minimize_function.__func__.__doc__ = ds
+
+    def load_config(self, path):
+        """
+        Load a YAML configuration file to set initial fitting parameters
+
+        Parameters
+        ----------
+        path : str
+        """
+        print("Loading SpectrumFitter configuration from: {}".format(path))
+        with open(path, 'r') as file:
+            d = yaml.safe_load(file)
+            if d is None:
+                return
+            self.nbins = d.pop('nbins', self.nbins)
+            self.range = d.pop('range', self.range)
+            for c in self.coeff_names:
+                if 'initial' in d:
+                    ini = c
+                    self.initial[ini] = d['initial'].pop(c, self.initial[ini])
+                    if(self.initial[ini] is not None):
+                        self.initial[ini] = float(self.initial[ini])
+                if 'limits' in d:
+                    lim = "limit_" + c
+                    list_ = d['limits'].pop(c, self.limits[lim])
+                    if(isinstance(list_,list)):
+                        self.limits[lim] = tuple([float(l) for l in list_])
+                    else:
+                        self.limits[lim] = list_
+                if 'fix' in d:
+                    fix = "fix_" + c
+                    self.fix[fix] = d['fix'].pop(c, self.fix[fix])
+            if 'initial' in d and not d['initial']:
+                d.pop('initial')
+            if 'limits' in d and not d['limits']:
+                d.pop('limits')
+            if 'fix' in d and not d['fix']:
+                d.pop('fix')
+            if d:
+                print("WARNING: Unused SpectrumFitter config parameters:")
+                print(d)
+
+    def save_config(self, path):
+        """
+        Save the configuration of the fit. If the fit has already been
+        performed, the fit coefficients will be included as the initial
+        coefficients
+
+        Parameters
+        ----------
+        path : str
+            Path to save the configuration file to
+        """
+        print("Writing SpectrumFitter configuration to: {}".format(path))
+        initial = dict()
+        limits = dict()
+        fix = dict()
+        coeff_dict = self.coeff if self.coeff else self.initial
+        for c, val in coeff_dict.items():
+            initial[c] = val
+        for c, val in self.limits.items():
+            limits[c.replace("limit_", "")] = val
+        for c, val in self.fix.items():
+            fix[c.replace("fix_", "")] = val
+        data = dict(
+            nbins=self.nbins,
+            range=self.range,
+            initial=initial,
+            limits=limits,
+            fix=fix
+        )
+        with open(path, 'w') as outfile:
+            yaml.safe_dump(data, outfile, default_flow_style=False)
+
+    def apply(self, *charges):
+        """
+        Fit the spectra
+
+        Parameters
+        ----------
+        charges : list[ndarray]
+            A list of the charges to fit. Should have a length equal to the
+            self.n_illuminations.
+        """
+        assert len(charges) == self.n_illuminations
+        bins = self.nbins
+        range_ = self.range
+        self.hist = []
+        for i in range(self.n_illuminations):
+            h, e, b = self.get_histogram(charges[i], bins, range_)
+            self.hist.append(h)
+            self.edges = e
+            self.between = b
+
+        self._perform_fit()
+
+    @staticmethod
+    def get_histogram(charge, bins, range_):
+        """
+        Obtain a histogram for the spectrum.
+
+        Look at `np.histogram` documentation for further info on Parameters.
+
+        Parameters
+        ----------
+        charge : ndarray
+        bins
+        range_
+
+        Returns
+        -------
+        hist : ndarray
+            The histogram
+        edges : ndarray
+            Edges of the histogram
+        between : ndarray
+            X values of the middle of each bin
+        """
+        hist, edges = np.histogram(charge, bins=bins, range=range_)
+        between = (edges[1:] + edges[:-1]) / 2
+
+        return hist, edges, between
+
+    def _perform_fit(self):
+        """
+        Run iminuit on the fit function to find the best fit
+        """
+        self.coeff = {}
+        self.p0 = self.initial.copy()
+        limits = self.limits.copy()
+        fix = self.fix.copy()
+        self._prepare_params(self.p0, limits, fix)
+
+        m0 = iminuit.Minuit(self._minimize_function,
+                            **self.p0, **limits, **fix,
+                            print_level=0, pedantic=False, throw_nan=True,
+                            forced_parameters=self.coeff_names)
+        m0.migrad()
+        self.coeff = m0.values
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', iminuit.HesseFailedWarning)
+            m0.hesse()
+        self.errors = m0.errors
+
+    def _prepare_params(self, p0, limits, fix):
+        """
+        Apply some automation to the contents of initial, limits, and fix
+        dictionaries.
+
+        Parameters
+        ----------
+        p0 : dict
+            Initial values dict
+        limits : dict
+            Dict containing the limits for each parameter
+        fix : dict
+            Dict containing which parameters should be fixed
+        """
+        pass
+
+    def _minimize_function(self, *args):
+        """
+        Function which calculates the likelihood to be minimised.
+
+        Parameters
+        ----------
+        args
+            The values to apply to the fit function.
+
+        Returns
+        -------
+        likelihood : float
+        """
+        kwargs = dict(zip(self.coeff_names, args))
+        x = self.between
+        y = self.hist
+        p = self.fit_function(x, **kwargs)
+        like = [-2 * poisson._logpmf(y[i], p[i])
+                for i in range(self.n_illuminations)]
+        like = np.hstack(like)
+        return np.nansum(like)
+
+    def fit_function(self, x, **kwargs):
+        """
+        Function which applies the parameters for each illumination and
+        returns the resulting curves.
+
+        Parameters
+        ----------
+        x : ndarray
+            X values
+        kwargs
+            The values to apply to the fit function
+
+        Returns
+        -------
+
+        """
+        p = []
+        for i in range(self.n_illuminations):
+            for coeff in self.multi_coeff:
+                kwargs[coeff] = kwargs[coeff + str(i)]
+            p.append(self._fit(x, **kwargs))
+        return p
+
+    @staticmethod
+    @abstractmethod
+    def _fit(x, **kwargs):
+        """
+        Define the low-level function to be used in the fit
+
+        Parameters
+        ----------
+        x : ndarray
+            X values
+        kwargs
+            The values to apply to the fit function
+
+        Returns
+        -------
+        ndarray
+        """
+        pass

--- a/ctapipe/analysis/camera/spe_fitter/gentile.py
+++ b/ctapipe/analysis/camera/spe_fitter/gentile.py
@@ -106,7 +106,7 @@ def pedestal_signal(x, norm, eped, eped_sigma, lambda_):
     eped_sigma : float
         Sigma of the zeroth peak, represents electronic noise of the system
     lambda_ : float
-        Poisson mean
+        Poisson mean (average illumination in p.e.)
 
     Returns
     -------
@@ -144,7 +144,7 @@ def pe_signal(k, x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct,
     spe_sigma : float
         Spread in the number of photo-electrons incident on the MAPMT
     lambda_ : float
-        Poisson mean (illumination in p.e.)
+        Poisson mean (average illumination in p.e.)
     opct : float
         Optical crosstalk probability
     pap : float
@@ -201,7 +201,7 @@ def sipm_spe_fit(x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct,
     spe_sigma : float
         Spread in the number of photo-electrons incident on the MAPMT
     lambda_ : float
-        Poisson mean (illumination in p.e.)
+        Poisson mean (average illumination in p.e.)
     opct : float
         Optical crosstalk probability
     pap : float

--- a/ctapipe/analysis/camera/spe_fitter/gentile.py
+++ b/ctapipe/analysis/camera/spe_fitter/gentile.py
@@ -1,0 +1,229 @@
+import numpy as np
+from math import factorial
+from scipy.special import binom
+from numba import jit
+from ctapipe.analysis.camera.spe_fitter import SPEFitter
+
+
+class GentileFitter(SPEFitter):
+    def __init__(self, n_illuminations, config_path=None):
+        """
+        SpectrumFitter which uses the SiPM fitting formula from Gentile 2010
+        http://adsabs.harvard.edu/abs/2010arXiv1006.3263G
+
+        Parameters
+        ----------
+        n_illuminations : int
+            Number of illuminations to fit simultaneously
+        """
+        super().__init__(n_illuminations, config_path)
+
+        self.nbins = 100
+        self.range = [-40, 150]
+
+        self.add_parameter("norm", None, 0, 100000, fix=True, multi=True)
+        self.add_parameter("eped", 0, -10, 10)
+        self.add_parameter("eped_sigma", 9, 2, 20)
+        self.add_parameter("spe", 25, 15, 40)
+        self.add_parameter("spe_sigma", 2, 1, 20)
+        self.add_parameter("lambda_", 0.7, 0.001, 6, multi=True)
+        self.add_parameter("opct", 0.4, 0.01, 0.8)
+        self.add_parameter("pap", 0.09, 0.01, 0.8)
+        self.add_parameter("dap", 0.5, 0, 0.8)
+
+    def _prepare_params(self, p0, limits, fix):
+        for i in range(self.n_illuminations):
+            norm = 'norm{}'.format(i)
+            if p0[norm] is None:
+                p0[norm] = np.trapz(self.hist[i], self.between)
+
+    @staticmethod
+    def _fit(x, **kwargs):
+        return sipm_spe_fit(x, **kwargs)
+
+
+C = np.sqrt(2.0 * np.pi)
+FACTORIAL = np.array([factorial(i) for i in range(15)])
+FACTORIAL_0 = FACTORIAL[0]
+NPEAKS = 11
+N = np.arange(NPEAKS)[:, None]
+J = np.arange(NPEAKS)[None, :]
+K = np.arange(1, NPEAKS)[:, None]
+FACTORIAL_J_INV = 1 / FACTORIAL[J]
+BINOM = binom(N - 1, J - 1)
+
+
+@jit(nopython=True)
+def _normal_pdf(x, mean=0, std_deviation=1):
+    """
+    Evaluate the normal probability density function. Faster than
+    `scipy.norm.pdf` as it does not check the inputs.
+
+    Parameters
+    ----------
+    x : ndarray
+        The normal probability function will be evaluated
+    mean : float or ndarray
+    std_deviation : float or array_like
+
+    Returns
+    -------
+    ndarray
+    """
+    u = (x - mean) / std_deviation
+    return np.exp(-0.5 * u ** 2) / (C * std_deviation)
+
+
+@jit(nopython=True)
+def _poisson_pmf_j(mu):
+    """
+    Evaluate the poisson pmf for a fixed k=J events
+
+    Parameters
+    ----------
+    mu : Average number of events
+
+    Returns
+    -------
+    ndarray
+    """
+    return mu ** J * np.exp(-mu) * FACTORIAL_J_INV
+
+
+@jit(nopython=True)
+def pedestal_signal(x, norm, eped, eped_sigma, lambda_):
+    """
+    Obtain the signal provided by the pedestal in the pulse spectrum.
+
+    Parameters
+    ----------
+    x : ndarray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    lambda_ : float
+        Poisson mean
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the signal provided by the pedestal.
+    """
+    p_ped = np.exp(-lambda_)  # Poisson PMF for k = 0, mu = lambda_
+    signal = norm * p_ped * _normal_pdf(x, eped, eped_sigma)
+    return signal
+
+
+@jit
+def pe_signal(k, x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct,
+              pap, dap):
+    """
+    Obtain the signal provided by photoelectrons in the pulse spectrum.
+
+    Parameters
+    ----------
+    k : int or ndarray
+        The NPEs to evaluate. A list of NPEs can be passed here, provided it
+        is broadcast as [:, None], and the x input is broadcast as [None, :],
+        the return value will then be a shape [k.size, x.size].
+        k must be greater than or equal to 1.
+    x : ndarray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    spe : float
+        Signal produced by 1 photo-electron
+    spe_sigma : float
+        Spread in the number of photo-electrons incident on the MAPMT
+    lambda_ : float
+        Poisson mean (illumination in p.e.)
+    opct : float
+        Optical crosstalk probability
+    pap : float
+        Afterpulse probability
+    dap : float
+        The first distance of the after-pulse Gaussians from the main peaks
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the signal provided by the photoelectrons. If k is an
+        integer, this will have same shape as x. If k is an array,
+        and k and x are broadcase correctly, this will have
+        shape [k.size, x.size].
+
+    """
+    # Obtain poisson distribution
+    pj = _poisson_pmf_j(lambda_)
+    pct = np.sum(pj * np.power(1-opct, J) * np.power(opct, N - J) * BINOM, 1)
+
+    sap = spe_sigma
+
+    papk = np.power(1 - pap, N[:, 0])
+    p0ap = pct * papk
+    pap1 = pct * (1-papk) * papk
+
+    pe_sigma = np.sqrt(k * spe_sigma ** 2 + eped_sigma ** 2)
+    ap_sigma = np.sqrt(k * sap ** 2 + eped_sigma ** 2)
+
+    signal = p0ap[k] * _normal_pdf(x, eped + k * spe, pe_sigma)
+    signal += pap1[k] * _normal_pdf(x, eped + k * spe * (1.0-dap), ap_sigma)
+    signal *= norm
+
+    return signal
+
+
+def sipm_spe_fit(x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct,
+                 pap, dap, **kwargs):
+    """
+    Fit for the SPE spectrum of a SiPM
+
+    Parameters
+    ----------
+    x : 1darray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    spe : float
+        Signal produced by 1 photo-electron
+    spe_sigma : float
+        Spread in the number of photo-electrons incident on the MAPMT
+    lambda_ : float
+        Poisson mean (illumination in p.e.)
+    opct : float
+        Optical crosstalk probability
+    pap : float
+        Afterpulse probability
+    dap : float
+        The first distance of the after-pulse Gaussians from the main peaks
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the total signal.
+    """
+
+    # Obtain pedestal signal
+    params = [norm, eped, eped_sigma, lambda_]
+    ped_s = pedestal_signal(x, *params)
+
+    # Obtain pe signal
+
+    params = [norm, eped, eped_sigma, spe, spe_sigma, lambda_, opct, pap, dap]
+    pe_s = pe_signal(K, x[None, :], *params).sum(0)
+
+    signal = ped_s + pe_s
+
+    return signal

--- a/ctapipe/analysis/camera/spe_fitter/pmt.py
+++ b/ctapipe/analysis/camera/spe_fitter/pmt.py
@@ -102,7 +102,7 @@ def pedestal_signal(x, norm, eped, eped_sigma, lambda_):
     eped_sigma : float
         Sigma of the zeroth peak, represents electronic noise of the system
     lambda_ : float
-        Poisson mean
+        Poisson mean (average illumination in p.e.)
 
     Returns
     -------
@@ -139,7 +139,7 @@ def pe_signal(k, x, norm, eped, eped_sigma, spe, spe_sigma, lambda_):
     spe_sigma : float
         Spread in the number of photo-electrons incident on the MAPMT
     lambda_ : float
-        Poisson mean (illumination in p.e.)
+        Poisson mean (average illumination in p.e.)
 
     Returns
     -------
@@ -179,7 +179,7 @@ def pmt_spe_fit(x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, **kwargs):
     spe_sigma : float
         Spread in the number of photo-electrons incident on the MAPMT
     lambda_ : float
-        Poisson mean (illumination in p.e.)
+        Poisson mean (average illumination in p.e.)
 
     Returns
     -------

--- a/ctapipe/analysis/camera/spe_fitter/pmt.py
+++ b/ctapipe/analysis/camera/spe_fitter/pmt.py
@@ -1,0 +1,201 @@
+import numpy as np
+from math import factorial
+from scipy.special import binom
+from numba import jit
+from ctapipe.analysis.camera.spe_fitter import SPEFitter
+
+
+class PMTFitter(SPEFitter):
+    def __init__(self, n_illuminations, config_path=None):
+        """
+        SpectrumFitter which uses the PMT fitting formula
+
+        Parameters
+        ----------
+        n_illuminations : int
+            Number of illuminations to fit simultaneously
+        """
+        super().__init__(n_illuminations, config_path)
+
+        self.nbins = 100
+        self.range = [-40, 150]
+
+        self.add_parameter("norm", None, 0, 100000, fix=True, multi=True)
+        self.add_parameter("eped", 0, -10, 10)
+        self.add_parameter("eped_sigma", 9, 2, 20)
+        self.add_parameter("spe", 25, 5, 30)
+        self.add_parameter("spe_sigma", 2, 1, 20)
+        self.add_parameter("lambda_", 0.2, 0.001, 6, multi=True)
+
+    def _prepare_params(self, p0, limits, fix):
+        for i in range(self.n_illuminations):
+            norm = 'norm{}'.format(i)
+            if p0[norm] is None:
+                p0[norm] = np.trapz(self.hist[i], self.between)
+
+    @staticmethod
+    def _fit(x, **kwargs):
+        return pmt_spe_fit(x, **kwargs)
+
+
+C = np.sqrt(2.0 * np.pi)
+FACTORIAL = np.array([factorial(i) for i in range(15)])
+FACTORIAL_0 = FACTORIAL[0]
+NPEAKS = 11
+N = np.arange(NPEAKS)[:, None]
+J = np.arange(NPEAKS)[None, :]
+K = np.arange(1, NPEAKS)[:, None]
+FACTORIAL_J_INV = 1 / FACTORIAL[J]
+BINOM = binom(N - 1, J - 1)
+
+
+@jit(nopython=True)
+def _normal_pdf(x, mean=0, std_deviation=1):
+    """
+    Evaluate the normal probability density function. Faster than
+    `scipy.norm.pdf` as it does not check the inputs.
+
+    Parameters
+    ----------
+    x : ndarray
+        The normal probability function will be evaluated
+    mean : float or ndarray
+    std_deviation : float or array_like
+
+    Returns
+    -------
+    ndarray
+    """
+    u = (x - mean) / std_deviation
+    return np.exp(-0.5 * u ** 2) / (C * std_deviation)
+
+
+@jit(nopython=True)
+def _poisson_pmf_j(mu):
+    """
+    Evaluate the poisson pmf for a fixed k=J events
+
+    Parameters
+    ----------
+    mu : Average number of events
+
+    Returns
+    -------
+    ndarray
+    """
+    return mu ** J * np.exp(-mu) * FACTORIAL_J_INV
+
+
+@jit(nopython=True)
+def pedestal_signal(x, norm, eped, eped_sigma, lambda_):
+    """
+    Obtain the signal provided by the pedestal in the pulse spectrum.
+
+    Parameters
+    ----------
+    x : ndarray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    lambda_ : float
+        Poisson mean
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the signal provided by the pedestal.
+    """
+    p_ped = np.exp(-lambda_)  # Poisson PMF for k = 0, mu = lambda_
+    signal = norm * p_ped * _normal_pdf(x, eped, eped_sigma)
+    return signal
+
+
+# @jit
+def pe_signal(k, x, norm, eped, eped_sigma, spe, spe_sigma, lambda_):
+    """
+    Obtain the signal provided by photoelectrons in the pulse spectrum.
+
+    Parameters
+    ----------
+    k : int or ndarray
+        The NPEs to evaluate. A list of NPEs can be passed here, provided it
+        is broadcast as [:, None], and the x input is broadcast as [None, :],
+        the return value will then be a shape [k.size, x.size].
+        k must be greater than or equal to 1.
+    x : ndarray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    spe : float
+        Signal produced by 1 photo-electron
+    spe_sigma : float
+        Spread in the number of photo-electrons incident on the MAPMT
+    lambda_ : float
+        Poisson mean (illumination in p.e.)
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the signal provided by the photoelectrons. If k is an
+        integer, this will have same shape as x. If k is an array,
+        and k and x are broadcase correctly, this will have
+        shape [k.size, x.size].
+
+    """
+    # Obtain poisson distribution
+    p = _poisson_pmf_j(lambda_)[0]
+
+    pe_sigma = np.sqrt(k * spe_sigma ** 2 + eped_sigma ** 2)
+
+    signal = norm * p[k] * _normal_pdf(x, eped + k * spe, pe_sigma)
+
+    return signal
+
+
+def pmt_spe_fit(x, norm, eped, eped_sigma, spe, spe_sigma, lambda_, **kwargs):
+    """
+    Fit for the SPE spectrum of a MAPM
+
+    Parameters
+    ----------
+    x : 1darray
+        The x values to evaluate at
+    norm : float
+        Integral of the zeroth peak in the distribution, represents p(0)
+    eped : float
+        Distance of the zeroth peak from the origin
+    eped_sigma : float
+        Sigma of the zeroth peak, represents electronic noise of the system
+    spe : float
+        Signal produced by 1 photo-electron
+    spe_sigma : float
+        Spread in the number of photo-electrons incident on the MAPMT
+    lambda_ : float
+        Poisson mean (illumination in p.e.)
+
+    Returns
+    -------
+    signal : ndarray
+        The y values of the total signal.
+    """
+
+    # Obtain pedestal signal
+    params = [norm, eped, eped_sigma, lambda_]
+    ped_s = pedestal_signal(x, *params)
+
+    # Obtain pe signal
+
+    params = [norm, eped, eped_sigma, spe, spe_sigma, lambda_]
+    pe_s = pe_signal(K, x[None, :], *params).sum(0)
+
+    signal = ped_s + pe_s
+
+    return signal


### PR DESCRIPTION
I would like to contribute the fitting classes I use for SPE spectra.

Initially contributed are a base class and two subclasses, one for PMTs and the other for SiPMs (using the formula defined in Gentile 2010).

The base class is defined to be flexible, allowing the easy definition of a new subclass containing a different SPE fitting formula to be contributed.

The base class can simultaneously fit N illuminations, allowing for a better handle on the fit parameters (as many should not change with average illumination).

The iminuit package is used to perform the fit, and the confidence on the resulting fit parameters is also extracted from the covariance matrix.