### PR TITLE
Fix neighbors

### DIFF
--- a/ctapipe/image/geometry_converter_hex.py
+++ b/ctapipe/image/geometry_converter_hex.py
@@ -397,8 +397,8 @@ def convert_geometry_hex1d_to_rect2d(geom, signal, key=None, add_rot=0):
         new_geom = CameraGeometry(
             cam_id=geom.cam_id + "_rect",
             pix_id=ids,  # this is a list of all the valid coordinate pairs now
-            pix_x=grid_x * u.meter,
-            pix_y=grid_y * u.meter,
+            pix_x=u.Quantity(grid_x.ravel(),  u.meter),
+            pix_y=u.Quantity(grid_y.ravel(),  u.meter),
             pix_area=pix_area * u.meter ** 2,
             neighbors=geom.neighbors,
             pix_type='rectangular', apply_derotation=False)

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -337,27 +337,30 @@ class CameraGeometry:
         if self.pix_type.startswith('hex'):
             k = 7
             radius = 1.1
+            norm = 2  # use L2 norm for hex
         else:
+            norm = 1  # use L1 norm for rectangular
+
             # if diagonal should count as neighbor, we
             # need to find at most 8 neighbors with a max distance
             # < than 2 * the pixel size, else 4 neigbors with max distance
             # < sqrt(2) pixel size
             if diagonal:
                 k = 9
-                radius = 2
+                radius = 2.95
             else:
                 k = 5
-                radius = np.sqrt(2)
+                radius = 1.95
 
         for i, pixel in enumerate(self._kdtree.data):
-            d, n = self._kdtree.query(pixel, k=k)
+            d, n = self._kdtree.query(pixel, k=k, p=norm)
 
             # remove self-reference
             d = d[1:]
             n = n[1:]
 
             # remove too far away pixels
-            mask = d < (0.98 * radius * np.min(d))
+            mask = d < radius * np.min(d)
             neighbors[i, n[mask]] = True
 
         return neighbors.tocsr()

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -318,7 +318,7 @@ class CameraGeometry:
     @lazyproperty
     def neighbors(self):
         '''A list of the neighbors pixel_ids for each pixel'''
-        return [np.where(r)[0] for r in self.neighbor_matrix]
+        return [np.where(r)[0].tolist() for r in self.neighbor_matrix]
 
     @lazyproperty
     def neighbor_matrix(self):

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -10,6 +10,7 @@ from astropy.coordinates import Angle
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from scipy.spatial import cKDTree as KDTree
+from scipy.sparse import lil_matrix, csr_matrix
 import warnings
 
 from ctapipe.utils import get_table_dataset, find_all_matching_datasets

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -345,9 +345,9 @@ class CameraGeometry:
             norm = 1  # use L1 norm for rectangular
 
             # if diagonal should count as neighbor, we
-            # need to find at most 8 neighbors with a max distance
-            # < than 2 * the pixel size, else 4 neigbors with max distance
-            # < sqrt(2) pixel size
+            # need to find at most 8 neighbors with a max L1 distance
+            # < than 3 * the pixel size, else 4 neigbors with max distance
+            # < 2 pixel size
             if diagonal:
                 k = 9
                 radius = 2.95

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -145,7 +145,7 @@ class CameraGeometry:
         Note this will not work on cameras with varying pixel sizes.
         """
 
-        dist = _get_min_pixel_seperation(pix_x, pix_y)
+        dist = _get_min_pixel_separation(pix_x, pix_y)
 
         if pix_type.startswith('hex'):
             rad = dist / np.sqrt(3)  # radius to vertex of hexagon
@@ -317,7 +317,7 @@ class CameraGeometry:
             return self._precalculated_neighbors
 
         # otherwise compute the neighbors from the pixel list
-        dist = _get_min_pixel_seperation(self.pix_x, self.pix_y)
+        dist = _get_min_pixel_separation(self.pix_x, self.pix_y)
 
         neighbors = _find_neighbor_pixels(
             self.pix_x.value,
@@ -571,13 +571,9 @@ class CameraGeometry:
         raise ValueError(f'Unknown pixel_shape {pixel_shape}')
 
 
-# ======================================================================
-# utility functions:
-# ======================================================================
-
-def _get_min_pixel_seperation(pix_x, pix_y):
+def _get_min_pixel_separation(pix_x, pix_y):
     """
-    Obtain the minimum seperation between two pixels on the camera
+    Obtain the minimum separation between two pixels on the camera
 
     Parameters
     ----------

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -69,6 +69,9 @@ class CameraGeometry:
                  pix_rotation="0d", cam_rotation="0d",
                  neighbors=None, apply_derotation=True):
 
