### PR TITLE
Fix for TargetIOR1Calibrator

### DIFF
--- a/ctapipe/calib/camera/r1.py
+++ b/ctapipe/calib/camera/r1.py
@@ -128,6 +128,7 @@ class CameraR1Calibrator(Component):
                 eventsource.metadata['is_simulation']):
             return HESSIOR1Calibrator(**kwargs)
         elif eventsource.__class__.__name__ == "TargetIOEventSource":
+            from ctapipe_io_targetio import TargetIOR1Calibrator
             return TargetIOR1Calibrator(**kwargs)
 
         return NullR1Calibrator(**kwargs)


### PR DESCRIPTION
Fix for returning TargetIOR1Calibrator from `CameraR1Calibrator.from_eventsource`.

This is a temporary small fix. Need to consider a long term approach.