### PR TITLE
Implemented FACT image cleaning

### DIFF
--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -227,7 +227,7 @@ def fact_image_cleaning(geom, image, arrival_times, picture_threshold=4,
 
     # Step 3
     pixels_above_boundary = image >= boundary_threshold
-    pixels_to_keep = dilate(geom, pixels_to_keep) & pixels_above_boundary 
+    pixels_to_keep = dilate(geom, pixels_to_keep) & pixels_above_boundary
 
     # nothing else to do if min_number_neighbors <= 0
     if min_number_neighbors <= 0:

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -184,8 +184,12 @@ def fact_image_cleaning(geom, image, arrival_times, picture_threshold=4,
     5: Remove pixels with less than N neighbors
     6: Remove pixels with less than N neighbors arriving within a given timeframe
 
-    Reference: FACT Project
-    Implementation: https://github.com/fact-project/fact-tools
+    Reference:
+        On the hunt for photons: analysis of Crab Nebula data obtained
+        by the first G-APD Cherenkov telescope, Thomas Fabian Temme
+        http://dx.doi.org/10.17877/DE290R-17773
+    Implementation:
+        https://github.com/fact-project/fact-tools
 
     Parameters
     ----------

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -131,3 +131,123 @@ def number_of_islands(geom, mask):
     island_labels[mask] = island_labels_compressed + 1
 
     return num_islands, island_labels
+
+
+def apply_time_delta_cleaning(geom, mask, arrival_times,
+                              min_number_neighbors, time_limit):
+    """ Remove all pixels from selection that have less than N
+    neighbors that arrived within a given timeframe.
+
+    Parameters
+    ----------
+    geom: `ctapipe.instrument.CameraGeometry`
+        Camera geometry information
+    mask: array, boolean
+        boolean mask of *clean* pixels before time_delta_cleaning
+    arrival_times: array
+        pixel timing information
+    min_number_neighbors: int
+        Threshold to determine if a pixel survives cleaning steps.
+        These steps include checks of neighbor arrival time and value
+    time_limit: int or float
+        arrival time limit for neighboring pixels
+
+    Returns
+    -------
+
+    A boolean mask of *clean* pixels.  To get a zero-suppressed image and pixel
+    list, use `image[mask], geom.pix_id[mask]`, or to keep the same
+    image size and just set unclean pixels to 0 or similar, use
+    `image[~mask] = 0`
+
+    """
+    pixels_to_remove = []
+    for pixel in np.where(mask)[0]:
+        neighbors = geom.neighbor_matrix_sparse[pixel].indices
+        time_diff = np.abs(arrival_times[neighbors] - arrival_times[pixel])
+        if sum(time_diff < time_limit) < min_number_neighbors:
+            pixels_to_remove.append(pixel)
+    mask[pixels_to_remove] = False
+    return mask
+
+
+def fact_image_cleaning(geom, image, arrival_times, picture_threshold=4,
+                        boundary_threshold=2, min_number_neighbors=2, time_limit=5):
+
+    """Clean an image by selection pixels that pass the fact cleaning procedure.
+    Cleaning contains the following steps:
+    1: Find pixels containing more photons than a threshold t1
+    2: Remove pixels with less than N neighbors
+    3: Add neighbors of the remaining pixels that are
+       above a lower threshold t2
+    4: Remove pixels with less than N neighbors arriving within a given timeframe
+    5: Remove pixels with less than N neighbors
+    6: Remove pixels with less than N neighbors arriving within a given timeframe
+
+    Reference: FACT Project
+    Implementation: https://github.com/fact-project/fact-tools
+
+    Parameters
+    ----------
+    geom: `ctapipe.instrument.CameraGeometry`
+        Camera geometry information
+    image: array
+        pixel values
+    arrival_times: array
+        pixel timing information
+    picture_threshold: float or array
+        threshold above which all pixels are retained
+    boundary_threshold: float or array
+        threshold above which pixels are retained if they have a neighbor
+        already above the picture_thresh
+    min_number_neighbors: int
+        Threshold to determine if a pixel survives cleaning steps.
+        These steps include checks of neighbor arrival time and value
+    time_limit: int or float
+        arrival time limit for neighboring pixels
+
+    Returns
+    -------
+
+    A boolean mask of *clean* pixels.  To get a zero-suppressed image and pixel
+    list, use `image[mask], geom.pix_id[mask]`, or to keep the same
+    image size and just set unclean pixels to 0 or similar, use
+    `image[~mask] = 0`
+
+    """
+
+    # Step 1
+    pixels_to_keep = image >= picture_threshold
+
+    # Step 2
+    number_of_neighbors_above_picture = geom.neighbor_matrix_sparse.dot(
+        (pixels_to_keep).view(np.byte))
+    pixels_to_keep = pixels_to_keep & (number_of_neighbors_above_picture
+                                       >= min_number_neighbors)
+
+    # Step 3
+    pixels_above_boundary = image >= boundary_threshold
+    pixels_to_keep = dilate(geom, pixels_to_keep) & pixels_above_boundary 
+
+    # nothing else to do if min_number_neighbors <= 0
+    if min_number_neighbors <= 0:
+        return pixels_to_keep
+
+    # Step 4
+    pixels_to_keep = apply_time_delta_cleaning(geom,
+                                               pixels_to_keep,
+                                               arrival_times,
+                                               min_number_neighbors,
+                                               time_limit)
+
+    # Step 5
+    number_of_neighbors = geom.neighbor_matrix_sparse.dot((pixels_to_keep).view(np.byte))
+    pixels_to_keep = pixels_to_keep & (number_of_neighbors >= min_number_neighbors)
+
+    # Step 6
+    pixels_to_keep = apply_time_delta_cleaning(geom,
+                                               pixels_to_keep,
+                                               arrival_times,
+                                               min_number_neighbors,
+                                               time_limit)
+    return pixels_to_keep

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -173,13 +173,13 @@ def test_fact_image_cleaning():
     # use LST pixel geometry
     geom = CameraGeometry.from_name("LSTCam")
     # create some signal pixels
-    values = np.zeros(len(geom)) 
-    timing = np.zeros(len(geom)) 
+    values = np.zeros(len(geom))
+    timing = np.zeros(len(geom))
     signal_pixels = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                              10, 11, 12, 13, 14, 37, 38, 111, 222])
     values[signal_pixels] = 5
     timing[signal_pixels] = 10