+        if pix_x.ndim != 1 or pix_y.ndim != 1:
+            raise ValueError(f'Pixel coordinates must be 1 dimensional, got {pix_x.ndim}')
+
         assert len(pix_x) == len(pix_y), 'pix_x and pix_y must have same length'
         self.n_pixels = len(pix_x)
         self.cam_id = cam_id

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -349,7 +349,7 @@ class CameraGeometry:
 
         if self.pix_type.startswith('hex'):
             k = 7
-            radius = 1.1
+            radius = 1.4
             norm = 2  # use L2 norm for hex
         else:
 

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -335,6 +335,15 @@ class CameraGeometry:
             return self.calc_pixel_neighbors(diagonal=False)
 
     def calc_pixel_neighbors(self, diagonal=False):
+        '''
+        Calculate the neighbors of pixels using
+        a kdtree for nearest neighbor lookup.
+
+        Parameters
+        ----------
+        diagonal: bool
+            If rectangular geometry, also add diagonal neighbors
+        '''
         neighbors = lil_matrix((self.n_pixels, self.n_pixels), dtype=bool)
 
         if self.pix_type.startswith('hex'):
@@ -342,18 +351,19 @@ class CameraGeometry:
             radius = 1.1
             norm = 2  # use L2 norm for hex
         else:
-            norm = 1  # use L1 norm for rectangular
 
+            radius = 1.95
             # if diagonal should count as neighbor, we
-            # need to find at most 8 neighbors with a max L1 distance
-            # < than 3 * the pixel size, else 4 neigbors with max distance
+            # need to find at most 8 neighbors with a max L2 distance
+            # < than 2 * the pixel size, else 4 neigbors with max L1 distance
             # < 2 pixel size
+
             if diagonal:
                 k = 9
-                radius = 2.95
+                norm = 2
             else:
                 k = 5
-                radius = 1.95
+                norm = 1
 
         for i, pixel in enumerate(self._kdtree.data):
             d, n = self._kdtree.query(pixel, k=k, p=norm)

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -82,6 +82,7 @@ def test_neighbor_pixels(cam_id):
     n_pix = len(geom.pix_id)
     n_neighbors = [len(x) for x in geom.neighbors]
 
+
     if geom.pix_type.startswith('hex'):
         assert n_neighbors.count(6) > 0.5 * n_pix
         assert n_neighbors.count(6) > n_neighbors.count(4)
@@ -94,6 +95,7 @@ def test_neighbor_pixels(cam_id):
     # whipple has inhomogenious pixels that mess with pixel neighborhood
     # calculation
     if cam_id != 'Whipple490':
+        assert np.all(geom.neighbor_matrix == geom.neighbor_matrix.T)
         assert n_neighbors.count(1) == 0  # no pixel should have a single neighbor
 
 
@@ -112,6 +114,7 @@ def test_calc_pixel_neighbors_square():
 
     assert set(cam.neighbors[0]) == {1, 20}
     assert set(cam.neighbors[21]) == {1, 20, 22, 41}
+
 
 def test_calc_pixel_neighbors_square_diagonal():
     x, y = np.meshgrid(np.arange(20), np.arange(20))
@@ -174,6 +177,7 @@ def test_precal_neighbors():
 
     nmat = geom.neighbor_matrix
     assert nmat.shape == (len(geom.pix_x), len(geom.pix_x))
+    assert np.all(nmat.T == nmat)
 
 
 def test_slicing():
@@ -201,7 +205,7 @@ def test_slicing_rotation(cam_id):
     assert sliced1.pix_x[0] == cam.pix_x[5]
 
 
-def test_rectangle_patch_neighbors(rectangle_pixel_patch_geom):
+def test_rectangle_patch_neighbors():
     pix_x = np.array([
         -1.1, 0.1, 0.9,
         -1, 0, 1,
@@ -221,8 +225,9 @@ def test_rectangle_patch_neighbors(rectangle_pixel_patch_geom):
         pix_type='rectangular',
     )
 
-    assert cam.neighbor_matrix.sum(0).max() == 4
-    assert cam.neighbor_matrix.sum(0).min() == 2
+    assert np.all(cam.neighbor_matrix.T == cam.neighbor_matrix)
+    assert cam.neighbor_matrix.sum(axis=0).max() == 4
+    assert cam.neighbor_matrix.sum(axis=0).min() == 2
 
 
 def test_border_pixels():


### PR DESCRIPTION
Alternative approach to #1014 

By using the L1 norm for rectangular grids, this works like before, but much better for square grids.

I also changed the hierarchy of `neighbors`, `neighbor_matrix`, and `neighbor_matrix_sparse`.

The actual data is now in `neighbor_matrix_sparse` and the rest is computed from that.
![chec](https://user-images.githubusercontent.com/5488440/54534636-1438e480-498d-11e9-9bf3-1519b5f21b16.png)
