### PR TITLE
clean up environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
   - numpy>=1.15.4
   - numpydoc
   - pandas
-  - pyhessio
   - pytest
   - pytest-cov
   - psutil

--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,16 @@
+# A conda environment with all useful package for ctapipe developers
 name: cta-dev
 channels:
   - default
   - cta-observatory
-  - conda-forge
 dependencies:
+  - ctapipe-extra=0.2.16
   - zeromq
   - pyzmq>=17  # needed for correct function of notebooks on OSX
   - astropy
   - bokeh
   - cython
-  - gammapy
+  - conda-forge::gammapy
   - graphviz
   - h5py
   - iminuit
@@ -28,7 +29,7 @@ dependencies:
   - scikit-learn
   - scipy
   - setuptools
-  - sphinx=1.7
+  - sphinx
   - sphinx_rtd_theme
   - sphinx-automodapi
   - traitlets
@@ -42,4 +43,4 @@ dependencies:
   - pip:
       - pytest_runner
       - eventio==0.11.0
-      - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.16.tar.gz
+

--- a/py3.6_env.yaml
+++ b/py3.6_env.yaml
@@ -2,15 +2,15 @@ name: cta-dev
 channels:
   - default
   - cta-observatory
-  - conda-forge
 dependencies:
+  - ctapipe-extra=0.2.16
   - python=3.6 # nail the python version, so conda does not try upgrading / dowgrading
   - zeromq
   - pyzmq>=17  # needed for correct function of notebooks on OSX
   - astropy
   - bokeh
   - cython
-  - gammapy
+  - conda-forge::gammapy
   - graphviz
   - h5py
   - iminuit
@@ -28,7 +28,7 @@ dependencies:
   - scikit-learn
   - scipy
   - setuptools
-  - sphinx=1.7
+  - sphinx
   - sphinx_rtd_theme
   - sphinx-automodapi
   - traitlets
@@ -42,5 +42,4 @@ dependencies:
   - pip:
       - pytest_runner
       - eventio==0.11.0
-      - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.16.tar.gz
       - https://github.com/cta-observatory/pyhessio/archive/v2.1.1.tar.gz

--- a/py3.7_env.yaml
+++ b/py3.7_env.yaml
@@ -2,15 +2,15 @@ name: cta-dev
 channels:
   - default
   - cta-observatory
-  - conda-forge
 dependencies:
+  - ctapipe-extra=0.2.16
   - python=3.7
   - zeromq
   - pyzmq>=17  # needed for correct function of notebooks on OSX
   - astropy
   - bokeh
   - cython
-  - gammapy
+  - conda-forge::gammapy
   - graphviz
   - h5py
   - iminuit
@@ -28,7 +28,7 @@ dependencies:
   - scikit-learn
   - scipy
   - setuptools
-  - sphinx=1.7
+  - sphinx
   - sphinx_rtd_theme
   - sphinx-automodapi
   - traitlets
@@ -42,5 +42,4 @@ dependencies:
   - pip:
       - pytest_runner
       - eventio==0.11.0
-      - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.16.tar.gz
       - https://github.com/cta-observatory/pyhessio/archive/v2.1.1.tar.gz


### PR DESCRIPTION
- remove *conda-forge* from channel list and only apply it to packages that need it (to avoid upgrading all packages to bleeding-edge versions)
- remove *ctapipe-extra* from pip install, go back to using conda package instead