### PR TITLE
Add mc header information to SimTelEventSource

### DIFF
--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -1,7 +1,7 @@
 import warnings
 import numpy as np
 from ctapipe.io.eventsource import EventSource
-from ctapipe.io.containers import DataContainer
+from ctapipe.io.containers import DataContainer, MCHeaderContainer
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.time import Time
@@ -25,6 +25,9 @@ class SimTelEventSource(EventSource):
             self.file_.telescope_descriptions,
             self.file_.header
         )
+
+        self.mc_header_information = MCHeaderContainer()
+        self._add_mc_header_information(self.mc_header_information)
 
     @staticmethod
     def prepare_subarray_info(telescope_descriptions, header):
@@ -97,6 +100,49 @@ class SimTelEventSource(EventSource):
             self.log.warning(msg)
             warnings.warn(msg)
 
+
+    def _add_mc_header_information(self, mcheader):
+        mcheader.run_array_direction = Angle(
+                self.file_.header['direction'] * u.rad
+        )
+        mc_run_head = self.file_.mc_run_headers[-1]
+        mcheader.corsika_version = mc_run_head['shower_prog_vers']
+        mcheader.simtel_version = mc_run_head['detector_prog_vers']
+        mcheader.energy_range_min = mc_run_head['E_range'][0] * u.TeV
+        mcheader.energy_range_max = mc_run_head['E_range'][1] * u.TeV
+        mcheader.prod_site_B_total = mc_run_head['B_total'] * u.uT
+        mcheader.prod_site_B_declination = Angle(mc_run_head['B_declination'] * u.rad)
+        mcheader.prod_site_B_inclination = Angle(mc_run_head['B_inclination'] * u.rad)
+        mcheader.prod_site_alt = mc_run_head['obsheight'] * u.m
+        mcheader.spectral_index = mc_run_head['spectral_index']
+        mcheader.shower_prog_start = mc_run_head['shower_prog_start']
+        mcheader.shower_prog_id = mc_run_head['shower_prog_id']
+        mcheader.detector_prog_start = mc_run_head['detector_prog_start']
+        mcheader.detector_prog_id = mc_run_head['detector_prog_id']
+        mcheader.num_showers = mc_run_head['num_showers']
+        mcheader.shower_reuse = mc_run_head['num_use']
+        mcheader.max_alt = mc_run_head['alt_range'][1] * u.rad
+        mcheader.min_alt = mc_run_head['alt_range'][0] * u.rad
+        mcheader.max_az = mc_run_head['az_range'][1] * u.rad
+        mcheader.min_az = mc_run_head['az_range'][0] * u.rad
+        mcheader.diffuse = mc_run_head['diffuse']
+        mcheader.max_viewcone_radius = mc_run_head['viewcone'][1] * u.deg
+        mcheader.min_viewcone_radius = mc_run_head['viewcone'][0] * u.deg
+        mcheader.max_scatter_range = mc_run_head['core_range'][1] * u.m
+        mcheader.min_scatter_range = mc_run_head['core_range'][0] * u.m
+        mcheader.core_pos_mode = mc_run_head['core_pos_mode']
+        mcheader.injection_height = mc_run_head['injection_height'] * u.m
+        mcheader.atmosphere = mc_run_head['atmosphere']
+        mcheader.corsika_iact_options = mc_run_head['corsika_iact_options']
+        mcheader.corsika_low_E_model = mc_run_head['corsika_low_E_model']
+        mcheader.corsika_high_E_model = mc_run_head['corsika_high_E_model']
+        mcheader.corsika_bunchsize = mc_run_head['corsika_bunchsize']
+        mcheader.corsika_wlen_min = mc_run_head['corsika_wlen_min'] * u.nm
+        mcheader.corsika_wlen_max = mc_run_head['corsika_wlen_max'] * u.nm
+        mcheader.corsika_low_E_detail = mc_run_head['corsika_low_E_detail']
+        mcheader.corsika_high_E_detail = mc_run_head['corsika_high_E_detail']
+
+
     def __generator(self):
         data = DataContainer()
         data.meta['origin'] = 'hessio'
@@ -153,48 +199,7 @@ class SimTelEventSource(EventSource):
             data.mc.shower_primary_id = mc_shower['primary_id']
 
             # mc run header data
