### PR TITLE
Fix pixel neighbour definition for curved focal planes (with rectangular pixels)

### DIFF
--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -686,19 +686,21 @@ def _rectangular_pixel_row_column(pix_x, pix_y):
 
     """
     # Estimate the maximum number of rows and columns of pixels
-    dist = _get_min_pixel_seperation(pix_x, pix_y) / 2
-    max_nrow = int(np.ceil((pix_y.max() - pix_y.min()) / dist))
-    max_ncol = int(np.ceil((pix_x.max() - pix_x.min()) / dist))
+    dist = _get_min_pixel_seperation(pix_x, pix_y)
+    max_nrow = int(np.ceil((pix_y.max() - pix_y.min()) / dist)) + 1
+    max_ncol = int(np.ceil((pix_x.max() - pix_x.min()) / dist)) + 1
 
     # Bin the pixel positions on a 2D grid
     hist_x = np.histogram2d(pix_x, pix_y, weights=pix_x, bins=[max_ncol, max_nrow])[0]
     hist_y = np.histogram2d(pix_x, pix_y, weights=pix_y, bins=[max_ncol, max_nrow])[0]
+    hist_xc = np.histogram2d(pix_x, pix_y, bins=[max_ncol, max_nrow])[0]
+    hist_yc = np.histogram2d(pix_x, pix_y, bins=[max_ncol, max_nrow])[0]
     # Find row and col with a complete number of pixels along them
     full_col = np.bincount(hist_x.nonzero()[0]).argmax()
     full_row = np.bincount(hist_y.nonzero()[0]).argmax()
     # Obtain coordinates of the pixels along this row and column
-    full_x = hist_x[:, full_col][hist_x[:, full_col].nonzero()]
-    full_y = hist_y[full_row, :][hist_y[full_row, :].nonzero()]
+    full_x = hist_x[:, full_col][hist_xc[:, full_col].nonzero()]
+    full_y = hist_y[full_row, :][hist_yc[full_row, :].nonzero()]
 
     # Define pixel bin edges based on full row and column of pixels
     mid_dist = _get_min_pixel_seperation(full_x, full_y) / 2

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -319,11 +319,20 @@ class CameraGeometry:
         # otherwise compute the neighbors from the pixel list
         dist = _get_min_pixel_seperation(self.pix_x, self.pix_y)
 
-        neighbors = _find_neighbor_pixels(
-            self.pix_x.value,
-            self.pix_y.value,
-            rad=1.4 * dist.value
+        if self.pix_type.startswith('rect'):
+            row, column = _rectangular_pixel_row_column(
+                self.pix_x.value,
+                self.pix_y.value
+            )
+            neighbors = _find_neighbor_pixels(column, row, rad=1)
+        elif self.pix_type.startswith('hex'):
+            neighbors = _find_neighbor_pixels(
+                self.pix_x.value,
+                self.pix_y.value,
+                rad=1.4 * dist.value
         )
+        else:
+            raise KeyError("unsupported pixel type")
 
         return neighbors
 
@@ -701,6 +710,7 @@ def _rectangular_pixel_row_column(pix_x, pix_y):
     row = np.digitize(pix_y, edges_y) - 1
 
     return row, column
+
 
 class UnknownPixelShapeWarning(UserWarning):
     pass

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -646,5 +646,61 @@ def _neighbor_list_to_matrix(neighbors):
     return neigh2d
 
 
+def _rectangular_pixel_row_column(pix_x, pix_y):
+    """
+    Get the row and column of rectangular pixels of a camera that are
+    arranged in a grid
+
+    The cameras in CTA with rectangular pixels have a curved focal plane
+    surface. Pixels on a curved focal surface do not have consistent x and y
+    coordinates along a single row or column. Therefore, a somewhat
+    reliable technique to obtain the row and column is to define bin edges
+    which the pixels are presumed to be within.
+
+    This function first finds a row and column of the camera which contains a
+    full set of pixels. The coordinates of these pixels are then used to
+    define the bin edges for the entire camera.
+
+    Parameters
+    ----------
+    pix_x : ndarray
+        X coordinates of camera pixels
+    pix_y : ndarray
+        Y coordinates of camera pixels
+
+    Returns
+    -------
+    row : ndarray
+        Row for each camera pixel
+    column : ndarray
+        Column for each camera pixel
+
+    """
+    # Estimate the maximum number of rows and columns of pixels
+    dist = _get_min_pixel_seperation(pix_x, pix_y) / 2
+    max_nrow = int(np.ceil((pix_y.max() - pix_y.min()) / dist))
+    max_ncol = int(np.ceil((pix_x.max() - pix_x.min()) / dist))
+
+    # Bin the pixel positions on a 2D grid
+    hist_x = np.histogram2d(pix_x, pix_y, weights=pix_x, bins=[max_ncol, max_nrow])[0]
+    hist_y = np.histogram2d(pix_x, pix_y, weights=pix_y, bins=[max_ncol, max_nrow])[0]
+    # Find row and col with a complete number of pixels along them
+    full_col = np.bincount(hist_x.nonzero()[0]).argmax()
+    full_row = np.bincount(hist_y.nonzero()[0]).argmax()
+    # Obtain coordinates of the pixels along this row and column
+    full_x = hist_x[:, full_col][hist_x[:, full_col].nonzero()]
+    full_y = hist_y[full_row, :][hist_y[full_row, :].nonzero()]
+
+    # Define pixel bin edges based on full row and column of pixels
+    mid_dist = _get_min_pixel_seperation(full_x, full_y) / 2
+    edges_x = np.array([*(full_x - mid_dist), full_x[-1] + mid_dist])
+    edges_y = np.array([*(full_y - mid_dist), full_y[-1] + mid_dist])
+
+    # Obtain the corresponding row and column bin for each pixel
+    column = np.digitize(pix_x, edges_x) - 1
+    row = np.digitize(pix_y, edges_y) - 1
+
+    return row, column
+
 class UnknownPixelShapeWarning(UserWarning):
     pass

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -195,3 +195,28 @@ def test_hashing():
     cam3 = CameraGeometry.from_name("ASTRICam")
 
     assert len(set([cam1, cam2, cam3])) == 2
+
+
+@pytest.fixture(scope="module")
+def rectangle_pixel_patch_geom():
+    pix_x = np.array([
+        -1.1, 0.1, 0.9,
+        -1, 0, 1,
+        -0.9, -0.1, 1.1
+    ]) * u.m
+    pix_y = np.array([
+        1.1, 1, 0.9,
+        -0.1, 0, 0.1,
+        -0.9, -1, -1.1
+    ]) * u.m
+    cam = CameraGeometry(cam_id=0, pix_id=np.arange(pix_x.size),
+                         pix_x=pix_x, pix_y=pix_y,
+                         pix_area=None,
+                         pix_type='rectangular')
+    return cam
+
+
+def test_rectangle_patch_neighbors(rectangle_pixel_patch_geom):
+    cam = rectangle_pixel_patch_geom
+    assert cam.neighbor_matrix.sum(0).max() == 4
+    assert cam.neighbor_matrix.sum(0).min() == 2

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -4,6 +4,7 @@ from ctapipe.instrument import CameraGeometry
 from ctapipe.instrument.camera import (
     _find_neighbor_pixels,
     _get_min_pixel_seperation,
+    _rectangular_pixel_row_column,
 )
 import pytest
 
@@ -220,3 +221,14 @@ def test_rectangle_patch_neighbors(rectangle_pixel_patch_geom):
     cam = rectangle_pixel_patch_geom
     assert cam.neighbor_matrix.sum(0).max() == 4
     assert cam.neighbor_matrix.sum(0).min() == 2
+
+
+def test_rectangular_pixel_row_column(rectangle_pixel_patch_geom):
+    cam = rectangle_pixel_patch_geom
+    row, column = _rectangular_pixel_row_column(cam.pix_x, cam.pix_y)
+    assert np.unique(column).size == 3
+    assert np.unique(row).size == 3
+    sort_x = np.argsort(cam.pix_x.value)
+    sort_y = np.argsort(cam.pix_y.value)
+    assert (np.diff(column[sort_x]) >= 0).all()
+    assert (np.diff(row[sort_y]) >= 0).all()


### PR DESCRIPTION
As demonstrated in #963, the current definition of pixel neighbours is not robust for cameras with curved focal planes. This is because pixel separation changes with distance from the camera centre.

As the CTA cameras with curved focal planes are also the cameras with pixels aligned on a rectangular grid, this PR will address this issue by defining the neighbours based on the row and columns of the pixels instead of the coordinates.