### PR TITLE
Fix HillasReconstructor in case of too few telescopes

### DIFF
--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -134,8 +134,10 @@ class HillasReconstructor(Reconstructor):
         # filter warnings for missing obs time. this is needed because MC data has no obs time
         warnings.filterwarnings(action='ignore', category=MissingFrameAttributeWarning)
         
-        # stereoscopy needs at least two telescopes
-        if len(hillas_dict) < 2:
+        # stereoscopy needs at least two telescopes with a valid width of the hillas ellipse
+        valid_telescopes = sum([1 if hillas_dict[x]['width'].value is not np.NaN else 0 for x in hillas_dict])
+
+        if valid_telescopes < 2:
             raise TooFewTelescopesException(
                 "need at least two telescopes, have {}"
                 .format(len(hillas_dict)))

--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -133,14 +133,16 @@ class HillasReconstructor(Reconstructor):
 
         # filter warnings for missing obs time. this is needed because MC data has no obs time
         warnings.filterwarnings(action='ignore', category=MissingFrameAttributeWarning)
-        
-        # stereoscopy needs at least two telescopes with a valid width of the hillas ellipse
-        valid_telescopes = sum([1 if not np.isnan(hillas_dict[x]['width'].value) else 0 for x in hillas_dict])
+
+        # stereoscopy needs at least two telescopes with valid widths
+        valid_telescopes = sum([1 if not np.isnan(hillas_dict[x]['width'].value)
+                                else 0
+                                for x in hillas_dict])
 
         if valid_telescopes < 2:
             raise TooFewTelescopesException(
                 "need at least two telescopes, have {}"
-                .format(len(hillas_dict)))
+                .format(valid_telescopes))
 
         self.initialize_hillas_planes(
             hillas_dict,

--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -135,7 +135,7 @@ class HillasReconstructor(Reconstructor):
         warnings.filterwarnings(action='ignore', category=MissingFrameAttributeWarning)
         
         # stereoscopy needs at least two telescopes with a valid width of the hillas ellipse
-        valid_telescopes = sum([1 if hillas_dict[x]['width'].value is not np.NaN else 0 for x in hillas_dict])
+        valid_telescopes = sum([1 if not np.isnan(hillas_dict[x]['width'].value) else 0 for x in hillas_dict])
 
         if valid_telescopes < 2:
             raise TooFewTelescopesException(

--- a/ctapipe/reco/tests/test_HillasReconstructor.py
+++ b/ctapipe/reco/tests/test_HillasReconstructor.py
@@ -1,10 +1,12 @@
 import numpy as np
 from astropy import units as u
+import pytest
 
 from ctapipe.image.cleaning import tailcuts_clean
 from ctapipe.image.hillas import hillas_parameters, HillasParameterizationError
 from ctapipe.io import event_source
-from ctapipe.reco.HillasReconstructor import HillasReconstructor, HillasPlane
+from ctapipe.reco.HillasReconstructor import (
+    HillasReconstructor, HillasPlane, InvalidWidthException, TooFewTelescopesException)
 from ctapipe.utils import get_dataset_path
 from astropy.coordinates import SkyCoord, AltAz
 
@@ -132,3 +134,70 @@ def test_reconstruction():
         fit_result.az.to(u.deg)
         fit_result.core_x.to(u.m)
         assert fit_result.is_valid
+
+
+def test_invalid_events():
+    """
+    The HillasReconstructor is supposed to fail
+    in these cases:
+    - less than two teleskopes
+    - any width is NaN
+    - any width is 0
+
+    This test uses the same sample simtel file as 
+    test_reconstruction(). As there are no invalid events in this
+    file, multiple hillas_dicts are constructed to make sure 
+    Exceptions get thrown in the mentioned edge cases.
+
+    Test will fail if no Exception or another Exception gets thrown."""
+
+    filename = get_dataset_path("gamma_test.simtel.gz")
+
+    fit = HillasReconstructor()
+
+    tel_azimuth = {}
+    tel_altitude = {}
+
+    source = event_source(filename)
+
+    for event in source:
+
+        hillas_dict = {}
+        for tel_id in event.dl0.tels_with_data:
+
+            geom = event.inst.subarray.tel[tel_id].camera
+            tel_azimuth[tel_id] = event.mc.tel[tel_id].azimuth_raw * u.rad
+            tel_altitude[tel_id] = event.mc.tel[tel_id].altitude_raw * u.rad
+
+            pmt_signal = event.r0.tel[tel_id].image[0]
+
+            mask = tailcuts_clean(geom, pmt_signal,
+                                  picture_thresh=10., boundary_thresh=5.)
+            pmt_signal[mask == 0] = 0
+
+            try:
+                moments = hillas_parameters(geom, pmt_signal)
+                hillas_dict[tel_id] = moments
+            except HillasParameterizationError as e:
+                continue
+
+        # construct a dict only containing the last telescope events 
+        # (#telescopes < 2)
+        hillas_dict_only_one_tel = dict()
+        hillas_dict_only_one_tel[tel_id] = hillas_dict[tel_id]
+        with pytest.raises(TooFewTelescopesException):
+            fit.predict(hillas_dict_only_one_tel, event.inst, tel_azimuth, tel_altitude)
+
+        # construct a hillas dict with the width of the last event set to 0 
+        # (any width == 0)
+        hillas_dict_zero_width = hillas_dict.copy()
+        hillas_dict_zero_width[tel_id]['width'] = 0 * u.m
+        with pytest.raises(InvalidWidthException):
+            fit.predict(hillas_dict_zero_width, event.inst, tel_azimuth, tel_altitude)
+
+        # construct a hillas dict with the width of the last event set to np.nan 
+        # (any width == nan)
+        hillas_dict_nan_width = hillas_dict.copy()
+        hillas_dict_zero_width[tel_id]['width'] = np.nan * u.m
+        with pytest.raises(InvalidWidthException):
+            fit.predict(hillas_dict_nan_width, event.inst, tel_azimuth, tel_altitude)

--- a/ctapipe/reco/tests/test_HillasReconstructor.py
+++ b/ctapipe/reco/tests/test_HillasReconstructor.py
@@ -151,14 +151,14 @@ def test_invalid_events():
 
     Test will fail if no Exception or another Exception gets thrown."""
 
-    filename = get_dataset_path("gamma_test.simtel.gz")
+    filename = get_dataset_path("gamma_test_large.simtel.gz")
 
     fit = HillasReconstructor()
 
     tel_azimuth = {}
     tel_altitude = {}
 
-    source = event_source(filename)
+    source = event_source(filename, max_events=10)
 
     for event in source:
 
@@ -169,7 +169,7 @@ def test_invalid_events():
             tel_azimuth[tel_id] = event.mc.tel[tel_id].azimuth_raw * u.rad
             tel_altitude[tel_id] = event.mc.tel[tel_id].altitude_raw * u.rad
 
-            pmt_signal = event.r0.tel[tel_id].image[0]
+            pmt_signal = event.r0.tel[tel_id].waveform[0].sum(axis=1)
 
             mask = tailcuts_clean(geom, pmt_signal,
                                   picture_thresh=10., boundary_thresh=5.)


### PR DESCRIPTION
@mackaiver , @MaxNoe and me faced an issue where the HillasReconstructor would fail even though there were two telescopes left after cleaning. It turned out that you could encounter situations where one of the hillas ellipses had a width of np.NaN because there were only a few pixels remaining which are all aligned.
This would render the weights useless and leave the h_max estimation with a singular matrix.

We decided that the HillasReconstructor should check for valid telescopes (that is telescopes with a defined width of the hillas ellipse) and that we would not even try to reconstruct other events (which should be very few if any).

Is there any reason against this approach?