-            data.mcheader.run_array_direction = Angle(
-                self.file_.header['direction'] * u.rad
-            )
-            mc_run_head = self.file_.mc_run_headers[-1]
-            data.mcheader.corsika_version = mc_run_head['shower_prog_vers']
-            data.mcheader.simtel_version = mc_run_head['detector_prog_vers']
-            data.mcheader.energy_range_min = mc_run_head['E_range'][0] * u.TeV
-            data.mcheader.energy_range_max = mc_run_head['E_range'][1] * u.TeV
-            data.mcheader.prod_site_B_total = mc_run_head['B_total'] * u.uT
-            data.mcheader.prod_site_B_declination = Angle(
-                mc_run_head['B_declination'] * u.rad)
-            data.mcheader.prod_site_B_inclination = Angle(
-                mc_run_head['B_inclination'] * u.rad)
-            data.mcheader.prod_site_alt = mc_run_head['obsheight'] * u.m
-            data.mcheader.spectral_index = mc_run_head['spectral_index']
-            data.mcheader.shower_prog_start = mc_run_head['shower_prog_start']
-            data.mcheader.shower_prog_id = mc_run_head['shower_prog_id']
-            data.mcheader.detector_prog_start = mc_run_head['detector_prog_start']
-            data.mcheader.detector_prog_id = mc_run_head['detector_prog_id']
-            data.mcheader.num_showers = mc_run_head['num_showers']
-            data.mcheader.shower_reuse = mc_run_head['num_use']
-            data.mcheader.max_alt = mc_run_head['alt_range'][1] * u.rad
-            data.mcheader.min_alt = mc_run_head['alt_range'][0] * u.rad
-            data.mcheader.max_az = mc_run_head['az_range'][1] * u.rad
-            data.mcheader.min_az = mc_run_head['az_range'][0] * u.rad
-            data.mcheader.diffuse = mc_run_head['diffuse']
-            data.mcheader.max_viewcone_radius = mc_run_head['viewcone'][1] * u.deg
-            data.mcheader.min_viewcone_radius = mc_run_head['viewcone'][0] * u.deg
-            data.mcheader.max_scatter_range = mc_run_head['core_range'][1] * u.m
-            data.mcheader.min_scatter_range = mc_run_head['core_range'][0] * u.m
-            data.mcheader.core_pos_mode = mc_run_head['core_pos_mode']
-            data.mcheader.injection_height = mc_run_head['injection_height'] * u.m
-            data.mcheader.atmosphere = mc_run_head['atmosphere']
-            data.mcheader.corsika_iact_options = mc_run_head['corsika_iact_options']
-            data.mcheader.corsika_low_E_model = mc_run_head['corsika_low_E_model']
-            data.mcheader.corsika_high_E_model = mc_run_head['corsika_high_E_model']
-            data.mcheader.corsika_bunchsize = mc_run_head['corsika_bunchsize']
-            data.mcheader.corsika_wlen_min = mc_run_head['corsika_wlen_min'] * u.nm
-            data.mcheader.corsika_wlen_max = mc_run_head['corsika_wlen_max'] * u.nm
-            data.mcheader.corsika_low_E_detail = mc_run_head['corsika_low_E_detail']
-            data.mcheader.corsika_high_E_detail = mc_run_head['corsika_high_E_detail']
-
+            self._add_mc_header_information(data.mcheader)
 
             # this should be done in a nicer way to not re-allocate the
             # data each time (right now it's just deleted and garbage

--- a/ctapipe/io/tests/test_simtel_event_source.py
+++ b/ctapipe/io/tests/test_simtel_event_source.py
@@ -4,6 +4,19 @@ from ctapipe.io.simteleventsource import SimTelEventSource
 
 dataset = get_dataset_path("gamma_test.simtel.gz")
 
+
+def test_simtel_mc_header():
+    import numpy as np
+    with SimTelEventSource(input_url=dataset) as reader:
+        header_info = reader.mc_header_information
+        assert header_info
+
+        # make sure mc infor in event is the same as the one accessed by the reader
+        event = next(iter(reader))
+        for key, value in event.mcheader.as_dict().items():
+            assert np.array_equal(header_info[key], value)
+
+
 def test_hessio_file_reader():
     with SimTelEventSource(input_url=dataset) as reader:
         assert reader.is_compatible(dataset)


### PR DESCRIPTION
One can access the MC header information from the SimTelEventSource now. No need to get the first event and check the header then. Since the header information never changes in a file I thought this might be convinient.

