### PR TITLE
Add get_pixel_id method

### DIFF
--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -204,7 +204,7 @@ class CameraGeometry:
         return np.ones(pix_x.shape) * area
 
     @lazyproperty
-    def all_pixels_kdtree(self):
+    def kdtree(self):
         """
         Pre-calculated kdtree of all pixel centers inside camera
 
@@ -556,7 +556,7 @@ class CameraGeometry:
 
         points_searched = np.dstack([x.to_value(u.m), y.to_value(u.m)])
 
-        kdtree = self.all_pixels_kdtree
+        kdtree = self.kdtree
         dist, pix_indices = kdtree.query(points_searched)
         pix_indices = pix_indices.flatten()
 

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -611,12 +611,12 @@ class CameraGeometry:
                 index = np.where(pix_indices == borderpix_index)[0][0]
                 # compare with inside pixel:
                 xprime = (points_searched[0][index, 0]
-                          - self.pix_x.to_value(u.m)[borderpix_index]
-                          + self.pix_x.to_value(u.m)[insidepix_index])
+                          - self.pix_x[borderpix_index].to_value(u.m)
+                          + self.pix_x[insidepix_index].to_value(u.m))
                 yprime = (points_searched[0][index, 1]
-                          - self.pix_y.to_value(u.m)[borderpix_index]
-                          + self.pix_y.to_value(u.m)[insidepix_index])
-                dist_check, index_check = kdtree.query([xprime, yprime], 
+                          - self.pix_y[borderpix_index].to_value(u.m)
+                          + self.pix_y[insidepix_index].to_value(u.m))
+                dist_check, index_check = kdtree.query([xprime, yprime],
                                                        distance_upper_bound=circum_rad)
                 del dist_check
                 if index_check != insidepix_index:

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -592,7 +592,7 @@ class CameraGeometry:
         pix_indices[pix_indices == self.n_pixels] = -1
 
         # 2. Accurate check for the remaing cases (within circumference, but still outside
-        # camera). It is first checked if any border pixel numbers are returned. 
+        # camera). It is first checked if any border pixel numbers are returned.
         # If not, everything is fine. If yes, the distance of the given position to the
         # the given position to the closest pixel center is translated to the distance to
         # the center of a non-border pixel', pos -> pos', and it is checked whether pos'

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -551,7 +551,7 @@ class CameraGeometry:
                    outside camera
         '''
 
-        if not np.all(self.pix_area == self.pix_area[0], axis=0):
+        if np.any(~np.isclose(self.pix_area.value, self.pix_area[0].value), axis=0):
             logger.warning(" Method not implemented for cameras with varying pixel sizes")
 
         points_searched = np.dstack([x.to_value(u.m), y.to_value(u.m)])

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -215,7 +215,7 @@ class CameraGeometry:
 
         """
 
-        pixel_centers = np.stack([self.pix_x.to_value(u.m), self.pix_y.to_value(u.m)]).T
+        pixel_centers = np.column_stack([self.pix_x.to_value(u.m), self.pix_y.to_value(u.m)])
         return KDTree(pixel_centers)
 
     @classmethod

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -564,14 +564,14 @@ class CameraGeometry:
         # particular pixel shape.
         
         border_mask = self.get_border_pixel_mask()
-        # get some pixel not at the border:
-        inside_pix_id = np.where(~border_mask)[0][0]
         #get all pixels at camera border:
         borderpix_ids = np.where(border_mask)[0]
         
         borderpix_ids_in_list = np.intersect1d(borderpix_ids, pixel_ids)
         if borderpix_ids_in_list.any():
