### PR TITLE
fix bug where wrong value was filled for num_mirror_tiles

### DIFF
--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -59,7 +59,7 @@ class SimTelEventSource(EventSource):
                 cam_settings['mirror_area'] * u.m ** 2
             )
             tel_description.optics.num_mirror_tiles = (
-                cam_settings['mirror_area']
+                cam_settings['n_mirrors']
             )
             tel_descriptions[tel_id] = tel_description
 


### PR DESCRIPTION
`OpticsDescription.num_mirror_tiles` was filled with a value of `mirror_area` and not `n_mirrors` in `SimTelEventSource`. This fixes that.

I didn't add a test to check for it, but probably there should eventually be a general test for all EventSources that checks that the SubarrayDescription is correctly filled (maybe easiest as a `validate()` method to `SubarrayDescription`?). I'll leave that to a future development, though, since it's a bit of work. 