### PR TITLE
Passing masked array to hillas_parameters

### DIFF
--- a/ctapipe/image/hillas.py
+++ b/ctapipe/image/hillas.py
@@ -46,7 +46,7 @@ def hillas_parameters(geom, image):
     >>> image_zeros[~clean_mask] = 0
     >>> hillas_zeros = hillas_parameters(geom, image_zeros)
     >>>
-    >>> # Slowest (2.73 times longer than fastest)
+    >>> # Slowest (1.51 times longer than fastest)
     >>> image_masked = np.ma.masked_array(image, mask=~clean_mask)
     >>> hillas_masked = hillas_parameters(geom, image_masked)
     >>>
@@ -71,6 +71,7 @@ def hillas_parameters(geom, image):
     pix_x = Quantity(np.asanyarray(geom.pix_x, dtype=np.float64)).value
     pix_y = Quantity(np.asanyarray(geom.pix_y, dtype=np.float64)).value
     image = np.asanyarray(image, dtype=np.float64)
+    image = np.ma.filled(image, 0)
     msg = 'Image and pixel shape do not match'
     assert pix_x.shape == pix_y.shape == image.shape, msg
 
@@ -96,11 +97,7 @@ def hillas_parameters(geom, image):
     # The ddof=0 makes this comparable to the other methods,
     # but ddof=1 should be more correct, mostly affects small showers
     # on a percent level
-    try:
-        cov = np.cov(delta_x, delta_y, aweights=image, ddof=0)
-    except ValueError:
-        # Handle masked arrays
-        cov = np.cov(delta_x, delta_y, aweights=np.ma.filled(image, 0), ddof=0)
+    cov = np.cov(delta_x, delta_y, aweights=image, ddof=0)
     eig_vals, eig_vecs = np.linalg.eigh(cov)
 
     # width and length are eigen values of the PCA

--- a/ctapipe/image/tests/test_hillas.py
+++ b/ctapipe/image/tests/test_hillas.py
@@ -94,6 +94,12 @@ def test_hillas_failure():
         hillas_parameters(geom, blank_image)
 
 
+def test_hillas_masked_array():
+    geom, image, clean_mask = create_sample_image(psi='0d')
+    cleaned_image = np.ma.masked_array(image, mask=~clean_mask)
+    hillas_parameters(geom, cleaned_image)
+
+
 def test_hillas_container():
     geom, image = create_sample_image_zeros(psi='0d')
 

--- a/ctapipe/image/tests/test_hillas.py
+++ b/ctapipe/image/tests/test_hillas.py
@@ -95,9 +95,20 @@ def test_hillas_failure():
 
 
 def test_hillas_masked_array():
-    geom, image, clean_mask = create_sample_image(psi='0d')
-    cleaned_image = np.ma.masked_array(image, mask=~clean_mask)
-    hillas_parameters(geom, cleaned_image)
+    geom_zeros, image_zeros = create_sample_image_zeros()
+    hillas_zeros = hillas_parameters(geom_zeros, image_zeros)
+
+    geom_masked, image, clean_mask = create_sample_image(psi='0d')
+    image_masked = np.ma.masked_array(image, mask=~clean_mask)
+    hillas_masked = hillas_parameters(geom_masked, image_masked)
+
+    compare_result(hillas_zeros.length, hillas_masked.length)
+    compare_result(hillas_zeros.width, hillas_masked.width)
+    compare_result(hillas_zeros.r, hillas_masked.r)
+    compare_result(hillas_zeros.phi.deg, hillas_masked.phi.deg)
+    compare_result(hillas_zeros.psi.deg, hillas_masked.psi.deg)
+    compare_result(hillas_zeros.skewness, hillas_masked.skewness)
+    compare_result(hillas_zeros.kurtosis, hillas_masked.kurtosis)
 
 
 def test_hillas_container():

--- a/ctapipe/image/tests/test_hillas.py
+++ b/ctapipe/image/tests/test_hillas.py
@@ -95,12 +95,14 @@ def test_hillas_failure():
 
 
 def test_hillas_masked_array():
-    geom_zeros, image_zeros = create_sample_image_zeros()
-    hillas_zeros = hillas_parameters(geom_zeros, image_zeros)
+    geom, image, clean_mask = create_sample_image(psi='0d')
 
-    geom_masked, image, clean_mask = create_sample_image(psi='0d')
+    image_zeros = image.copy()
+    image_zeros[~clean_mask] = 0
+    hillas_zeros = hillas_parameters(geom, image_zeros)
+
     image_masked = np.ma.masked_array(image, mask=~clean_mask)
-    hillas_masked = hillas_parameters(geom_masked, image_masked)
+    hillas_masked = hillas_parameters(geom, image_masked)
 
     compare_result(hillas_zeros.length, hillas_masked.length)
     compare_result(hillas_zeros.width, hillas_masked.width)

--- a/ctapipe/image/tests/test_hillas.py
+++ b/ctapipe/image/tests/test_hillas.py
@@ -66,6 +66,13 @@ def compare_result(x, y):
     assert ux.unit == uy.unit
 
 
+def compare_hillas(hillas1, hillas2):
+    hillas1_dict = hillas1.as_dict()
+    hillas2_dict = hillas2.as_dict()
+    for key in hillas1_dict.keys():
+        compare_result(hillas1_dict[key], hillas2_dict[key])
+
+
 def test_hillas_selected():
     """
     test Hillas-parameter routines on a sample image with selected values
@@ -77,13 +84,7 @@ def test_hillas_selected():
     results = hillas_parameters(geom, image)
     results_selected = hillas_parameters(geom_selected, image_selected)
 
-    compare_result(results.length, results_selected.length)
-    compare_result(results.width, results_selected.width)
-    compare_result(results.r, results_selected.r)
-    compare_result(results.phi.deg, results_selected.phi.deg)
-    compare_result(results.psi.deg, results_selected.psi.deg)
-    compare_result(results.skewness, results_selected.skewness)
-    # compare_result(results.kurtosis, results_ma.kurtosis)
+    compare_hillas(results, results_selected)
 
 
 def test_hillas_failure():
@@ -104,13 +105,7 @@ def test_hillas_masked_array():
     image_masked = np.ma.masked_array(image, mask=~clean_mask)
     hillas_masked = hillas_parameters(geom, image_masked)
 
-    compare_result(hillas_zeros.length, hillas_masked.length)
-    compare_result(hillas_zeros.width, hillas_masked.width)
-    compare_result(hillas_zeros.r, hillas_masked.r)
-    compare_result(hillas_zeros.phi.deg, hillas_masked.phi.deg)
-    compare_result(hillas_zeros.psi.deg, hillas_masked.psi.deg)
-    compare_result(hillas_zeros.skewness, hillas_masked.skewness)
-    compare_result(hillas_zeros.kurtosis, hillas_masked.kurtosis)
+    compare_hillas(hillas_zeros, hillas_masked)
 
 
 def test_hillas_container():


### PR DESCRIPTION
The error `ValueError: aweights cannot be negative` is raised when passing a masked numpy array to `hillas_parameters`.  This is due to the line `cov = np.cov(delta_x, delta_y, aweights=image, ddof=0)` where the image is the masked numpy array.

I could have sworn this used to work! This PR will attempt to allow this functionality.