-    # manipulate some of those 
+    # manipulate some of those
     values[[1, 2]] = 3
     values[7] = 1
     timing[[5, 6, 13, 111]] = 20

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -167,3 +167,32 @@ def test_number_of_islands():
     n_islands_true = 5
     assert n_islands == n_islands_true
     assert_allclose(island_mask, island_mask_true)
+
+
+def test_fact_image_cleaning():
+    # use LST pixel geometry
+    geom = CameraGeometry.from_name("LSTCam")
+    # create some signal pixels
+    values = np.zeros(len(geom)) 
+    timing = np.zeros(len(geom)) 
+    signal_pixels = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                             10, 11, 12, 13, 14, 37, 38, 111, 222])
+    values[signal_pixels] = 5
+    timing[signal_pixels] = 10
+    # manipulate some of those 
+    values[[1, 2]] = 3
+    values[7] = 1
+    timing[[5, 6, 13, 111]] = 20
+
+    mask = cleaning.fact_image_cleaning(geom,
+                                        values,
+                                        timing,
+                                        boundary_threshold=2,
+                                        picture_threshold=4,
+                                        min_number_neighbors=2,
+                                        time_limit=5)
+
+    expected_pixels = np.array([0, 1, 2, 3, 4, 8, 9, 10, 11])
+    expected_mask = np.zeros(len(geom)).astype(bool)
+    expected_mask[expected_pixels] = 1
+    assert_allclose(mask, expected_mask)


### PR DESCRIPTION
As pointed out on the recent LST Analysis Bootcamp we might want to access different cleaning methods from MAGIC and FACT within ctapipe.

This cleaning method is based on the the one used at FACT, a java implementation can be at the FACT github repo:
https://github.com/fact-project/fact-tools

The results for simple gamma showers seem to be comparable with the tailcuts_clean method with these cleaning levels used for both methods:
cleaning_level = {
    'LSTCam': (3.5, 7.5, 2),
    'NectarCam': (3, 5.5, 2),
    'DigiCam': (2, 4.5, 2),
}

- performs cleaning based on pixel value and timing information
- default values are rather loose, higher picture and boundary thresholds could prove useful
- added unit test