### PR TITLE
fixed bug in coordinate transformation

### DIFF
--- a/ctapipe/coordinates/camera_frame.py
+++ b/ctapipe/coordinates/camera_frame.py
@@ -85,8 +85,8 @@ def camera_to_telescope(camera_coord, telescope_frame):
     # as an Attribute of `CameraFrame` that maps f(r, focal_length) -> theta,
     # where theta is the angle to the optical axis and r is the distance
     # to the camera center in the focal plane
-    delta_alt = u.Quantity((x_rotated / focal_length).to_value(), u.rad)
-    delta_az = u.Quantity((y_rotated / focal_length).to_value(), u.rad)
+    delta_alt = u.Quantity((x_rotated / focal_length).to_value(u.dimensionless_unscaled), u.rad)
+    delta_az = u.Quantity((y_rotated / focal_length).to_value(u.dimensionless_unscaled), u.rad)
 
     representation = UnitSphericalRepresentation(lat=delta_alt, lon=delta_az)
 

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -129,7 +129,7 @@ def test_cam_to_tel():
 
 
 def test_cam_to_hor():
-    # Coordinates in any fram can be given as a numpy array of the xyz positions
+    # Coordinates in any frame can be given as a numpy array of the xyz positions
     # e.g. in this case the position on pixels in the camera
     pix_x = [1] * u.m
     pix_y = [1] * u.m

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -138,18 +138,18 @@ def test_cam_to_hor():
 
     # first define the camera frame
     pointing = SkyCoord(alt=70*u.deg, az=0*u.deg,frame=AltAz())
-    camera_frame = CameraFrame(focal_length=focal_length)
+    camera_frame = CameraFrame(focal_length=focal_length, telescope_pointing=pointing)
 
     # transform
     camera_coord = SkyCoord(pix_x, pix_y, frame=camera_frame)
     altaz_coord = camera_coord.transform_to(AltAz())
 
     # transform back
-    altaz_coord2 = SkyCoord(az=altaz_coord.az, alt=altaz_coord.alt, frame=hf)
+    altaz_coord2 = SkyCoord(az=altaz_coord.az, alt=altaz_coord.alt, frame=AltAz())
     camera_coord2 = altaz_coord2.transform_to(camera_frame)
     
     # check transform
-    assert camera_coord.x == camera_coord2.x
+    assert np.isclose(camera_coord.x.to_value(u.m), camera_coord2.to_value(u.m))
 
 
 def test_ground_to_tilt():

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -129,6 +129,7 @@ def test_cam_to_tel():
 
 
 def test_cam_to_hor():
+    from ctapipe.coordinates import CameraFrame
     # Coordinates in any frame can be given as a numpy array of the xyz positions
     # e.g. in this case the position on pixels in the camera
     pix_x = [1] * u.m

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -128,6 +128,30 @@ def test_cam_to_tel():
     assert camera_coord.separation_3d(camera_coord2)[0] == 0 * u.m
 
 
+def test_cam_to_hor():
+    # Coordinates in any fram can be given as a numpy array of the xyz positions
+    # e.g. in this case the position on pixels in the camera
+    pix_x = [1] * u.m
+    pix_y = [1] * u.m
+
+    focal_length = 15000 * u.mm
+
+    # first define the camera frame
+    pointing = SkyCoord(alt=70*u.deg, az=0*u.deg,frame=AltAz())
+    camera_frame = CameraFrame(focal_length=focal_length)
+
+    # transform
+    camera_coord = SkyCoord(pix_x, pix_y, frame=camera_frame)
+    altaz_coord = camera_coord.transform_to(AltAz())
+
+    # transform back
+    altaz_coord2 = SkyCoord(az=altaz_coord.az, alt=altaz_coord.alt, frame=hf)
+    camera_coord2 = altaz_coord2.transform_to(camera_frame)
+    
+    # check transform
+    assert camera_coord.x == camera_coord2.x
+
+
 def test_ground_to_tilt():
     from ctapipe.coordinates import GroundFrame, TiltedGroundFrame
 

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -150,7 +150,7 @@ def test_cam_to_hor():
     camera_coord2 = altaz_coord2.transform_to(camera_frame)
     
     # check transform
-    assert np.isclose(camera_coord.x.to_value(u.m), camera_coord2.to_value(u.m))
+    assert np.isclose(camera_coord.x.to_value(u.m), camera_coord2.y.to_value(u.m))
 
 
 def test_ground_to_tilt():


### PR DESCRIPTION
When transforming from horizon frame to camera frame and back, it gives different results.
When specifying pixels in meters, everything is fine, but not for millimetres for example.

Changed
`u.Quantity((x_rotated / focal_length).to_value(), u.rad)`
to 
`delta_alt = u.Quantity((x_rotated / focal_length).to_value(u.dimensionless_unscaled), u.rad)`

Added unit test to check correct handling of units.