### PR TITLE
Factory V3

### DIFF
--- a/ctapipe/core/tests/test_factory.py
+++ b/ctapipe/core/tests/test_factory.py
@@ -193,3 +193,27 @@ def test_default_passing():
     ExampleFactory.value.default_value = old_default
     obj = ExampleFactory.produce()
     assert (obj.value == old_default)
+
+
+def test_component_definition_after_factory():
+    """
+    Test if a component defined after the factory definition will be
+    obtainable by the factory
+    """
+    class ExampleComponent5(ExampleComponentParent):
+        value = Int(1234445, help="").tag(config=True)
+
+    assert "ExampleComponent5" in ExampleFactory.product.values
+    obj = ExampleFactory.produce(product='ExampleComponent5')
+    assert (obj.value == 1234445)
+
+def test_component_definition_after_factory_help_message():
+    """
+    Test if a component defined after the factory definition will be
+    inside the help message
+    """
+
+    class ExampleComponent5(ExampleComponentParent):
+        value = Int(1234445, help="").tag(config=True)
+
+    assert "ExampleComponent5" in ExampleFactory.class_get_help()


### PR DESCRIPTION
As an alternative suggestion to #916, I would like to propose some improvements to the existing `Factory` that:

- [x] Keeps the distinction between a Factory and a Component, therefore avoiding every Component containing Factory functionality due to inheritance
- [ ] Addresses the issues highlighted in #915 
- [ ] Avoids confusion in the setting of traitlets
- [ ] Simplifies the code in the `Factory` definition
- [ ] Improves on the Component discovery, removing the Factory's dependance on the Components being defined before it is (potentially preparing it for a plugin system)

This is a work-in-progress and a test of concept. I will see how successfully I can achieve these goals. Other goals may also be identified and added to this list as I progress.