### PR TITLE
fix test: wrong path and wrong reader

### DIFF
--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -1,5 +1,6 @@
 import tempfile
 
+import h5py
 import numpy as np
 import pytest
 import tables
@@ -66,15 +67,15 @@ def test_prefix(tmp_path):
     )
 
     with HDF5TableWriter(
-        tmp_file.name,
+        tmp_file,
         group_name='blabla',
         add_prefix=True
     ) as writer:
         writer.write('events', [hillas_parameter_container, leakage_container])
 
-    df = pd.read_hdf(tmp_file.name)
-    assert 'hillas_x' in df.columns
-    assert 'leakage2_pixel' in df.columns
+    dataset = h5py.File(tmp_file, 'r')['blabla']['events']
+    assert 'hillas_x' in dataset.dtype.fields
+    assert 'leakage2_pixel' in dataset.dtype.fields
 
 
 def test_write_containers(temp_h5_file):


### PR DESCRIPTION
Master was broken. 

Reason: a test `io/tests/test_hdf5.py` made a wrong assumption, see below. 

----
The test `test_prefix(tmp_path)` is using a `HDF5TableWriter` and assumes the output of `HDF5TableWriter` can be read with `pandas.read_hdf`, but that is not the case. 

As we know HDF5 files are not HDF5 files .. there are "raw" HDF5 files, which simply contain plain old datasets .. these are usually fast and small but sometimes cumbersome to use. 

And there are "pandas HDF5 files"  .. these are great to explore with pandas but sometimes end up very large or rather slow... 

I am not quite sure, why this test ever worked in the PR but now in the master, it fails. It should always have failed. 

Anyway for the test to pass I could either the the `HDF5TableReader` to read the file, but I do not like tests to depend on each other, so I used plain old `h5py` to open the output of the Writer and assert some contents to exist. 

There are other tests, which confirm the Reader can read what the Writer has written.

@cta-observatory/ctapipe-core-devs please review quickly so the master will work again.