### PR TITLE
normalize index column name in subarray table

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -236,7 +236,7 @@ class SubarrayDescription:
 
         with quantity_support():
             for tel_type in types:
-                tels = tab[tab['tel_description'] == str(tel_type)]['id']
+                tels = tab[tab['tel_description'] == str(tel_type)]['tel_id']
                 sub = self.select_subarray(tel_type, tels)
                 tel_coords = sub.tel_coords
                 radius = np.array([

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -160,7 +160,7 @@ class SubarrayDescription:
             tel_coords = self.tel_coords
 
             tab = Table(dict(
-                id=np.array(ids, dtype=np.short),
+                tel_id=np.array(ids, dtype=np.short),
                 pos_x=tel_coords.x,
                 pos_y=tel_coords.y,
                 pos_z=tel_coords.z,

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -26,6 +26,8 @@ def test_subarray_description():
         tel_descriptions=tel
     )
 
+    sub.peek()
+
     assert len(sub.telescope_types) == 1
 
     assert str(sub) == "test array"
@@ -50,6 +52,7 @@ def test_subarray_description():
     assert subsub.tel_ids[3] == 6
 
     assert len(sub.to_table(kind='optics')) == 1
+
 
 
 if __name__ == '__main__':

--- a/ctapipe/tools/display_summed_images.py
+++ b/ctapipe/tools/display_summed_images.py
@@ -63,7 +63,7 @@ class ImageSumDisplayerTool(Tool):
             break
 
         group = camtypes.groups[self.telgroup]
-        self._selected_tels = list(group['id'].data)
+        self._selected_tels = list(group['tel_id'].data)
         self._base_tel = self._selected_tels[0]
         self.log.info(
             "Telescope group %d: %s", self.telgroup,

--- a/docs/examples/InstrumentDescription.ipynb
+++ b/docs/examples/InstrumentDescription.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "tab = subarray.to_table()\n",
-    "sc_tels = tab[tab['num_mirrors'] == 2]['id']  # select tel_id of entries where the mirror type is SC\n",
+    "sc_tels = tab[tab['num_mirrors'] == 2]['tel_id']  # select tel_id of entries where the mirror type is SC\n",
     "newsub = subarray.select_subarray(\"SCTels\", sc_tels)\n",
     "newsub.info()"
    ]
@@ -111,7 +111,7 @@
    "source": [
     "gtab = tab.group_by('num_mirrors')\n",
     "sc = gtab.groups[0]\n",
-    "newsub = subarray.select_subarray(\"SCTels\", sc['id'])\n",
+    "newsub = subarray.select_subarray(\"SCTels\", sc['tel_id'])\n",
     "newsub.info()"
    ]
   },
@@ -241,7 +241,7 @@
    "outputs": [],
    "source": [
     "df = subarray.to_table().to_pandas()\n",
-    "df.set_index('id')"
+    "df.set_index('tel_id')"
    ]
   },
   {
@@ -278,25 +278,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lsts = subarray.select_subarray(\"LSTs\", df.loc[g.groups['LST:LSTCam']]['id'])\n",
+    "lsts = subarray.select_subarray(\"LSTs\", df.loc[g.groups['LST:LSTCam']]['tel_id'])\n",
     "lsts.info()\n",
     "lsts.peek()\n",
     "lsts.footprint"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -315,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Just a simple change suggested in #1059 to change the column 'id' in the output of `SubarrayDescription.to_table()` to be `tel_id`