### PR TITLE
Use conda packages instead of pip 

### DIFF
--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -1,9 +1,14 @@
 from .array import get_array_layout
 from .eventseeker import EventSeeker
 from .eventsource import EventSource, event_source
-from .simteleventsource import SimTelEventSource
 from .hdf5tableio import HDF5TableReader, HDF5TableWriter
 from .tableio import TableWriter, TableReader
+
+# import event sources to make them visible to EventSource.from_url
+from .simteleventsource import SimTelEventSource
+from .lsteventsource import LSTEventSource
+from .nectarcameventsource import NectarCAMEventSource
+from .targetioeventsource import TargetIOEventSource
 
 from ctapipe.core.plugins import detect_and_import_io_plugins
 
@@ -11,7 +16,6 @@ detect_and_import_io_plugins()
 
 __all__ = [
     'get_array_layout',
-    'SimTelEventSource',
     'HDF5TableWriter',
     'HDF5TableReader',
     'TableWriter',
@@ -19,4 +23,8 @@ __all__ = [
     'EventSeeker',
     'EventSource',
     'event_source',
+    'SimTelEventSource',
+    'NectarCAMEventSource',
+    'LSTEventSource',
+    'TargetIOEventSource',
 ]

--- a/ctapipe/io/lsteventsource.py
+++ b/ctapipe/io/lsteventsource.py
@@ -24,8 +24,6 @@ class LSTEventSource(EventSource):
     EventSource for LST r0 data.
     """
 
-
-
     def __init__(self, config=None, tool=None, **kwargs):
 
         """

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -20,9 +20,16 @@ class SimTelEventSource(EventSource):
 
     def __init__(self, config=None, tool=None, **kwargs):
         super().__init__(config=config, tool=tool, **kwargs)
+
         self.metadata['is_simulation'] = True
+
+        # traitlets creates an empty set as default,
+        # which ctapipe treats as no restriction on the telescopes
+        # but eventio treats an emty set as "no telescopes allowed"
+        # so we explicitly pass None in that case
         self.file_ = SimTelFile(
             self.input_url,
+            allowed_telescopes=self.allowed_tels if self.allowed_tels else None,
             skip_calibration=self.skip_calibration_events
         )
 

--- a/ctapipe/io/tests/test_available_sources.py
+++ b/ctapipe/io/tests/test_available_sources.py
@@ -1,0 +1,17 @@
+def test_available_sources():
+    from ctapipe.io.eventsource import EventSource
+    from ctapipe.core import non_abstract_children
+
+    # make this before the explicit imports to make sure
+    # all classes are avaialble even if not explicitly imported
+    children = non_abstract_children(EventSource)
+
+    from ctapipe.io.simteleventsource import SimTelEventSource
+    from ctapipe.io.lsteventsource import LSTEventSource
+    from ctapipe.io.nectarcameventsource import NectarCAMEventSource
+    from ctapipe.io.targetioeventsource import TargetIOEventSource
+
+    assert SimTelEventSource in children
+    assert LSTEventSource in children
+    assert NectarCAMEventSource in children
+    assert TargetIOEventSource in children

--- a/environment.yml
+++ b/environment.yml
@@ -42,5 +42,5 @@ dependencies:
   - eventio=0.17.1
   - ctapipe-extra=0.2.17
   - pytest-runner
-  - pyhessio=2.1
+
 

--- a/environment.yml
+++ b/environment.yml
@@ -42,4 +42,5 @@ dependencies:
   - eventio=0.17.1
   - ctapipe-extra=0.2.17
   - pytest-runner
+  - pyhessio=2.1
 

--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,6 @@ dependencies:
   - tqdm
   - conda-forge::nbsphinx
   - eventio=0.17.1
-  - ctapipe-extra=0.2.*
+  - ctapipe-extra=0.2.17
   - pytest-runner
 

--- a/environment.yml
+++ b/environment.yml
@@ -39,9 +39,7 @@ dependencies:
   - pytables
   - tqdm
   - conda-forge::nbsphinx
-  - pip:
-      - pytest_runner
-      - eventio==0.17.1
-      - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.17.tar.gz
-
+  - eventio=0.17.1
+  - ctapipe-extra=0.2.*
+  - pytest-runner
 

--- a/py3.6_env.yaml
+++ b/py3.6_env.yaml
@@ -39,8 +39,6 @@ dependencies:
   - pytables
   - tqdm
   - conda-forge::nbsphinx
-  - pip:
-      - pytest_runner
-      - eventio==0.17.1
-      - https://github.com/cta-observatory/pyhessio/archive/v2.1.1.tar.gz
-      - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.17.tar.gz
+  - eventio=0.17.1
+  - pytest-runner
+  - ctapipe-extra=0.2.17

--- a/py3.6_env.yaml
+++ b/py3.6_env.yaml
@@ -42,3 +42,4 @@ dependencies:
   - eventio=0.17.1
   - pytest-runner
   - ctapipe-extra=0.2.17
+  - pyhessio=2.1

--- a/py3.7_env.yaml
+++ b/py3.7_env.yaml
@@ -39,8 +39,6 @@ dependencies:
   - pytables
   - tqdm
   - conda-forge::nbsphinx
-  - pip:
-      - pytest_runner
-      - eventio==0.17.1
-      - https://github.com/cta-observatory/pyhessio/archive/v2.1.1.tar.gz
-      - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.17.tar.gz
+  - eventio=0.17.1
+  - pytest-runner
+  - ctapipe-extra=0.2.17

--- a/py3.7_env.yaml
+++ b/py3.7_env.yaml
@@ -42,3 +42,4 @@ dependencies:
   - eventio=0.17.1
   - pytest-runner
   - ctapipe-extra=0.2.17
+  - pyhessio=2.1


### PR DESCRIPTION
No more pip installs in environment.yml

- now use eventio (and corsikaio) packages on cta-observatory conda channel
- also use pytest-runner from conda (was pip's pytest_runner)
