### PR TITLE
Fix set_line_hillas

### DIFF
--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -237,15 +237,13 @@ class ArrayDisplay:
         coords = self.tel_coords
         c = self.tel_colors
 
+        r = np.array([-range, range])
         for tel_id, params in hillas_dict.items():
             idx = self.subarray.tel_indices[tel_id]
             x_0 = coords[idx].x.value
             y_0 = coords[idx].y.value
-            m = np.tan(Angle(params.psi))
-            x_end = np.sqrt(range ** 2 / (1 + m ** 2))
-            y_end = m * x_end
-            x = [x_0 - x_end, x_0 + x_end]
-            y = [y_0 - y_end, y_0 + y_end]
+            x = x_0 + np.cos(params.psi) * r
+            y = y_0 + np.sin(params.psi) * r
             self.axes.plot(x, y, color=c[idx], **kwargs)
             self.axes.scatter(x_0, y_0, color=c[idx])
 

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -242,11 +242,11 @@ class ArrayDisplay:
             x_0 = coords[idx].x.value
             y_0 = coords[idx].y.value
             m = np.tan(Angle(params.psi))
-            x = x_0 + np.linspace(-range, range, 50)
-            y = y_0 + m * (x - x_0)
-            distance = np.sqrt((x - x_0) ** 2 + (y - y_0) ** 2)
-            mask = np.ma.masked_where(distance < range, distance).mask
-            self.axes.plot(x[mask], y[mask], color=c[idx], **kwargs)
+            x_end = np.sqrt(range ** 2 / (1 + m ** 2))
+            y_end = m * x_end
+            x = [x_0 - x_end, x_0 + x_end]
+            y = [y_0 - y_end, y_0 + y_end]
+            self.axes.plot(x, y, color=c[idx], **kwargs)
             self.axes.scatter(x_0, y_0, color=c[idx])
 
     def add_labels(self):

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -240,13 +240,13 @@ class ArrayDisplay:
         r = np.array([-range, range])
         for tel_id, params in hillas_dict.items():
             idx = self.subarray.tel_indices[tel_id]
-            x_0 = coords[idx].x.value
-            y_0 = coords[idx].y.value
+            x_0 = coords[idx].x.to_value(u.m)
+            y_0 = coords[idx].y.to_value(u.m)
             x = x_0 + np.cos(params.psi) * r
             y = y_0 + np.sin(params.psi) * r
             self.axes.plot(x, y, color=c[idx], **kwargs)
             self.axes.scatter(x_0, y_0, color=c[idx])
-
+q
     def add_labels(self):
         px = self.tel_coords.x.value
         py = self.tel_coords.y.value

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -246,7 +246,7 @@ class ArrayDisplay:
             y = y_0 + np.sin(params.psi) * r
             self.axes.plot(x, y, color=c[idx], **kwargs)
             self.axes.scatter(x_0, y_0, color=c[idx])
-q
+
     def add_labels(self):
         px = self.tel_coords.x.value
         py = self.tel_coords.y.value


### PR DESCRIPTION
The current implementation of set_line_hillas did not work for huge values of `m`. This is an quick fix which calculates the actual start end end points of the line exactly. This works also in the case of (almost) vertical lines as you can see in the plot attached.

![event0](https://user-images.githubusercontent.com/15632125/53089419-d3c08500-350c-11e9-9936-03638e1cd898.png)