### PR TITLE
Filter HorizonFrame warnings during reconstruction

### DIFF
--- a/ctapipe/coordinates/__init__.py
+++ b/ctapipe/coordinates/__init__.py
@@ -1,7 +1,7 @@
 '''
 Coordinates.
 '''
-from .horizon_frame import HorizonFrame
+from .horizon_frame import HorizonFrame, MissingFrameAttributeWarning
 from .telescope_frame import TelescopeFrame
 from .nominal_frame import NominalFrame
 from .ground_frames import GroundFrame, TiltedGroundFrame, project_to_ground
@@ -16,4 +16,5 @@ __all__ = [
     'GroundFrame',
     'TiltedGroundFrame',
     'project_to_ground',
+    'MissingFrameAttributeWarning',
 ]

--- a/ctapipe/coordinates/horizon_frame.py
+++ b/ctapipe/coordinates/horizon_frame.py
@@ -1,14 +1,16 @@
+import warnings
 from astropy.coordinates import (
     AltAz,
     FunctionTransformWithFiniteDifference,
     CIRS,
     frame_transform_graph,
 )
-import warnings
 
 
 HorizonFrame = AltAz
 
+class MissingFrameAttributeWarning(Warning):
+    pass
 
 # astropy requires all AltAz to have locations
 # and obstimes so they can be converted into true skycoords
@@ -25,12 +27,12 @@ def altaz_to_altaz(from_coo, to_frame):
     # check if coordinates have obstimes defined
     obstime = from_coo.obstime
     if from_coo.obstime is None:
-        warnings.warn('Horizontal coordinate has no obstime, assuming same frame')
+        warnings.warn('Horizontal coordinate has no obstime, assuming same frame', MissingFrameAttributeWarning)
         obstime = to_frame.obstime
 
     location = from_coo.location
     if from_coo.obstime is None:
-        warnings.warn('Horizontal coordinate has no location, assuming same frame')
+        warnings.warn('Horizontal coordinate has no location, assuming same frame', MissingFrameAttributeWarning)
         location = to_frame.location
 
     if obstime is None or location is None:

--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -9,7 +9,7 @@ from ctapipe.reco.reco_algorithms import Reconstructor
 from ctapipe.io.containers import ReconstructedShowerContainer
 from itertools import combinations
 
-from ctapipe.coordinates import HorizonFrame, CameraFrame, GroundFrame, TiltedGroundFrame, project_to_ground
+from ctapipe.coordinates import HorizonFrame, CameraFrame, GroundFrame, TiltedGroundFrame, MissingFrameAttributeWarning, project_to_ground
 from astropy.coordinates import SkyCoord, spherical_to_cartesian, cartesian_to_spherical
 import warnings
 
@@ -120,6 +120,9 @@ class HillasReconstructor(Reconstructor):
             if len(hillas_dict) < 2
         '''
 
+        # filter warnings for missing obs time. this is needed because MC data hass no obs time
+        warnings.filterwarnings(action='ignore', category=MissingFrameAttributeWarning)
+        
         # stereoscopy needs at least two telescopes
         if len(hillas_dict) < 2:
             raise TooFewTelescopesException(
@@ -195,7 +198,6 @@ class HillasReconstructor(Reconstructor):
             dictionaries of the orientation angles of the telescopes
             needs to contain at least the same keys as in `hillas_dict`
         """
-
         self.hillas_planes = {}
         horizon_frame = HorizonFrame()
         for tel_id, moments in hillas_dict.items():

--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -120,7 +120,7 @@ class HillasReconstructor(Reconstructor):
             if len(hillas_dict) < 2
         '''
 
-        # filter warnings for missing obs time. this is needed because MC data hass no obs time
+        # filter warnings for missing obs time. this is needed because MC data has no obs time
         warnings.filterwarnings(action='ignore', category=MissingFrameAttributeWarning)
         
         # stereoscopy needs at least two telescopes


### PR DESCRIPTION
The warning is produced due to missing attributes which are unknown for MC data.