### PR TITLE
modernize formatting code for python 3.6+

### DIFF
--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -153,7 +153,7 @@ class ThresholdGainSelector(GainSelector):
         self.log.debug("Loaded threshold table: \n %s", tab)
 
     def __str__(self):
-        return "{}({})".format(self.__class__.__name__, self.thresholds)
+        return f"{self.__class__.__name__}({self.thresholds})"
 
     def select_gains(self, cam_id, multi_gain_waveform):
 

--- a/ctapipe/coordinates/representation.py
+++ b/ctapipe/coordinates/representation.py
@@ -38,10 +38,10 @@ class PlanarRepresentation(BaseRepresentation):
             )
 
         if not isinstance(x, self.attr_classes['x']):
-            raise TypeError('x should be a {0}'.format(self.attr_classes['x'].__name__))
+            raise TypeError('x should be a {}'.format(self.attr_classes['x'].__name__))
 
         if not isinstance(y, self.attr_classes['y']):
-            raise TypeError('y should be a {0}'.format(self.attr_classes['y'].__name__))
+            raise TypeError('y should be a {}'.format(self.attr_classes['y'].__name__))
 
         x = self.attr_classes['x'](x, copy=copy)
         y = self.attr_classes['y'](y, copy=copy)

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -71,7 +71,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
 
         for key, value in kwargs.items():
             if not self.has_trait(key):
-                raise TraitError("Traitlet does not exist: {}".format(key))
+                raise TraitError(f"Traitlet does not exist: {key}")
 
         # set up logging
         if self.parent:

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -28,9 +28,9 @@ class Field:
         self.ucd = ucd
 
     def __repr__(self):
-        desc = '{}'.format(self.description)
+        desc = f'{self.description}'
         if self.unit is not None:
-            desc += ' [{}]'.format(self.unit)
+            desc += f' [{self.unit}]'
         return desc
 
 
