### PR TITLE
Add a component to make cleaning configurable

### DIFF
--- a/ctapipe/image/__init__.py
+++ b/ctapipe/image/__init__.py
@@ -1,5 +1,14 @@
-from .hillas import *
-from .cleaning import *
+from .hillas import (
+    hillas_parameters,
+    HillasParameterizationError,
+    camera_to_shower_coordinates,
+)
+from .cleaning import (
+    tailcuts_clean,
+    ImageCleaning,
+    dilate,
+    fact_image_cleaning,
+)
 from .pixel_likelihood import *
 from .charge_extractors import *
 from .waveform_cleaning import *
@@ -8,3 +17,14 @@ from .muon import *
 from .geometry_converter import *
 from .leakage import *
 from .concentration import concentration
+
+
+__all__ = [
+    'HillasParameterizationError',
+    'hillas_parameters',
+    'camera_to_shower_coordinates',
+    'tailcuts_clean',
+    'fact_image_cleaning',
+    'dilate',
+    'ImageCleaning',
+]


### PR DESCRIPTION
In many examples and pipelines, one can see code like this:

```
cleaning_levels = {
    'LSTCam': (5, 3, 2),
    'CHEC': (10, 4, 2),
}

levels = cleaning_levels[camera.cam_id]
tailcuts_clean(camera, image, picture_thresh=levels[0], boundary_threshold=levels[1])
```

I tried to make a Component that should make this configurable via traitlets