### PR TITLE
Cache camera geometries by camera name

### DIFF
--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -196,3 +196,11 @@ def test_calibration_events():
     ) as reader:
         for e in reader:
             pass
+
+
+def test_camera_caching():
+    '''Test if same telescope types share a single instance of CameraGeometry'''
+    source = SimTelEventSource(input_url=gamma_test_large_path)
+    event = next(iter(source))
+    subarray = event.inst.subarray
+    assert subarray.tel[1].camera is subarray.tel[2].camera


### PR DESCRIPTION
Just using `lru_cache` is not possible, as numpy arrays and dicts are not hashable.

We could use `cachetools` but here is a solution by hand.