-            # now check in detail
+            # Get some pixel not at the border:
+            inside_pix_id = np.where(~border_mask)[0][0]
+            # Check in detail whether location in border pixel or outside camera:
             for borderpix_id in borderpix_ids_in_list:
                 index = np.where(pixel_ids==borderpix_id)[0][0]
                 # compare with inside pixel:

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -215,7 +215,7 @@ class CameraGeometry:
 
         """
 
-        pixel_centers = np.stack([self.pix_x.to_value(u.m),self.pix_y.to_value(u.m)]).T
+        pixel_centers = np.stack([self.pix_x.to_value(u.m), self.pix_y.to_value(u.m)]).T
         return KDTree(pixel_centers)
 
     @classmethod
@@ -532,13 +532,13 @@ class CameraGeometry:
         trans = delta_x * -sin_psi + delta_y * cos_psi
 
         return longi, trans
-    
+
     def get_pixel_id(self, x, y):
         '''
         Return the camera pixel number which contains a given position (x,y) 
         in the camera frame. The (x,y) coordinates can be arrays (of equal length),
-        for which the methods returns an array of pixel ids. A warning is raised if the position
-        falls outside the camera.
+        for which the methods returns an array of pixel ids. A warning is raised if the 
+        position falls outside the camera.
 
         Parameters
         ----------
@@ -547,45 +547,52 @@ class CameraGeometry:
 
         Returns
         -------
-        pixel_ids: Pixel number or array of pixel numbers. Returns -1 if position falls outside camera
+        pixel_ids: Pixel number or array of pixel numbers. Returns -1 if position falls 
+                   outside camera
         '''
-        
+
         if not np.all(self.pix_area == self.pix_area[0], axis=0):
             logger.warning(" Method not implemented for cameras with varying pixel sizes")
-        
-        points_searched = np.dstack([x.to_value(u.m),y.to_value(u.m)])
+
+        points_searched = np.dstack([x.to_value(u.m), y.to_value(u.m)])
 
         kdtree = self.all_pixels_kdtree
         dist, pixel_ids = kdtree.query(points_searched)
         pixel_ids = pixel_ids.flatten()
-        
+
         # Check if the position lies inside the camera. It is first checked if any border
         # pixel numbers are returned. If not, everything is fine. If yes, the distance of 
-        # the given position to the closest pixel center is translated to the distance to the
-        # center of a non-border pixel', pos -> pos', and it is checked whether pos' still lies
-        # within pixel'. If not, pos lies outside the camera. This approach does not need to 
-        # know the particular pixel shape, but as the kdtree itself, presumes all camera pixels
-        # being of equal size.
-        
+        # the given position to the closest pixel center is translated to the distance to 
+        # the center of a non-border pixel', pos -> pos', and it is checked whether pos' 
+        # still lies within pixel'. If not, pos lies outside the camera. This approach  
+        # does not need to know the particular pixel shape, but as the kdtree itself, 
+        # presumes all camera pixels being of equal size.
+
         border_mask = self.get_border_pixel_mask()
-        #get all pixels at camera border:
+        # get all pixels at camera border:
         borderpix_ids = np.where(border_mask)[0]
-        
+
         borderpix_ids_in_list = np.intersect1d(borderpix_ids, pixel_ids)
         if borderpix_ids_in_list.any():
             # Get some pixel not at the border:
             inside_pix_id = np.where(~border_mask)[0][0]
             # Check in detail whether location is in border pixel or outside camera:
             for borderpix_id in borderpix_ids_in_list:
-                index = np.where(pixel_ids==borderpix_id)[0][0]
+                index = np.where(pixel_ids == borderpix_id)[0][0]
                 # compare with inside pixel:
-                xprime = points_searched[0][index,0] - self.pix_x.to_value(u.m)[borderpix_id] + self.pix_x.to_value(u.m)[inside_pix_id]
-                yprime = points_searched[0][index,1] - self.pix_y.to_value(u.m)[borderpix_id] + self.pix_y.to_value(u.m)[inside_pix_id]
+                xprime = points_searched[0][index, 0] \
+                    - self.pix_x.to_value(u.m)[borderpix_id] \
+                    + self.pix_x.to_value(u.m)[inside_pix_id]
+                yprime = points_searched[0][index, 1] \
+                    - self.pix_y.to_value(u.m)[borderpix_id] \
+                    + self.pix_y.to_value(u.m)[inside_pix_id]
                 dist_check, index_check = kdtree.query([xprime, yprime])
                 if index_check != inside_pix_id:
-                    logger.warning(" Coordinate ({} m, {} m) lies outside camera".format(points_searched[0][index,0],points_searched[0][index,1]))
+                    logger.warning(" Coordinate ({} m, {} m) lies outside camera"
+                                   .format(points_searched[0][index, 0], 
+                                           points_searched[0][index, 1]))
                     pixel_ids[index] = -1
-        
+
         return pixel_ids if len(pixel_ids) > 1 else pixel_ids[0]
 
 

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -563,17 +563,22 @@ class CameraGeometry:
         # pixel. If not, pos lies outside the camera. This approach does not need to know the  
         # particular pixel shape.
         
-        borderpix_ids = np.where(self.get_border_pixel_mask())[0]
+        border_mask = self.get_border_pixel_mask()
+        # get some pixel not at the border:
+        inside_pix_id = np.where(~border_mask)[0][0]
+        #get all pixels at camera border:
+        borderpix_ids = np.where(border_mask)[0]
+        
         borderpix_ids_in_list = np.intersect1d(borderpix_ids, pixel_ids)
         if borderpix_ids_in_list.any():
             # now check in detail
             for borderpix_id in borderpix_ids_in_list:
                 index = np.where(pixel_ids==borderpix_id)[0][0]
-                # compare with central pixel in the camera:
-                xprime = points_searched[0][index,0] - self.pix_x.to_value(u.m)[borderpix_id] + self.pix_x.to_value(u.m)[0]
-                yprime = points_searched[0][index,1] - self.pix_y.to_value(u.m)[borderpix_id] + self.pix_y.to_value(u.m)[0]
+                # compare with inside pixel:
+                xprime = points_searched[0][index,0] - self.pix_x.to_value(u.m)[borderpix_id] + self.pix_x.to_value(u.m)[inside_pix_id]
+                yprime = points_searched[0][index,1] - self.pix_y.to_value(u.m)[borderpix_id] + self.pix_y.to_value(u.m)[inside_pix_id]
                 dist_check, index_check = kdtree.query([xprime, yprime])
-                if index_check != 0:
+                if index_check != inside_pix_id:
                     logger.warning(" Coordinate ({} m, {} m) lies outside camera".format(points_searched[0][index,0],points_searched[0][index,1]))
                     pixel_ids[index] = -1
         

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -57,7 +57,7 @@ def test_guess_camera():
 def test_position_to_pix_index():
     geom = CameraGeometry.from_name("LSTCam")
     x, y = 0.80 * u.m, 0.79 * u.m,
-    pix_id = geom.get_pixel_id(x, y)
+    pix_id = geom.position_to_pix_index(x, y)
     assert pix_id == 1790
 
 

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -54,9 +54,9 @@ def test_guess_camera():
     assert geom.pix_type.startswith('rect')
 
 
-def test_get_pixel_id():
+def test_position_to_pix_index():
     geom = CameraGeometry.from_name("LSTCam")
-    x, y = 0.80 * u.m, 0.79 * u.m, 
+    x, y = 0.80 * u.m, 0.79 * u.m,
     pix_id = geom.get_pixel_id(x, y)
     assert pix_id == 1790
 

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -54,6 +54,13 @@ def test_guess_camera():
     assert geom.pix_type.startswith('rect')
 
 
+def test_get_pixel_id():
+    geom = CameraGeometry.from_name("LSTCam")
+    x, y = 0.80 * u.m, 0.79 * u.m, 
+    pix_id = geom.get_pixel_id(x, y)
+    assert pix_id == 1790
+
+
 def test_get_min_pixel_seperation():
     x, y = np.meshgrid(np.linspace(-5, 5, 5), np.linspace(-5, 5, 5))
     pixsep = _get_min_pixel_seperation(x.ravel(), y.ravel())


### PR DESCRIPTION
Added CameraGeometry.get_pixel_id() method to return the pixel number(s) corresponding to a (or an array of) x,y position(s), to be used like:
```
>>> geom = CameraGeometry.from_name("LSTCam")
>>> x, y = 0.1 * u.m, 0.1 * u.m
>>> geom.get_pixel_id(x, y)
138
>>> x, y = [0.1, 0.3] * u.m, [0.1, 0.4] * u.m
>>> geom.get_pixel_id(x, y)
array([138, 876])
```
