### PR TITLE
Fix passing config to CameraCalibrator

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -60,7 +60,6 @@ class CameraCalibrator(Component):
         if r1_product:
             self.r1 = CameraR1Calibrator.from_name(
                 r1_product,
-                config=config,
                 parent=self,
             )
         else:

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -61,4 +61,4 @@ def test_config():
         config=config
     )
     assert calibrator.dl1.extractor.window_shift == window_shift
-    assert calibrator.dl1.extractor.window_shift == window_width
+    assert calibrator.dl1.extractor.window_width == window_width

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -8,6 +8,7 @@ from ctapipe.calib.camera import (
 from ctapipe.image.extractor import LocalPeakWindowSum
 from ctapipe.io import SimTelEventSource
 from ctapipe.utils import get_dataset_path
+from traitlets.config.configurable import Config
 
 
 def test_camera_calibrator(example_event):
@@ -45,3 +46,19 @@ def test_eventsource_override_r1():
         r1_product="NullR1Calibrator"
     )
     assert isinstance(calibrator.r1, NullR1Calibrator)
+
+
+def test_config():
+    window_shift = 3
+    window_width = 9
+    config = Config({"LocalPeakWindowSum": {
+        "window_shift": window_shift,
+        "window_width": window_width,
+    }})
+    calibrator = CameraCalibrator(
+        r1_product='HESSIOR1Calibrator',
+        extractor_name='LocalPeakWindowSum',
+        config=config
+    )
+    assert calibrator.dl1.extractor.window_shift == window_shift
+    assert calibrator.dl1.extractor.window_shift == window_width


### PR DESCRIPTION
Passing a config to CameraCalibrator currently raises the error:

```python
ValueError: Only one of `config` or `parent` allowed If you create a Component as part of another, give `parent=self` and not `config`
```

This PR fixes that.