### PR TITLE
Only detect plugins when they need to exist in global

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from inspect import isabstract
 from traitlets.config import Configurable
 from traitlets import TraitError
+from ctapipe.core.plugins import detect_and_import_io_plugins
 
 
 def non_abstract_children(base):
@@ -140,6 +141,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         instace
             Instance of subclass to this class
         """
+        detect_and_import_io_plugins()
         subclasses = {
             base.__name__: base
             for base in non_abstract_children(cls)

--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -7,10 +7,6 @@ from .tableio import TableWriter, TableReader
 # import event sources to make them visible to EventSource.from_url
 from .simteleventsource import SimTelEventSource
 
-from ctapipe.core.plugins import detect_and_import_io_plugins
-
-detect_and_import_io_plugins()
-
 __all__ = [
     'get_array_layout',
     'HDF5TableWriter',

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -7,6 +7,7 @@ from traitlets import Unicode, Int, Set, TraitError
 from ctapipe.core import Component, non_abstract_children
 from ctapipe.core import Provenance
 from traitlets.config.loader import LazyConfigValue
+from ctapipe.core.plugins import detect_and_import_io_plugins
 
 __all__ = [
     'EventSource',
@@ -240,6 +241,7 @@ class EventSource(Component):
         instance
             Instance of a compatible EventSource subclass
         """
+        detect_and_import_io_plugins()
         available_classes = non_abstract_children(cls)
 
         for subcls in available_classes:


### PR DESCRIPTION
As first described in #1035, I am having trouble with the following issue with the io plugins, specifically regarding the TargetIOR1Calibrator:

```
(cta) 09:27 [Jason ~/Software/ctapipe_io_targetio]  (master)  $ python -c "from ctapipe.calib.camera.r1 import CameraR1Calibrator"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/Jason/Software/ctapipe/ctapipe/calib/__init__.py", line 5, in <module>
    from .camera import *
  File "/Users/Jason/Software/ctapipe/ctapipe/calib/camera/__init__.py", line 8, in <module>
    from .dl1 import *
  File "/Users/Jason/Software/ctapipe/ctapipe/calib/camera/dl1.py", line 14, in <module>
    from ...image import NeighbourPeakIntegrator, NullWaveformCleaner
  File "/Users/Jason/Software/ctapipe/ctapipe/image/__init__.py", line 1, in <module>
    from .hillas import *
  File "/Users/Jason/Software/ctapipe/ctapipe/image/hillas.py", line 11, in <module>
    from ..io.containers import HillasParametersContainer
  File "/Users/Jason/Software/ctapipe/ctapipe/io/__init__.py", line 12, in <module>
    detect_and_import_io_plugins()
  File "/Users/Jason/Software/ctapipe/ctapipe/core/plugins.py", line 16, in detect_and_import_io_plugins
    return detect_and_import_plugins(prefix='ctapipe_io_')
  File "/Users/Jason/Software/ctapipe/ctapipe/core/plugins.py", line 10, in detect_and_import_plugins
    in pkgutil.iter_modules()
  File "/Users/Jason/Software/ctapipe/ctapipe/core/plugins.py", line 11, in <dictcomp>
    if name.startswith(prefix)
  File "/Users/Jason/anaconda3/envs/cta/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/Users/Jason/Software/ctapipe_io_targetio/ctapipe_io_targetio/__init__.py", line 15, in <module>
    from .calibration import TargetIOR1Calibrator
  File "/Users/Jason/Software/ctapipe_io_targetio/ctapipe_io_targetio/calibration.py", line 1, in <module>
    from ctapipe.calib import CameraR1Calibrator
ImportError: cannot import name 'CameraR1Calibrator' from 'ctapipe.calib' (/Users/Jason/Software/ctapipe/ctapipe/calib/__init__.py)
```

It happens because when importing the CameraR1Calibrator, the `__init__.py` files end up leading to import the io plugins, which in turns tries to import the `TargetIOR1Calibrator`, which requires `CameraR1Calibrator` to be defined.

One solution I have is to be a bit more careful about when we import the plugins, instead only importing when we need them to exist in the global namespace. I.e. when we are using the factory methods.