### PR TITLE
allow enums in containers and support in tableio

### DIFF
--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -1,3 +1,4 @@
+'''Implementations of TableWriter and -Reader for HDF5 files'''
 import enum
 from functools import partial
 
@@ -153,6 +154,7 @@ class HDF5TableWriter(TableWriter):
 
                 if isinstance(value, enum.Enum):
                     def transform(enum_value):
+                        '''transform enum instance into its (integer) value'''
                         return enum_value.value
                     meta[f'{col_name}_ENUM'] = value.__class__
                     value = transform(value)
@@ -346,6 +348,7 @@ class HDF5TableReader(TableReader):
                 colname = attr[:-5]
 
                 def transform_int_to_enum(int_val):
+                    '''transform integer 'code' into enum instance'''
                     enum_class = tab.attrs[attr]
                     return enum_class(int_val)
 
@@ -354,7 +357,6 @@ class HDF5TableReader(TableReader):
                     colname,
                     transform_int_to_enum
                 )
-
 
     def _map_table_to_container(self, table_name, container):
         """ identifies which columns in the table to read into the container,

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -1,3 +1,4 @@
+import enum
 from functools import partial
 
 import numpy as np
@@ -150,6 +151,13 @@ class HDF5TableWriter(TableWriter):
                     )
                     continue
 
+                if isinstance(value, enum.Enum):
+                    def transform(enum_value):
+                        return enum_value.value
+                    meta[f'{col_name}_ENUM'] = value.__class__
+                    value = transform(value)
+                    self.add_column_transform(table_name, col_name, transform)
+
                 if isinstance(value, Quantity):
                     if self.add_prefix and container.prefix:
                         key = col_name.replace(container.prefix + '_', '')
@@ -184,6 +192,7 @@ class HDF5TableWriter(TableWriter):
                     typename = type(value).__name__
                     coltype = PYTABLES_TYPE_MAP[typename]
                     Schema.columns[col_name] = coltype()
+
 
                 self.log.debug("Table %s: added col: %s type: %s shape: %s",
                                table_name, col_name, typename, shape)
@@ -331,6 +340,21 @@ class HDF5TableReader(TableReader):
                 colname = attr[:-5]
                 tr = partial(tr_add_unit, unitname=tab.attrs[attr])
                 self.add_column_transform(table_name, colname, tr)
+
+        for attr in tab.attrs._f_list():
+            if attr.endswith("_ENUM"):
+                colname = attr[:-5]
+
+                def transform_int_to_enum(int_val):
+                    enum_class = tab.attrs[attr]
+                    return enum_class(int_val)
+
+                self.add_column_transform(
+                    table_name,
+                    colname,
+                    transform_int_to_enum
+                )
+
 
     def _map_table_to_container(self, table_name, container):
         """ identifies which columns in the table to read into the container,

--- a/docs/examples/containers_with_enums_and_table_writer.ipynb
+++ b/docs/examples/containers_with_enums_and_table_writer.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# containers_with_enums_and_table_writer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create some example Containers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import enum\n",
+    "from ctapipe.io import HDF5TableWriter\n",
+    "from ctapipe.core import Container, Field\n",
+    "from astropy import units as u\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class WithEnum(Container):\n",
+    "    \n",
+    "    # this class could also be defined in global namespace \n",
+    "    # outside this container, but this looks a bit tidier.\n",
+    "    # both variants work however\n",
+    "    class EventType(enum.Enum):\n",
+    "        pedestal = 1\n",
+    "        physics = 2\n",
+    "        calibration = 3\n",
+    "    \n",
+    "    event_type = Field(\n",
+    "        EventType.calibration, \n",
+    "        f'type of event, one of: {list(EventType.__members__.keys())}'\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "let's also make a dummy stream (generator) that will create a series of these containers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_stream(n_event):\n",
+    "    data = WithEnum()\n",
+    "    for i in range(n_event):\n",
+    "        data.event_type = WithEnum.EventType(i % 3 + 1)\n",
+    "        yield data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for data in create_stream(3):\n",
+    "    for key, val in data.items():\n",
+    "        print('{}: {}, type : {}'.format(key, val, type(val)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing the Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with HDF5TableWriter('container.h5', group_name='data') as h5_table:\n",
+    "    for data in create_stream(10):\n",
+    "        h5_table.write('table', data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls container.h5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading the Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "data = pd.read_hdf('container.h5', key='/data/table')\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Reading with PyTables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tables\n",
+    "h5  = tables.open_file('container.h5')\n",
+    "table = h5.root['data']['table']\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table.attrs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ctapipe.io import HDF5TableReader\n",
+    "\n",
+    "def read(mode):\n",
+    "    \n",
+    "    print('reading mode {}'.format(mode))\n",
+    "\n",
+    "    with HDF5TableReader('container.h5', mode=mode) as h5_table:\n",
+    "\n",
+    "        for group_name in ['data/']:\n",
+    "\n",
+    "            group_name = '/{}table'.format(group_name)\n",
+    "            print(group_name)\n",
+    "\n",
+    "            for data in h5_table.read(group_name, WithEnum()):\n",
+    "\n",
+    "                print(data.as_dict())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "read('r')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -10,7 +10,7 @@ the Tutorials section for more complete examples)
 .. toctree::
     :maxdepth: 1
     :caption: Algorithms
-    
+
     dilate_image
     nd_interpolation
     convert_hex_to_square
@@ -18,10 +18,11 @@ the Tutorials section for more complete examples)
 .. toctree::
     :maxdepth: 1
     :caption: Core functionality
-    
+
     InstrumentDescription
     camera_display
     containers
     Tools
     provenance
     table_writer_reader
+    containers_with_enums_and_table_writer


### PR DESCRIPTION
Connected slightly to #972

just, in case we want to use `enum.Enum` somewhere I thought we might want to be able to serialize them as well. 

Not sure this is the best way to do it. I've read somewhere that HDF5 natively supports storing enumeration types, so that it deals with the back and forth trafo from the numeric value to the actual enum instance. But for the moment I did this in ctapipes own io layer.