@@ -173,7 +173,7 @@ class Container(metaclass=ContainerMeta):
                 if isinstance(val, Container) or isinstance(val, Map):
                     if flatten:
                         d.update({
-                            "{}_{}".format(key, k): v
+                            f"{key}_{k}": v
                             for k, v in val.as_dict(
                                 recursive,
                                 add_prefix=add_prefix
@@ -236,7 +236,7 @@ class Map(defaultdict):
                 if isinstance(val, Container) or isinstance(val, Map):
                     if flatten:
                         d.update({
-                            "{}_{}".format(key, k): v
+                            f"{key}_{k}": v
                             for k, v in val.as_dict(
                                 recursive, add_prefix=add_prefix
                             ).items()

--- a/ctapipe/core/logging.py
+++ b/ctapipe/core/logging.py
@@ -32,4 +32,4 @@ class ColoredFormatter(logging.Formatter):
         else:
             record.highlevel = ""
 
-        return super(ColoredFormatter, self).format(record)
+        return super().format(record)

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -63,7 +63,7 @@ class Provenance(metaclass=Singleton):
         activity = _ActivityProvenance(activity_name)
         activity.start()
         self._activities.append(activity)
-        log.debug("started activity: {}".format(activity_name))
+        log.debug(f"started activity: {activity_name}")
 
     def add_input_file(self, filename, role=None):
         """ register an input to the current activity
@@ -115,7 +115,7 @@ class Provenance(metaclass=Singleton):
 
         activity.finish(status)
         self._finished_activities.append(activity)
-        log.debug("finished activity: {}".format(activity.name))
+        log.debug(f"finished activity: {activity.name}")
 
     @contextmanager
     def activity(self, name):

--- a/ctapipe/core/support.py
+++ b/ctapipe/core/support.py
@@ -4,5 +4,5 @@ class Singleton(type):
 
     def __call__(cls, *args, **kw):
         if not cls.instance:
-            cls.instance = super(Singleton, cls).__call__(*args, **kw)
+            cls.instance = super().__call__(*args, **kw)
         return cls.instance

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -100,7 +100,7 @@ class Tool(Application):
 
     """
 
-    config_file = Unicode(u'', help=("name of a configuration file with "
+    config_file = Unicode('', help=("name of a configuration file with "
                                      "parameters to load in addition to "
                                      "command-line parameters")).tag(config=True)
 
@@ -122,9 +122,9 @@ class Tool(Application):
         """ handle config and any other low-level setup """
         self.parse_command_line(argv)
         if self.config_file != '':
-            self.log.debug("Loading config from '{}'".format(self.config_file))
+            self.log.debug(f"Loading config from '{self.config_file}'")
             self.load_config_file(self.config_file)
-        self.log.info("ctapipe version {}".format(self.version_string))
+        self.log.info(f"ctapipe version {self.version_string}")
 
     @abstractmethod
     def setup(self):
@@ -158,20 +158,20 @@ class Tool(Application):
         """
         try:
             self.initialize(argv)
-            self.log.info("Starting: {}".format(self.name))
-            self.log.debug("CONFIG: {}".format(self.config))
+            self.log.info(f"Starting: {self.name}")
+            self.log.debug(f"CONFIG: {self.config}")
             Provenance().start_activity(self.name)
             Provenance().add_config(self.config)
             self.setup()
             self.is_setup = True
             self.start()
             self.finish()
-            self.log.info("Finished: {}".format(self.name))
+            self.log.info(f"Finished: {self.name}")
             Provenance().finish_activity(activity_name=self.name)
         except ToolConfigurationError as err:
-            self.log.error('{}.  Use --help for more info'.format(err))
+            self.log.error(f'{err}.  Use --help for more info')
         except RuntimeError as err:
-            self.log.error('Caught unexpected exception: {}'.format(err))
+            self.log.error(f'Caught unexpected exception: {err}')
             self.finish()
             Provenance().finish_activity(activity_name=self.name,
                                          status='error')
@@ -190,4 +190,4 @@ class Tool(Application):
     @property
     def version_string(self):
         """ a formatted version string with version, release, and git hash"""
-        return "{}".format(version)
+        return f"{version}"

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -42,11 +42,11 @@ class Path(TraitType):
             if os.path.exists(value):
                 if os.path.isdir(value) and not self.directory_ok:
                     raise TraitError(
-                        'Path "{}" must not be a directory'.format(value)
+                        f'Path "{value}" must not be a directory'
                     )
                 if os.path.isfile(value) and not self.file_ok:
                     raise TraitError(
-                        'Path "{}" must not be a file'.format(value)
+                        f'Path "{value}" must not be a file'
                     )
 
             return value

--- a/ctapipe/image/geometry_converter_hex.py
+++ b/ctapipe/image/geometry_converter_hex.py
@@ -353,8 +353,8 @@ def convert_geometry_hex1d_to_rect2d(geom, signal, key=None, add_rot=0):
         # total rotation angle:
         rot_angle = (add_rot * 60 * u.deg) - extra_rot
 
-        logger.debug("geom={}".format(geom))
-        logger.debug("rot={}, extra={}".format(rot_angle, extra_rot))
+        logger.debug(f"geom={geom}")
+        logger.debug(f"rot={rot_angle}, extra={extra_rot}")
 
         rot_x, rot_y = unskew_hex_pixel_grid(geom.pix_x, geom.pix_y,
                                              cam_angle=rot_angle)

--- a/ctapipe/image/muon/muon_diagnostic_plots.py
+++ b/ctapipe/image/muon/muon_diagnostic_plots.py
@@ -75,7 +75,7 @@ def plot_muon_efficiency(outputpath):
     contrw = axrw.hist(t['RingWidth'], nbins)
     axrw.set_xlim(0.2 * min(t['RingWidth']), 1.2 * max(t['RingWidth']))
     axrw.set_ylim(0., 1.2 * max(contrw[0]))
-    axrw.set_xlabel('Ring Width ($^\circ$)')
+    axrw.set_xlabel(r'Ring Width ($^\circ$)')
 
     plt.draw()
 

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -276,7 +276,7 @@ def analyze_muon_source(source):
     A ctapipe event container (MuonParameter) with muon information
 
     """
-    log.info("[FUNCTION] {}".format(__name__))
+    log.info(f"[FUNCTION] {__name__}")
 
     if geom_dict is None:
         geom_dict = {}

--- a/ctapipe/instrument/atmosphere.py
+++ b/ctapipe/instrument/atmosphere.py
@@ -25,7 +25,7 @@ def get_atmosphere_profile_table(atmosphere_name='paranal'):
     'altitude' (m), and 'thickness' (g cm-2) as well as others.
 
     """
-    table_name = '{}.atmprof'.format(atmosphere_name)
+    table_name = f'{atmosphere_name}.atmprof'
     table = get_table_dataset(table_name=table_name,
                               role='dl0.arr.svc.atmosphere')
     return table

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -284,7 +284,7 @@ class CameraGeometry:
         if version is None:
             verstr = ''
         else:
-            verstr = "-{:03d}".format(version)
+            verstr = f"-{version:03d}"
 
         tabname = "{camera_id}{verstr}.camgeom".format(camera_id=camera_id,
                                                        verstr=verstr)
@@ -458,12 +458,12 @@ class CameraGeometry:
 
     def info(self, printer=print):
         """ print detailed info about this camera """
-        printer('CameraGeometry: "{}"'.format(self))
+        printer(f'CameraGeometry: "{self}"')
         printer('   - num-pixels: {}'.format(len(self.pix_id)))
-        printer('   - pixel-type: {}'.format(self.pix_type))
+        printer(f'   - pixel-type: {self.pix_type}')
         printer('   - sensitive-area: {}'.format(self.pix_area.sum()))
-        printer('   - pix-rotation: {}'.format(self.pix_rotation))
-        printer('   - cam-rotation: {}'.format(self.cam_rotation))
+        printer(f'   - pix-rotation: {self.pix_rotation}')
+        printer(f'   - cam-rotation: {self.cam_rotation}')
 
     @classmethod
     def make_rectangular(cls, npix_x=40, npix_y=40, range_x=(-0.5, 0.5),

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -157,10 +157,10 @@ class OpticsDescription:
         return self.tel_type, self.tel_subtype
 
     def info(self, printer=print):
-        printer('OpticsDescription: "{}"'.format(self))
-        printer('    - mirror_type: {}'.format(self.mirror_type))
-        printer('    - num_mirror_tiles: {}'.format(self.num_mirror_tiles))
-        printer('    - mirror_area: {}'.format(self.mirror_area))
+        printer(f'OpticsDescription: "{self}"')
+        printer(f'    - mirror_type: {self.mirror_type}')
+        printer(f'    - num_mirror_tiles: {self.num_mirror_tiles}')
+        printer(f'    - mirror_area: {self.mirror_area}')
 
     def __repr__(self):
         return "{}(tel_type='{}', tel_subtype='{}')".format(
@@ -168,7 +168,7 @@ class OpticsDescription:
 
     def __str__(self):
         if self.tel_subtype != '':
-            return "{}-{}".format(self.tel_type, self.tel_subtype)
+            return f"{self.tel_type}-{self.tel_subtype}"
         else:
             return self.tel_type
 

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -82,9 +82,9 @@ class SubarrayDescription:
         for tel_id, desc in self.tels.items():
             teltypes[str(desc)].append(tel_id)
 
-        printer("Subarray : {}".format(self.name))
-        printer("Num Tels : {}".format(self.num_tels))
-        printer("Footprint: {:.2f}".format(self.footprint))
+        printer(f"Subarray : {self.name}")
+        printer(f"Num Tels : {self.num_tels}")
+        printer(f"Footprint: {self.footprint:.2f}")
         printer("")
         printer("                TYPE  Num IDmin  IDmax")
         printer("=====================================")
@@ -213,7 +213,7 @@ class SubarrayDescription:
             tab = Table(cols)
 
         else:
-            raise ValueError("Table type '{}' not known".format(kind))
+            raise ValueError(f"Table type '{kind}' not known")
 
         tab.meta.update(meta)
         return tab

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -70,7 +70,7 @@ def test_get_min_pixel_seperation():
 def test_find_neighbor_pixels():
     x, y = np.meshgrid(np.linspace(-5, 5, 5), np.linspace(-5, 5, 5))
     neigh = _find_neighbor_pixels(x.ravel(), y.ravel(), rad=3.1)
-    assert set(neigh[11]) == set([16, 6, 10, 12])
+    assert set(neigh[11]) == {16, 6, 10, 12}
 
 
 @pytest.mark.parametrize("cam_id", cam_ids)

--- a/ctapipe/io/array.py
+++ b/ctapipe/io/array.py
@@ -16,9 +16,9 @@ def get_array_layout(instrument_name):
     """
     name = instrument_name.lower()
     try:
-        layoutfile = get_dataset_path('{}_arraylayout.fits'.format(name))
+        layoutfile = get_dataset_path(f'{name}_arraylayout.fits')
     except KeyError:
-        layoutfile = get_dataset_path('{}_arraylayout.fits.gz'.format(name))
+        layoutfile = get_dataset_path(f'{name}_arraylayout.fits.gz')
     return load_array_layout_from_file(layoutfile)
 
 

--- a/ctapipe/io/eventseeker.py
+++ b/ctapipe/io/eventseeker.py
@@ -218,7 +218,7 @@ class EventSeeker(Component):
         for event in self._source:
             if event.count == index:
                 return event
-        raise IndexError("Event index {} not found in file".format(index))
+        raise IndexError(f"Event index {index} not found in file")
 
     def _get_event_by_id(self, event_id):
         """
@@ -243,7 +243,7 @@ class EventSeeker(Component):
         for event in self:  # Event Ids may not be in order
             if event.r0.event_id == event_id:
                 return event
-        raise IndexError("Event id {} not found in file".format(event_id))
+        raise IndexError(f"Event id {event_id} not found in file")
 
     def __len__(self):
         """

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -125,10 +125,10 @@ class EventSource(Component):
         if not exists(self.input_url):
             raise FileNotFoundError("file path does not exist: '{}'"
                                     .format(self.input_url))
-        self.log.info("INPUT PATH = {}".format(self.input_url))
+        self.log.info(f"INPUT PATH = {self.input_url}")
 
         if self.max_events:
-            self.log.info("Max events being read = {}".format(self.max_events))
+            self.log.info(f"Max events being read = {self.max_events}")
 
         Provenance().add_input_file(self.input_url, role='dl0.sub.evt')
 

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -159,10 +159,10 @@ class HDF5TableWriter(TableWriter):
 
                     if req_unit is not None:
                         tr = partial(tr_convert_and_strip_unit, unit=req_unit)
-                        meta['{}_UNIT'.format(col_name)] = str(req_unit)
+                        meta[f'{col_name}_UNIT'] = str(req_unit)
                     else:
                         tr = lambda x: x.value
-                        meta['{}_UNIT'.format(col_name)] = str(value.unit)
+                        meta[f'{col_name}_UNIT'] = str(value.unit)
 
                     value = tr(value)
                     self.add_column_transform(table_name, col_name, tr)

--- a/ctapipe/io/targetioeventsource.py
+++ b/ctapipe/io/targetioeventsource.py
@@ -231,6 +231,6 @@ class TargetIOEventSource(EventSource):
     def _get_event_by_id(self, event_id):
         if ((event_id < self._first_event_id) |
                 (event_id > self._last_event_id)):
-            raise IndexError("Event id {} not found in file".format(event_id))
+            raise IndexError(f"Event id {event_id} not found in file")
         index = self._reader.GetEventIndex(event_id)
         return self._get_event_by_index(index)

--- a/ctapipe/io/toymodel.py
+++ b/ctapipe/io/toymodel.py
@@ -76,7 +76,7 @@ def toymodel_event_source(geoms, max_events=100, single_tel=False, n_channels=1,
                 centroid,
                 width,
                 length,
-                '{}d'.format(psi)
+                f'{psi}d'
             )
             image, _, _ = toymodel.make_toymodel_shower_image(
                 geom,

--- a/ctapipe/plotting/bokeh_event_viewer.py
+++ b/ctapipe/plotting/bokeh_event_viewer.py
@@ -57,11 +57,11 @@ class BokehEventViewerCamera(CameraDisplay):
         if t is None:
             t = tels[0]
         if t not in tels:
-            raise KeyError("Telescope {} has no data".format(t))
+            raise KeyError(f"Telescope {t} has no data")
 
         try:
             self.image = self._view_options[v](e, t, c, time)
-            self.fig.title.text = '{0} (T = {1})'.format(v, time)
+            self.fig.title.text = f'{v} (T = {time})'
         except TypeError:
             self.image = None
 
@@ -102,7 +102,7 @@ class BokehEventViewerCamera(CameraDisplay):
     @view.setter
     def view(self, val):
         if val not in list(self._view_options.keys()):
-            raise ValueError("View is not valid: {}".format(val))
+            raise ValueError(f"View is not valid: {val}")
         self._view = val
         self._set_image()
 
@@ -205,11 +205,11 @@ class BokehEventViewerWaveform(WaveformDisplay):
         if t is None:
             t = tels[0]
         if t not in tels:
-            raise KeyError("Telescope {} has no data".format(t))
+            raise KeyError(f"Telescope {t} has no data")
 
         try:
             self.waveform = self._view_options[v](e, t, c, p)
-            self.fig.title.text = '{0} (Pixel = {1})'.format(v, p)
+            self.fig.title.text = f'{v} (Pixel = {p})'
         except TypeError:
             self.waveform = None
 
@@ -265,7 +265,7 @@ class BokehEventViewerWaveform(WaveformDisplay):
     @view.setter
     def view(self, val):
         if val not in list(self._view_options.keys()):
-            raise ValueError("View is not valid: {}".format(val))
+            raise ValueError(f"View is not valid: {val}")
         self._view = val
         self._set_waveform()
         self._set_integration_window()

--- a/ctapipe/plotting/camera.py
+++ b/ctapipe/plotting/camera.py
@@ -103,14 +103,14 @@ class CameraPlotter:
 
         geom = self.get_geometry(tel)
         axes = axes if axes is not None else plt.gca()
-        axes.annotate("Pixel: {}".format(p0),
+        axes.annotate(f"Pixel: {p0}",
                       xy=(u.Quantity(geom.pix_x).value[p0],
                           u.Quantity(geom.pix_y).value[p0]),
                       xycoords='data', xytext=(0.05, 0.98),
                       textcoords='axes fraction',
                       arrowprops=dict(facecolor='red', width=2, alpha=0.4),
                       horizontalalignment='left', verticalalignment='top')
-        axes.annotate("Pixel: {}".format(p1),
+        axes.annotate(f"Pixel: {p1}",
                       xy=(u.Quantity(geom.pix_x).value[p1],
                           u.Quantity(geom.pix_y).value[p1]),
                       xycoords='data', xytext=(0.05, 0.94),

--- a/ctapipe/plotting/charge_resolution.py
+++ b/ctapipe/plotting/charge_resolution.py
@@ -213,10 +213,10 @@ class ChargeResolutionPlotter(Component):
         """
         self.ax.set_xscale('log')
         self.ax.get_xaxis().set_major_formatter(
-            FuncFormatter(lambda x, _: '{:g}'.format(x)))
+            FuncFormatter(lambda x, _: f'{x:g}'))
         self.ax.set_yscale('log')
         self.ax.get_yaxis().set_major_formatter(
-            FuncFormatter(lambda y, _: '{:g}'.format(y)))
+            FuncFormatter(lambda y, _: f'{y:g}'))
 
     def save(self):
         """
@@ -226,11 +226,11 @@ class ChargeResolutionPlotter(Component):
 
         output_dir = os.path.dirname(self.output_path)
         if not os.path.exists(output_dir):
-            print("Creating directory: {}".format(output_dir))
+            print(f"Creating directory: {output_dir}")
             os.makedirs(output_dir)
 
         self.fig.savefig(self.output_path, bbox_inches='tight')
-        print("Figure saved to: {}".format(self.output_path))
+        print(f"Figure saved to: {self.output_path}")
         Provenance().add_output_file(self.output_path)
 
         plt.close(self.fig)
@@ -364,4 +364,4 @@ class ChargeResolutionWRRPlotter(ChargeResolutionPlotter):
     def _finish(self):
         self.ax.set_xscale('log')
         self.ax.get_xaxis().set_major_formatter(
-            FuncFormatter(lambda x, _: '{:g}'.format(x)))
+            FuncFormatter(lambda x, _: f'{x:g}'))

--- a/ctapipe/tools/bokeh/file_viewer.py
+++ b/ctapipe/tools/bokeh/file_viewer.py
@@ -172,7 +172,7 @@ class BokehFileViewer(Tool):
         try:
             self.event = self.seeker[val]
         except IndexError:
-            self.log.warning("Event Index {} does not exist".format(val))
+            self.log.warning(f"Event Index {val} does not exist")
 
     @property
     def event_id(self):
@@ -183,7 +183,7 @@ class BokehFileViewer(Tool):
         try:
             self.event = self.seeker[str(val)]
         except IndexError:
-            self.log.warning("Event ID {} does not exist".format(val))
+            self.log.warning(f"Event ID {val} does not exist")
 
     @property
     def telid(self):
@@ -406,7 +406,7 @@ class BokehFileViewer(Tool):
                 cmdline = []
                 for key, val in self.w_dl1_dict.items():
                     if val.value:
-                        cmdline.append('--{}'.format(key))
+                        cmdline.append(f'--{key}')
                         cmdline.append(val.value)
                 self.parse_command_line(cmdline)
                 kwargs = dict(config=self.config, tool=self)

--- a/ctapipe/tools/camdemo.py
+++ b/ctapipe/tools/camdemo.py
@@ -19,7 +19,7 @@ from ctapipe.visualization import CameraDisplay
 
 
 class CameraDemo(Tool):
-    name = u"ctapipe-camdemo"
+    name = "ctapipe-camdemo"
     description = "Display fake events in a demo camera"
 
     delay = traits.Int(50, help="Frame delay in ms", min=20).tag(config=True)
@@ -63,7 +63,7 @@ class CameraDemo(Tool):
         self.imclean = False
 
     def start(self):
-        self.log.info("Starting CameraDisplay for {}".format(self.camera))
+        self.log.info(f"Starting CameraDisplay for {self.camera}")
         self._display_camera_animation()
 
     def _display_camera_animation(self):
@@ -85,11 +85,11 @@ class CameraDemo(Tool):
         maxwid = np.deg2rad(0.3)
         maxlen = np.deg2rad(0.5)
 
-        self.log.debug("scale={} m, wid=({}-{})".format(scale, minwid, maxwid))
+        self.log.debug(f"scale={scale} m, wid=({minwid}-{maxwid})")
 
         disp = CameraDisplay(
             geom, ax=ax, autoupdate=True,
-            title="{}, f={}".format(tel, tel.optics.equivalent_focal_length)
+            title=f"{tel}, f={tel.optics.equivalent_focal_length}"
         )
         disp.cmap = plt.cm.terrain
 
@@ -159,7 +159,7 @@ class CameraDemo(Tool):
         frames = None if self.num_events == 0 else self.num_events
         repeat = True if self.num_events == 0 else False
 
-        self.log.info("Running for {} frames".format(frames))
+        self.log.info(f"Running for {frames} frames")
         self.anim = FuncAnimation(fig, update,
                                   interval=self.delay,
                                   frames=frames,

--- a/ctapipe/tools/dump_instrument.py
+++ b/ctapipe/tools/dump_instrument.py
@@ -79,12 +79,12 @@ class DumpInstrumentTool(Tool):
                                                    'CAMGEOM',
                                                    cam_name)
 
-            self.log.debug("writing {}".format(cam_name))
+            self.log.debug(f"writing {cam_name}")
             tel_id = cam_types[cam_name].pop()
             geom = self.inst.subarray.tel[tel_id].camera
             table = geom.to_table()
             table.meta['SOURCE'] = self.infile
-            filename = "{}.camgeom.{}".format(cam_name, ext)
+            filename = f"{cam_name}.camgeom.{ext}"
 
             try:
                 table.write(filename, **args)
@@ -99,7 +99,7 @@ class DumpInstrumentTool(Tool):
 
         tab = sub.to_table(kind='optics')
         tab.meta['SOURCE'] = self.infile
-        filename = '{}.optics.{}'.format(sub.name, ext)
+        filename = f'{sub.name}.optics.{ext}'
         try:
             tab.write(filename, **args)
             Provenance().add_output_file(filename, 'dl0.sub.svc.optics')
@@ -113,7 +113,7 @@ class DumpInstrumentTool(Tool):
                                                'subarray')
         tab = sub.to_table(kind='subarray')
         tab.meta['SOURCE'] = self.infile
-        filename = '{}.subarray.{}'.format(sub.name, ext)
+        filename = f'{sub.name}.subarray.{ext}'
         try:
             tab.write(filename, **args)
             Provenance().add_output_file(filename, 'dl0.sub.svc.subarray')

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -105,7 +105,7 @@ class ChargeResolutionGenerator(Tool):
 
         output_directory = os.path.dirname(self.output_path)
         if not os.path.exists(output_directory):
-            self.log.info("Creating directory: {}".format(output_directory))
+            self.log.info(f"Creating directory: {output_directory}")
             os.makedirs(output_directory)
 
         with pd.HDFStore(self.output_path, 'w') as store:

--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -76,7 +76,7 @@ def _info_version():
     """Print version info."""
     import ctapipe
     print('\n*** ctapipe version info ***\n')
-    print('version: {0}'.format(ctapipe.__version__))
+    print(f'version: {ctapipe.__version__}')
     # print('release: {0}'.format(version.release))
     # print('githash: {0}'.format(version.githash))
     print('')
@@ -99,7 +99,7 @@ def _info_tools():
 
     scripts = get_all_descriptions()
     for name, desc in sorted(scripts.items()):
-        text = "{:<30s}  - {}".format(name, desc)
+        text = f"{name:<30s}  - {desc}"
         print(wrapper.fill(text))
         print('')
     print('')
@@ -116,7 +116,7 @@ def _info_dependencies():
         except ImportError:
             version = 'not installed'
 
-        print('{:>20s} -- {}'.format(name, version))
+        print(f'{name:>20s} -- {version}')
 
     print('\n*** ctapipe optional dependencies ***\n')
 
@@ -129,7 +129,7 @@ def _info_dependencies():
         except AttributeError:
             version = "installed, but __version__ doesn't exist"
 
-        print('{:>20s} -- {}'.format(name, version))
+        print(f'{name:>20s} -- {version}')
 
 
 def _info_resources():
@@ -137,12 +137,12 @@ def _info_resources():
 
     print('\n*** ctapipe resources ***\n')
 
-    print("ctapipe_resources version: {}".format(ctapipe_resources.__version__))
+    print(f"ctapipe_resources version: {ctapipe_resources.__version__}")
 
     print("CTAPIPE_SVC_PATH: (directories where resources are searched)")
     if os.getenv('CTAPIPE_SVC_PATH') is not None:
         for directory in datasets.get_searchpath_dirs():
-            print("\t * {}".format(directory))
+            print(f"\t * {directory}")
     else:
         print("\t no path is set")
     print("")

--- a/ctapipe/tools/utils.py
+++ b/ctapipe/tools/utils.py
@@ -56,7 +56,7 @@ def get_all_descriptions():
                 descrip.replace("\n", "")
                 descriptions[name] = descrip
             except RuntimeError as err:
-                descriptions[name] = "[Couldn't parse docstring: {}]".format(err)
+                descriptions[name] = f"[Couldn't parse docstring: {err}]"
         else:
             descriptions[name] = "[no documentation. Please add a docstring]"
 

--- a/ctapipe/utils/CutFlow.py
+++ b/ctapipe/utils/CutFlow.py
@@ -114,7 +114,7 @@ class CutFlow:
                 .format(cut, [a for a in self.cuts.keys()]))
         elif self.cuts[cut][0] is None:
             raise PureCountingCut(
-                "'{}' has no function associated".format(cut))
+                f"'{cut}' has no function associated")
 
     def cut(self, cut, *args, weight=1, **kwargs):
         """

--- a/ctapipe/utils/fitshistogram.py
+++ b/ctapipe/utils/fitshistogram.py
@@ -85,14 +85,14 @@ class Histogram:
         if self.ndims < 1:
             raise ValueError("No dimensions specified")
         if self.ndims != len(self._ranges):
-            raise ValueError("Dimensions of ranges {0} don't match bins {1}"
+            raise ValueError("Dimensions of ranges {} don't match bins {}"
                              .format(len(self._ranges), self.ndims))
 
         if self.axis_names is not None:  # ensure the array is size ndims
             self.axis_names = np.array(self.axis_names)
             self.axis_names.resize(self.ndims)
         else:
-            self.axis_names = ["axis{}".format(x) for x in range(self.ndims)]
+            self.axis_names = [f"axis{x}" for x in range(self.ndims)]
 
     def __str__(self,):
         return ("Histogram(name='{name}', axes={axnames}, "

--- a/ctapipe/utils/json2fits.py
+++ b/ctapipe/utils/json2fits.py
@@ -53,7 +53,7 @@ def traitlets_config_to_fits(config, fits_filename, overwrite=True):
     try:
         hdu_list.writeto(fits_filename, overwrite=overwrite)
     except OSError:
-        logging.exception('Could not do save {}'.format(fits_filename))
+        logging.exception(f'Could not do save {fits_filename}')
         raise
 
 
@@ -122,9 +122,9 @@ def json_to_fits(json_filename, fits_filename, overwrite=True):
         try:
             hduList.writeto(fits_filename, overwrite=overwrite)
         except OSError:
-            logging.exception('Could not do save {}'.format(fits_filename))
+            logging.exception(f'Could not do save {fits_filename}')
             raise
 
     except FileNotFoundError:
-        logging.exception('Could not open  {}'.format(fits_filename))
+        logging.exception(f'Could not open  {fits_filename}')
         raise

--- a/ctapipe/utils/tests/test_json_2_fits.py
+++ b/ctapipe/utils/tests/test_json_2_fits.py
@@ -52,7 +52,7 @@ class Foo(Configurable):
 
     i = Int(0, help='The integer i.').tag(config=True)
     j = Int(1, help='The integer j.').tag(config=True)
-    name = Unicode(u'Brian', help='First name.').tag(config=True)
+    name = Unicode('Brian', help='First name.').tag(config=True)
 
 
 class Bar(Configurable):
@@ -82,7 +82,7 @@ class MyApp(Application):
     key_much_too_long_for_fits = Unicode('value short enough')
     key_and_value_too_long = Unicode(5 * 'value to long as wellenough')
     short = Unicode(20 * 'value to long')
-    config_file = Unicode(u'', help='Load this config file').tag(config=True)
+    config_file = Unicode('', help='Load this config file').tag(config=True)
 
     def init_foo(self):
         # Pass config to other classes for them to inherit the config.
@@ -108,7 +108,7 @@ class MyApp(Application):
         # s = self.generate_config_file()
         fname = os.path.join('.', 'foo.json')  # self.config_file)
         if not os.path.exists(fname):
-            self.log.warn('Generating default config file: {}'.format(fname))
+            self.log.warn(f'Generating default config file: {fname}')
             with open(fname, 'w') as f:
                 f.write(str(json.dumps(self.config)))
 

--- a/ctapipe/version.py
+++ b/ctapipe/version.py
@@ -131,7 +131,7 @@ def update_release_version(pep440=False):
     """
     version = get_version(pep440=pep440)
     with open(VERSION_FILE, "w") as outfile:
-        outfile.write("version='{}'".format(version))
+        outfile.write(f"version='{version}'")
         outfile.write("\n")
 
 

--- a/ctapipe/visualization/bokeh.py
+++ b/ctapipe/visualization/bokeh.py
@@ -219,8 +219,8 @@ class CameraDisplay:
         self.cdsource.selected.on_change('indices', source_change_response)
 
     def _on_pixel_click(self, pix_id):
-        print("Clicked pixel_id: {}".format(pix_id))
-        print("Active Pixels: {}".format(self.active_pixels))
+        print(f"Clicked pixel_id: {pix_id}")
+        print(f"Active Pixels: {self.active_pixels}")
 
     def highlight_pixels(self):
         alpha = [0] * self._n_pixels
@@ -381,5 +381,5 @@ class WaveformDisplay:
         self.fig.on_event(Tap, wf_tap_response)
 
     def _on_waveform_click(self, time):
-        print("Clicked time: {}".format(time))
-        print("Active time: {}".format(self.active_time))
+        print(f"Clicked time: {time}")
+        print(f"Active time: {self.active_time}")

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -153,8 +153,8 @@ class CameraDisplay:
 
         self.axes.set_aspect('equal', 'datalim')
         self.axes.set_title(title)
-        self.axes.set_xlabel("X position ({})".format(self.geom.pix_x.unit))
-        self.axes.set_ylabel("Y position ({})".format(self.geom.pix_y.unit))
+        self.axes.set_xlabel(f"X position ({self.geom.pix_x.unit})")
+        self.axes.set_ylabel(f"Y position ({self.geom.pix_y.unit})")
         self.axes.autoscale_view()
 
         # set up a patch to display when a pixel is clicked (and
@@ -439,7 +439,7 @@ class CameraDisplay:
         self._active_pixel.set_visible(True)
         self._active_pixel_label.set_x(xx)
         self._active_pixel_label.set_y(yy)
-        self._active_pixel_label.set_text("{:003d}".format(pix_id))
+        self._active_pixel_label.set_text(f"{pix_id:003d}")
         self._active_pixel_label.set_visible(True)
         self._update()
         self.on_pixel_clicked(pix_id)  # call user-function
@@ -448,7 +448,7 @@ class CameraDisplay:
         """virtual function to overide in sub-classes to do something special
         when a pixel is clicked
         """
-        print("Clicked pixel_id {}".format(pix_id))
+        print(f"Clicked pixel_id {pix_id}")
 
     def show(self):
         self.axes.figure.show()


### PR DESCRIPTION
Since we dropped support for Python 3.5, we can now use some of the features of 3.6 everywhere. This PR upgrades the use of `str.format` to use f-strings instead (cleaner).  The edits were not made manually, rather I used the pyupgrade refactoring tool (https://github.com/asottile/pyupgrade)