### PR TITLE
Fix broken telescope id string, Fixes #1058

### DIFF
--- a/.coverage.dapmcw186.24220.071001
+++ b/.coverage.dapmcw186.24220.071001
@@ -1,0 +1,1 @@
+!coverage.py: This is a private format, don't read it directly!{"lines":{}}

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -35,8 +35,8 @@ def analyze_muon_event(event):
 
     """
 
-    names = ['LST:LSTCam', 'MST:NectarCam', 'MST:FlashCam', 'MST-SCT:SCTCam',
-             '1M:DigiCam', 'GCT:CHEC', 'ASTRI:ASTRICam', 'ASTRI:CHEC']
+    names = ['LST_LST_LSTCam', 'MST_MST_NectarCam', 'MST_MST_FlashCam', 'MST_SCT_SCTCam',
+             'SST_1M_DigiCam', 'SST_GCT_CHEC', 'SST_ASTRI_ASTRICam', 'SST_ASTRI_CHEC']
     tail_cuts = [(5, 7), (5, 7), (10, 12), (5, 7),
                 (5, 7), (5, 7), (5, 7), (5, 7)]  # 10, 12?
     impact = [(0.2, 0.9), (0.1, 0.95), (0.2, 0.9), (0.2, 0.9),

--- a/ctapipe/instrument/guess.py
+++ b/ctapipe/instrument/guess.py
@@ -1,34 +1,39 @@
+"""
+Methods for guessing details about a telescope from some metadata (so that
+we can create TelescopeDescriptions from Monte-Carlo where some
+parameters like the names of the camera and optics structure are not
+stored in the file.
+"""
 from collections import namedtuple
+
 import astropy.units as u
 
-
-GuessingKey = namedtuple('GuessingKey', ['n_pixels', 'focal_length'])
+GuessingKey = namedtuple("GuessingKey", ["n_pixels", "focal_length"])
 GuessingResult = namedtuple(
-    'GuessingResult', ['type', 'name', 'camera_name', 'n_mirrors']
+    "GuessingResult", ["type", "name", "camera_name", "n_mirrors"]
 )
 
 
 TELESCOPE_NAMES = {
-    GuessingKey(2048, 2.28): GuessingResult('SST', 'GCT', 'CHEC', 2),
-    GuessingKey(2368, 2.15): GuessingResult('SST', 'ASTRI', 'ASTRICam', 2),
-    GuessingKey(2048, 2.15): GuessingResult('SST', 'ASTRI', 'CHEC', 2),
-    GuessingKey(1296, 5.60): GuessingResult('SST', '1M', 'DigiCam', 1),
-    GuessingKey(1764, 16.0): GuessingResult('MST', 'MST', 'FlashCam', 1),
-    GuessingKey(1855, 16.0): GuessingResult('MST', 'MST', 'NectarCam', 1),
-    GuessingKey(1855, 28.0): GuessingResult('LST', 'LST', 'LSTCam', 1),
-    GuessingKey(11328, 5.59): GuessingResult('MST', 'SCT', 'SCTCam', 1),
-
-    # None CTA Telescopes
-    GuessingKey(960, 15.0): GuessingResult('MST', 'HESS-I', 'HESS-I', 1),
-    GuessingKey(2048, 36.0): GuessingResult('LST', 'HESS-II', 'HESS-II', 1),
-    GuessingKey(1440, 4.998): GuessingResult('SST', 'FACT', 'FACT', 1),
+    GuessingKey(2048, 2.28): GuessingResult("SST", "GCT", "CHEC", 2),
+    GuessingKey(2368, 2.15): GuessingResult("SST", "ASTRI", "ASTRICam", 2),
+    GuessingKey(2048, 2.15): GuessingResult("SST", "ASTRI", "CHEC", 2),
+    GuessingKey(1296, 5.60): GuessingResult("SST", "1M", "DigiCam", 1),
+    GuessingKey(1764, 16.0): GuessingResult("MST", "MST", "FlashCam", 1),
+    GuessingKey(1855, 16.0): GuessingResult("MST", "MST", "NectarCam", 1),
+    GuessingKey(1855, 28.0): GuessingResult("LST", "LST", "LSTCam", 1),
+    GuessingKey(11328, 5.59): GuessingResult("MST", "SCT", "SCTCam", 1),
+    # Non-CTA Telescopes
+    GuessingKey(960, 15.0): GuessingResult("MST", "HESS-I", "HESS-I", 1),
+    GuessingKey(2048, 36.0): GuessingResult("LST", "HESS-II", "HESS-II", 1),
+    GuessingKey(1440, 4.998): GuessingResult("SST", "FACT", "FACT", 1),
 }
 
-UNKNOWN_TELESCOPE = GuessingResult('UNKNOWN', 'UNKNOWN', 'UNKNOWN', -1)
+UNKNOWN_TELESCOPE = GuessingResult("UNKNOWN", "UNKNOWN", "UNKNOWN", -1)
 
 
 def guess_telescope(n_pixels, focal_length):
-    '''
+    """
     From n_pixels of the camera and the focal_length,
     guess which telescope we are dealing with.
     This is mainly needed to add human readable names
@@ -45,7 +50,7 @@ def guess_telescope(n_pixels, focal_length):
     -------
     result: GuessingResult
         A namedtuple having type, telescope_name, camera_name and n_mirrors fields
-    '''
+    """
 
     # allow unit input
     focal_length = u.Quantity(focal_length, u.m).to_value(u.m)
@@ -53,4 +58,4 @@ def guess_telescope(n_pixels, focal_length):
     try:
         return TELESCOPE_NAMES[(n_pixels, round(focal_length, 2))]
     except KeyError:
-        raise ValueError(f'Unknown telescope: n_pixel={n_pixels}, f={focal_length}')
+        raise ValueError(f"Unknown telescope: n_pixel={n_pixels}, f={focal_length}")

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -113,6 +113,11 @@ class OpticsDescription:
 
     @classmethod
     def get_known_optics_names(cls, optics_table="optics"):
+        """
+        return the list of optics names from ctapipe resources, i.e. those that can be
+        constructed by name (this does not return the list of known names from an
+        already open Monte-Carlo file)
+        """
         table = get_table_dataset(optics_table, "get_known_optics")
         return np.array(table["tel_description"])
 

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -3,9 +3,11 @@ Classes and functions related to telescope Optics
 """
 
 import logging
-from ..utils import get_table_dataset
-import numpy as np
+
 import astropy.units as u
+import numpy as np
+
+from ..utils import get_table_dataset
 
 logger = logging.getLogger(__name__)
 
@@ -41,14 +43,14 @@ class OpticsDescription:
         if the units of one of the inputs are missing or incompatible
     """
 
-    @u.quantity_input(mirror_area=u.m**2, equivalent_focal_length=u.m)
+    @u.quantity_input(mirror_area=u.m ** 2, equivalent_focal_length=u.m)
     def __init__(
-            self,
-            name,
-            num_mirrors,
-            equivalent_focal_length,
-            mirror_area=None,
-            num_mirror_tiles=None
+        self,
+        name,
+        num_mirrors,
+        equivalent_focal_length,
+        mirror_area=None,
+        num_mirror_tiles=None,
     ):
 
         self.name = name
@@ -58,20 +60,22 @@ class OpticsDescription:
         self.num_mirror_tiles = num_mirror_tiles
 
     def __hash__(self):
-        '''Make this hashable, so it can be used as dict keys or in sets'''
-        return hash((
-            self.equivalent_focal_length.to_value(u.m),
-            self.mirror_area,
-            self.num_mirrors,
-            self.num_mirror_tiles,
-        ))
+        """Make this hashable, so it can be used as dict keys or in sets"""
+        return hash(
+            (
+                self.equivalent_focal_length.to_value(u.m),
+                self.mirror_area,
+                self.num_mirrors,
+                self.num_mirror_tiles,
+            )
+        )
 
     def __eq__(self, other):
-        '''Make this hashable, so it can be used as dict keys or in sets'''
+        """Make this hashable, so it can be used as dict keys or in sets"""
         return hash(self) == hash(other)
 
     @classmethod
-    def from_name(cls, name, optics_table='optics'):
+    def from_name(cls, name, optics_table="optics"):
         """
         Construct an OpticsDescription from the name. This is loaded from
         `optics.fits.gz`, which should be in `ctapipe_resources` or in a
@@ -90,27 +94,27 @@ class OpticsDescription:
         OpticsDescription
 
         """
-        table = get_table_dataset(optics_table, role='dl0.tel.svc.optics')
-        mask = table['tel_description'] == name
+        table = get_table_dataset(optics_table, role="dl0.tel.svc.optics")
+        mask = table["tel_description"] == name
         if mask.sum() == 0:
-            raise ValueError(f'Unknown telescope name {name}')
+            raise ValueError(f"Unknown telescope name {name}")
 
-        flen = table['equivalent_focal_length'][mask].quantity[0]
+        flen = table["equivalent_focal_length"][mask].quantity[0]
 
-        num_mirrors = 1 if table['mirror_type'][mask][0] == 'DC' else 2
+        num_mirrors = 1 if table["mirror_type"][mask][0] == "DC" else 2
         optics = cls(
             name=name,
             num_mirrors=num_mirrors,
             equivalent_focal_length=flen,
-            mirror_area=table['mirror_area'][mask].quantity[0],
-            num_mirror_tiles=table['num_mirror_tiles'][mask][0],
+            mirror_area=table["mirror_area"][mask].quantity[0],
+            num_mirror_tiles=table["num_mirror_tiles"][mask][0],
         )
         return optics
 
     @classmethod
-    def get_known_optics_names(cls, optics_table='optics'):
-        table = get_table_dataset(optics_table, 'get_known_optics')
-        return np.array(table['tel_description'])
+    def get_known_optics_names(cls, optics_table="optics"):
+        table = get_table_dataset(optics_table, "get_known_optics")
+        return np.array(table["tel_description"])
 
     def __repr__(self):
         return (

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -2,7 +2,7 @@
 Description of Arrays or Subarrays of telescopes
 """
 
-__all__ = ['SubarrayDescription']
+__all__ = ["SubarrayDescription"]
 
 from collections import defaultdict
 
@@ -52,16 +52,14 @@ class SubarrayDescription:
         self.tels = tel_descriptions or dict()
 
         if self.positions.keys() != self.tels.keys():
-            raise ValueError('Telescope ids in positions and descriptions do not match')
+            raise ValueError("Telescope ids in positions and descriptions do not match")
 
     def __str__(self):
         return self.name
 
     def __repr__(self):
         return "{}(name='{}', num_tels={})".format(
-            self.__class__.__name__,
-            self.name,
-            self.num_tels,
+            self.__class__.__name__, self.name, self.num_tels
         )
 
     @property
@@ -94,27 +92,21 @@ class SubarrayDescription:
         printer("=====================================")
 
         for teltype, tels in teltypes.items():
-            printer("{:>20s} {:4d} {:4d} ..{:4d}".format(
-                teltype, len(tels), min(tels), max(tels)
-            ))
+            printer(
+                "{:>20s} {:4d} {:4d} ..{:4d}".format(
+                    teltype, len(tels), min(tels), max(tels)
+                )
+            )
 
     @property
     def tel_coords(self):
         """ returns telescope positions as astropy.coordinates.SkyCoord"""
 
-        pos_x = np.array([p[0].to('m').value
-                          for p in self.positions.values()]) * u.m
-        pos_y = np.array([p[1].to('m').value
-                          for p in self.positions.values()]) * u.m
-        pos_z = np.array([p[2].to('m').value
-                          for p in self.positions.values()]) * u.m
+        pos_x = np.array([p[0].to("m").value for p in self.positions.values()]) * u.m
+        pos_y = np.array([p[1].to("m").value for p in self.positions.values()]) * u.m
+        pos_z = np.array([p[2].to("m").value for p in self.positions.values()]) * u.m
 
-        return SkyCoord(
-            x=pos_x,
-            y=pos_y,
-            z=pos_z,
-            frame=GroundFrame()
-        )
+        return SkyCoord(x=pos_x, y=pos_y, z=pos_z, frame=GroundFrame())
 
     @property
     def tel_ids(self):
@@ -136,8 +128,8 @@ class SubarrayDescription:
         If the tel_ids are not contiguous, gaps will be filled in by -1. 
         For a more compact representation use the `tel_indices` 
         """
-        idx = np.zeros(np.max(self.tel_ids)+1, dtype=int) - 1 # start with -1
-        for key,val in self.tel_indices.items():
+        idx = np.zeros(np.max(self.tel_ids) + 1, dtype=int) - 1  # start with -1
+        for key, val in self.tel_indices.items():
             idx[key] = val
         return idx
 
@@ -157,13 +149,13 @@ class SubarrayDescription:
         tel_ids = np.asanyarray(tel_ids).ravel()
         index_map = self.tel_index_array
         return index_map[tel_ids]
-  
+
     @property
     def footprint(self):
         """area of smallest circle containing array on ground"""
         x = self.tel_coords.x
         y = self.tel_coords.y
-        return (np.hypot(x, y).max() ** 2 * np.pi).to('km^2')
+        return (np.hypot(x, y).max() ** 2 * np.pi).to("km^2")
 
     def to_table(self, kind="subarray"):
         """
@@ -176,13 +168,13 @@ class SubarrayDescription:
         """
 
         meta = {
-            'ORIGIN': 'ctapipe.inst.SubarrayDescription',
-            'SUBARRAY': self.name,
-            'SOFT_VER': ctapipe.__version__,
-            'TAB_TYPE': kind,
+            "ORIGIN": "ctapipe.inst.SubarrayDescription",
+            "SUBARRAY": self.name,
+            "SOFT_VER": ctapipe.__version__,
+            "TAB_TYPE": kind,
         }
 
-        if kind == 'subarray':
+        if kind == "subarray":
 
             ids = list(self.tels.keys())
             descs = [str(t) for t in self.tels.values()]
@@ -192,37 +184,39 @@ class SubarrayDescription:
             cam_types = [t.camera.cam_id for t in self.tels.values()]
             tel_coords = self.tel_coords
 
-            tab = Table(dict(
-                tel_id=np.array(ids, dtype=np.short),
-                pos_x=tel_coords.x,
-                pos_y=tel_coords.y,
-                pos_z=tel_coords.z,
-                name=tel_names,
-                type=tel_types,
-                num_mirrors=num_mirrors,
-                camera_type=cam_types,
-                tel_description=descs,
-            ))
+            tab = Table(
+                dict(
+                    tel_id=np.array(ids, dtype=np.short),
+                    pos_x=tel_coords.x,
+                    pos_y=tel_coords.y,
+                    pos_z=tel_coords.z,
+                    name=tel_names,
+                    type=tel_types,
+                    num_mirrors=num_mirrors,
+                    camera_type=cam_types,
+                    tel_description=descs,
+                )
+            )
 
-        elif kind == 'optics':
+        elif kind == "optics":
             unique_types = set(self.tels.values())
 
             mirror_area = u.Quantity(
-                [t.optics.mirror_area.to_value(u.m**2) for t in unique_types],
-                u.m**2,
+                [t.optics.mirror_area.to_value(u.m ** 2) for t in unique_types],
+                u.m ** 2,
             )
             focal_length = u.Quantity(
                 [t.optics.equivalent_focal_length.to_value(u.m) for t in unique_types],
                 u.m,
             )
             cols = {
-                'description': [str(t) for t in unique_types],
-                'name': [t.name for t in unique_types],
-                'type': [t.type for t in unique_types],
-                'mirror_area': mirror_area,
-                'num_mirrors': [t.optics.num_mirrors for t in unique_types],
-                'num_mirror_tiles': [t.optics.num_mirror_tiles for t in unique_types],
-                'equivalent_focal_length': focal_length,
+                "description": [str(t) for t in unique_types],
+                "name": [t.name for t in unique_types],
+                "type": [t.type for t in unique_types],
+                "mirror_area": mirror_area,
+                "num_mirrors": [t.optics.num_mirrors for t in unique_types],
+                "num_mirror_tiles": [t.optics.num_mirror_tiles for t in unique_types],
+                "equivalent_focal_length": focal_length,
             }
             tab = Table(cols)
 
@@ -251,8 +245,9 @@ class SubarrayDescription:
         tel_positions = {tid: self.positions[tid] for tid in tel_ids}
         tel_descriptions = {tid: self.tel[tid] for tid in tel_ids}
 
-        newsub = SubarrayDescription(name, tel_positions=tel_positions,
-                                     tel_descriptions=tel_descriptions)
+        newsub = SubarrayDescription(
+            name, tel_positions=tel_positions, tel_descriptions=tel_descriptions
+        )
         return newsub
 
     def peek(self):
@@ -269,23 +264,21 @@ class SubarrayDescription:
 
         with quantity_support():
             for tel_type in types:
-                tels = tab[tab['tel_description'] == str(tel_type)]['tel_id']
+                tels = tab[tab["tel_description"] == str(tel_type)]["tel_id"]
                 sub = self.select_subarray(tel_type, tels)
                 tel_coords = sub.tel_coords
-                radius = np.array([
-                    np.sqrt(tel.optics.mirror_area / np.pi).value
-                    for tel in sub.tels.values()
-                ])
-
-                plt.scatter(
-                    tel_coords.x,
-                    tel_coords.y,
-                    s=radius * 8,
-                    alpha=0.5,
-                    label=tel_type,
+                radius = np.array(
+                    [
+                        np.sqrt(tel.optics.mirror_area / np.pi).value
+                        for tel in sub.tels.values()
+                    ]
                 )
 
-            plt.legend(loc='best')
+                plt.scatter(
+                    tel_coords.x, tel_coords.y, s=radius * 8, alpha=0.5, label=tel_type
+                )
+
+            plt.legend(loc="best")
             plt.title(self.name)
             plt.tight_layout()
 

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -69,6 +69,7 @@ class SubarrayDescription:
 
     @property
     def num_tels(self):
+        """number of telescopes in this subarray"""
         return len(self.tels)
 
     def __len__(self):
@@ -121,12 +122,12 @@ class SubarrayDescription:
 
     @property
     def tel_index_array(self):
-        """ 
+        """
         returns an expanded array that maps tel_id to tel_index. I.e. for a given
         telescope, this array maps the tel_id to a flat index starting at 0 for
         the first telescope. `tel_index = tel_id_to_index_array[tel_id]`
-        If the tel_ids are not contiguous, gaps will be filled in by -1. 
-        For a more compact representation use the `tel_indices` 
+        If the tel_ids are not contiguous, gaps will be filled in by -1.
+        For a more compact representation use the `tel_indices`
         """
         idx = np.zeros(np.max(self.tel_ids) + 1, dtype=int) - 1  # start with -1
         for key, val in self.tel_indices.items():
@@ -153,9 +154,9 @@ class SubarrayDescription:
     @property
     def footprint(self):
         """area of smallest circle containing array on ground"""
-        x = self.tel_coords.x
-        y = self.tel_coords.y
-        return (np.hypot(x, y).max() ** 2 * np.pi).to("km^2")
+        pos_x = self.tel_coords.x
+        pos_y = self.tel_coords.y
+        return (np.hypot(pos_x, pos_y).max() ** 2 * np.pi).to("km^2")
 
     def to_table(self, kind="subarray"):
         """

--- a/ctapipe/instrument/telescope.py
+++ b/ctapipe/instrument/telescope.py
@@ -13,9 +13,9 @@ Todo:
   telescope :-))
 
 """
-from .optics import OpticsDescription
 from .camera import CameraGeometry
-from .guess import guess_telescope
+from .guess import UNKNOWN_TELESCOPE, guess_telescope
+from .optics import OpticsDescription
 
 
 class TelescopeDescription:
@@ -41,13 +41,7 @@ class TelescopeDescription:
        the camera associated with this telescope
     """
 
-    def __init__(
-        self,
-        name,
-        type,
-        optics: OpticsDescription,
-        camera: CameraGeometry
-    ):
+    def __init__(self, name, type, optics: OpticsDescription, camera: CameraGeometry):
 
         self.name = name
         self.type = type
@@ -55,11 +49,11 @@ class TelescopeDescription:
         self.camera = camera
 
     def __hash__(self):
-        '''Make this hashable, so it can be used as dict keys or in sets'''
+        """Make this hashable, so it can be used as dict keys or in sets"""
         return hash((self.optics, self.camera))
 
     def __eq__(self, other):
-        '''Make this hashable, so it can be used as dict keys or in sets'''
+        """Make this hashable, so it can be used as dict keys or in sets"""
         return hash(self) == hash(other)
 
     @classmethod
@@ -85,16 +79,12 @@ class TelescopeDescription:
         camera = CameraGeometry.from_name(camera_name)
         optics = OpticsDescription.from_name(optics_name)
 
-        tel_type='unknown'
-        tel_name='unknown'
         try:
-            t = guess_telescope(camera.n_pixels, optics.equivalent_focal_length)
-            tel_type = t.type
-            tel_name = t.name
+            result = guess_telescope(camera.n_pixels, optics.equivalent_focal_length)
         except ValueError:
-            pass # couldn't detect name
+            result = UNKNOWN_TELESCOPE
 
-        return cls(name=tel_name, type=tel_type, optics=optics, camera=camera)
+        return cls(name=result.name, type=result.type, optics=optics, camera=camera)
 
     def __str__(self):
         return f"{self.type}_{self.optics}_{self.camera}"

--- a/ctapipe/instrument/telescope.py
+++ b/ctapipe/instrument/telescope.py
@@ -33,7 +33,7 @@ class TelescopeDescription:
     ----------
     name: str
         Telescope name
-    type: str
+    tel_type: str
         Telescope type
     optics: OpticsDescription
        the optics associated with this telescope
@@ -41,10 +41,10 @@ class TelescopeDescription:
        the camera associated with this telescope
     """
 
-    def __init__(self, name, type, optics: OpticsDescription, camera: CameraGeometry):
+    def __init__(self, name, tel_type, optics: OpticsDescription, camera: CameraGeometry):
 
         self.name = name
-        self.type = type
+        self.type = tel_type
         self.optics = optics
         self.camera = camera
 

--- a/ctapipe/instrument/telescope.py
+++ b/ctapipe/instrument/telescope.py
@@ -84,7 +84,7 @@ class TelescopeDescription:
         except ValueError:
             result = UNKNOWN_TELESCOPE
 
-        return cls(name=result.name, type=result.type, optics=optics, camera=camera)
+        return cls(name=result.name, tel_type=result.type, optics=optics, camera=camera)
 
     def __str__(self):
         return f"{self.type}_{self.optics}_{self.camera}"

--- a/ctapipe/instrument/telescope.py
+++ b/ctapipe/instrument/telescope.py
@@ -85,18 +85,25 @@ class TelescopeDescription:
         camera = CameraGeometry.from_name(camera_name)
         optics = OpticsDescription.from_name(optics_name)
 
-        t = guess_telescope(camera.n_pixels, optics.equivalent_focal_length)
+        tel_type='unknown'
+        tel_name='unknown'
+        try:
+            t = guess_telescope(camera.n_pixels, optics.equivalent_focal_length)
+            tel_type = t.type
+            tel_name = t.name
+        except ValueError:
+            pass # couldn't detect name
 
-        return cls(name=t.name, type=t.type, optics=optics, camera=camera)
+        return cls(name=tel_name, type=tel_type, optics=optics, camera=camera)
 
     def __str__(self):
-        return str(self.optics) + ":" + str(self.camera)
+        return f"{self.type}_{self.optics}_{self.camera}"
 
     def __repr__(self):
-        return "{}({}, type={}, optics={}, camera={})".format(
-            self.name,
-            self.type,
+        return "{}(type={}, name={}, optics={}, camera={})".format(
             self.__class__.__name__,
+            self.type,
+            self.name,
             str(self.optics),
             str(self.camera),
         )

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -263,3 +263,8 @@ def test_hashing():
     cam3 = CameraGeometry.from_name("ASTRICam")
 
     assert len(set([cam1, cam2, cam3])) == 2
+
+@pytest.mark.parametrize("camera_name", CameraGeometry.get_known_camera_names())
+def test_camera_from_name(camera_name):
+    camera = CameraGeometry.from_name(camera_name)
+    assert str(camera) == camera_name

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -1,3 +1,4 @@
+""" Tests for CameraGeometry """
 import numpy as np
 from astropy import units as u
 from ctapipe.instrument import CameraGeometry
@@ -7,6 +8,7 @@ cam_ids = CameraGeometry.get_known_camera_names()
 
 
 def test_construct():
+    """ Check we can make a CameraGeometry from scratch """
     x = np.linspace(-10, 10, 100)
     y = np.linspace(-10, 10, 100)
     geom = CameraGeometry(cam_id=0, pix_id=np.arange(100),
@@ -23,6 +25,7 @@ def test_construct():
 
 
 def test_known_camera_names():
+    """ Check that we can get a list of known camera names """
     cams = CameraGeometry.get_known_camera_names()
     assert len(cams) > 4
     assert 'FlashCam' in cams
@@ -34,16 +37,20 @@ def test_known_camera_names():
 
 
 def test_make_rectangular_camera_geometry():
+    """ Check that we can construct a dummy camera with square geometry """
     geom = CameraGeometry.make_rectangular()
     assert geom.pix_x.shape == geom.pix_y.shape
 
 
-def test_load_hess_camera():
+def test_load_lst_camera():
+    """ test that a specific camera has the expected attributes """
     geom = CameraGeometry.from_name("LSTCam")
     assert len(geom.pix_x) == 1855
+    assert geom.pix_type == "hexagonal"
 
 
 def test_position_to_pix_index():
+    """ test that we can lookup a pixel from a coordinate"""
     geom = CameraGeometry.from_name("LSTCam")
     x, y = 0.80 * u.m, 0.79 * u.m,
     pix_id = geom.position_to_pix_index(x, y)
@@ -51,6 +58,7 @@ def test_position_to_pix_index():
 
 
 def test_find_neighbor_pixels():
+    """ test basic neighbor functionality """
     n_pixels = 5
     x, y = u.Quantity(np.meshgrid(
         np.linspace(-5, 5, n_pixels),
@@ -117,6 +125,10 @@ def test_calc_pixel_neighbors_square():
 
 
 def test_calc_pixel_neighbors_square_diagonal():
+    """
+    check that neighbors for square-pixel cameras are what we expect,
+    namely that the diagonals are included if requested.
+    """
     x, y = np.meshgrid(np.arange(20), np.arange(20))
 
     cam = CameraGeometry(
@@ -133,6 +145,7 @@ def test_calc_pixel_neighbors_square_diagonal():
 
 
 def test_to_and_from_table():
+    """ Check converting to and from an astropy Table """
     geom = CameraGeometry.from_name("LSTCam")
     tab = geom.to_table()
     geom2 = geom.from_table(tab)
@@ -145,7 +158,7 @@ def test_to_and_from_table():
 
 
 def test_write_read(tmpdir):
-
+    """ Check that serialization to disk doesn't lose info """
     filename = str(tmpdir.join('testcamera.fits.gz'))
 
     geom = CameraGeometry.from_name("LSTCam")
@@ -160,6 +173,10 @@ def test_write_read(tmpdir):
 
 
 def test_precal_neighbors():
+    """
+    test that pre-calculated neighbor lists don't get
+    overwritten by automatic ones
+    """
     geom = CameraGeometry(cam_id="TestCam",
                           pix_id=np.arange(3),
                           pix_x=np.arange(3) * u.deg,
@@ -181,6 +198,7 @@ def test_precal_neighbors():
 
 
 def test_slicing():
+    """ Check that we can slice a camera into a smaller one """
     geom = CameraGeometry.from_name("NectarCam")
     sliced1 = geom[100:200]
 
@@ -197,6 +215,7 @@ def test_slicing():
 
 @pytest.mark.parametrize("cam_id", cam_ids)
 def test_slicing_rotation(cam_id):
+    """ Check that we can rotate and slice """
     cam = CameraGeometry.from_name(cam_id)
     cam.rotate('25d')
 
@@ -206,6 +225,7 @@ def test_slicing_rotation(cam_id):
 
 
 def test_rectangle_patch_neighbors():
+    """" test that a simple rectangular camera has the expected neighbors """
     pix_x = np.array([
         -1.1, 0.1, 0.9,
         -1, 0, 1,
@@ -231,6 +251,7 @@ def test_rectangle_patch_neighbors():
 
 
 def test_border_pixels():
+    """ check we can find border pixels"""
     from ctapipe.instrument.camera import CameraGeometry
 
     cam = CameraGeometry.from_name("LSTCam")
@@ -248,6 +269,7 @@ def test_border_pixels():
 
 
 def test_equals():
+    """ check we can use the == operator """
     cam1 = CameraGeometry.from_name("LSTCam")
     cam2 = CameraGeometry.from_name("LSTCam")
     cam3 = CameraGeometry.from_name("ASTRICam")
@@ -258,6 +280,7 @@ def test_equals():
 
 
 def test_hashing():
+    """" check that hashes are correctly computed """
     cam1 = CameraGeometry.from_name("LSTCam")
     cam2 = CameraGeometry.from_name("LSTCam")
     cam3 = CameraGeometry.from_name("ASTRICam")
@@ -266,5 +289,6 @@ def test_hashing():
 
 @pytest.mark.parametrize("camera_name", CameraGeometry.get_known_camera_names())
 def test_camera_from_name(camera_name):
+    """ check we can construct all cameras from name"""
     camera = CameraGeometry.from_name(camera_name)
     assert str(camera) == camera_name

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -5,6 +5,7 @@ import pytest
 
 def test_guess_optics():
     from ctapipe.instrument import guess_telescope
+
     answer = guess_telescope(1855, 28.0 * u.m)
 
     od = OpticsDescription.from_name(answer.name)
@@ -15,18 +16,26 @@ def test_guess_optics():
 
 def test_construct_optics():
     OpticsDescription(
-        name='test',
+        name="test",
         num_mirrors=1,
         num_mirror_tiles=100,
-        mirror_area=u.Quantity(550, u.m**2),
+        mirror_area=u.Quantity(550, u.m ** 2),
         equivalent_focal_length=u.Quantity(10, u.m),
     )
 
     with pytest.raises(TypeError):
         OpticsDescription(
-            name='test',
+            name="test",
             num_mirrors=1,
             num_mirror_tiles=100,
             mirror_area=550,
             equivalent_focal_length=10,
         )
+
+
+@pytest.mark.parametrize("optics_name", OpticsDescription.get_known_optics_names())
+def test_optics_from_name(optics_name):
+    optics = OpticsDescription.from_name(optics_name)
+    assert optics.equivalent_focal_length > 0
+    # make sure the string rep gives back the name:
+    assert str(optics) == optics_name

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -1,3 +1,4 @@
+""" Tests for OpticsDescriptions"""
 import pytest
 from astropy import units as u
 

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -1,9 +1,11 @@
-from ctapipe.instrument.optics import OpticsDescription
-from astropy import units as u
 import pytest
+from astropy import units as u
+
+from ctapipe.instrument.optics import OpticsDescription
 
 
 def test_guess_optics():
+    """ make sure we can guess an optics type from metadata"""
     from ctapipe.instrument import guess_telescope
 
     answer = guess_telescope(1855, 28.0 * u.m)
@@ -15,6 +17,8 @@ def test_guess_optics():
 
 
 def test_construct_optics():
+    """ create an OpticsDescription and make sure it
+    fails if units are missing """
     OpticsDescription(
         name="test",
         num_mirrors=1,
@@ -35,6 +39,7 @@ def test_construct_optics():
 
 @pytest.mark.parametrize("optics_name", OpticsDescription.get_known_optics_names())
 def test_optics_from_name(optics_name):
+    """ try constructing all by name """
     optics = OpticsDescription.from_name(optics_name)
     assert optics.equivalent_focal_length > 0
     # make sure the string rep gives back the name:

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -1,3 +1,4 @@
+""" Tests for SubarrayDescriptions """
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -11,6 +12,7 @@ from ctapipe.instrument import (
 
 
 def example_subarray(n_tels=10):
+    """ generate a simple subarray for testing purposes """
     pos = {}
     tel = {}
 
@@ -24,6 +26,7 @@ def example_subarray(n_tels=10):
 
 
 def test_subarray_description():
+    """ Test SubarrayDescription functionality """
     n_tels = 10
     sub = example_subarray(n_tels)
     sub.peek()
@@ -58,6 +61,7 @@ def test_subarray_description():
 
 
 def test_to_table(example_event):
+    """ Check that we can generate astropy Tables from the SubarrayDescription """
     sub: SubarrayDescription = example_event.inst.subarray
 
     assert len(sub.to_table(kind="subarray")) == sub.num_tels

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -77,9 +77,9 @@ def test_tel_indexing(example_event):
 
 
 def test_get_tel_ids_for_type(example_event):
-    """ 
+    """
     check that we can get a list of telescope ids by a telescope type, which can
-    be passed by string or TelscopeDescription instance 
+    be passed by string or `TelescopeDescription` instance
     """
     sub: SubarrayDescription = example_event.inst.subarray
 

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -2,30 +2,26 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
-from ctapipe.instrument import (
-    SubarrayDescription,
-    TelescopeDescription,
-)
+from ctapipe.instrument import (CameraGeometry, OpticsDescription,
+                                SubarrayDescription, TelescopeDescription)
 
 
-def test_subarray_description():
+def example_subarray(n_tels=10):
     pos = {}
     tel = {}
-    n_tels = 10
 
     for tel_id in range(1, n_tels + 1):
         tel[tel_id] = TelescopeDescription.from_name(
-            optics_name="MST",
-            camera_name="NectarCam",
+            optics_name="MST", camera_name="NectarCam"
         )
         pos[tel_id] = np.random.uniform(-100, 100, size=3) * u.m
 
-    sub = SubarrayDescription(
-        "test array",
-        tel_positions=pos,
-        tel_descriptions=tel
-    )
+    return SubarrayDescription("test array", tel_positions=pos, tel_descriptions=tel)
 
+
+def test_subarray_description():
+    n_tels = 10
+    sub = example_subarray(n_tels)
     sub.peek()
 
     assert len(sub.telescope_types) == 1
@@ -36,12 +32,14 @@ def test_subarray_description():
     assert sub.tel_ids[0] == 1
     assert sub.tel[1].camera is not None
     assert 0 not in sub.tel  # check that there is no tel 0 (1 is first above)
-    assert len(sub.to_table()) == n_tels
     assert len(sub.camera_types) == 1  # only 1 camera type
-    assert sub.camera_types[0] == 'NectarCam'
+    assert isinstance(sub.camera_types[0], CameraGeometry)
+    assert isinstance(sub.telescope_types[0], TelescopeDescription)
+    assert isinstance(sub.optics_types[0], OpticsDescription)
+    assert len(sub.telescope_types) == 1  # only have one type in this array
+    assert len(sub.optics_types) == 1  # only have one type in this array
+    assert len(sub.camera_types) == 1  # only have one type in this array
     assert sub.optics_types[0].equivalent_focal_length.to_value(u.m) == 16.0
-    assert sub.telescope_types[0] == 'MST:NectarCam'
-    assert sub.tel_coords
     assert isinstance(sub.tel_coords, SkyCoord)
     assert len(sub.tel_coords) == n_tels
 
@@ -51,9 +49,38 @@ def test_subarray_description():
     assert subsub.tel_indices[6] == 3
     assert subsub.tel_ids[3] == 6
 
-    assert len(sub.to_table(kind='optics')) == 1
+    assert len(sub.to_table(kind="optics")) == 1
+    assert sub.telescope_types[0] == sub.tel[1]
 
 
+def test_to_table(example_event):
+    sub: SubarrayDescription = example_event.inst.subarray
 
-if __name__ == '__main__':
-    test_subarray_description()
+    assert len(sub.to_table(kind="subarray")) == sub.num_tels
+    assert len(sub.to_table(kind="optics")) == len(sub.optics_types)
+
+
+def test_tel_indexing(example_event):
+    """ Check that we can convert between telescope_id and telescope_index """
+    sub: SubarrayDescription = example_event.inst.subarray
+
+    assert sub.tel_indices[1] == 0  # first tel_id is in slot 0
+    for tel_id in sub.tel_ids:
+        assert sub.tel_index_array[tel_id] == sub.tel_indices[tel_id]
+
+    assert sub.tel_ids_to_indices(1) == 0
+    assert np.all(sub.tel_ids_to_indices([1, 2, 3]) == np.array([0, 1, 2]))
+
+
+def test_get_tel_ids_for_type(example_event):
+    """ 
+    check that we can get a list of telescope ids by a telescope type, which can
+    be passed by string or TelscopeDescription instance 
+    """
+    sub: SubarrayDescription = example_event.inst.subarray
+
+    types = sub.telescope_types
+
+    for teltype in types:
+        assert len(sub.get_tel_ids_for_type(teltype)) > 0
+        assert len(sub.get_tel_ids_for_type(str(teltype))) > 0

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -2,8 +2,12 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
-from ctapipe.instrument import (CameraGeometry, OpticsDescription,
-                                SubarrayDescription, TelescopeDescription)
+from ctapipe.instrument import (
+    CameraGeometry,
+    OpticsDescription,
+    SubarrayDescription,
+    TelescopeDescription,
+)
 
 
 def example_subarray(n_tels=10):

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -40,4 +40,4 @@ def test_telescope_from_name(optics_name, camera_name):
     assert camera_name in str(tel)
     assert tel.camera.pix_x.shape[0] > 0
     assert tel.optics.equivalent_focal_length.to("m") > 0
-    assert tel.type in ["MST", "SST", "LST", "unknown"]
+    assert tel.type in ["MST", "SST", "LST", "UNKNOWN"]

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -1,22 +1,44 @@
-def test_hash():
-    from ctapipe.instrument.telescope import TelescopeDescription
-    from ctapipe.instrument.optics import OpticsDescription
-    from ctapipe.instrument.camera import CameraGeometry
+import itertools
 
-    types = ['LST', 'MST', 'SST']
-    names = ['LST', 'MST', 'SST-1M']
-    cameras = ['LSTCam', 'FlashCam', 'DigiCam']
+import pytest
+
+from ctapipe.instrument.camera import CameraGeometry
+from ctapipe.instrument.optics import OpticsDescription
+from ctapipe.instrument.telescope import TelescopeDescription
+
+
+def test_hash():
+
+    types = ["LST", "MST", "SST"]
+    names = ["LST", "MST", "SST-1M"]
+    cameras = ["LSTCam", "FlashCam", "DigiCam"]
 
     telescopes = []
     for name, type, camera in zip(names, types, cameras):
         for i in range(3):
 
-            telescopes.append(TelescopeDescription(
-                name=name,
-                type=type,
-                optics=OpticsDescription.from_name(name),
-                camera=CameraGeometry.from_name(camera)
-            ))
+            telescopes.append(
+                TelescopeDescription(
+                    name=name,
+                    type=type,
+                    optics=OpticsDescription.from_name(name),
+                    camera=CameraGeometry.from_name(camera),
+                )
+            )
 
     assert len(telescopes) == 9
     assert len(set(telescopes)) == 3
+
+
+optics_names = OpticsDescription.get_known_optics_names()
+camera_names = CameraGeometry.get_known_camera_names()
+
+@pytest.mark.parametrize("camera_name", camera_names)
+@pytest.mark.parametrize("optics_name", optics_names)
+def test_telescope_from_name(optics_name, camera_name):
+    tel = TelescopeDescription.from_name(optics_name, camera_name)
+    assert optics_name in str(tel)
+    assert camera_name in str(tel)
+    assert tel.camera.pix_x.shape[0] > 0
+    assert tel.optics.equivalent_focal_length.to("m") > 0
+    assert tel.type in ['MST', 'SST', 'LST', 'unknown']

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -16,12 +16,9 @@ def test_hash():
         for i in range(3):
 
             telescopes.append(
-                TelescopeDescription(
-                    name=name,
-                    type=type,
-                    optics=OpticsDescription.from_name(name),
-                    camera=CameraGeometry.from_name(camera),
-                )
+                TelescopeDescription(name=name, tel_type=type,
+                                     optics=OpticsDescription.from_name(name),
+                                     camera=CameraGeometry.from_name(camera))
             )
 
     assert len(telescopes) == 9

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -1,5 +1,3 @@
-import itertools
-
 import pytest
 
 from ctapipe.instrument.camera import CameraGeometry
@@ -33,6 +31,7 @@ def test_hash():
 optics_names = OpticsDescription.get_known_optics_names()
 camera_names = CameraGeometry.get_known_camera_names()
 
+
 @pytest.mark.parametrize("camera_name", camera_names)
 @pytest.mark.parametrize("optics_name", optics_names)
 def test_telescope_from_name(optics_name, camera_name):
@@ -41,4 +40,4 @@ def test_telescope_from_name(optics_name, camera_name):
     assert camera_name in str(tel)
     assert tel.camera.pix_x.shape[0] > 0
     assert tel.optics.equivalent_focal_length.to("m") > 0
-    assert tel.type in ['MST', 'SST', 'LST', 'unknown']
+    assert tel.type in ["MST", "SST", "LST", "unknown"]

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -1,3 +1,4 @@
+""" Tests for TelescopeDescriptions """
 import pytest
 
 from ctapipe.instrument.camera import CameraGeometry
@@ -25,13 +26,14 @@ def test_hash():
     assert len(set(telescopes)) == 3
 
 
-optics_names = OpticsDescription.get_known_optics_names()
-camera_names = CameraGeometry.get_known_camera_names()
+OPTICS_NAMES = OpticsDescription.get_known_optics_names()
+CAMERA_NAMES = CameraGeometry.get_known_camera_names()
 
 
-@pytest.mark.parametrize("camera_name", camera_names)
-@pytest.mark.parametrize("optics_name", optics_names)
+@pytest.mark.parametrize("camera_name", CAMERA_NAMES)
+@pytest.mark.parametrize("optics_name", OPTICS_NAMES)
 def test_telescope_from_name(optics_name, camera_name):
+    """ Check we can construct all telescopes from their names """
     tel = TelescopeDescription.from_name(optics_name, camera_name)
     assert optics_name in str(tel)
     assert camera_name in str(tel)

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -247,7 +247,5 @@ class HESSIOEventSource(EventSource):
             num_mirror_tiles=num_tiles,
         )
 
-        return TelescopeDescription(
-            name=telescope.name, type=telescope.type,
-            camera=camera, optics=optics,
-        )
+        return TelescopeDescription(name=telescope.name, tel_type=telescope.type,
+                                    optics=optics, camera=camera)

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -135,12 +135,9 @@ class SimTelEventSource(EventSource):
                 num_mirror_tiles=cam_settings['n_mirrors'],
             )
 
-            tel_descriptions[tel_id] = TelescopeDescription(
-                name=telescope.name,
-                type=telescope.type,
-                camera=camera,
-                optics=optics,
-            )
+            tel_descriptions[tel_id] = TelescopeDescription(name=telescope.name,
+                                                            tel_type=telescope.type,
+                                                            optics=optics, camera=camera)
 
             tel_idx = np.where(header['tel_id'] == tel_id)[0][0]
             tel_positions[tel_id] = header['tel_pos'][tel_idx] * u.m

--- a/docs/examples/InstrumentDescription.ipynb
+++ b/docs/examples/InstrumentDescription.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,25 +43,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : MonteCarloArray\n",
-      "Num Tels : 98\n",
-      "Footprint: 4.92 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "      LST_LST_LSTCam    4    1 ..   4\n",
-      "    MST_MST_FlashCam   25    5 ..  29\n",
-      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray = event.inst.subarray\n",
     "\n",
@@ -70,72 +54,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=98</i>\n",
-       "<table id=\"table48025685576\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>tel_id</th><th>pos_x</th><th>pos_y</th><th>pos_z</th><th>name</th><th>type</th><th>num_mirrors</th><th>camera_type</th><th>tel_description</th></tr></thead>\n",
-       "<thead><tr><th></th><th>m</th><th>m</th><th>m</th><th></th><th></th><th></th><th></th><th></th></tr></thead>\n",
-       "<thead><tr><th>int16</th><th>float64</th><th>float64</th><th>float64</th><th>str5</th><th>str3</th><th>int64</th><th>str8</th><th>str18</th></tr></thead>\n",
-       "<tr><td>1</td><td>-20.0</td><td>65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>2</td><td>-20.0</td><td>-65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>3</td><td>80.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>4</td><td>-120.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>5</td><td>0.0</td><td>0.0</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>6</td><td>0.0</td><td>151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>7</td><td>0.0</td><td>-151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>8</td><td>146.65599060058594</td><td>75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>9</td><td>146.65599060058594</td><td>-75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>89</td><td>956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>90</td><td>956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>91</td><td>-239.19699096679688</td><td>1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>92</td><td>-239.19699096679688</td><td>-1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>93</td><td>-956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>94</td><td>-956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>95</td><td>1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>96</td><td>1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>97</td><td>-1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>98</td><td>-1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=98>\n",
-       "tel_id        pos_x        ... camera_type  tel_description  \n",
-       "                m          ...                               \n",
-       "int16        float64       ...     str8          str18       \n",
-       "------ ------------------- ... ----------- ------------------\n",
-       "     1               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     2               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     3                80.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     4              -120.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     5                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
-       "     6                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
-       "     7                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
-       "     8  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
-       "     9  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
-       "   ...                 ... ...         ...                ...\n",
-       "    89   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    90   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    91 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    92 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    93  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    94  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    95  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    96  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    97 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    98 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.to_table()"
    ]
@@ -149,38 +70,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=3</i>\n",
-       "<table id=\"table48031953864\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>description</th><th>name</th><th>type</th><th>mirror_area</th><th>num_mirrors</th><th>num_mirror_tiles</th><th>equivalent_focal_length</th></tr></thead>\n",
-       "<thead><tr><th></th><th></th><th></th><th>m2</th><th></th><th></th><th>m</th></tr></thead>\n",
-       "<thead><tr><th>str18</th><th>str5</th><th>str3</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>MST_MST_FlashCam</td><td>MST</td><td>MST</td><td>103.83055877685547</td><td>1</td><td>84</td><td>16.0</td></tr>\n",
-       "<tr><td>SST_ASTRI_ASTRICam</td><td>ASTRI</td><td>SST</td><td>14.562566757202148</td><td>2</td><td>2</td><td>2.1500000953674316</td></tr>\n",
-       "<tr><td>LST_LST_LSTCam</td><td>LST</td><td>LST</td><td>386.7332458496094</td><td>1</td><td>198</td><td>28.0</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=3>\n",
-       "   description      name type ... num_mirror_tiles equivalent_focal_length\n",
-       "                              ...                             m           \n",
-       "      str18         str5 str3 ...      int64               float64        \n",
-       "------------------ ----- ---- ... ---------------- -----------------------\n",
-       "  MST_MST_FlashCam   MST  MST ...               84                    16.0\n",
-       "SST_ASTRI_ASTRICam ASTRI  SST ...                2      2.1500000953674316\n",
-       "    LST_LST_LSTCam   LST  LST ...              198                    28.0"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.to_table(kind='optics')"
    ]
@@ -194,23 +86,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : SCTels\n",
-      "Num Tels : 69\n",
-      "Footprint: 4.92 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tab = subarray.to_table()\n",
     "sc_tels = tab[tab['num_mirrors'] == 2]['tel_id']  # select tel_id of entries where the mirror type is SC\n",
@@ -227,24 +105,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : SCTels\n",
-      "Num Tels : 29\n",
-      "Footprint: 1.06 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "      LST_LST_LSTCam    4    1 ..   4\n",
-      "    MST_MST_FlashCam   25    5 ..  29\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "gtab = tab.group_by('num_mirrors')\n",
     "sc = gtab.groups[0]\n",
@@ -261,20 +124,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel = subarray.tel[5]\n",
     "tel"
@@ -282,142 +134,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$103.83056 \\; \\mathrm{m^{2}}$"
-      ],
-      "text/plain": [
-       "<Quantity 103.83055878 m2>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.optics.mirror_area"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "84"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.optics.num_mirror_tiles"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$16 \\; \\mathrm{m}$"
-      ],
-      "text/plain": [
-       "<Quantity 16. m>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.optics.equivalent_focal_length"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.camera"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[-0.028867999,~-0.072168998,~0.057735,~\\dots,~-0.54848301,~-0.50518101,~-0.54848301] \\; \\mathrm{m}$"
-      ],
-      "text/plain": [
-       "<Quantity [-0.028868  , -0.072169  ,  0.057735  , ..., -0.54848301,\n",
-       "           -0.50518101, -0.54848301] m>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.camera.pix_x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb2f419080>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsnXeYVdW5/z/r9N7P9N47M8PA0HvvXXoXERETTYwmGrFEY6JGjTFG0343vd7E1JvE1JubYjSKFUE6DAwM03vZvz9OYe+zN0KMCpj9fR54OOdz9tn7nBn2u961vut9hSRJ6NKlS5cuXRcjw6W+AF26dOnSdeVIDxq6dOnSpeuipQcNXbp06dJ10dKDhi5dunTpumjpQUOXLl26dF209KChS5cuXbouWnrQ0KVLJiFEjhBCEkKY/s33OSSEmPZOXZcuXZeL9KCh6z9W0Rt7txCiI/YHSHuPzu0RQjwshDgSPff+6OPQe3F+XbrervSgoes/XfMlSXLF/gAn3u0TCiEswDNAOTAL8ABjgCZg5Lt9fl26/h3pQUOXrreQEGKTEOI1IUS7EOKAEOIaGQsJIX4qhGgRQpwVQvxJCCH/P1UthNgjhGgVQnxHCGGLPr8eyAIWS5L0qiRJQ5IkNUqSdLckST+PvvctQog3o+d9VQixWHbejUKIPwshPhM99wEhxJjo80eFEI1CiA3vxfej6z9PetDQpeut1QjMI5INbAI+I4SojbKbgGNAGEgGPgrI6/KsIJJJ5AJVwMbo89OAX0qS1PEW530TGA94gTuBrwshUmW8HtgDBIFvAt8GRgAFwFrgMSGE61//uLp0vbX0oKHrP10/io7WW4QQP0qEkiT9TJKkN6WI/gD8isjNHKAfSAWyJUnqlyTpT5KymNujkiSdkCTpLPAToDr6fBBoeKuLkiTpe9FjhyRJ+g6wD+XU1UFJkr4iSdIg8B0gE7hLkqReSZJ+BfQRCSC6dL2j0oOGrv90LZIkyRf9sygRCiFmCyH+Gp1+agHmALHF6k8D+4FfRaeIbkk4/KTs311AbOTfRCTYnFdCiPVCiBdiAQ2okJ0X4JTs390AkiQlPqdnGrrecelBQ5eu80gIYQV+ADwAJEuS5AN+DggASZLaJUm6SZKkPGA+cKMQYupFvPVvgJlCCOd5zpsNPAXsBILR874cO68uXZdSetDQpev8sgBW4DQwIISYDcyIQSHEPCFEgRBCAG3AYPTPhfQ14CjwAyFEiRDCIIQICiE+KoSYAziJrI2cjp5nE5FMQ5euSy49aOjSdR5JktQO7AK+CzQDq4GnZS8pJJI1dAB/AR6XJOn3F/G+vUQWw18Hfk0k4PydyPTT3yRJehV4MPqep4BK4M/vyIfSpevflNCbMOnSpUuXrouVnmno0qVLl66Llh40dOnSpUvXRUsPGrp06dKl66KlBw1dunTp0nXR+rfKP1+OCoVCUk5OzqW+DF26dOm6ovTcc8+dkSQpfKHXve+CRk5ODv/4xz8u9WXo0qVL1xUlIcThi3mdPj2lS5cuXbouWnrQ0KVLly5dFy09aOjSpUuXrouWHjR06dKlS9dFSw8aunTp0qXroqUHDV26dOnSddHSg4YuXbp06bpo6UFDly5dunRdtPSgoeuy1pnjTTxy7ZP89afPafKmhmYeve6L/PlHf9fkzada+OzOL/KnH/xVk7ecbuVzu77M77+j3a6iramdxz/wFX77zT9p8vbmDp648av8+r/+gFabgY6WTp788H/xy6/8TpN3tnXx1Ee+zs+f+g1DQ0Mq3tXezZc++k1+8sSvNHl3Zw9fvf3b/OixXzA4qO7/1NPVy/+74zv88JGfMTig5r3dvXz97u/z/Yd+wkD/gIr39fTxzXt/yHc+9WP6+/rVvLefb9//I75133/T16vmut5/et/106irq5P0HeHvD/3yK7/jc7u+RE9nLwAjZlVz148/gskcKWTwm6//kUd3PEV3Rw8AtdMqufvpW7DYLAD87tt/5uFrvkBXezcA1ZPLuevpW7A7bQD86Qd/5cGtn6eztQuAyvGl3PPTW3G47QD834+f5YHNn6O9uROA8rHF3POTW3H5Il1a//az5/jUxs/R1tQOQEl9IZ/46a14gm4Anv2fF7h/3aO0nonworp87vnprfiTvAD887cvce/qR2hpbAWgoCaXe356K8FUPwB7/vgqn1j5Gc6ebAEgb1g2dz99C0mZkVbhr/zfXu5e8SBNJ5oByKnI5O6nbyElJwmA1/++j7uWPcjpY00AZJWmc/fTt5CWnwLAvucPcOfSBzh1+DQAmcVp3Pmjm8ksTgfgzRcPsXvJpzl5sBGAtIIU7vrRzWSXZQJw6JWj3LHofk68GWlNnpqXzO4ffpi8qux/+Wet69JLCPGcJEl1F3rd+66MiK4rX//41YuU1hfw/G9ejAcMgGd/+QJ9Pf28+PtXKB5RwPPP7IkHDIDnf/MS3R09vPy/r1NQm8sLv30pHjAAXvjdK3S2dvH63/aRV5XNC797OR4wAF7602u0NbWz77kDZJVlsOcPr8QDBsArf95LS2MrB/YcJqMoNf76mF7/2z6aGpo58toxUvKSeeXPr8cDBsAb/3iTM8eaOLH/JElZIV79vzfiAQNg/z8PcurwaRqPnCGY6uP1v+2LBwyAAy8e5uTBRppPtuANe9j77P54wAA49PJRTuw/SVtTOy6fk33PHYgHDIAjrx3n6N4TdLV3Y3Pa4ueL6ejeExx57Tj9vQOYLCYO7DkcDxgAJ/af5NDLR5EkEAIOvXwkHjAAGg6c4sCew3rQeJ9LDxq6Lhsd2HOYz93wZfb84VV8SV6Ss0Oq19w+/5Ps+eOreENuUqMjZrnuXvEQL/7+FdwBF5nFaSp+/7rP8sLvXsblc5JdnqHiD279PC/89mUcHjv5w9Q3v0ev+yL/fOYlHG47BbW5Kv7EjV/l+d+8hN1lo6guX8W/eOs3eP7Xe7A5rJTUF6r4f+3+Ds/9ag9Wu4XyMcUq/s17f8jzv96D2WqiYlypin/vgad57td7MFlMVE1Q8/9+9Of88zd7MJqMVE0qV/GfPvErnn/mJQwGwbDJ6rbkv/zyb3n+mZcQQlAzRW9b/p+oSzo9JYT4MjAPaJQkSfUbKIQQwCPAHKAL2ChJ0vNv9Z769NSVq3tWPsQfvvsXxXPekJvWM+0IIUjJDdNwoFHJwx5aT7cBkemRhgOnFNyX5I2P5tPykxUjYwB/spfmU+fngVQfZxsio/20ghRO7D+p4KE0P2eio31Nnh7gzPGz5+cZQc5Es4H0whSO71PypMwgjUebznt8UlaIxiNnzsuTs0OcOvwWPCfMqUOnz/v5U3KT4tmG1vebmpcU/5kUDs/jo9+4gYwidbDWdfnrYqenLvVC+FeBWW/BZwOF0T/bgM+/B9ek6zLSoutnY7GZqZ5STp7GyH/R9bOx2i1UTSijUGPkv3DnLKwOKxVjSygeUaDiC66bhc0ZGfWXjVaP7BdcOzOSNYzIp3JciYrP3T4Dh8dOQU0u1Roj97nXTMfpdZBblc3waVUqPufqqZGspyyDupnVKj5ry9RI1lSSzqh5w9V88xQ8ITfpBSmMXqD+/z594yR8SV5S85IZt6RezddPxJ/iIzk7zPhlo1R8yprxBNP8hDODTFo5VsUnrxxLKCNAKD3AlntX6wHjP0CXfCFcCJED/PQ8mcYXgN9LkvSt6OO9wCRJkhrO9356pnHl6qmbv8Z3H3g6/tjmsNLTdW5Nw2gyKhxAVoeF3q6++GOD0cDQ4DmHkdVuobf77XOL3UKfnBsEQ0Pn/r9YbGb6es45hoRBIMm42Wam/6241Uy/zHEUSawlYv8lzVYT/b0yR5MAAXFuspgY6Evg4tw5zBYT/X1KR5T8MxrNRgb7B8/PE77vyHMGBgeGVP+OafcPP8zYRSPRdeXpSsk0LqR04Kjs8bHoc7reh7r6U+v4wBPbcPocjF00kpFzaxV8cGCQnZ/dgsvvpH5urermNDQ4xM7HIrxuZjXjl4/S5O6Ai9ppVUxePU7Fr39sC56gm+pJ5czYMFHJhyR2PrYZb9hD5fhSZm+ZquDSkMTOx7bgS/JQNrqIedunq/lnN+NP9lIysoBF1yuTbEmS2PHIZgKpfgqH57HsxvnKL0iCaz+ziVB6gPzqHK66eaGKb39wA+HMILmVWaz66GKN73gtydlhssoyWPfxZSq+9f41pOQmkVmSxoa7rlLxTfesIq0ghbSCFDbds0rF25ra+ert3+ZLt36D7o5uFdd15etyzzR+BtwnSdL/Rh8/A9wsSdJzCa/bRmT6iqysrOGHD19ULxFdl5l+9NgvePJD/xUfHcvXK2KSj859SR5aGhP5udG5L+yhJeF4eXagdbzVZqG3p++855dnP1rvL+dax9tdtrjjS4s73Da62qM85KH1TAL32Olq645yt8KdBeD02OmMck/QrXB3ATh9Djpbus7LXT4nHS0Rx5g74KL9bIeCu/3OuKNM/u84lx0TSPVz148/QrGGIUDX5af3S6ZxDMiUPc4ATiS+SJKkJyVJqpMkqS4cvmC3Ql2XkYaGhvjj9/9C65k2Xv7f1xTTKa2n25i+fiJCQGZJGjVTKxXTOS2NbczYMBFhEKQXpjJ8RpViOqfldBszNkxCGARp+cmMnF2jmE5qaWxjxsZJGIwGknPC1M+rjQeM2PlnRnlSVojRC+oU02Utp9uYtWkyRpORUEaQsYtHKnjr6TZmbpqM0WwkkOpj/NJRCotwa/R4k8WEP9nLxBWj4wEDoPVMG7M2TcFsMeENe5i0cmw8YER4OzM3TsZiM+MJupm8alw8YEBk1D9z4yQsdgtuv5Opa8bHA0aMz9gwCZvTitPnYNq6CfGAAdB+tiPOHW4b09dNVASJ9uZOpq+biMNtw+6yMWPDJEWQOdvQzOFX5BMFut4Putwtt08DO4UQ3wbqgda3Ws/QdWXp1b++wWM7v8i+5w/i8jk1LbaHXonsC2g60YzVYdXmQxJnG5pxeuwqfvjVYxF+sgV3wKXJhwaHaDnVSmt0051cR14/ztDgEK2n2xR7KuLHv36cwYFBWk+30nyqRcWP7T3BYP8gbU0dnG1oVvGjb5xgoG+AtqZ2xZ6L+PH7TtDfN0BHc2fchSXX8Tcb6OvpZ6B/kDPHm1T8xIFT9HX3MdA3QOPRMyrecPAUPZ29CAGNh9X85MFGerv6EALFno44P9xId0dv/LW63v+61JbbbwGTgBBwCrgDMANIkvRE1HL7GBGHVRewSZKkt1zl1hfCrxzdtfwB/vSDvymei1lUjSYjqblJHNunHCOEMgKcOXYWg9FAWkEKx/YqE8+YRdUQzT6OJvKoRdVgEGQUpXHk9eMKHrOgCiHILEnjyGtKHrOgCiHIKk3n8KvHFFxuS80uy1Bxue01uzxTNRKX226zyzM4/Iry+IzCFI7tO//xmcVp8c+sdf4L8azS9PhnvhDPKsvgSCKXPVc5vpQPf+U6UvOS0XX564qYnpIkaZUkSamSJJklScqQJOlLkiQ9IUnSE1EuSZJ0nSRJ+ZIkVV4oYOi68jV17QRMZiNlo4tIL1Jv3pu2dgImi4mSkQVklqjtnVPWTMBsNVNYl09Oeaaarx6PxWYmvzqH3KosNV81DqvdQm5VFgU1agvvpKvGYnVYyS7PoHB4ngYfg81lI6s0nZKRaovvhGWjsbtsZBSlUjaqSMXHLx2Fw+MgLT+FSo3Ne+OWjsLlc5KSm8SwiWUqPmbRCNwBF0lZIWqmVqr5whF4gm7CGUFqp6stwPVzh+MNewim+Rk+c5iaz6nFn+wlkOKjfnaNio+YWU0g1Yc37GHxrjl6wHgf6pIvhL/T0jONK0dfue1bfPPeH8Yf2902umVz+gaDQVGkz+620y0rC5JoYZUvMl8UF0JRRFCLyy2wNpeNHhlPtMDanFZF2ZNEC6yKo7S4Wh1WeruU3Gg0MBjjCRZhUNpiNbnMVptoEQYwmY0MRHmiBRiUtl6VBRilrVjr+I996wNMukq9v0PX5acrItPQ9Z+tTfes4gNf2IbL72T80nrqZihHtkNDQ+x6fCvugIsxC0dQn2DBlYYkbvj81XiCLurnDmfs4pEqvuvzV+MJuqmbWc3EFaOVXIpwb9hN7bRKpiRYcCVJYtfjV+NL8lA9uZwZGyYpP4AE1z++FX+yN2LB3TpVzR/bSiDFR9mYYuZfO0P1Hex4ZBPBND8lIwtYsmuOil/7yCZCGYGIBfem+Wr+0AbCmaGIBfcjC1X8mgfWk5wdJrcyi9W3LVXxrfevJSU3ieyyDNbdobbgbrl3NWkFKWQWp7HxrpUqvuHOq8goTiO9MIVNn1DzWBXgR3c8pXKC6boypWcaui6Zvv3J/+Yrt30rvmHO5XfSIbdwJozUVRbPC3GUI3ktLt+gpjo/ypG4NjfFS4rL7apxLhupu3wOOmTuJVCO/uV2WE3udSgKLIIyu3B4HHS1JXDZBki5HTcmefbjcNsVBR4TeWImmPhcYqYWec9zFmKXz8ndT39Es2aWrksvPdPQdVlqoH+AX375t5w53sQbz72p2GHd0dzJ/GtnYDAaKKjJZfj0KsX0UntzJ/N3zMRgNJBXlc2IWdWa3GgykFOeyah5wxU7vNubO1lw3UyMZiOZJemMWThCsaO5o7mTBdfNwmQ2kl6Yyvgl9fGAEeMLd87CbDWRlp/MxOWjFT0oOlpi3ExyTphJK8cqdmx3tHSxcOcsLDYzSVkhpq4er5gu6oxyq8NCKD3A9PUTlby1iwXXzcTmsBJM9TNjwyTFdFRXWxcLdkTKnvhTfMzaPFmxY76zrZv510bKnnjDHmZvmaKYLutq72be9hk4vQ48QTdzrp6m4N3tPczdNh2X34nL72TutumKINLd0cOcqyNlT5xeB/O2z1BYiDtaOjn2hm5+vNJ1uVtudb2P9PwzL/HZ657i2BsN2JxWkrPVe2pe+N0rDA0OcfT14wz0qxdRX/ztyxG+97hmU6M9v3+FwYEhju1rwGBSj4le/P0rDPYP0vDmSSw2s4q/9MdXGegf5OTBU9hdNjX/w6v09w5w8tBpnF6Hir/8v6/T39tP45Ez8b4aibyvp5/TR89w9A3VliNe+b+99Hb10dd9liOvHVPx1/66j56uXnq6ejmswV//+366O3ro7ujh4EvqPRJ7n90f3evRzYGXjqj4G/94M57NvPnCIRXf/8+D8Wxr/wsHVfzNFw7F92rse+5NFdd15UvPNHS9Z3r6c7+IjzR7Ons5/OoxUvMiDYMsNjNZpRkcjVpge7v7OPTyUdIKIg4qs9VMdnlG3CLb3zvAwZeOkF6YCkSmkXIrsuIW0YG+AQ68eDheHt1oMpBbmRW3sA70D/LmC4fIKolUpTEYDeQNy+Zg9EY6ODDE/n8eJLssUj5dGAT5w3LiN9qhwSH2PS/jAvKrc+M3WmlIYt9zB8ipyIzzghoZlyI36NzKcw6uwtpc9j9/MM73PvumojdFYW0e+547EH+89+/7yR+Wc44Pz+ONf5y7Ue99dj/51Yk84XgVVx4vd5AVDs9j77P7FcfLy8MX1uay91n58W8qikiOmFWt6ejSdWVJDxq6Lqnq5w2P3rBzCGcG1HxObfyGn5SlzkxGzqnBaDaSU5FJSo6aj5hVjcliIqssg7R8deYyfOYwTBYTmSVppBekqvmMYZitZjKKUsks1uYWm5m0ghSyStVl0WqnVWG1W0jJS9a0ANdMrcTmsJKcE9ZsXjRscgV2l42krJDiBh9T1cQy7G47ofSApkW4cnwpTo+DQKqfIg2LcMW4Elw+J74kL8Uj1OU+yscU4w648IY8lGr0/yitL8ITdOMOuCjVqBJcPLIQb9iDy+dkwvIxJGWpN3DqurKkL4Tres/0tbu+x9fu/F58Wilx4TfRApu4cJxogVUtLCcsjKsWli/EUS6cay08yxfOtbh84VxeJ+ocP7dwrsXltlathWmL1Rzvxa21MC23wGotTMsX1rW4fGFdyyIsf+7t8Ju/upPp65WFIHVdHtIXwnVddlr38eXsenwrLr+TiSvGUD1JWaMyYoHdhjvgYtziempnVKn549vwBF2MXjCCkXOUFlwkuOHxiMV25Jxaxi4cqcm9ITd1M4cxQaN/xM7HtuANe6iZUqGy4ALs/OwW/MleqiaWMX2D+ua349FNBFJ8VIwtUVtwgR2PbCSQ6qdUowouwPaHNhJKD1A8Ip9Fu9StZq55cD3hzCCFtXks++A8Fd/2qXUkZ4fJG5bNisQquMCWT0aq2OZUZLLqVnUV3I2fWEVafgrZZRms0aiCu373CjKKUskoTmP97hUqvvb2ZWSVpJNekKJp0W1v7uDha77AfWsfUbSi1XXlSM80dL1n+urt3+Ybn/hB/HHiSDtxM96/zAXAuWxFzZWZitZIX55pqEb6CZlK4mZDUGYiWpmAgmuM9OWZimozIcrNelojebnFV4vLN+BpbSaUZyJamwXl3GKz0NeTwO1m+rr7Va+NSW4Btjms3Pnjj1Crr3NcFtIzDV2XhXq6evnhIz+j4cApDr2idOt0tXWz7Kb5GE0GyseWMDxhc19XWzfLPzQfk9lI6agiRs6pUR//oQWYzCaKR+QzesEIxfRWV1s3K25eiNlqpqAml3GLRyIfI3W1dbP8wwswW83kVWUzacUYhUW3q72bq25eiMVuIac8kykrxymCVnd7Nys+vBCr3UJmSRrT1k1QWHi723tYcfNCbE4r6YWpzNw4Wck7eljx4QXYXTbS8pOZvXWqwuLb09HDig8twOG2k5KTxNxt0xRNk3o6e1l203ycHjvhzBDzr52hsPj2dPay/Kb5uHxOQhkBFl43S7Fju7erl6UfnIc74CKQ6mPR9bMVN/ne7j6WfmAu3pAbX7KXxTfMVfC+nj4W75qDL8mLL+xhyQfmxgNGhPez6PrZ+FN8eIIult04X2EB7unq5WRC+1hdl7+Mu3fvvtTX8I7qySef3L1t27ZLfRm6gP97+lk+Nude/vC9v/DTL/ya/r5+VX+GM8fP0tHcScupFkCirUnJm4430362I8qhLaF/xNmGZtqa2qN9MSRVf4mzDc20nmmP971I7F/RcqqV1tNttJ5uQ5JQ9cdoaWyLvOZMG5IkqfpvtJxpo/lUK+1NHUhDkqoSbuuZds42tNB+tiNSTTeBt53toOlEM+3NnQwNDMX7lcfU3twR+Y5aOhnsH1TxztYuTh87S1dbFwN9A2re1sXpo010tXXT39uv4t0d3TQePkN3Rw+9PX20JPCezl5OHjpNT2cvvV29quvv7erl5MHGiA24U4N399Fw4BS93X10tXervr/R8+s0a3jpeu915513NuzevfvJC71OzzR0vWv6xZeeic9b9/f2c3zfybhF1e62kVuZReORSDnu/r4Bju1tILciYkG1Oa3kDcuOl+Me6B/k6Osn4g4jq8NCfnVOvBz34MAgR147HregWu0WCmtzaTgQ4UODQxx+9Rj5UYeR2WqiaHgeJ96MVIwdGpI49MpRCmojNzCTJZK9HI9W2ZUkOPTy0bgDyWQ2UjKygONvxLjEwZeOUBRtOGQ0GSipL1RU4T340pF4n3KD0UDpqMK4xRjgwJ7DlNRHuDAIykYXKarsHthzmNJRhTJerKhCe2DPYUpHR4ogChFxPsmr5B7Yc5iyMeccTuVjijn08rm9HAf3HFHyscVxC3Ls+svHvjUvG1McnQaE8jFFCn7o5aOUjSmK8/FL61XZo67LX3rQ0PWeqnRUIUII0vJT8ATV/S2KRxYgDILUvGS8Yc95eUpOEr5kdf+LohH5GIwGwlkh/Mk+9fHD86JNlcIEUv3q4+vyMJqMhDOCBNPUFuCC2jyMZiPBtAChdDUvrM3FZDERSPWTlBlU8fzqHMxWM4EUH8nZSSqeV5WDxWbGn+wjJUfNcyuzsdot+MIeUvM1eHkmVocVT9CtaTHOLsvA7rLhDrjie1zkyipNx+624/I7ydDgmcXpODx2nF5HfA+Mghel4fTasbvtZJVkqHhGYRouvwOb00bF2FJ8Gj1MdF3e0hfCdb1r+vYn/5uv3P7t+DqBJ+hSTj+JaCXbOFe3H5UvHF+Qh9yq6Sv5wrAWl1tctd5fbnHV5LLFXk0uWxjWap8qbw+ryWWL2VpcvpiuVRtLvhivxeVmAK3aWHKuZVGW2461LMjyY7SMBzc+tV3Va13XpZG+EK7rkmvlLYu59jMbcfkcTLxqDOVjSpQvkOC6RzfFq9wOm6TuD3HdI5tx+Z2MWTBCs//DdY9uxh1wUT+3lhGz1FMdOx7eiCfoom7GMMYsUP9/2P7QJjwhN7VTKxm3tF7Fr/nMBrxhD8MmlTNp5Rg1f3ADviQvFeNKmLp2vJo/sAF/io+y0cXM3DRZxbd+ai2BVD8lIwqYu01twd1y3xpC6ZEqt/N3zFTxTZ9YSTgzSF51tmaV3I13rSQpO0RuZRbLblRXyV13x3JScpPIKstguYZFd+3ty+JVblfdorborrp1CRlFqaQXprBGo4ruVR9eSFZpOql5yay/Y7mKt51t55PrHuW2+fdxTKOsiq7LT3qmoetd0+c/+FV++MjP4o8TLaDyLEGLy+2v7wo3CEXBRPmoH9QWX7ldFNSbERMtqokWX6vdTK/MXZTYj0NlUU2w+Mo37ml9Rq1+F/J+HJpc9jMwW0yKHu2gtADLszYtLu/tEeeyY+R24Zjk12QyG9n9ww9TP3c4ut576ZmGrkuijpZOvn739zn86lFOHDipYD2dvay9fRkmi4nhM6qonValyc1WM9VTKlSLpD2dvaz7+HIsNjOVE0oZnZA59HT2svbjy7HYLZSPLWZcQn+Nns5e1t2xHKvDQkl9IRNXKDOHnq4ItzmtFNXlMXW1MnPo7epj3R3Lsbts5NfkMCNhc19vdx/r7liGw20ntzKLWVumKCy+vd39rLtjOU6vg+yyDOZtm6HgfT39rP34Mlw+J5nFaSzcMUsRtPp7+ll7+zLcARdpBSks3jVHERT7ewdYc9tSPCE3KblJLP3gvHjAiPFVH12CL+whOTvM8g/NVwTt/r4BVt66GF+yl3BmkKtuXqiwAA/0DXDVRxYRTPMTTPOz8pZFCj44MMh6lW4KAAAgAElEQVSKmxcSyggQSPGx6tbFiiAz2D/I8pvmk5QVwpfkZfXHliiC2ED/II1H9Q1/l7v0TEPXO6bffut/efyGL9N6pj2ymJwZ4OTB04rXeMMeWk+3YTAaSM4Oxd1NMfmSPLQ0tmEwCJJzk2h4U+nj96f4aD7ZgsEgSMlLjvfbjimY6qepoTmy2F6QHO+3HVOsB3mEp8TdUYkcIKMoVVXKO5wZ5HT0xqbFYz3IATKK01Q9zJOzw3FHmLxfd0wpOWFOHjo/l/cg1+T5yfHvTIvLe5RrXf+FeHphavw7k/87Jvkx8n7n8eOLUuOOM/m5Ytr1+NXM365uVqXr3Zeeaeh6z/XMN/4Y3ycxODDIqUNn4kXwvCE3+cNy4vskhgaHaDjQGLeYugMuCmtz4z7+oSGJhjdPxS2mLp+Dorp8mk+2xPmJ/Scpi1pMnV4HJSMLaGpoBiIW2OP7TsYtona3jdJRRfGAEOENVIyLcpeNsjHnOMCxNxqonBBpGGR1WCgfWxIPGDFeFeN2C5XjS+MBA+DY3hMMm1QOEM+OYgED4KiMm60mhk0qjweMGK+eEuEms5Fhk8rjASORG00GqqdUKILs0b0nqJkaKdViMEa4/CZ97I0GqmW8RoPXTKlEGESET61UBInj+xqonlKBMAiEQVAztUIRZI7vO0n1lAoMRkOUV8YDBsCJ/SepnlyB0WRECMH09RNV2aGuy0960ND1rkmSpHjPDG/Yi81lVb0mZiv1hjzYNPpXJOckIQR4Qh7s7vNzd8CFw21X8+wwwiDwBNw4NI5Pyopwl9+J06Puj5GUGcJgELh8Tlwa/TNCmSEMRgNOrwOnT4OnBzCaDDg8Djx+dX+NUHoAo9mIw23HHVBbkIOpAUwWE3a3HU9IfXwwNYDZYsLusmv27/Cn+DFbzdhdNnwaFuZAsg+L3YLNYcUbVttf/cleLFZzxAasYY/1J3mx2ixYbRb8SWqLsy/sxWq3YLaY8KeouTfsweqI8NTcZBwe9c9Q1+UlfXpK1zumH3zmp3zp1m/EF1N9yV7VDmN57SN/sle1Q1m+MKrF5YvFsakqueSL0VpcvtityWWL5VpcbnHV5LJ6VFpcbjv1J/toPqXkctuq1ueXt5TV4vKWtrGpPgWX2Xa1uNw2HJtKVHCZbdkb8qj6fsuf07I4+8Ke+K57LYvyDZ/fxrxr1C4yXe++9OkpXe+5ln5wHpvuXYXDbWfiijGKBjwxXX3/GhweO+OXjopPPSn4J9fi8NgZvaCOivElGsevxel1UD+3lmGTy1V8831rcPkc1M0YRp2GRXfLJ9fg8jupmVpJvcZu5C33rcYdcFE1sUzTorv53lV4gm4qxpUwQcOiu+melXjDHkpHFTFphdqiu/GulfiSPBSPKGDqWnUV3Q13rsCf4qOgNpcZGhbddXcsI5jmJ29YNnM0quiuuW0ZoYwAORVZzNNYG1h162KSskJklaaz8Dp1Fd0VNy8kOSdMRlEqS25QW3iX3zSf1Lxk0gpSWHaT2sK7+IY5pBemkpKbxIoPqy28C66fRWZJGknZIVbeoubNja3csfhT3Djx4+x7/oCK67r00jMNXe+YPrPtCX7+xWfijxMtqnJ7JqgtqomWTovdQp+MJ1o2Ey2qF+QJllA1V1qA5VkRqC28iRbWC/FEC2/i51XxhO8rVn4j9n9Wm5+z+GpZXOXn0LLIym3IiZ8nwg0MDQ2dl8u/Q2EQIEkKh1gil3/exGs2GAS3fedGxi9Vl7DX9c5LzzR0vSc6e7KZp27+Gm889yZnTpxVsL7ufjbevRKLzcLo+XXUJFhse7v72HTPKqx2CyPn1DBi5rCE4/vYfO8arA4rw2cMY/R85e9zX08/m+9dhc1ppWZKBeMTFlEjfDU2l42qiWVMumqMim+5bw12t53ysSVMSbDY9vf2s+W+1Tg8dkpHFTJj46QEPsCW+1bj9Dooqstj9pYpKr75vtW4/E4KanKYf61y5D/QN8DmT6zCHXCRW5nF4utnK3n/IJs/sQpvyE12WQZLb5yn2Bcy0D/IxnsimUtmcRrLPzRfcYMe7B9k490r8Sf7SC9MYeUtixQ36cGBQTbsXkEwzU9qXhKrP7ZEsW9laHCI9XcsJ5wRJDk7zLrbl8UDRoyv/fgykrJChDODrNu9XBF0pSGJ1R9dSkpOEsH0AOvvukrFV966mLT8ZPwpPjbevVIR5IaGJM4mTO/puvTSMw1db1s//+IzfOGm/0dXezdCCELpAVVjndgcvhCCUEZA4T4C5Ry+3K4ak3wOPik7ROPhBO530d4c4XI7a0zyefPknDCnDiVYgEPuuONLi8vn/VNyk+IFEs9xb7yya0pOEicPKbl8XUPr+GCqj6aGt+BpfppONF8U17r+UEaQM9GfiRYPZwTjPzOt7y8pM0Tj0TNRHuJUwvcv/5lp/fzk7ym3K18s3/nZLZrTaLreeemZhq53XX/6wV/iTYokSaLpZDNVEyOlQGLd5WKLvpIkcfpoU3wdItadTl6rqPHIGWqmRRryBFJ9lI4qVNRaajx8Jl5KxJfkoWxMUTxgAJw6fDrek8Mb9lAxrkSx0Hrq0GnqotmMJ+iiakKZopT6qUOnGTGrGojUaRo2qVyxUHzyYGN8w6HT46BmSoWiFPjJQ+e4w2OndlqVYiH85MFG6udGug3aXTaGTx8WDxhxHu1GaHNaqZtZHQ8IMT5qbi1CRKb2RsyuUfBTh05TP7cWYRBYbGZGzq6JB4wYHzU30pPdbDVRP6dWEeRPHY4cbzRF+dzaeMCI8DPUzx2O0WzEZDExam6tIkg0HjlD/ZxaTBYTRrORUfOGK4LQ6aNNjJxdg9lqwmgyaPIRs2uw2MwYjAbmXzuTySvHouvykh40dL1zkiLrBBCZrxdGoXqJ1WYBInPXBqP6189sjR5vNmlyS5Qbz8PNVlOEmwwYtXjs/Kbzn18IgdFkxGhSc5PZFOFmw/mPN0SON2gdbzFF9j2YDBjNRjW3Rj6XwWjQPr/VjDAaIseb1MebLWYMhujxGu9vtBgxRPddaJ7fYkIIA0IYMJlNGp/fgEEIBGC0qLnRbIxygUnr/GZj9P3Fed7fiDAYEAIs0eCi6/KSPj2l623rx5/7JU/d/LX4YrZ8qgQAEbW4Ri2swXQ/TcebFe8ht7jKd2PHJK/SKp9KiUluYdXi8ukvremPC3F5ZVgtLp8+0+Ly6TEtLp8e0+Ly6TGtzye33cqnorR5gDPHlN9vIMUXXzfQ+v5jO+xB4+eb8JwWl79nINXH2QblGoX8muTXElNsekqSpLgRQNe7I316Ste7rnnbp7Pqo0uwOiyMXzqKnPJMBRcI1ty2DKvDythFI+INkuRae/sybE4r9fOGxxsYybXmtggfMauGEg2L7prblmF32aidVknFOLVFd9XHlmB32xk2uTy++1qu1bctxeGxUzG+RFULCyJVXJ1eB2Vjihg5W23RXXnrYlx+J8UjC1QL9QBX3bwwstt9eB5jNXY7r7h5IZ6Qm7xh2UxYPlrFl920EF+Sh9zKLCavUlt0l944D3+Kl6zSdKatU1fZXXLDXAKpfjKK05i5YZKKL7x+NqH0AGkFycxKWMgHmL9jJuGsEKl5SZr7J+ZeM53knCSSs8MsuFZdhXfWlimk5icTzgiwcOdsFZ+xYTIZRakE0wOaFt+zDc18ZMZdXDv8Zl78wysqruu9l55p6Hrbum/tI/z2m/8bf5xokU20tCZaUFU8ocpqouU10aJ6QZ7wfokW1QvxxPdLtKgmvj7RspvIDSYDQzKeaImVV6TVOp/BKBgalGSPlZbXRAurFkc6Z9mV22c1j0+oAixE5K/Ya2ID/9gtRMU1LLeJ51Cf89w1JVqMAW752i6mrlEHR13/vvRMQ9e7ooYDp3j4mi+w54+vqnbzDvQNcPX9a7E5bUxYNoqqhJF9f+8A2x5Yj91lY+zikQxP2HzX3xflbhuj5g+nfq5yZD/QN8D2hzbgcNsZMauGMYtGqPmD6yOL0NOrVCP3gf5Btj+0AafXQfXkciavHqfJXT4nleNLmbFeWcV2cGCQax/agDvgomxMMbMTNtcNDgxxzYMb8ARdlIwsZG7CyHwoyr0hN4XD81h0nXLkPTg4xDUPrMeX5CW/OoelH5irPH5Q4upPryOQ4iOnIku1eU4akrj6/rUE0/xkl2Ww6tbFKr75vlWEMgJkFKex5rYlan7vapKyQqQVpLA2of+FJMHGO68iJSeJlNwkNtx1lSIgSBKs372CtPxkkrPDbPrEKhLHpGtvW0pGUSrhzCBbP7lWtU9j1a2LySpJJ5Qe4Or715A4qE38ndP13kvPNHRdtH748M/44q3fiI/uE+eghUFgtpji2YPWHLY8u9Di8jUOrTlyBddYI5GX+QimBWg6cf41Eq05fPkahyb3OemMlvHQ4vI1kGB6gCYVd9ERdXxpXZ+89IbW55d3P9Ti8tIfWlxuEQ6k+jnb8FZc/fORW4i1yqT4U7w0n4wcr1XmRH5O+bm0uFYZkx0Pb2KxRrMpXf++9ExD1zuuv/38OcV0UNvZDuqiFtX0olSKhucpppuaT7Yyan6koU5qfjKlowoV/GxDS7xUR0pumPKxxYomSU0nmuPZRFJ2iMoJpUp+vDm+ThDKCDBsUnk8YESOP8u4JZFSH8E0PzVTKuIBA+DM8bOMj5YC8Sd7GT69SmEBPnP8LBOWjkKISM2kupnD4gEjkXuCbkbOrlG0U206fpYJy0YjDAK330n93Np4wIhd34RloyMFD30ORs+vU9RqajrRzMTlozEaDTi9dsYsHKFol9t0opkJy0ZjNBmwu22MXTRScZNtOtHMhOWjMZlN2JxWxi2uV9ykzzY0M2HZKMxWEzaHlfFLE3kLE5aNwmIzY7VbmLBslCJINJ9sYfzSUVjsFiw2c5SfO775VCvjltRHChJaTUxcPloRpFoaWxm7uB6b04bJouatp9sYu2gkdpcNk9nIig8tUG2w1PXeS+1506XrIiVJEl3Rm2xvVy9Wu0XFYzfRvu4+Vdc3gPboTbi3u1/VVQ5QHC8PWDHFbuJ9Pf0X5H0aPNYTu6+3n96ePjVv7USSIlNnfT0a79/WFeX9ipIoCj4k0d8/qFjviamrvYuhwSEG+gbolXUNjB/f3s3QkER/36Ciq2BM3R3dDA1KDPQP0tPVo+bt3QwODiIGoKdTi/cw0D+INCQpAu659++hv28Ag0EoAq6cx36uWsf3dPYy0DfA0JAU39Oj5D0M9PUzODCozbt66e8bYHBgkLamds2fsa73Vvr0lK6L1i++9AxP3PT/6GrrxmA0EEzzKyyiBqMBh9tOR0snBoMglBFU7RB2+Rx0tHQhhCApK6TagRyzsAohSM4Oq3ZYe4NuWqPz2lo7pL1hN62nIzw1L0mjydO5KRF5Q6OY5FMq8oZGcS6bkknLT+ZEApdPCWlx+ZSW1vvLLahax8ttuVo8KStI45Gm835++Q5src8v3zWuxeXfudb3fyEuvyatHeryc2rtMI9NTw30D2ju89D19qVPT+l6xzV17QQW7pyN2Wpm9II60vKTVa9ZvGsOZpuZ+rnDyShOU/ElH5yHxWamblY12eUZKr70A3Ox2C3UTqskd1iW+v1vmIPVbqF6cgUFGlV0F++ai9VhpXJCGcUjClR80a7Z2JxWyscUxxs4ybXw+tnY3TZK6gupHFeqPv66WTjcdorq8jQtvAt2zMTpdZBfnaOqtQUwb/sMXD4nuZVZjJyltvDOu2Y67oCLrLIMRs1T98qes3Ua3pCbjOI0xiwcoeKztkzFl+QhrSBFs9DfjI2T8Cd7SclNYsJyNZ++fhLBVD/J2SEmrVRX6Z26Zjyh9AChjICmi2nKqnEkZYUIpvmZvm6iik9YPoaU3CQCKT5maFiAxy8dRWp+Mr4kr6qWF0R2nd8w7ja2VtzIX36iDw4vhfRMQ9dFa/fST/Pn//57/HGiZVa+SA1qy6rVYVVMwSRaThOr4l6QJ1atTbD8JlpcE6vqJlpSEz+Pmlvok01hJVpSVVVxEyytie+faDdNtAAnVq1VVc1N4OqqtygssFpVb+Wf8YI8wVIcee7cz+BCPPH7SLxmraq5ci4ijuHoXxHd+NR2Zm9Rl4jX9a/risg0hBCzhBB7hRD7hRC3aPCNQojTQogXon+2Xorr/E/WwZePcO+ah/n7L/4Zby4UkyTBtk+vw+GxM3nVONXmusH+QXY8vBGHx87EFaOpmVKu5o9uxul1MHbxSEYkjLwH+wfZ+dnNkUXiBXXxRfU4Hxhk56ObcfmcjJxdoxpZDw0MsfOzm3H7nQyfMYyJK5QW3KHBIa5/bAvugIvqyRVMXTdBxXc+tgVPyE3VxDJmbpqk5EMS1392C96wh/IxxczdNi2BD3Hdo5vxJXkpHVXI/ITNb9KQxI5HNuFP8VFUl8+SDyottpIkce1nNhJM9VNQk8uymxao+DUPbSCUHiCvKouVtyRYbCW45tPrCWcGyS7PZM1tS0nU1k+uITknTGZJOusTLLYAm+9dTWpeMulFqWy4e6WKb7z7KtILU0jNT2bTJ1ar+Prdy8ksTiMlN4mtn1qr4mtuW0p2WQZJWSG2fXqdiq+8dTG5lVmEM4Js/8xGRcAA4tUAdL13umSZhhDCCLwBTAeOAc8CqyRJelX2mo1AnSRJOy/2ffVM453TN+75Af9153fjo79EC2SkLpCIjyQTeaSGkyE+UtSyUMpH11qd5OTZihaXj961LJwX4vLsR5ufy260uDy70uJyC7AWl5dB0fp8Drc9vkCs9f3JLcJaXN7pT6uTntwirNVJT14mRW731eLyf8ckf095ReI4l12T/FpikncCdPocdLZ0Kfi1D21kScJ+Fl1vT1dCpjES2C9J0gFJkvqAbwPqVl66Lple+N1LiumCno4exi+LjObzq3MorM1XTA91NHfE58FzK7MoHV2kmC5pPd3G5NWRqqXZZRlUTihVTMe0NLYxZU1kw11mSRrDJpcrprdaGtuYunY8QkB6YQq106oU0z0tja1MXzcBISILrnUzhqn5+okIgyA5J8zIOTWK6bIYNxgMhDODjJpXq5gOa2lsZcaGiRiMBkLpAcYsHKGYjotxo8lAINXH2MUjFY6iCJ+E0WzEn+xl/NJRipFyS2MbMzdOwmQ24g17mLhitMJR1Hq6jRkbJmG2mPAEXUy6aozCIhzjFqsZt9/J5FXj4gEDoO1MO9PXT8Rqt+D0OZiyerziJt3W1M60dROxOqw4PHamrZ2gCAJtTR1MWzsBu8uG3W1T8fazHUxdMx67247NaWX6+omKINTe3MGU1eNxeh1Y7ZYIlwWxjuZOJq8ci8vvxGK3MGPDJEU72c6WLiZdNRZ30IXFZmb9HSuYe40yu9P17utSBo104Kjs8bHoc4laKoTYI4T4vhAiU4MjhNgmhPiHEOIfp0+f1nqJrndA0pDE0dePA5E9Ct2d6umqI69FeNOJZk0L5dHXTwBw9mSL4oYX07Eobz7ZqhpVAhzbewJJiuwBSBy1AhyN8pbT7efnQxKtp9tUo26A4/saGBoaoq2pg7Yz6uOP7zvJ0OAQ7Wc7VFkDwPH9pxgcGKKjuVOTn3jzJIP9g7Q3d6r6g0f4KQb6B+ls6VRtrANoOHiK/r4BOlu744UE5Tp5qJG+3n662ntUGwcBTh1upLe7j662bs4cb1LxxiOn6e3qpbu9m9NHz6j50TN0d/TQ09GjKJse0+ljTfR0dNPT2atyPgGcOdZEV3s3vd19KuccRH5vOlu76OvuUznnAJoaztLZ0kVfTz8HXz6synx0vfu6lNNTy4GZkiRtjT5eB4yUJOl62WuCQIckSb1CiO3ACkmS1JYKmfTpqXdOv/n6H3nixq/SeqYds9VMINWnsEgazUbcPictp9swmY2EM4I0yC2WAvxJEQuryWwknBU6r4XVaDKSnBPmxP6TCh6rsmowGkjNS+b4vgYFj1lUDQZBWkEKx95Q8phF1WAQpBemcnTvCQWP2TqFEGQUp8WDYkwxi6oQgsyStHhQjCklJ8zJ6HeSVZqu4nKLaVZZBkdePabgcttsdlkGhxN5QUr8O9Hi6YUpHN938rzvn1GUGv9ONHlxGsei30lWaQZHXlPyzOK0+Hem9fkyS9Lj35n83zFllaRzJMZl7xXnsnNmFKVx7I3z8/SiVI4n/Hy3P7iBxTfMob+3H6vdiq63rytheuoYIM8cMgDFb4wkSU2SJMXy/6cAtQdR17umsYtGMGX1eIwmA7XTKglnBBXcYDAwbV1kOmbYlAqScsIKLhCR6RiTkcqJZaTlqS26semY8nHFZBSmqvj0jZMwWUyUjS4iq1SdiE5fPwmz1URJfSE5FWqL7rS1E7HYzBTV5ZOnUWV32roJWO0WCmpyKKxRW3inrBmH1WEhtypLswrv5DUTsDmt5FRkUlKvtvBOXjkOu8tGVmk65WOKVXziVWNweOxkFKVSOV5t8Z24fAxOr4O0/GRNi++EpaNx+Z2k5CRRO7VSxccurscdcJGUFaJuxjAVH7NwBN6wh1BGgBGzq1V89II6fEkeAqm+eIMouUbNHU4gxYc/2cvoBer7zcg5NQTTA3jDHsYsUlf5rZtRRTgziCfoZtwSNa+dVklydhi336lpIT5x4CQ76j7CxqJd/Obrf1TVqtL1zutSZhomIgvhU4HjRBbCV0uS9IrsNamSJDVE/70Y+IgkSW/ZZV7PNN45fWzevfz95/+MP060lMoXcUFt+ZQv4oLaUimvAwVqC+sFuWyRGdQWVhVPqJr6r3MUFlab06baZS2/hkQLcuJ3kGhBBqVNONFiDEoLqyaX2WYTLb4Xw+XGg0SLr5qbVTu05c8lWq5VPOH3BZS26URL9cVwvT3s29dln2lIkjQA7AT+B3gN+K4kSa8IIe4SQsS8hbuEEK8IIV4EdgEbL83V/ufo1b/s5fYFn+QP3/uLquyF0WjgmgfW4/Q6mLZuIqX1yv4WkgQ7HtmE0+dg8qpxlI9XWnCHBofY9bmtuPxOJiwfTc3UCiUfktj1+NW4/E7GLR4Zb70q5zd8/mrcARej59cxaqHy91saktj1+avxBF2MmF3D+GjdqXPXJ3H941vxhNwRC+5VYzS5N+yhZkoF0xI2r0kSXP+5rfiSvFRNUFtwAa5/bCv+ZC/lY4uZc7V6kfa6RzbHW9ku2KG+uV338CaC6X6K6/I1XUHbH9pAOCOoacEFuOaB9SRlh8irylZVuQXY9ql1pOQkkXMeC+6W+1aTmp9MVmk663dfpeKbP7GS9MJUMopS2Xi3mq/fvYLMknTSClLYcp/agrv248vILssgJTeJq+9XW3BX3bKI3MoskrPDXPPgehVf8eEFFFTnEM4Mcu1nNqi4VqkWXe+s9M19uuJ66iNf57uf/nH8caKF0mQxMdg/GB+JJ3KD0YA0JJ2XCxEZzceyBZVFM8ql83GUI/W3w+UjbS0uH/26/U7aEyygcouwJpeNpLUspPLR/QW5zC4bkzw70eLy7EZux71YLs/uEjNJUGZfiZlk4jGJmWIit7ls9CTUq5Jfk1amJudamdr2Bzew9IPz0PWv67LPNHRdfnrtb28oHg/0DcRLQVSMLaawNlcxZ9zT2cPMjZMRAkpGFVI6ulDBO5o7mbN1KkIIikbkUzWxTDG91H62gznbIrygNpeaqZWK6aX2sx3M3TYdYRDkVWVTN3OYYnqr/WwH866ZjsEoyCnPoH5OjYrP3z4do9FAZkkaoxfUKXY8t5/tYN61MzCajKQXpjB20QjFdEl7cyfzr52B0WwkLT+Z8UtHKSzC7c2dLNgxC7PFREpOmIkrRiumazqaO1mwYyZmq4mkrBCTV41VTAfFuMVmJpQeYOra8UreEuV2C8FUH9PXT1TcJDtaItdndVjxJ3uZsXGS4ibb2drF/O0zsLtseMMeZm2arOLzrpmOw2PHE3Qze8tUxU2+q62budum4fQ6cAdczLl6qmK6rqu9mzlbp+L2u3D6HMzdNl0RZLrbe5i1ZQrugAun18Hca5S8p6OHmZsm4w17sLvtzNs+QxHEejp7mbEhUvbE5rQx/1ol7+3qZfr6iQRS/dicVrZ9ej0Ld+pTU++2jLt3777U1/CO6sknn9y9bdu2S30ZV6T+56u/o/HwOZuk0Wig7WwHHS2ddEaLFMotjsIg6Gzrov1sB11t3ZHXJ9hYuzt6aGtqj3CTIV5MMKbezj5az7TR1daNyWxUbW7r6+6jpbGNrvaeKFfaWHt7+mk51UpXezdmi0nVv6G/Z4Czp1robu/BZDGp+j8M9A1wtqGZno4eTFazyuY62D9I04lmujt6MFvNqv4TA/0DEftxRy9mq1nVv2JwYIgzx87S3dGDxaLmQ4MSp4820dPVi8VqVvXnkKRIvaXerl7MVpOKI6Dx8Gl6u/rOy08dOh09Xv3+wiA4eTBiwzVZjCpuMBpoOHCKvu4+TGb1+xtMRk68eZL+nn6MJoOKmywmTuw/SX9vP0ajmputJo6/0cBA3wBCoPp+zDYTx/Y2MNCvzS1WM8feOMFA3yASEhVjS/AE3Oj613XnnXc27N69+8kLvU6fntIV1x+//xce/8BXaDrRjN1lw5fkVVQ5NVvN+MIeTh9rwuawEkjzKyyysU1vjUfOYLVbCGeGVBbK5OwQpw6fwWIzk5wdVlkwYxZVs9VMal6yygIaqwxrtphIK0zh8CvaFlWjyUBmSTqHXj6q4OmFqRzf14DBaCC7LIODLx1R8JgFVRgEuRVZHNhzWMFjtlIhIK8qmzdfVPKYLfV8PKc8g0PRa86vzuHNFw4peUVm/JoLanLZ/8+DCp5bmRW/Zi2eV5Udv+a3w+XXdCGudf3yY7R5Dvv/GXkub1g2BxK+H/nx8mvV4rlVWRzco/z5bfvUOhbfMIeezl5cPie6Ll769JSuf1nDJpUzYnYNwiAoHV2EL6wcsRkMgrsz3a0AACAASURBVPq5tRgMguL6AgIpXgUXQjBq3nAMBkFRXT6BNJ/qHGMWjsRgNFBYm0c4M6ji9fPqMJgM5A/LJjk7pOKj59dhNBvJqcwiJTdJxUfNG47JbCSnIou0/BT1+8+txWQxkV2WQbqGxbd+Ti1mq4msknQyS9RVekfOrsZiM5NelEZWqbpKb92sGix2C6n5KZoW4OEzhmF1WEnNSya/KkfFa6dXYXPZSM4OU6BhAa6dVonDbSecGaRweJ6KV0+uwOGxE0zzUzxCbREeNqkcp9eBP8VHSYKRAaByfCkuvxNf2KNZBbhiXAmeoBtP0K2qNQZQOroIb9iDO+DUtBCX1hfhT/bi8jk1LcTFI/IJpPpxeBxUT65Q8cLheQTTAzjcNmo0LMZHXjvOtqqbWF+wkx899gsGBwdVr9H170nPNHTFdfP0u/jnMy/FHydaMhMXbhMtk4kLs4kW28SF10SLrIoLoVgjSaw9lFjlVbWwm7Cw/i/zhM/g9NrpbFUu/Moru2otHJtMRgaitlBNbjYx0D9wXi63vWotLFus5nhzqUSLMCh/hhfiWgvPcluvFrc5rPHmUFoWYPkxiVWGI/ycbVnLAiz/zBfiWhbhax5Yz7Ib56PrwtIzDV0XpWf/5wVunPRx/uerv6O/L8GzbzZFLLY+BzM3TlaNfIXBwI6HN+HyOZm6dgIlo5T9K6QhieujFtvJK8dSNbFMxXc9HrHQTlg2itppypGjJEnc8ESEj12ktuBKUsxi62bUvOGMTqiCiwQ3PH41npCbEbOqGbe0XsV3RS22tdOqVBZcOGexrZ5cwTSN/hDXfXYL/mQfleNLmbVpsorveHQzgVQ/5WOKmbNNbcHd8fBGgml+SuoLWaCxv2D7gxsJZwQpqstnqYYFd9sD60nKCpFfncPyD6ktuFvuX0tyTjhaBXeRiseq2GaXZbBaw4K78a6VpBemkFmSzrqPq6vgrr1jGZnFaaQXprLxLnUV3DUfi1SxTctPYdO9q1R81a0Ri21KbhJbNCy4y29aQP6wHJKyw1z9KXUV3CU3zKVweCRrvfYhtQU3cR+Irn9fF8w0hBAGYBiQBnQDr0iSdOotD7qE0jONi9ejO57iJ0/8Kv44MVNI3LyVONJPzDQSR+qJm/ESR9IXk2nAuc12To+DzrbzZyKq90+w+KpG8gmZhtZIX55pXJBrWFDlG9DsbruqvLw8E9HKBOQb5LS43AKslQmYbWb63yKTkI/etSysCq6RKcif08wkZJmIVqYgvyb5tWpyjc2E8u8ksR8J6JnGv6J/O9MQQuQLIZ4E9gOfBFYBO4BfCyH+KoTYFA0ouq5QHXhJucgoSVLc4lo3c5gqsxjoG2DBjpkYDIKaaZWqOfGezl4WXT8bg0FQNbFMlVl0tXWz5ANzMZgMVIwrUW3u62ztYukH52I0GSgbXcSIWdWKoNDZ1sWym+ZjMhspGpFP/bxa1fsvu3E+JrOJgtpcxiwaqQhaXW3dLP/QfMxWE3nDshm/ZJQiaHW1dbPsQ/OxWM3kVGQy6aqxium1CF+IxW4hszSdKavHKXl7N8s/tACr3UJ6USrT109U7Fjubo+c3+a0kpafwsyNk+MBAyJOs2U3zcfuspGSm8TsrVMVO6q7O3pYftP8yJpGVoi526YpbpI9nb0su3E+Tq+DcEaQ+dtnKG7CPZ29LP3gPFx+J8E0Pwuum6W4ifd29bLkhrm4Ay78KT4W7Zyt5N19LNo1B2/Igy/Jw+JdcxRBore7j4U7Z+FP9uINuVnygbmKvuZ9Pf0s2DGTQKoPd8DF/2fvvcPkuM4z39/pnOP05JwDMDMYDAY55xwGIBKRQQAkwSAGiRQpBolKVCZX9l3ttdf23Wyvvbb3+q591155LVmmIjMJksg5Y4DJHWr/qO6aqjoFAqBAiSLme555gO63T3d1dXedc77v/d63+zPLDJNYcjDJ8n0LyCuJEYj4WfvociM+lGTpnnkkyuL4Qj7WPbrCMIkmh1Ms3j2XgsoE3qCHB7+/m9UPLWE0bm98mMnuC8DvA3sV03ZECJEPbAK2AH/88R3eaPwmI5VM85O/+hlKRuHNH71LtMBY6M6kMvz4v/2UTEbh7R8fIF4cNeBKRuHHf6Hi777yvmWh+0d//gqZVIYDPztIQaVc6P7RX/yUdCrD+784RGG1XOj+0Z+/QiqZ5tCrRxislQvd//yXPyWVTHH49WPSqhXgx//tZySHUhx587jB1S8XP/mrnzM8lOTY2ycQCAn/l7/6KcMDw5w8cAqHwy7j//3nDA0Mc+r9M7g9Lgl/5f/9JYN9Q5w+dBZPQBbY+9n/9ysGegcZ6B3kvZ99ION/+yr91wbovzbAuz+V8Z//3av09fTT19PPWz85IOG//J+v03u5j97Lfbz5o3ck/Ff/6w2t4fH1f3pbwl//x7c0ufLXfvimjP/vdzTa86v/8IaEv/njdzVa8y//5+sS/tZPDmi03J//7asS/s4r72se6T/9H7+S8AM/+0AT1fy7P/lHxs5oprLFUhx7ND5iXHenoCjKRkVR/rd5wshi5xRF+a6iKKMTxu9wbPjcao2BFIoHiRdHuZTtYxjsG+LS6SsUZy/Mwaifgqp8jSc/NDDMuWMXKK1XGUj+sI/ShmLOn1B/0MODSU59cEYTGfSFvFS0lGly2cmhJCcOnKaiWWUgeQMeqsaWaz/45HCK4++eonKM+oP3+N1Ut1VwJquim0qmOfbOSarGqgwlt89NbXuVphibTqU5+vYJqtsqADU1UtdRpVGEM+kMR946Tk17JaCmPurH12gqqpmMwuE3j2k+5A6Xg4bOGk0xNpNROPzGMY3B5HDaaeiq1aTfFUXh0OtHNZFDu8NOY1etphKrKAqHXjtKfZbhZLPbaJpUZ1CxPfjaURq6anV4vYFCfPDVI9puz2YTNE824odeO0rTJBUXQtA8pd5AMVbx+hF8cr2BwnrotaMGBlXzlAYDRfbQ68do0uOT6zn8uhFvnlyvpRmbJ9cbxh9+w4g3TTLiR948TvPkemy2HF5nwI++dZymSSN448RaA/7uK+/zL//9FwwPDlvK0I/GR4sbppeEEHYhxAohxINCiEdyf7+JgxuNjzdq2itpzF6UyptL8Yd9Btxmt2l4aWOxxHsXNqFddMoaiwnGAqZXUHEhoLSuiHCe3HSVu2gU1xQQyQ9LeNNEFS+qLiBaIFN4mybVI2yCwsoEsSIZb+yqw2YX5FckiBfHZHxCLXa7arqUVyrjDRNqsTvs5JXESJTLO6OGzhocTjux4hgF5QkJrx9fg9PlIFYUsaQI13dU43Q7iBaEKbJQAa4bV4Xb6yKSCFFisbOqaavA7XMRygtRXCtTiKvHVuDxewjFA5TWyxTiqjFleAMeglE/ZY2yinBFcxm+kJdA1E+FhcpwRVMpgYgPf1hdFJijrLGEQMSHN+ixpCCX1qvfG4/fQ3WrjJfUFRGKB3H73JYqxcU1BYQToaxSsUxRPvzGUXY1P8y2ugf4D1/5c41pNhofPW6mEP43wCDwBqDt5xVFef7jPbSPFqOF8JuPR2Y+wxv/NJKicHmcJIdSWh3BbO/pcNrJpDNancCM2+w2UJTr4rnH5OoAVri+cGxlP6ovvn8kXFdYtsL1xVar49MXcy1xnQqrlbaVvlhshesLx5a4rjBspV2lp7Ba4frCsZV9qr5Yb0VB1pMBfCEf/VeNuD/kpU/DZeKA/jmtCvuBiI/e7DFZUYz178mqsK/XA7Mq7O/6yibJS3001LidlNtSRVHWKIryrKIoz+f+bsMxjsZvIf7xv/wz947/LH/5/f8hNT65PC52fmUT/rCPhTtmU2VaGTqcDu55cQv+sI/5W2ZS22FsLhNCsO/b2zWV28ZJcvPY/S+pFN2Z6yZbNofd//JOAlE/U1d30TZHbv6673s7NZXb8QtbLfAdBGMBuhaPY+JS2f/hvu9u11Rup66aIOH3fmcb4USI9tljmLFWVuHf9+3tRPJDtM5oZvamaRK+95tbVZXbKQ3M3ypTdPd8cwuxoihNk+pYtGuuhO/6+t3Ei6PUd9awfN98Gf/qZk3ldtUDiyV851c2kF+eR1VrOd0PyRTdbV/aoKncWlF0tz67TlO5Xf85maK7+em1msqtlUruhidXU9ZYTHFtIVueWSvhdz2+koqWMgqr8i1Vctd8ZrmmcrvjBZmiu2r/Ymrbq0iUxdn1tc0SvvzehdR31hAvibHnRZnCqydGjMZHi5vZaXwd+HtFUf7uQx/4CYnRncb142tbX+Lv/90/abfNzWr6VTLIK0UzJfJGfhqSH4bOKwLklabkt3ED3KySaqb4mleiZoqvhJsovla4/vei3xWoOAa/DWmlK0CA1oxoRVE1+G3cALf0y7DbSH8YrlP5taKwGvEP99Ow8ssw4BZ+GfrX1L+WJW7lp6F7T+bvw83goyq414/budP4F+AvhBADQoirQohrQoirNxw1Gp+4MFup2ux2Vj+wGLvDxtTVXdRki8a5UBSF7s8sw+6wM3l5Jw0m57rkUIr1n12Jw2lnwpJxjJlmlI0Y7B1i45OrcTjtdCxoZdwcI8V2oHeQTZ9fg8PloH3OGDoXtkv45qe6cboctM5slii2gznc46RlaoPkDDfYN8TmL3Tj8jhpnFgn7RwG+4bY/HQ3bq+L+s4aZm+cZlLxHWLzF9bi8bupHVfFvLuN/hqD/er4XBF/4Y45hklpqF8d7wt6qWgpZcnueejXaEMDw2x+uht/2EtZYzHL711ouMjl8EDET0ldESvvX2TAhweTbHpqDcFYgKLqAlY/tESbMHL4xs+vIZQXpKAiwdpHlhku0smhJBueWE0kP0SiLM66R5eb8BTrP7eKaGGEvJIYd312pWGSSA2nuOvxlcSLo8QKI2x4YpURT6ZZ99hy8krjRArCbHxytWGSSifTdH9mGfnleYTzQmz6/Bojnkqz+qElFFblE4oH2Px0t2ESzKQzrNy/iOKaAoJRvyW+/N6FlDYU4w/7eOwP77P0KBmNW4ub2WkcAlYBb1gxqT5pMbrTuH48OOXzvPMv72u3PX4PDqed3it9qhhhQYjzxy5quMvjxO1zc+1Sb7aYG+XsUZ1HuMNOIOKj58I1HE47eaUxzhw+b3jNSH6YK+d6sDvs5JeZPMQZ8Qi32W0UViY09lMuYkVRLp2+jM0mKKwukD3Ei6NcPKXiRTWFsod4SYwLJy8hhKCkzsJDvDTO+RMXVby+SPPLzkXOQxysPa5zHuKgkgFy7KlcFFbla4wvvV/2zeJF1QWaaKSVB7feY9wS13mMW+F6j3Gr49d7jFu9f73HuP7/VriVx7f+OXNikgZcd8z692KJ686FFV7ZUsbjf3Q/9eNlTa7RuL07jfeBN38XJozR+PDY/qWNGsU1XhwlrySqdYAnh5L0XurTKK7RQpXtkyvEJodTXD57RaOwRvJDlDUW05OVQk8l05w7dpG6LEU1nBekurVckzJPp9KcPnyO+k61DhKMBahpr9SkyjPpDKcOnqWhS/1BByI+6jqqNSnyTEbh1AdnNIqpP+yjYUKNRgHOZBROvn+apskq7g16aOyq1Tj/iqJw4r3TtExR2V7egIemSfUaRVhRFE4cOEXLVNXH2+1z0TylQZswAI4fOMXYrBuh2+uiZWqjYRI9/u4pxs5Qd1suj5Mx0xq1CQHg2LsntYZHp9vB2BlNMj5LxR1OO60zmw0qw8ffPUnb7BYNb5vVYrhI6nG7w0777BbDRfb4uydpnz0GIUQWH6NNGLnjb5/dghACm91G+5wxhkn2+IFTtM8Zg7AJhE2ouG6SOHHgFG2zr4+ffO80bbNbsNltCKHi+kno5PunaZvVgt1hH8F1k9ypD87QNrMFh1Ptj2mf3WLED56ldWYzDpfaftY2y4gfees4P//b1xjoHeDMEePiZTRuPm5m0jgN/FAI8eQo5fZ3O/LL4hRUqrTQeHEMp8dpwIUQGi00XhTF7TU1p2WprwCxwihun9y8VpjFo4UR3H6PhOeUZ6MFYbxBa1wIdYfiC1ngtQUIgWrcE/LKeHUhwiYI54UkCjFAYWUBwiYIxQPWeFUBNpsgFA8StJDWLijPx2a3EYj6CUYt8IoEdocNf8RPKC5TjPPL4tiddvxhH+F4yALPw5HD82Q8URLH4bKr0vUJa9zpcuAJuC0pzPHiKE63A7fPZUlhjhfHtB2mFR4rjOD2uHB7XcQLo9a4z43b4yJeZIEXRPD43TjdDksKtGq45MbpcpBXIuPh/BAev0fFS+Xm0XAihDfgwe60WzaXvv+LQ2yvf5CdjQ/xbz737yTZl9G4cdxMeupZq/s/qQyq0fTU9eOhqU/x9k9G3PncPhfJoZSWJw8nQvScHylXOd1OMumMVoyM5IcMJknqinBEFC6XisqFEAKH065JXZhxMBZOrXB9MTZaEJZMlvSFTytcX0y2wvXFbEtcVwy3wvXF+khBmCtmXEdhtRqvJxNE88NcNr1/PUXV6vzoKahWuJ6CGk4EJRMsPa3X/PmDkVYcygtKJlv6+6wozOG8oLYbDcb8XLtkpADrX9PKPleP+yN++kz2tvr3bEURvhG+/YsbLFlgd2LctvSUnmY7Srn93YpMJsPf/Jv/ybb6B/jPL/6lBdPExZZn1uINeli0czalDcbmMKfLwbbn1+MNepm3ZaYkx2Cz29j5lU34Ql5mb5xGzbhK6Rh2f20zvpCXmesm09gl55L3fkOl8E5d3cWYbGpIH/d8Yyv+sI/Jy8dLWlagmu4EIn66Fo+jw8Jf4Z4X7yYQ9TN+fisTFo+T8F1f30wwFqB9zhgmL5d/L7u+uplQPEjrjGamre6S8B1f2Ug4L0TL1AZm3SWr5O748gYi+SEaJ9UxZ+N0Cd/+pQ1EC8LUd9Ywf/ssCd/2/HriRVFqx1WxeLdM0b37C+vIK4lR3VrB0r0yRXfT090kyuJUtJSx8n6ZorvhidUUVCQoayxh9YOyTtNdn11JUXU+JXVFrHtUFv5b+8gyimsLKaopYN3jMoV39UNLKW0oprAyn41PrpHwlfcvpLy5lPzyPEuV3WX75lM1tpxEaZytz8oqu4t3zaGmvZJ4cZStz98l4Qu3z6JufDXRwoilCu9o1v3W47o7jaxY4cuKokgCMkIIP7AeGFIU5d9/vId4azG60xiJ57q/wY//4qfabbMKq5lSaqbImv0RzBRYM6XT/HxmSqaZQmqmXJpxM2XTTAk2UzJvFTdTMs3vx4ybKcdmiq+ZwirjRgqrmeJrVmk14+bzaab4WlFc9TRjK4qr/hitKK76c6D3DsmF/j4riqv+Oc3nw3xMVuP170nYBCiKgYGmPydmfxUwnlPz+QS49zvbWWPRz3Inxu3Yafwe8AUhxDtCiD8VQvyeEOIPhRD/BPwzEAT+7DYd72h8DHHhxEXDbZfXybpHV+B0OZizaZok62Cz29jwxCqcbicz75qiFbVzkckobH66G5fbybQ1k2iebNwZJIdSbHvuLlweJ5NXdNI2y7gzGBoYZvuXNuDyuJi4tIPOBW0SvuNLG3F7XXQuaqdriXFnMDwwzM4vb8TtczFu3lipOW94YJgdL2zE43fTNquZGSb/DHX8JjwBD2OmNTLH1Jw3PJhk55c34g16aJ5cz/wtM4zvbzDJji9vxBfy0jChhkW75pjef5KdX9mIP+KjtqNK8s9IDqXY8eVNBKJ+qlvLWXH/IsMFLDmcYscLGwnGAlS2lLL6oSUGPDWcYvsLGwgnQpQ1lrD20RUGim8qmWb7F9cTyQ9TUlfE+s+uMuDpZJptz68nVhihqKaAjU+uMVzE06k0W59bR7wkRmFlPpue6jZcxNOpDHc/s5ZEWZz88jzufmadYRLJpDNsemoN+RUJ8kpibH3+LsMklMkobHxS1TuLFUXZ9vxdhkksk86w/rMrKa4tJFoQYfuXNhgmQSWjsPbRFZQ2FBNJhNjxwgbDJKooCqsfXkpFcymheJAdL2w0TMKKorBy/yKqxpYTjAV46j8+PDphfIS4mZpGAOgEilD9NN5RFEWWz/yExOhOYyT2T3yCAz87qN32BjwoGYXB/iHsDjuR/JDGPgJ1pS9sgsG+IWx2G7HCiMY+AnVV53I76b82gM0miJfENMVRUFeC3oCH/qvWOIx4dgghSJTFDewkGMmxCyHIL49z9qg1DlBQmdAEDnOhz7EXViY4Y8L1OXI93TUX+hy4Fa6vS+T8zA14lkJ8vfE5ijBAUVW+REGOF8e4eEo954XV+ZwxPX9eaYwLJy5d9/lzFOLr4fllcc4dvz6eKI9rtGur85tfkce57GeipxvnQn+fnq6cC/1nkiiLS9+PwqqERtu2xkeOOUenvj4e5cLJywZcf84Lq/L53J88wJipsjLBnRi3s6bRqyjKDxVF+Y+Kovy3T/KEMRrG2Pft7dpuoaSukLySmFb0TafSDPYNaT7SRdX5FFbla+mlTDpD7+U+TSW1oDJBWUOxlt7KZBQun+3RKKr55XlUt1ZoRd1MRuHCiUtaHSJeEqNufLVG8VUUhXPHLmg+0bHCCA1dtdqEoCgKZ49eoD3bEBjJD9M0qd6gxXT2yHnNkyNXV9AXas8cOU/HfFVqJBQPMnZao6HQe+bwOcYvUPFg1E/rzGZDIfnM4XN0LlR3Q/6wj7ZZLYZC9ulD5+hcpOK+kJf2OWO1CSM3fsJitWHRG1A9rfWT9OnD51RPdiHw+N2Mn9+mTRgAZw6do2tJB0II3D4XnQvatAkj9/xdS1RPd5dH3Z2d1+0uVbwDm92G0+NkwqJ2bcKQcLeDrsXjDH06Z4+cZ+KSDuwOGw6Xg4lLOrQJA+Ds0fN0LR6H3WnH7rQzcUmHYRI5d+wCXYvH4XA5sDtsTFzaYZjEzx+/yIRF7TjdDmz2LH7YAvc4EVl/ev0kd+HkJToXtGmLnYlLzPhlxi9ow+NzI4Sga8k4wyR95vA5Xv2HN7l2uZcjb42oA4/Gh8eoidKnODw+N26f6tngcrsQNtPHLRjBPS5VcNCEe/y58U7sFv4R3oBKi3W6HJZ4brzTbY3nxjuugxvHy19XT8CbHW//0PEOlx27U7aP8WRpwXaXQ+P/6yN3fhwuu8b/N4z3uhFCzb07XRavn8XtTjtOy/EuEGptwOmW8dwF0e6wSxRpALfHhc0msDkELrcF7nVhEwK73YbLwt/D5XFis9kQNpvl8zuzuM0mPhwXAtf1cLsNIaxf3+lWcXW8NW63q6/vMlPAAYfbic2h9n24vPLrO1wO7E6b4buuj3deeZ9tdQ+wt/0xvrvvB5pXyGhcP26Ynvpdi9H0lLpKF0JI6SmP3006mSY5nEIIQSQ/ZFg5uzwuFEUhOZRECEG0IKz5a4B6YbTZbVqxOFYU0Qx1QE1PudxOrZgdK45y6ZQxPaAvlutTNbnQF9ut0g96iqo+VXOzuJ52mVcal+o+esvbRGmM86bxeoqrPhWUC336zOr59bRUK1xPUbU6fn16zer86NNrVrg+vRYviXHRjOvSa1afjx7PdevrQ3+f/rG50D+nFQVZn56zohDrj9lMATe/Z/251HDdObXCtzyzjq3PySysOyFuZ0f4aPyORCqZ4k+/+VdsKNnDHz3znyQmitvnZt2jqh3p/K0zJX8Hl8fJ+s+uxO1zM2fTNErqjP4NdoedTZ9fg9vnZtb6qVp3eS5sNht3f2Etbp+b6d2TLP0Rtjy7Do/fw5SVEzQDI33c/cw6vAEPE5d20DixVsafXYc36GHCwnYtNWbAv7AOX8jLuLljaZshU3Tv/sJaLdVkRdHd/PQa/GEfY6Y1MmGRTNHd/NQaAlE/zZPrmbRsvIRvelLVgmqYUGOporvhyVWE8oLUdVQxo1tW0V3/xGrCiRDVbZXM3iir6N71+AqiBWEqx5Qx11SoB5UCGyuKUt5UwoJtsspu98NLySuJUVpfzGJTIR9g1QOLyS/Po7imkKV7ZArvyvsXUVCZoLAqnxX3LZTwZfvmU1RdQH55HqstVHiX7J5LSV0hidI43RY6UAt2zKKssYR4cdSS4jt/ywwqW8qIFkYsVXrnbJpGdWsFkfwQ65+QVXpnrptC7bgqwnkhNjw5KpH+UeJmCuH1wONABTp7WEVR5G/cJyDu5J3Gk4tf4Od/+5p220yhlW6bKLTm22YKrVnV1UzJNVNazRRWMyX11m8bKavSbRNl1UxRveXbJgqr+baZwnoj3ExZNVNc9Qq1Vo83U1LNt80qvrf6eJXSOkJJtcZHKK3SbRMFWL6tyvxe7/bNHqPx8YJM+vrjpXNqum1WXt7/8i5W3r+IOzFu507jT4FfAk+jTh65v9H4hIW5m9cb8LDhiVW4vS4W7ZhNeaNxZ+B0O9n89FrcPnXnUWVSubXZbGx9bj1un4s5G6dq1qO5yKQVdrywEbfPzQwLf4zkUIp7vn43Hr+bqau7GGda2SeHktzzoopPXt7JhEVtEr7nG1vwBjx0LRknNd8lh1Lc880teINexs9vY9oaI8U2NZxizze3qjuPOWOYvWGqJe4P+xg7o4m5m43Nd6lkmr3f3Eog4qdlagMLdxrXSelkmr3f3EIw6qdxYi1L7plngW8lFA9Q31nNctPKPJ1Ks+ebWwnnBalpr2S1aeWdTmXY840tRPLDVLVWsPYR48o7k85wz9fvJlYYoaK5jA2mlXUmnWH31zYRL45S1ljMRtPKWsko7PzKJhJlcUrqitjyhXUGiq+SUT/f/IoERdUFbH12naEHQskobH1+PYVV+RRUJtj+pQ2GC7qiqOme4ppCEmVxdnzZjCts+nw3pfVF5JXE2P31zdLueMMTqyhvKiVWFOWeF+82jAdY99gKqsaUEy0Is+cbW6Xxqx9eSk17JeFEiL3f3GKYMED156gfX00oHuTZP3/sjp0wbiVuZqfxC0VR5H34JzTu5J3GfZ2f5f1fHtZuewMekkNJUsk0QgjC+SGDzIXb5yKTJHaeygAAIABJREFUyozUOApCXD4zgjuzhdXcat9cw7A5bDgc9uvWOMC4O4kXRbl4+qPXOKxy8PqGxY9SAzHWOGRcX8Owwo01jBvhFjUOHUXYsoahr3FYvD99jSNeEuWiiWKqrwtYnV+99MlHqmEURrS6l1UNQ/+diBZEJK9u/XfCSkblRjUO/TmJJEJcOX/9GoeVDIr+nEcLwjzx7x6yTFveCXE7dxp/LYS4TwhRJISI5f5uwzGOxm2Oz/xgn5bnr26tIK80rqVLFEUhnUxrFNjKljKKqgq0dI6iKAz1DWsU1/KmUsoaiw3pod4r/RqFtaS+mJrWSkP6qef8VU2qo6imkIauWkM66+Lpy5onRmFVgubJ9Yb018VTl5m8XF2f5FfkMWZqoyFddvHkJSavVOsEeaUxWmc0GTrcL5y8xJRsHSFeHKV9dovBJOrCiUuaFEi0MMy4uWMNWkQXTlzSdiuR/BDj57cZ7FIvnLjE9DUTEUK9AHUuajdQgPV4MKZKmxjxi0zvnoSwCfwRHxOXdhguYhdOXGL62knY7LasdEqnoVB74eQlZqydhN1hxxf0MmXlBMPu8uLJy0zP4p6Ah6mrJhgushdPXWZ69yQcLgcev5tpq7sMi4gcnhM0nLZmomESuHT6MtPXTMTlceLyOJnePdFAlLh85grT1kzE5XXhdDuYvnaSYRFx+ewVpq7qwu1z4XA5mLF2kmERcflcD1NWTcATUCX7Z6ybbKAgXznXw5QVnXiDHuwOOzPWTjJMolfOX2Xy8k58IR82u03Cr164xsRl4wlE/CO4bpK+fLaHN//pHS6ducw7r4xYCIyGMWSOnxzbsv/qU1IKIFcxR+O3GoN9Q9pFWGUwGXeRiqJoF+GhwWEcJgqqgqI54Q0NDGGzm1RmMyN4cnCYtIniqCho4nzJoWFJkgLQairJoRSpZErC+7XnT5FKyXju+VNDKZJJ+fn7dc9vdp1T8dz4NKnhpIRrzz+cJmmF9w6iKFl80ALvG8GHh2R8sG8QJaNO4FbjB/uGyKQzpJIpyXVPff0h0qk0qWRKcvUDGOobIpNOk04Khgcsnr9/UPtcLMf3D5FKprFnFIYHhiR8sH84u3PFUM/Sxg8Mk06mUBT1WCR8cJh0Mk06nZH8vQGGB5KkhlNqH5HJP1wdnySdTJNJp63HDyZJJ1URzoE+eXxycJjkcFLFLZ7/zR+/y3/9zn+n/9oAszZMZc+LW0hYqOneyTFKuf0URCqZwuF0SOkpX8hLJpUZ6QBPhAwru1wPQ64DPFoYMaR/XB61N2Ogd1DtEC+KGtIrdocdt891/Q5wAf6Qmv65Xgd4IOKj90r/R+8AjwW4msULK/MlnwR9eseqA/rGHeIjtE7rDvCwltLTGyblQp/SsRpv6BC3wPXpE6vnN3SIW3SQJ8ryOH/8wnXfn75r2+r86ju8rTrsDR3gum7xXOg/E8sOcd0x3Qi36hDXnzOr9J/+nFml9/TjrdKnm5/qZvuXZKHDT2PctvSUEMIphHhQCPFn2b/9Qgi5i2Y0fuMx2D/EH33hP9Gd2Mn/9cgfSUU+t8/Nkj3zcLoczNowhXiJ0d/A5XGy/N6FOF0OpndPIr88z4DbHXZW7l+M0+1g6qouiquNFF2b3cbqB5fgdDuZtLyT0nqjSi4KdD+yDJfHSdfSDomiC7D2keW4PE7GL2ylqrVCxj+zDLfXRce8VmrHVUl492eW4fa5aJvVonW362PNw0vx+N2Mmd5E86R6GX9oCZ6Ah6bJ9ZrBkj5WP7gUb9BLQ1et1r2uj1X7F+MLe6nrqKJjnpwLX3n/QgIRPzVtlUxYKFN4l9+7kGA0QOWYMiYtk3+vS/fMJxQPUt5UwpSVMoV32Z75hBMhSuuLmL5GpvAu3j2HaEGY4poCZq6bLOGLds0hVqQabs21UOGdv20meSUx8svzmHu3TPGdt2UG+WV55JXGWbh9toTP3jiVgsoEsaIIC3fK+My7plBUU0C0MMLiXbKK7/S1kyipKyKSCLHUpOUFMHVlF2UNxYTzgizfK+OTlo2noqWMYCzA8nsXSPiExR1Ut1UQiPpZsX+0CH4zcTOF8P8bcAJ/nL1rC5BWFGX3x3xsHynupJ3GIzOf4Y1/eke7babU6ovAAJ6Ax7DlN6veun1uhvqvr3prptSan89MkTU/n5mSaqbs3kj19oa4pGrrNKRoJPwGqra3jN9A1VZSzTWr2propLKqrVHF1Xw+zRRY8/kyU2DN50MIEMJGJnN9VVv9e7BWtdWp3tpGnmsEH3lNK9Va/TELkU2w6lVt9aq3AkAYGF/SOTOd0xudc/Nn9tDv72GZheT8pzFuZyF8gqIo2xRF+Yfs3w5AXvKMxm88+q4aDWX8YT+bnlqDN+Bh+b0LKa0vNuAen5st2ea4xbvnUjHG6I/hdDnY8YKq8rpg+yzqOoxlK5sQqj9G0MPczdNpzupS5SKTzrDvWyrFddb6KZLKbSqZ5r7vbscX8jK9eyLjs0X1XKSTae5/aQf+sI8pKycwcWmHJR7IFpGnmJrn0qk097+0k0DET+fCdmaumyLh+1/eRTAaYNzcsczeaKTgZtIZ7n95F8F4gLZZLczfNkvC97+8k1BekDHTGiWV20xGYf9LOwknQjRPrmf5voXS+Pu+t4NIfpiGrlpWmfwrlIzCfd/bQawwQl1HtUSxVRSFfd/eTrw4SnVbJes/t0oav/db20iUxqkaW86mz68xjYd7XtxCfnke5U2l3P3sWgnf9fXNFFblU9pQzLYvrsccO17YSHFNAcW1hex4QU7bbH1+PaX1RRRV57Pra5skfMszaylrLKGgIsGeb2zBvGbd9Pk1VLaUkSiLs/db28xlOdZ/bpVK8iiJce93d0h+GGsfWUZdRzWxoij3v7RDouiufmgJDRNqiBaE2f/STglfft9CmifVE8kP8cJfP3HHTBi3Ejez0/glsE5RlIPZ29XAnymK0vGhA39LcSftNPZ1PM7BV49ot71Bj1oIzf4QzDIJHr+b4YHhEdzk1ObyOEkl09d18nM47SgK13Xys9lUb+kRJz9Z5kG/0rN26hvZrVg54elX95a4bjdk6eSn2/18FKe+Gzr56XZnVu9Pv/uzxn30X8059cnnzx/20tejjrdy2tO721nhegqxFQVV755n5cSnryEF4wGuXew14rox+nqUhuteMxAN0HvZiOu/s3pJl1zoabWBsI9ekxOf/j3rz6U2XnfOfUGPRpzIhf4zDUT8fO5PHrDs/P80xu3caTwO/C8hxA+FEP8I/APw6K97gABCiEVCiANCiA+EEE9Y4G4hxH/O4q8IISpvx+t+WuLJf/8QHfPVPHrLlAbySuKG9IgQQqPANk6so7CqwOifkExrP4j6zhrKGksM6YahgWGmZimqteOqqG6rNKQz+q70M32tmkevaq2goavWkC7pOX+NWRvU1X5FSxljpjYaUgNXzvUwK7vaL2sspnVmsyG9deVsD7M3qXhJXSHtc8YY0kFXzvYwd/N0hFALmh3zWw3ps8tne5iXxQsqE3Quajekyy6f7WHelhkIm1qk71rSYWDkXD7bw/wtM7DZbOSVxJi0fLyMb52RJQlEmLJygiGdd+WcOt7usBEtCDN1dZchXXjlXA/zt87E4VRl6mesnWS4yF05d5X522bicDkI5QWZuW6yNmGo5/cq87fOxOl2EowFmLV+isEOtef8VeZtnYnL4yQQ8TN7w1QDhfjqhWvM2zIDt8+FL+RlzqZpBrvVqxevMffu6Xj8brxBL3M3T9cmDIBrF3uZu3k63oAHj9/NvLtnGCaZa5d6mbNxGr6gF7fPxbwtMwyTVO/lXmZvmIo/7MOVlbbRL3J6r/Qxa/0UAlE/Lo+T+VtnGvowenv6mbluMqF4AKfbyYJtMw2TZP/VfqZ3TyKcCOFw2pm/baZhku6/Nsi0NROJFoSxO+0s2DbLsAjovdLHu6+8z9mj5/nF/z+itHCnxw0pt4qi/L0Qog5oAATwrqIoMtftFkMIYQe+D8wHTgA/E0L8laIob+setgu4rChKrRBiA/B1VMfA0UCVrj57RGWbnD9xUVKpTacznMkyRy6evCSplGYyGY1ZcuHkJXwhrwFX0hlOvn9aHX/qEqF40DheUTT80unLRAvDxvGKwsn3VPzK2SuWKrWn3j+j4ueu4rZQMT31gXp8Peev4Qv5JPzkB2dQFOi5cI1QLCjjB8+iKHD1Yq+0qgU4ffAsSkbh2qVerl26JuGnDp0jk8lw7XKftKoGVR49k87Qe6XfUiH1zJHzpFMZ+nr6uXpefv6zR86TSqbpvdwnNbZp+HCKvivW+LljF0gOJUmn0oaeiVycP3aB4UG1wdMSP36Rof5hhE1IjX2g9o4M9g0hBBLzCNT7BrPUVrN4I6i9OQNZmrEVfunMFfqvDaBkFIk5BWrvR//VATLpjDV+roe+nn7SqYzE7AJ1Yu670kcqmeasiVkH6sR67XIf6WSa04fPSvhrP3yLP/3WXzE8mGTC4nHc/70dlNQWSY+7k+LD7F7nKIryD0II2dgXUBTlz3+tFxZiMvCcoigLs7efzD7vV3WP+dvsY34ihHAAZ4CE8iE5tTshPTXQN4jX72HvuMc49NpR7f5AxI+iKPT19OP2ugjGAoYfui/oxWa30XulD5fHSTgRMlAY3T43Lo+Ta5d6cbqdxAojBn8Ep8uBL+Sl58I1HE47eSUxww/VZrcRigW4cv4qDqedRFlcopDmUi52h538ijxOHzT+UHNdxTa7jaKqfE5+cMaA5yisNpugqKZQm7RykaNV2myC4tpCTrxnxHPKtUIISuuLOH7glBHPUlSFEJQ2FHP83ZMGPL8iwbnsOSlrLJFwPW21rKmE4+8YcT2FtLyphGMmvKimQDsnVnhxTSGnDp657vOX1BZq58xqfEldkXbOrPDS+iLtnFm9v9KGYk5kz1lZQ7F0/vS4/v+5KGss5vi7p6TXGsFHXlN/rLkobyzhWBYvri3klOn7oX9P+nNpiVtQmPW4FUV5wxOr2fUVuVbzaYjbkZ7KSWQut/hb9msfIZQAeueTE9n7LB+jKEoK6AGkThshxB4hxM+FED8/f15ebXxa4trlXr7/4B/SnbeT7+791wahNVDZSLM2TMXmsDFpeSfhRMiAOz1O5myaht1hp2tJB7HCiAF3OO3M2zIDu8POhEXtxEuMjf82h435W2did9oZP7+N/IqEdIwLd87G4bTTPmcsRdUFEr5491wcLgetM5sprZNXbEt2zcHpcjB2ehNljeavAyzaORun20nzlAYqW8okfOGO2bg8Thon1lHdVinhC7bPxu11Ud9ZY0nhXbB9Fh6fm9pxldR3yhTe+Vtn4PG7qW6toGlinYTP2zIDb8BD5ZgyxkyRVXjnbp6OL+SlrLGEsdNkFd7ZG9V0TUldEe2zx0j4rA1quqaopoCOua0SPnPdFEKxgJqOM9npAkzvnkg4ESK/PI+uxTIFeOrqiUTyQ2o6ziKXP3XFBGJFEeLFUUsK8OQVncSLo0QKwlr3vT4mLhlPoixOJBFiuoXK74RF7eRX5BGKB5mxTsY75rdSVJ1PMBpg9vqpEt4+eywldUX4Iz5LleDWGc2UNRTjD/kkrTGAlqmNVLSU4Q16mHe3jI/GzRXCqxRFOXyj+275hYVYByzMUXeFEFuALkVRHtA95q3sY05kbx/MPkbe52bj07zTkOxbTZRYvY4SyJRYM26mxJopui6Pi+HB4eviZvqi+XjMlE6ziq6Zsmk+XjOFVRpvwj0BN4O9I+/HTKc0q/aqFNYRVddbxzFQWM0UYvMxmM83Qn2NDxuvP0dmii8YVVvNlGgwfgZmSjQYKa5WuJ7iav68wUhxNdNdzWPMFGDza1rh+vdsVqg141YUYP05EbYsPVd3ydPTtq3G6z8Tm03w8L/ea9lP8mmI21kI/68W9/3ZrR+SFCcA/VKxFDh1vcdk01NhQE6s3iFhln0IxYJsemoNvpCXVQ8spqjGuLL3Bb1sff4ufCEvy/ctoKzRSMF1e13s+PJG/GEfi3fNoca0Mnc47dzz4t34wz4WbJ9Fg3nlLQT3fmc7/rC6ajN7LasU1V0EIj5mrZ9K+5wWCX/w+7sJRP1M757IhIXGlXEmo/Dg791DMOpnysoJdC3rsMZjASYu7WDaaqPKrZJRePD3dhOKB5mwSKbgKorCA7+3m3BekI65Y6WVp4YnQrTNapH8KRQFHvhXu4kUhBkzrVFSuQXY//JOYoURmic3yM1lCtz/0k7ixVEaumpZbaLgAtz33e3kZa1yrfwj9n1nO4myODVtldz12ZUSvvebWyioyKNqbDmbn+6W8HuyFNuK5lK2PLtOwnd9dRPFNYWUNRSz7UtyOXH7F9dTWl9MSW0hO7+8UcK3PHcX5U0lFFUXcM+Ld0v45qe7qRxTRkFlgr3f2CLhG55YTXVrBfnleez7zjYJv+uxFdR1VJNXGuf+7+6Q8DUPLaWhq5Z4cZT9L++SKLwr7l9E86R6YoUR9r+8Uxq/dO98xkxtJFIQ5kt//eSndsK4lfiwmkYj0AK8iFF3KgQ8riiK3B57Ky+sTgLvAXOBk8DPgE2Koryle8z9wFhFUfZlC+FrFEX5UFutT/NOY2/7Yxx6faSGYW7O09MlQV4ZmymQbq+L4cGktpI24063g9RwegQ3USztDjtKJqOt9s3jhRAIwXVxMK7urHD9StmKAqpfCVuN169+Q/EAV03FbH0zl55OOoKPrIStxutXulavfyNcv9K1xHUrXT1dNhf6z9iKourxe7RCtXmnCcbdmxWup6Wad5rm+26Ee4NeTdsrF/rXNO8kze/J/H2+GVz/mzA3g4IqLHnt0ofhI5+J2+vi8T/ab9lZ/2mI27HTaECtXUQw1jM6gHt+3QPM1ij2A38LvAP8F0VR3hJCfFEIkVtS/QEQF0J8ADwCSLTcOyme+4vHNRXWiUs7pJqD060qjwKMmztGqikIm2DGXeoXvnVmM2WNJYbmqHQqzZxN00DAmGmNVLdWGPDh/mHmZd3imibX0TChxpAe6uvpZ9HO2QghaJhQy5hpjQb82qVeFu2agxAqhbd9doshHXDtUi9L7pmHsAlq2iromN9qSG9dvXhNwyvHlDFhUbuB4nvtUi9L987DZrdR3lTKxKUdhnTJ1Yu9LNs7H7vdRkl9EZNXTDB0/1691MuyffOxO+0U1xQwdXWXIV1z9WIvy/ctwOG0U1iVz/S1kwzpomuXelm2bwEOl4P88jxm3jVFwpfvW4DT7SCvNM7sDdMMF6kc7vK4iBdHmbt5uiFd1Xu5j2X75uP2uYkWRJi3ZYbhItl7pY9le+fj8buJ5IdYsG2WNmHkPp+le+bhDXoI5QVZuGO24SLd19PPkt1z8QW9BGMBFu2aY+hj6L86wOLdc/GHfQQifhbvnmuYJPqvDrBo5xwCUT++kJcl98wz4APXBli4YzaheABv0MPSPfMMk9RA7yDzt80inAjhCXhYtne+YRIc7Bti/paZRArCuH1ulu2T8bmbpxMriuLyulh+7wLDImpoYJjZG6eRVxLLSugs0CaMHD5r/RQSZXk43Q5W3LvAMIkPDQzzwa9+raz8pyKuS7lVFOUvgb8UQkxWFOUnH8eLK4ryN8DfmO57Rvf/QUDeM9+hUVRVwLN/9hhnjpyjsDKfveMeM+CpZIp3f/oBAIdfP4Y7K0iYi3QyzYFXVPzIm8fxR4wU1kw6w9s/eQ8UOPrWcUJ5xkJ6JqOoOHD8nVMSxRYF3vzRuyiKwvEDJ8krkdVB3/7nAygKnPrgDPkVeRL+1j8fQMkonHj/tGHC0cb/RMVPHzonUYzV53+PTDrD6UNncLnlr/fb//Ie6XSGc0cv4PV7JPydf3mfdDLNuWMXCET8Mv7K+6SSaS6cuChRkAEO/PQDUsMpLpy8xBkLCue7P/uA5FCKS6cvc/rQGQl/7xcHGR4c5tKZpMQcA/jgl4cZ6h9ieGBIozPr4/1fHdLUjo8fOCnhB187ysC1QQauDXLsnRMSfuiNY9ru9ehbxyX8yJvHtAv9kTePyfjbx7Xd0GHdrjgXx945qe3WDr4m48cPnNR6Lawu0MffO0XPuR4UBYM4Zy5OfnCGy2cuoyjw3s8PSvjpg2e4ePoySkbhwM8+kPFD57h46hKZdIZ3firjo/Hh6anPKoryohDiZaRMICiK8uDHfXAfJT7N6Slz/N0f/5AfPP4n9Fy4hj/swxf0Grjw/ogPp8vJlXM92upRT6H1Bjx4Ax4unbmCN+AhnAgZKIYuj4tgzM/FU5fx+NzEiiKc0lEYHU470YII509cxO11kVcalyiSOeVSl8dJfnmeRLEsqMjj7NELON1OCisTEoUzp0LqdDkoqimQKapZ2qTDaaekroijbxsvhDkKqt1hp6yxmCNvGi+EJXWFnHz/DDa7jYqmUg6bLoQ52qjNJqgcU25ID8IIhfR6eI7CKYSgqrXcQJEGqGgu5ejbJxBCUN1WYejwB9X35Ej24l3TXinhVWPKtWO2xMeWc/iND8FbK7SL+43w6rYK6fj199W0VUgTQU1bJQdfU5+zurVCOj/616xqLefw68dMeAUHXz0qvRer8ZVjyqTPV4/nzrX5+A69fhRFUSwpyNWtFRx+4xiKolA7ropH/s0+SV7n0xK3Iz2VU8L7OfALi7/R+C3HhEXtdC5oQwhom9Us7RycLicTFrUjhGDsjEaCsYABd7gcTFzSgRCClqkNhE07C7vDxqSl4xE2QdOUeqIFRoqusAkmr5iAzSZomFhHvMiooguqCqnNbqNhQg2JMnlnMXV1FzaHjbqOKgoqZQrv5BUTsDts1LRXWlJ4p6ycgMNpp2psOcW1hRbjO3E4HVS2lEpaXACTlnXicDkobyqhrEmm+E5aOh6X20lpQ7GlSu/EJeNxeZwU1xZS1Vou4V1LOnD7XBTVFFDTXinhnYva8fjdFFQmLC9GnQvb8AY9FFQkLCnAHfNb8QW9JEpjNJrseAHGzR2LP+wjXhKzVPltn91CIOonWhCmxYIi3D6rhVA8SCQ/TOv0JgkfO72JcCJEKB5k7EyZQtwytYFoQZhgLGBJIW6eVE+sKEIg4qNjjqwS3NhVT15pDH/YpxmA6aOhs4b8sjjeoIfOhe0SXjuumsLKfLwBj6aOoA/1e5WPx+eia4msjDR5eScvv/JVHv2D+/j+z772qZ0wbiVuyU9DCGEDAoqiyK2vn5C4k3Ya93c9YdiCmwuJ5sKo3nrVCjdTNs24mVLpj/jouzKSkzaropoLq0IYFUmtcBihuMo46FVNrXAhRmi4vrCPflNhV0+BtSr86gvzVoVd/Xu0xHW0UTNRAYyFe2vcoZlTWRWGHS47qeH0dXGX26mZP1kVhp0ep2b+5PG5GDRRfPWFe4kijPE7YkXx1ReTrQrL+te0ovjqj/mGuAUFWE/71p8rS9xhJ2UyCtN/pg6nncf/7f3M2XRn9GvcTj+N/yCECAkh/MDbwAEhxOM3GjcaH3+Yne8CET9bnl2HP+xjxf2LKKkzrrw9AQ/bv7QBf9jH0r3zKWsyrrxdbie7v343/oiPRTvnSCtjh8POvm9tIxDxMX/rTAv/CsH+rMrsnE3TGDPNSMFVFIUHshTbmeumSBTcHMU1GPMzbfVEOk0UXEWBB39/N8F4gMkrOulaNk7CH/i93YTiAboWj7NsLnvg+yrFtnNBG9MtWDAPfH8XkUSIcXNkCi7A/pd3ESkI0zqzmQUmFVyA+7+3k2hhhDFTG1l8j0zPvPd7O4gVRWmaVM+yfbK/w33f3Ua8JEbDhBpWPyRTcO/9lkqxre2oYu0jco/tPS/eTUFFguq2CkkFF2D311SKbeWYMjY+JVNwd35FVbEtbyphyzNrJVyl2BZRWl/MdgsV3C3P3kV5Y4mqgvtlWQV301PdVLSUUVRdwO6vb5bwDU+oKrYFlaoKrjnWPbac2nFVJMrz2PutrRK++sElNHTWkFca497vyBTcFfctpGliHfHiKPe9JONL7plHy9RGYoURvvTXT94xE8atxM00972qKEq7EGIzMB74HPALRVHkveInIEZ3Gr+5nYYZ/13Yaeh3EjfaafhDXvo+dKchq6h+3DsN/er6RjsNb8DNQO+H7DQsdiKGncJH2WnoxnwcOw39e/5oO40R2q/+XOdCv9Nwuhw89of33TETx+1s7nNmnfpWAX+pKEoSi8L4aPzm44W/foJFO2ZjswlmrZ8i1QQcLgfzt85ECJWiW9pg3FkIm2DxrjmqGu6iNqrGGHPy6VSapXtUimvH3LFSTn1oYIgV9y3CZhO0zmqhZYpxZ9HX08/qB5ZgswnGTG+ifXaLjD+0BJvdRtPkesYvaDVMKn09/XR/Zhl2h42Grlq6lnRI+JqHl+Jw2qnrqGLS8k4D46q/p5+1jy7D4XJQ01bBtDUTDRTfvp5+1j6i4lVjypixbrIRvzqgOQuWN5Uwe8NUw6TYf7Vfw0vri5h793RDR3P/tQHWProct89FcU0B87fONFCE+68N0P2ZZXh8boqq8lm0Y7bhIjbQO8jaR5bjDXjIr0iweNdcw0VyoHeQ7s8swxfyklcaZ+meeQZf8oHeIdY8vFStaRRHWb5vgcGXfLBviNUPLSEQ9RMrjLDivoWGi/xQ/xCrH1ySrWmEWLV/kWGSGB4YZuX+RWpNIy/IqgcXGyaZoYFhVty3UKtprHloqSEdlhxKsnzfAmJFUQIRP90PLzVMYsmhJEv3zCevRK1pdD+yzDBJJodTLN49l/zyPHxBL2sfXW5QJEgNp1m4Yw6FVfl4Ah7WPrLM0CeSSqZYsG0WRTUFuH1u1j26wpBuTA6npML4aID9ueee+9AHPP/88w7UDvBLwFeff/75CmDpc889928//sO79fjBD37w3J49e37bh/EbCW/Aw5SVE1hx30Lmb53F//iDv+fS6RElU7vTzpnD5xnsG+Jv4YzOAAAgAElEQVTymSsoKIaVtd1u4+zR8wz0Dqo+1wLDzsFms3H++AX6rw5w+VwPQmDgvQshuHjyEn09/Vw524OwITWnXT57hd4rfVw514MQQmqOu3Kuh2uXeuk5fxUhkPwdrpzv4erFXq6evwoCg3Q2qOq3PReucfXCNYRNSP4RPReu0XP+Klcv9iIEkj/F1YvXuHIuhwvJ3+La5V4un1GPUQgk/4xrl/u4fOaKRjM14309/Vw8dZneK/0gVNVWffRfU/G+nn4URbHAB7lw4mL2c1MkpdqB3gHOH7+oKsFmMtL4wf5hzh27wMC1QTJpWel2eGBY+w6kkmlpfHIwyZnD5xjsGyI5nJLxoSRnDp1jqH+Y5JCMp5JpTh08y/DAMEODw9L5SafSnPrgDMODSYb6hyQ8k1VaTg4lGewblPxTlIzCiQOnSA6n6O8dkD5fUDj+7klSwyn6rw4YpNUBECoNOJ1M09vTJ31/Wmc00z5HLuB/GuP5558//dxzz/3gRo+74U5DUZSXFEUpURRliaLGUUA2+x2N31rkWE8bn1xDoiyevS9IIOLXLoL91wbou9JPQVZkMBQPEikIaxeRgd5BrpzrobBK9QEPRv0kyuKaXPZg3xDnT1zSGEr+sI/imgKN4js0MMzpQ+c0n3BfyEt5U4lG8R0eTHLivdOalInH76aypUyj+CaHkhx/9xQVTSpDye1zUTW2XFMpza36ciKFbq+LmrZKTfE1lUxz9K0TVI1Vd0tOt4Pa9kqNApxOpTny5nGqsz7kDpeDuo5qjQKcSWc4/MYxqrN1HIfTTv34ak2RNZNROPT6MWqyIod2h436zhpNkTWTUTj02lHqOlQ8xxjLUTwVReHgq0eoG6+yb4RN0NhVy9G3jHhuNydsgsaJdYZeiA9+dUSrI9lsgqZJdQaK6cFfHTEwqJom1Rl6JT741REaJ6q4EIKmSfUGCuzBV4/QqBNhbJpcr9FlLfFJdQYK7sFXj9A0yYjrKbyHXjtK06Q6LQ3ZNNGEv37MML7RhB9+/RiNE+uw2dTxDV21BvzIG8dpnFiXTWNCfWe1EX/rOI1ddVp/jxk/9vYJGrpqsTvsAIyd0SS5O47GzRXCw0KIb+dUZIUQ3wLkrqfR+K1Hw4QaGiaoF4Wa9ip8QaM/ht1h136UVWPL8Zv8KewOO82T60FA5ZhyAiYKr80mVFqmgPLmUonCK4RgzLRGhBCUN5ZIFF6AsdObETZBWWMJkfywhLdMb0TYBKV1RURNKrwALdMaVdn0mgJiRTLePKUBm91GcU2h1DGv4vXYHXaKqvK1CdaAT6rD7rSTX5EgUS5TgJsn1WVl3/MorMyX8MaJ9TjdDhKlcQqrZIpw44RanB4neSUximpkinBDZw1ur4tYYYQSCwpxXUc1bq+LcH7YkkJcO64KT8BDJD9MWYNMIa5pq8Qb8BCMB6iwoBhXt1bgC3kJxQOWFOOqseUEsh3h5nQmqGZbwVgAf9hH1dgKCS9vUr833qDHkoJc1lBCJNsRXmuBl9YXE0qEcPvc2gRswOuKiBVFcXtd2m9BH+r3JorL46ShS1Yp7lo0jn/96jd45s8e49s//CIVzbKS8p0eN1MI/6/Am8AfZ+/aArQpimLps/HbjjupEG4Oc2H8ZrSn9DnsG2pPmXC7w0YmrVwXv93aUx8J1xWmb6RNZYXri60fRVvKgJu0wcBYTLbSlrqR9pQBv5H2lIkiDcZiuRWFWF94tir864v5VvapRu0powoyGMkIVoX5G+K692SlEmzQnrLA9efU43Pzuf/nAUn48k6J21kIr1EU5VlFUQ5l/54HRjtcPoGhZIyyzr6Qj63P3YU/7GPZvgWSf4Xb52bHlzepKre751LRYlxZOl1Odn8tq3K7bZbkP2Gz29n3bZWCO3fzdBosmsvuy1JwZ62fKqnggkphVVVuJ9E2S24Ou/+lnQRjqsrteAt/iP0v78qq3I5n4hK5eWv/SzsJxYN0LmxjyirZ/+G+7+1QVW7njdV0u8x4JD9E++wWy1TFvu9sJ1oQZuz0RubdPUPGv7VNVbmdUs/CnXMkfO83t2gqt8v3zpfwe76+hbzSGPXjq1lx/0IJ3/21zarKbXslax6WKbo7v7yBgooEVa3lrHtkuYRve349hdWqyu2GJ1ZL+Nbn7qK4tpCyxmI2PyXjm57uprShmJK6QkuV3A1PrKK8qZSimgK2PS9rja57bAWVY1WVWyuV3O7PLKWmTVW53fVVmaK7av9i6jqqSJTGuedFmYK7bN8CTeV27zdkfMnuuTRPVhsMn/uLx+/YCeNW4mZ2Gj9BVbX9Ufb2VOCbiqJ8IqUe7+SdxsPTn+atHx/Qbt/IT8NMwTXjt+qnYaaQ3qqfxo38Mm4V//X9NEBP8b2Rn4bVSlj/Hm/kl3FD3ILCavDTsPLb0H0GlrjBT8NhEHAEk5+GFX4jPw3dGP1zjeA6Pw0TZdt8zObvkxm39MO4oV/GCEXYZrfx2B/cx/ytRgn8OyVu507jXuD7QogjQoijwL8C9v66Bzgatz9e+Osn6X54KU63k0U7Zks5cYfTwYr7FmJz2JjWPVHaWYDaHGV32JiyopPaDuPOIp1Ms/bR5diddiYu7aBpslGWYmhgmPWfXYXDaWf8wjZaTbISA72DbPz8GhwuB+PmjmX8vFYZf3K16uw3q1mSdRjoHWTz09043U7GTGtk8opOCd/01BpcHidNk+uYvsa4ahzsG2Lz0924vC4aJtQwc/0UA4V3sG+ITU+twe1zUTuuijmbpkv45i+sVZ372iqYv3WWYVIa7Bti81PdeAMeKlrKWLRrjuEiNdQ/zOanu1WSQGMJS/fMk/BNn+/WnPuW37vAiA8Ms+mpNQSifoprCli5f7HBlGh4MMnGJ1cTzDr3rXloieEiOzyYZMMTqwjnBUmU5dH9mWUGinByKMX6z64kkh8mryTGuseWGy7yyaEUdz2+glhhhFhRlLseX2mYJFLDKdY+upx4cYxoQZgNT6wyTDKpZJruzywjURonnAhl8ZFJLJ3KsPqhJRRUJAjFg2z6/BrDJJdOpVm5fxGFVfkEYwE2PmXEM+kMK+5dqDr3hX1semqNYZLNpDNqU2tjMb6Ql81PdxsowqrQpSwyORrGuGkZESFECOCTLCECd/ZOIxc5D3HZ6c+Lw2Hj2uWcR3iY88cvaLjb58Llcek8wsOcPTqC6z3CnS4H8eIYZ46MCBwKmyCcF+LKuR7VQ7wszhmTR3isMMKlM1ewO+wUVOQZBBAB4kVRLp6+jM1uo7AqX/KAjpfEuJj1ALf0CC+NceHEh3iEl8U5f/zidT3C8yvyOHc05xFepLGnclFQkdAYYVYe2jf0AM8KMF4Xv5FHuM4Xu7ypVFKqvRUPcEtc7wFu8f70vuCWuO4+a4/wD8f1x2TpEW7AVbHJ6+F6P3VrvED6/m15Zh1bn/tQy55PbdxOGZG4EOIl4IfA/xJCfE8IIdNORuMTEznJ721f3EBZtqEvr0Rd/eWKgsODSfp6+ijPMmhiRVESZXlaITc5lOTK+atUjlHZI9GCMEU1hVqfRHI4xfmTF6luUxky4USIyuYyjeKbSqY5e/i8RkENxYNUt1ZoFN90SuXv5xgwgaif2nFVXDytUnwz6QynPjijUVADET9146u5eFI1bsxkFE6+f1qro/hCXhom1HDhxAh+4r3TNGbZYt6Ah8auWs4fVynCqnz7KZUthppaappUz7nsJKkoCsffPUXLFBV3+9w0T24wqAQff/ckLdk6jdvromVqg0El+Ng7JxkzXcVzu6PTh4z42KwIoMPlYOyMJm3CyOG53ZrDaad1RrNhEj32zgkNt9lttM5sNlxkj71zktZZLRreNrPZMImquDpe2ARts1oMF/Hj756kbVYLQghsNkH77BbDJHv8XfX4chTXtlkthknkxIFTtM1qwWYTCCFomy3jrTNVNl1uvH4SO/n+aVpnNmsUWBk/Q+uMJuwO9TLWOrPZgJ86eIaxM5pwuFSJ/LEzmkz4WcZMa8TpdgIwadn4OzY1dStxM+mp/wScB7qBtdn//+eP86BG4/ZEUXUBhVll2ERZHLfXZcBtNhsltWpxPFEaw+Mz4sJmoyRbPI+XxPCY/Dlyq3WAeHEUT8CIA5Rk8WhhGF/IK+G5SS1aYI2XNqjjI/kh/GGfhJc1FCMERBIh/Bb+F6W1RQibIJQXJGCiCIO6mhU2QSgelCjEoK7sbTYboZifcJ4FXlOAzW4jEPVbUoyLqwqwO2wEo34iCZliXFiVj91pxx/2EbWgIBdUJHC47PhCXtm/JIu7PE78YR8xC4pyfnkeLo8TX9BDrFimIOeX5eH2ufAFvcSLZZXiRGkcl8+F2+e2pDAnSuN4/B48fjeJUnktGS+O4vk/7L13mBzXeeb7VnXOOU5PzjnngEkAJiDMAJgEzACDMEMSBMEABjATBEmToAJFUZKtsJKu7bXXe++15fV12HXc+9iy1/KKtgLFgDwIk3PsUPtHdReq6tQQFAUSpFTv80Bgz29OdXU1VKfO973n+wwaqHVqySrHDp8NerMOap0a7gSS27026E1aqDUqyf4rNo8VBoueLa2fTFqgrW4LDBY9lCoFfBIW6NKthfjOz76M1/77szj7p6clKynLEuqjJML/jWGYUtHPfvRRljF3Q3J46pYeqHqSa8oEsE/TG6sbXPLY4jILdsCqtSqEgmEuji7mSpUCDAMuTi7mNE2BVtBcHFzMAWHy3Oo2Ezt4+YlRq9tC7NDmJz4lOc/CKsX5iVEpzk9mfxzOt5VK81u1j6Q432wgdX0MFh2W51kudX35ZgaL00TsoDda9ezudABmp4nYgc+3oEq11+XbiqUsxvyWuFIWY/4xpSzE/HMyWA1YFlmI+Z+Zfy2kuJSFmH9NTTYDnvz9B1HeRrrufhN1JxPhf0dRVD9FUXT0Ty+A/+9XP0VZn7TEDwQavQYHnu2BzqRF+7EWIlGu0qhw6Ewv9CYdth1qRGKOcPOXUqXEkZf7oTfp0DLYgNTCJAGnaBrHXj0AvVmHxr4ayf4PI68PQW/RoX5vFXKqyf4NI+dYi2/N7nLkN5D9G0ZfH4LRqkdVZwmKW8j+C6OvD8JoM6BsexHKt5MW3WPnBmGyG1HSWoCqnaUEP/rqAZgdRhQ25qJWwqJ77NUDMDtNyK/PxpZe0kB45JX9sLrMyKnOQFM/adE98nI/bB4LMivSJEMhh17sh91nRXppCtokLLoHz/TBEWdHalESdkhYdIee74Er4EBSXjx2399G8APP7oM70YWEnAD2SFTRHXiyG95kN+Iz/dgrUUW377Fd8Kd54U/zou/x3QTf+8hOBDJ88KW40f8kadHd81AnErLj4Ely4cAzZJXd3fe3ISkvHu54Bw5KWHh33LMVKYWJcMbZcegMWUW3/VgL0ktTYPdZMXyW5NsONSKzPA02jwVP/cHD8oTxMfRRVhqLYHeAx2wUCgCx6Z9hGIZck99FySuNW3qs9Qze/tufcq/FFlz+Uy9AVjUVb8YSVzUVW0zFlkzx8fj2TpYLLaZiS+XtuPh8xJbK23KRpZjkQouq2OIrrsIqtvgSXGTxFVuWCS66nixnEPu/LGFxpQAK4Lj4eostwlIWVpqmEYnu95GywPKvkZSFlT+Gf6xb/NZ7UjQFMLc+j/icKTpqd+Zxvm1XbImWuibiysr8a05RFB759n1oOyxXRQLu4EqDYRgTwzA0wzCq6B86+jPTZ23CkCXU2T89jaHneqA369B1oh0JWeKVgwK9j+6GUq1EY18tUgvFZR8o9J/uhkqjRP3eKqJ/RigYxoFn9kGlUaFmdzny6oQrg43VDRw80wu1VoXKHSUoEa0M1lc2MHy2D2qtCmVtRShvLyL5SwNQ69Qo2ZpPrAw2VjcwfLYfGr0ahU25xOa8jVV2vEavQX59Nhr7aoR8bQOHX+qHzqhFTnUG0T9jYy2Iwy8NQGfSIrMiDduGhTeX4HoQh1/qh96sQ3pJMtqPtUjwARiseqQUJmLHvVsFN7DgRgjDZ/thshmQlBePrgfahXw9hOEX+2B2GJGQFYc9D3UIbrChjRAOnemDxWVGIMOHnlO7BDwcDOPgmV7YPBb4Uz3ofbxLMKmFQ2EMPdcDu88GbxK7MuDf5MOhCAaf2wdnnB3uBCcOPLNXMElEwhHsf3ovXPEOuAIODD67TzDJRCIRDDzZDU+iCw6/DUMv9AgmKSbCoPex3fCleGDzWHHwTK9gkmMiDHpO7UJcug9WtwXDZ/sFFmCGYVcu8Zl+mJ0mHD7bT+wT2f1AO5KipU2Gz/YLJmmGYTDFa48s66Ppl+rc93mQvNIgFQqGoFQpcbLmKbzzz+9zP48ltteW16FQKmDzWDAVdScBbG8GpVqJlcVV0AoaDp9N0INcoVRAo1djZWEVNE3BEWfn3EkxxUpb0DQFZ8CBiStTAh6Li1MUBXeCU+BOAm7FwCmKgjvRifFLIs6LgfPtrjHxY9xSnJ9XiPUb5ytmEd6U+2yYiTq+pLjDb+OKPvLttDE54+zcNZca7wo4uGsuyaMW4s14rEc7y90C9xZwy2K82fXhc0+yG+Mi7k1yc7ZrT5KL+H68yS7cvDhJHCsmX7IbN6LHlOLeFDdn23bFOwUWcfFn5l8LjvOuOf9ax3ToTB8GnyWbTf0m6k7mNGR9zqVUsZbD0dcPchZYb7IbrngnF14Kh8JYXljhVhOeRCf8aV5uh3ckHMH81AJX8NAZsCMxJ8AlGiMRBtPXZ5Fby+YpHH4b0oqTuVpIkQiDiStTXJ7C5rUioyyVS6QyDIPxy5OcBdTqNiOrIo1LmjIMg/FLkyiM9uSwOE3IrsoQJHJvXpzgylibHUbk1mYKEsU3L06gpJVd7RhtBuTXZwsS0TcujHN9qA0WPQq25AhKid+4MI7SbSzXm3UobMrlJowYj3Ub1Bm1KGrO4yYMALhxfhzlbexqSmvQoLglX3ATu3HhFtfo1CjZWiCYpFnOxuDVWhXKthUKbpIxTtEUVFoVyrYXCibpGxcmUNHOcqVaifK2IsFN+ubFCZS3FYFW0FCoFAQf53MljYr2YsE+nfFLkyhvK4JCpWB5RzE3YQDAxOUplG0vglKlAEVTqGgv5iYMPldplCzvKBbs85m8OoXSbYUsp4CK9iLBJDl5dRqlWwug0aujPWKKBJP01LUZlLQWQGvQgKIotByoR9tRMm8k68Ol3AxQFPXnAI4zDHPp0zsdWZ+k9CYd9NHKtjqjlkiUAxTHtUYt54+/hSkYLAZuvEIl4gBni9XqNVB+HG5mj6/RaTh/vXA8y9U6NVSSnD2+WquGSq0iuN6sA0VRUGvVkse/xVWcf1/AjTr2pqyR5jrTLa7WqgmuNWhBK2go1UrCAg0AOqPuNlwDhVIBpVoJ9WacZm/qGh1pgdYYouNVSmj0JI+dH62gNuHR742S5hq9BgolDSbMSI/XR697MAytUUuO16mhUCrAhBloDdJcpVYhEmagNZIWbbVODaVKgeB6CDoTyQsbc/HY9+7H1Ng0siSq3Mq6vTYNT0VdUi+BrW57Ltqx7zMvOTy1ucThKY1ejUgoguBGCBRFweo2C5rgqDRKABSXzOWHagCAVtJQKhVcstjuswqaQAFCi2tst7eA85Ll/FBOTPx6UrHd4JtxqfAD33b5cTi/iqoU59tGpTjflirF+RZUKc63zUpzM+an2NWU1PXjh+ekrr/VY+EaG/FDbTHZPBbu34T4+wfYFWOs8ZIU5/+bkLIY889JkvM+k5TF+Lac92/G7rPhqd9/EIWNwg6Sslj9yuEphmH+CEAxADOAH1EU9ShFUY/E/tzBc5V1l6TWqtH7RBc0ejVahxq4BksxKVVK7H+qG1q9Bs3767gGSjHRNI3BZ3ugNWiwpbdGsn/CwRd6oTVoULenEmnFSQQffrEPOqMW1bvKJKvkHjzTC51Ji8qOEm53tpjrzTqUbitEfgNZJffgC73Qm/Uobs5DsUQHtoPP93ChqLK2IoIPPbsPRpsBeXVZqOosIfjgs/tgshuRXZWO2q4Kgu9/eg/MThMyylNRv7eK4ANPdcPiMiOtJFmyim7fE12weSxIKUhEyyDZq7rvcbYWVFJuPLYeIl1APY/uhCPOhoTsOLSPtBB874OdcMU7EJfuQ+doK8G7TnbAk+SCP9WDXcdJC+/u49vhTXHDm+TG7hMk33HPNvjTvXAnOCUtvG3HWhDI9MMZcKDnFFmFd/twExJzAnD4bZIW39ahLUjOT4DNa0X/EyRv6q9FalESrG4zHvnWvfKEcQf0oYlwiqLUAE4D2A92FzhnjYiWSP/MSV5pbK5nd72Kf/6zf+Nei6vCil+LLbXi1+Kqq+LXYsuqSqsS9KgWW0rFFlWxJVXMxfZK8e+LOfFaVHX1l+Viy6rY4iq2rIq52LIqPh6toBAJMzwuPJ54/G1fiyywYgux+LXYEhsrF8K9FnOp36eENmS+LZntt0Jx50RRrGd4s9+X/ozCa0ReM+E1ffh37kHHCDk5yroDKw2KotoAvA1AD6Ak2lPjTOzPHTxXWZ+Snv9/HsW9XzwUrUDazdWViolW0Bh8bh80ejVaDtQjvUTYNoVhgEMv9kGj16CxrwY5oif/4EYIR17ZD41eg/q9VVzdI46vBTHy2iC0Bo1kf4zgehAj5wahM2pR2VmCyh2lJH99CDqjFmXbi4gn++BGCKOvD0Fv0qGkJR9beoSb70IbIYy+fhB6sw4FjTlo3l9P8Hu+cBAGix55dVnYeqhRYvwQjFYDsqvT0SGy2IaDYYy+PgST3YjM8lTsuHcbwUe+MASzw4S0kmTiyTwcCmPk3BAsLjNSChOx9+GdIh7BsdcGYfNYkJQbj55HhTwSjuDYawdg97Eri/4nuoQ8EsGRVwbgjLMjkOHDftHmukiEweGXB+COd8Kf6sXQcz0CCy/DsG4jT5IL3iQXDp3pE/IIg6Hne+FL8cCd4MTw2QHBDR8ADjy9F3FpXjgDdhx+ZUAwiTEMg4HT3YjP9MPht+HYqweI8b2P7kJiTgA2jxUj5wYFEwQA7HtkJ1IKEmF1mTH6+iCxD4XoES7rl9aH5TT+fwD3Mgzzs0/3lH41ySuN24thGFAURfTfUGvVYBgGwfUgKIqCzWsR5CiUKiVoBcWtHsQxdIqmoNGquR4dUjF2/mrldjmM2+YgohVtN+N8u2pM/DIbUpyfo5Di/BzFx+H8HIUk58XlXQE7JkWfjx/3dwYcxD4DAZe4fjaPFbPj7Hcqdf35OQqH347p68Lx/LyHVI6Ef0ypHAn/nPjvJcl5+RSO875zqRwI/5pIlWE5/NIA9j/1mWw6etd1J3Ia9Z+3CUPWR1Ns5/EDbx3jqqQmZMchLt3LhX8YhsHK/CpnYQ1k+pGYGxCEm+anFrnVgj/Ni/SSFEFTp+nrsyhvZy2ivhQ3sirSBOGt6euzqIz2zHAnOpFTnSEIj01dm0FVdLXhincgry5LUEtoamyG2/Dn8NtRsCVHwCfHplGzmy0FYvdZUdSUJ2gyxedWtwXFLfmCWkiTY9Oo7a4ARbEl30u3FghqLU2OTaO2i+UmhxFl24sIXrenEhRNwWgzoLy9WFALanJsGnXdFaAVNAwWPSo7SwSJ3MmxGdTtqQStoKE361C1o0xwk5wam0ZddyVoJQ1tNC8k4NfY8QolDY1ejZrd5dyEEbv+dXsqoVQpoNapUdtVIbiJT1+fQV13BZQqJVQaFWq7KgSTwPSNWdR2V3BOs7o9lYJJaObGLGq7KlinmkqJ+j2Vgkls9uYcanaXQ6NnHU/1e0V8fB7Vu8o4R1b93krBQ8LcxDyqdpRCZ9KC5vg0jy+gqrMURqsBtILGznu3SZZekfXLaVPLraxff22sBbkyG8H1IFeiOiYGEHApi2nM+RRcDxIlJYQ8JM2jxw9thAQNhSR56EN4MESEIgBwkxg7nuQbq+sfOn59ZQMMwyAcCiEkNX49yoNhoitd7PyYCMvDEnwjet3CoTBCGyQPrgfBRKI8GJLgG2DCEURCYUE+RzCeYUNP4t3SMR6JMEA4IsgXcXwjBIaJAAy9yfhb1y24Jj0+EomAYSLYkDh+aIP9dxEOR4iugiwPg4lEEIkw0jwYRiQUAbPJ+Ny6LDz63eOYHZ9HUm48wWX98pJ3hP8GiwhP6dSgaQpry+ugaQp2n03w5KdUK6FSK7G6tMZyv03w5EfRFHRGLVYWVkFRFJwBcod4LDxEURRc8eQOcX54SGqHMD/8I7UDmV9lVZLfwR3kUpwfcpHi/JCNFOeHd6Q4P3xzW57kwk3R5+eHb/gNpWLi76r2JDoFTbgA4Q5z/n/HxD+mK8GBySvC75//nUqF5/jfmVR4js+lwm/8a+JL8eD0751EThXpupNFSt4RLuuXlkqtRNeJdqg0KtTvqyL6EygUNPY82MHWmuqq4HptxERRFPY9shNqrQrVO8uQkE22k+15bBfUWjXKO4qRnE8++fU8ugsanRpl2wuRVpRM8lM7odFrUNySJ1lFd9+pndAaNChozOEaLAn4IzugNWqRV5eFvGgDJb72PrwDOpMW2VUZkvbMPQ92QG/WIaMslailBbDtcg0WPdJKkrnd3XztPtEOo82A5IJEVHWSVXZ33d8Gk8OIxNx4ySq7O+7dBovThPgsP1FrK8atbjPiMnzY0kdaeDtHt8LutcKf6iFqbQFA+9EWOPx2eJJcaBkiq/BuG26EK94Bd4IT2yQK/bUMNcCd6IIzYEf7EdLi23KgHt4UN+w+GzokLL6NfbXwp3lh81gIIwEANOyrRnymHxaXGTuPbyd4bVcFEnMDMDtMGDk3KE8Yn4DklcZvsF7q/xL+4Y9+yL0WV7UVV5kVV8kVW2q1eo0gpyG2qIotuWJL6+24uGqt2MIqPh+iKu5tuNjSK7Z33paLLL9EVVwxF41XqpSCEJS46q34ehBVbwkOYVVb0fUSn6Nk1SyuMSwAACAASURBVFveOUpVvRVUtZWoeksraUS4qrfC6yE+J7G9VvyZpKri8v+Nia8XAJz8+gh2Skw+skjJKw1Zt9VT//khnPr2ffCnejB8tp/oj0HTNI68PACdUYvWoQZklQs33zEMMHJuCDqTFk0DtVxr05jCwTDu/dIw9CYdGvZVEf0vQsEwjr9xGHqzDrVdFcTmulAwjONfOQyDRY+qHaWo3in89xwOhnH/m0dgsOhR3lZEbJ4Lh1hutBpQurUAjaL+FuFQGMffPAKjzYCiply0DgmfvCPhCO5/8whMDiPyG7Kx/UgTyb9yBGanCTk1megUJVkjEQb3v3kEFpcZWZXp2CWy2EbCERx/4zBsHgsySlOw56FO0fVlcM+XDsHusyKtOAk9j+0i+RcPwRFnQ3J+AvpEFluGAUbPDcEVcCAxJx4HniZdQ8deG4Qn0YX4TD8GJfpXHHl5AN5kN+LSfRg+00fwQy/2wZ/qhS/FgyOvDBD84PM9CGT44Uly4ehrBwh+4Om9SMgOwBXvxOjrQwTvO92NpLwEOOPsuOcLByF+xu05tROphUlw+G2478uHiNI4fOODrDsjeaUhi9OppufxH//wc+61SqNEJMxwT59ii6NCSYOiKO5JUMwpin165jr18UpW3HqPW0/vUhZL/upAkvNWH1KcX6ZEyuLJtwDz7ai3uBZry2ubcv7qTOr9+RZgqfF8C7DUeH4ZEynOzwFJWVBNNiMWZ5einLSgmuwGLM6w46XKcPDLnEhxvoWYn0/iOG+MNDdhfjLayc9uxJKoEyD/M0l1+hNwXlfCmI69Oii5k1wWKXmlIeuX1iPfupezsKYWJSEpN14QrlhZXEVNNM6eUpCItJIUQThkcWYRddE4e1JuPLKrMgThmLnxeTREu93FZ8Uhry5LEO6ZHZ/nel7EZfhQ0JgrCCfNjs+jaT+7WvClelDcnCcIV82Oz6N5oBYUxSZkS7cWCJpAzd6cQ8v+elAUm/AtbysSWIBnx6OcpuCMs6Oyo4SbMGK89UADaJqG3WdF1c5SQThvdnweLQcaQCtoWN0WVO8uF1iAZ8fn0DpYD4WShsVpQm13heBJeHZ8Hq2DDVCoFDA7jKjfV8VNGHyuVCtgtBnQ0FMtuInOTcyj5UA9VGolDFY9GvtquAmD5QtoOVDP9gw369DYX8tNGAAwP7mA5v310OjU0Bm1aB6oE7R7jXGtQQOtUYvm/XUCC/HC9BKaBmqhM2qh0bEbRPmTzML0Ehr7a6E3sT3BWwbruQkDAJZmlrCltwZ6ix5qjQqtgw2CSXBpdhkNPdUw2gxQqZVoHRLxuRXU762C1W2BSqNC/+lu7Douh6butGTLrSxOU9dmOGfK7Pg8jFa98BciDI/PweIS9uBiGHB8bnIBtIJ8Jon1Y1iYWoBaS1p4Y6W2F6YWoZeoUjoeLbW9OL0Es91Ijr88CYYBFmeXJEMTNy9PgGHYG4z4qRQAxq9OgYkwWJ5f4cq6C/kkIpEIludXBTfcmCavTiESjmBlcZV4agaAiavTCIciWF1aI/pvA8Dk2BTCwTBWl9axILF7efLaNEIbYaxhnXjqB9i9E6xNliFWFTG+sRZEKBgmVn0AMHOT5RRNYUa0KgLYvRexiVhcnBBg/92sr7I2ZPHGPwCYG5/D6vIamGgpfbHmJxewvryOSDiCKdHGwhhfXVxFOBQhnFMAkF2ZjlPfuQ+LM0vwJrkJLutX110JT1EUZQdbyyoJwCUAvQzDEP+CKIoKA/hJ9OUVhmF2iX9HLDk89fH1SONz+Mn/fId7rdaqoNGpsTi7DKVKAYffLrBoKpQKGCx6LEwvsjzOTlhcrS4z5iYXoFAq4Ip3kBbVaMiFVtDwJrlw/bx0EySapuBN8eD6BzeFPGphpSgK/jQPrr0v5LFdzRRFIS7di7H3bgg43/YZyPCRnNf4Jz7Tj6vvXhdwvu1UivMtovFZflz9hZDzmxhJcX6TofisOFz9xTUh5zUZkuL+NA+ufzC+6fnFpXu5axbI9GPsw3iGH2PvCTn/mkldP/7P4tJ9uPa+kMdn+nD13RvRc/US3y//mvhTvbh+fnOenJ+Ax79/QtJ1J+v2+qyHp04D+BuGYdIB/E30tZRWGYYpiv657YQh685KoVRg26FGKJQKlLcXwZXgFHCKptB2pBlKlQLFWwvgSyaf7NqPtUCpUqCoOQ8BkUWX5a1QqpUo2JKDQKZfcrxKo0Refbbk5iyWq5BdnYEUiSq77UeboNapkFWZhrRi8may/XATNHoNMspSJC2824cboTVokFachKxKsv/C1kON0Bq1SM5PQE5NJsmHtkBv0iExNyBZhbdlqB4Giw6BTD+KmsgqvE3762C0GuBP86I02iCKr+aBOpjsRvhS3FwDKL4ae2phdprgSXKhooOs0tuwrxpWlxmueAdhNACAuj1VsHktcPhtqO0mLcC13ZWw+22w+6yo3UNagGt2lcMVcMDqtqB+H8krO0vhTnDC4jSjsbeG4GXbi+BNdsPsMEpWAS5pLYQ/zQujzYC+J7rkCeNT0N1aabwLoJFhmBsURfkA/D3DMMT/4yiKWmIYhoxBfIjklcbH1xePfh1/+d2/417zk7gAaVnVm3RcZz+AtNiKq+aKLZtiC6/YsnlbLqq6ezsutnTejvOT6ABp6RRbksUWWDEXv4fYYgyKPUaMi6+3+DNKcYWC5nbWi6sKA8LvQGwhBoQWV3EVYjEXf9/in4ktwIDQdixlAeafs5QFWK1RcTvLpSy+D7x1DLsk9m/Iur0+6ysND8MwNwAg+vdmwUctRVE/oijqnymK6trkd2TdIZ36znE8919PIbUoCfd9eZiockvTNEajVWBbhxq41q8xMRGGs8g2DdRxda1iCocieOCtozBa2SRuaavwyTkSjuDk147BaDOgrrsCFe1FJP/6MZjsRlTtLOXqRknx8rYi1O8TWnCZCIOTXzsGs8OE0q0FxJMrE2Fw8hsjsDhNKGrKw9aDDULOMHjga0dhdZtR0JCD9qMtBD/x1aOweSzIrcnEjnvIJOz9bx6B3WtFVmU62X+CAU68eRQOvw0ZZamS/Sfue2MYroADacXJ6H2MdAWNfvEg3AlOpBQmYv/pboKPnBuCN8mFxNx4DD67l+BHXz0AX6oHCVlxOPQCabE9/PIA4tJ9iEv34fDZfoIfPNOL+Ew//KkeHH2VtNgOPrcPiTkBeJPdGD1HWmwHntyD5PwEuBNduPeLBwne+8RupBYlwRXvwH1fHiY4f5KX9cnoE1tpUBT11wC8EuhpAN9nGMbK+91ZhmFsEsfwMwxznaKoFAB/C6CFYZjzEr83CmAUABISEkovX758pz7Gb7Qe3/oifvw3P+FeK1UKRMIRboOW2EJJK2iAYXjcRCR7+U+HUpz/dCnF+U+vkpz3pCvF+U/P0vzW07cU5z/dS1lI+RZgKc5fffBLosTE3yApyXmrL76dNia+BVjKospf/RmtBiLZz19d8u2+t7geKwvsz/h24Zj4PzOYdVjmrVTFxxSvZMXnLF6pirl4JQoA93zhIPY9QjZzknV73fWVBsMwrQzD5En8+QGA8WhYCtG/JzY5xvXo3xcA/D3YToJSv/dNhmHKGIYpc7lcn8jn+U3U498/geb9dQAF5FRnIK0kRbCjd2VxDVsPbgEoIKsiDdlV6QK+OLOEtiPNoCgK6SXJKNiSIwgnLEwvov1YCyiKQmpREoqb8wThCI7TFJLzE1C6rVAQ7liYXkTHSAtoBY2EnAAq2osF4RKWt4JW0Ahk+lG1o1QQblmYXkTnPa1QKBXwp3lRvbtcEK5ZmF5E5+hWKFQK+FLcqNtTKQgHLUwvYcc9W6FUK+FOdKJhX7XAArwwvYTO0a1QqZVwxTuwpa9GEK5anGHHq7UqOOLsaN5fJ9hRz3GdGjavFS0HGgQ3ycXZJXSOtkKj18DqtmDrwS0CC/DS7DI6R1qhNWhgcZqw7VCj4Ca8NLeMjmMt0Bm1MNkN2H64SXATX55bQfvRZujNOhitBrQdaeYmDIDdONd2pBkGiw56sw7tR1sEk8jywiq2DzfBaDNAZ9Ki/ViLYBJaWVjFtkONMDuM0Bq06BxpFUxyq0traB1qgMVlhkavQeeokK8traFlsB6ugAN6kw5Hf+uAZPdAWXdWd8ty+6cADgF4Nfr3D8S/QFGUDcAKwzDrFEU5AdQCOPepnuVvuC7+5Ap+8b8+ABjg6i+uweK2CDjDMPjFv7wPMMDYezdg94kXiwx+/sN3wTAMxt6/AXcCOaG/88P3wDAMrn9wExGJRPo7//IemAiD6+dvElV4Wf4+IuEIxi9OQK0mLby/+F9RfmkCOoNGgn+AcCiMiStTMFoMBH/vRx8gHAxj8uo0zHYTwd/90XmENkKYvjaDcc8kwT/48QUEN0KYvj7L2Y35ev/HF7GxFsTMjVnOJSUY//ZFbKxuILgexI0LNwl+/t8vY31lHRur64QzCQAu/OQy1pbXsba8jrH3rxP84k+vYnVpDRRFEc4rALj88zFuIrkixd8Zw/L8avR3rxL86rvXuBv95Z+RfOy961icWQbDMLjwkysEv/7BTSxMLYBhgAv/QUYQ0otT8NBv34PVxVXYPFaCy7rzuluJcAeAPwKQAOAKgB6GYWYoiioD2/jpGEVRNQB+B2yLWRrAGwzDfOd2x5YT4XdOj7W8gLf/7lZLFZVaCbPThOnrs9Do1HD47QILJE3TcPhtmBybhlqrgiveQVhgYxZVlUYFT6KTsGjGqqSq1Ep4U9ykRTVaxVSpUsCf5sOVd8YEPGZRVSgVCGT4cPnnQh6zddIKGglZcbgkupHFLKY0TSExJx4Xfyq8kcUspDRNITE3HhdFN7qYBZSi2NWR+EYXs8VuxhNzAtw5pxYm4vy/b85TChNxQcST8uJx6adXNx3P55Lj8xNwKfqZpHhyfgL3mVMKEnDhP4SfP7kgERejn4n/uzGlFCRyn1mS896Tf65SPKcmE6e+fR8SsuIg61fXXQ9PfZgYhplmGKaFYZj06N8z0Z//iGGYY9H//ieGYfIZhimM/n3bCUPWJytaQaN2dwVomkJOTSbsftGTHQXURpsKZVWmwxlwEMeo31sFWkEjsyIVnkRy5VG3l20alFaaQlTZBcA1DUopSoI/zUPw2mjToOT8BAQySItvze5yKNVKJOXGIyGbvNnU7C6HWqNCQnYAiblkld6qneVQa1WIy/AjuYC0+FbtKINGp4Y/zYuUQpJXdpZAa9DAl+JBemkKwcvbi6EzauFNciNTVOsLAMraiqA36eBOcCJbwgJctq0IBosOzoAdOdWkBbi0tQBGqwF2vw15ddkEL2nOh9lhhM1jQUE9aREubMqDxWmC1WVGYSNpES5oyIbVbYbZYUJxM1kFOK8uC3avFUabASWtpIU4tzoTjjg7DBY9SreRVYKzqzLgindAb9Zh+3CT5Hcs65OVXHtK1qb62oP/CX/y1b/gXosTo+KqrOLEqNgSKU58ii2ut+Pi47MOWIqzwBLjRRZYqcQr/z0ILrLAii3GgNDCejsuriIMCBP7Uolfvi1VivMtrGIL8Ufh/MS+uEoxy9XYWGPzMIRFWPQzKQswP/EvxfnnJGURFnAJi/CJrx7F7vvlPMad0Gd6pSHr86H7v3IEr/7VM8ivz8bD37wXGaXCzW8UTeH4G4dhtBrQcqAe2aL+FUyEwQNRC21jXy3Rn4KJMHjwGyMw2Qyo31tFbF5jIgwe/O0RmOxG1Owu51rHcpwBTn79GMwOIyo7SQsuwzA4+fURmJ0mlLcVoUFkwQXY0tkWlxklrQVoGqgTQoblVrcFRU15aBVZcAHg/jdZi21+fTbajjRL8COw+6xRCy7ZavT4G4fh8NuQVZGG3Q+0E/y+Lw/DGXAgozQFex/uJPjoFw7CleBEalESeh8j97+OvD4ET5ILyfkJ6Jew4B75rf3wpbiRmBPAfokquMMv9SMuzYv4LD8OvtBL8KEzvQhk+tkquC+RFtzBZ/YhITvAWnB/i7TgDpzuRnJ+ArxJboy8Nkjw3sd2IbUwEe5EJ+75AmnRleomKOuTlbzSkPWR9VTHy/jXv3ybey3enCVeiRArBTEXbZYjOcBfSUhxirrVo0HKAspf7Xwczl8pSHLeNZDi/JWE1EqHbxGWWqnwn66lxvOf3nUmHVYXP4RLrFT4KwV+RV9uPM9CLN7syI65tRKQ5LzVi9RKhW+bFfdLEZ8zf2NfTPd/5Qi6JCZbWb+85JWGrDuu0793Ep2jW0HRFAqbcomY+trSOnYd3w6KppDfkI0CUdmM5bkVdD3QzuZEqjNQ3JIn6H+wPLeC7pMd0ZxHGkq3FxF8z4MdUCgVSC9NQUVHicDiuzy/gu6HOqBUKZBalISa3eWC8Njy/Ar2PNzJ5jTy4lG/p5LkD7E8ISeALb3Vgh3sy/Mr2PvwDqi1KgQy/WgaqBVMmizvhFqrgj/Ni5bBeoFFeGVhFXsf3gGNns1pbD20RfCkvLLIcq1BA3eiC21HmgXhmJWFVex9qBM6oxbOgAMdx1oE4Z7VxVWus6DDb0PnaKuQL61xnQVtXit23rtNcBNfW15D1wPtMNmNsLot2Hl8u+Amvr6yjt33t8HsMMLiNGH3iTZBuGt9hf3+LS4zTHYjuh5oF4S71lc3sOPebbC5LTBaDeg+2SGwEG+sbqBztBUOvw0Gix57HuoUTHIb60G0H2uBP80Li9PENliSq9h+6lK88MILd/sc7qi++c1vvjA6Onq3T+PXUv/23/8Df/zmn2N5fgXzkwugaEqw+YwChdnxeSzNLWNhchEURRGb42Yn5rE0u4z5qQVQNM31645pYWoBC9NLWJhaBE3TmJ8SVmqdn17AwtQiFqcXQSkootLr0swS5iYXWE5TRKXXxZllzE3MY3FmOcqFlV6X5lYwNz6PxZkl0DRN9K9YmlvG7M05LM0ugaYpgq8srmHmxiyW55ZBURTRv2N1cQXT12exPLcCiiIrxa4tr2FqbIZbUYj5+soGJq9OY2VhFQyAmRsivraBiStTWF1cA8MwBA+ub2D88hTWltYQiURIvhHCzYsTWFteRyQUId4/HArjxoUJrK9sIBwMEzwUCuPG+XFsrG4gFAwRPBKO4Pr5m9hYCyK4HiSuDxNhcO39GwiuB7G+ukFc320HG/HofzqOXfdtR15dNmhafu69Uzpz5syNF1544Zu3+z35isv6yPrB1/6Cqwi7tryOm5cm4U9lHUx6sw5xGT6uCu7ayjrG3rvOuVt0Ri0Sc+K4iq8ba0Fc/cU1xEeLFGoNGiTlxXNVboPrQVx5Z4zrM67RqZGcn8BVbA1uhHD5Z2NIjBYxVGtVSC1M4iy8oWAYl356Fcl5CQDYME9qURJXpTUcCuPiT64gOT/K1UqklyRzexUi4Qgu/MdlpEQdUkoVu7rheITB+X+/jNSiJADsTvaMslRuL0IkwuD825e4Iom0gkZmWSou/Yy1yzIMgw9+fIkr1ULTFDIr0jgLKssvcg4rmqaQVZEmsOh+8L8vckUWKYpCVmWawCL7wf++iMxyIT//tjQHgKzKdJx/+9It/uOLyKxI4/E0fPDji5vzijSc/zF//CVBkcesCuH4829fQlZlGhemzCwX8gv/flnAy9uKULWzFCq1CgaJPTWyPh3Jk4asjy2KolDQkAOKAhJz42FxkpvfWE4hIScAq2hzIAAUNuWCoinEZ/ph95Kbswq35ICiKQQyfHD4iUozKGjIBq2g4E/zwhmwEzyvIQsKBQ1fihvueNICnF+fDYVKAU+SC24JC3BeXRaUKgU8iS74JPoz5NZmcju+YxMoXzk1mVBplHAF7IiTqPKbXZUOtVYNh9+GQAZZ5Te7Mp3bER4vsR8hszwVWoMGVreZm2D5Si9Nhc6ohcVpQlJuAslLUqA36WB2mJCcR1YRTitKgsGih8luREpBEsFTCxJhtBlgsBq4CZSv5LwEmBwmGMw6pJWQFuPEnHiYnSbojFpklJE8ITseFpcJOqMGZduL4I53Er8j69OVnAiX9ZH13Wf+AH/wW3/M5RnEtZFoBQ0mwtziNgMWeWUfKIoCRYHLQ4h57BixPAO/FSl7AHYD4aYcwtpV0vxWYluqthM/MS11fnwuVduJn3iWGs/nUrWf+Mng23OyvSk/MS2VmOdzqcS6zqDB6odxnm1YKnHP/5mUxZh/TKnaUXqLHivRc5ayCMsW209OciJc1h3X4ZcG8OYPX0bVjlI89Z8fEoQ2AHZSOP4V1oLbNFBH9JdgGAYn3joKo82ALb3VyN9Cbh478dZRmGwG1HVXorhFtPmLAR742lGY7EZU7ypDeTvZH+L+rx6B2WFERXsxqneR/R9OfPUozE4TyrYVom5PBcGPf+UwLC4zipvz0NhP9m84/pVhWN0WFGzJQetgPcHv+dIwbF4L8mozsW24ieD3fvEQ7D4bsqsy0DHSQvDRLwzBEWdHRlkqdt5PlvgefX0QrngH0kqS0X2yg+BHXtkPd6ITKQWJ2HeKLNx35OUBeJPdSMqLR98TZJXcgy/2wZ/qQUJOAP1PkhbdwWd7EMjwIZDhw+Cz+wi+/+k9iM+Kgz/Ni0MSFt2+x3cjMTcAX4obh8+SVXR7T+1Ecn4CPEkuHH1lP8HFpdBlffqSVxqyPrae7z6Hf/rBv3KvxRZcsQVUvNlP/CRK05TADSW2iBJcNF5s8RWPF1t8SQ7wLb5iCypFsf8Tew+pJ2H+Z5TaLMfnUhZVISf7cfBXUlIWVv53ILWZjm8Bvh2X2kzH/xl/4+AtfquKsFQ/Dv57SvXTuB1/6LdH0TlK7neR9atLXmnI+sR1+vdOoufRnVAoFSjbXoS82iwBX11cRd8TXVCoFChuyUdxc56Ir6H/yS4oVQoUNuaibLuwbMTq0hoGntoDlVqJvLosVHaWEuMHnuyGSqNCTnUGakWb+1aX1rD/qT1Qa1XIrEhDw74qgYV3dWkN+5/eA7VOjfSSFDT21wn42vIa9j+9Fxq9BimFiWgZbBBMSmvL6xh4ag+0Ri2S8uKxbbhRMCmuraxj/1N7oDNqkZAdh7ajzQK+vrKOgae6oTfrEMjwofOerSK+gYEnu2Gw6OFP9WDX8e2CKsDrqxvoP90Fo80Ab7IbXQ+0C26yG2tB9D3RBbPDBHeCE3se7BRYgDfWguh9fDcsTjOccXbsfXiHgAfXg+h9bBesbgvsPit6Tu0UTCLBjRD2ndoJu88Km8eC3sd2CSaJ4HoIex/eAYffBovLjL4nugSTVDgYxp4HO+CKd8DsNKH/NMl3n2hHUl48XPEOPPn7D8oTxmdAsuVW1sfWP/7xv+APX/sBVhdXMXl1CgwDIsZ/4/xNrCysYmpsGpEIQ/Dr529ieX4VU2MzYCIRIsdw88I4luaWMXVtBpGwBL80gaXZZUxfn0E4zBAW3/HLk1iYXsLsjVmEQ2GCT1yZxMLUImZvziEUChMW4MmxacxPLmBuYgGhjRDmRXxqbBpzE/OYm1hAcCNEWICnr89gdnwe81OLCK4HCT5zfRYzN+ewML2EjdUNgs+Oz2H6+iwWZ5extrJO8ol5TF+bwdLcMlaX1gg+P7WAyavTWJ5fwcriKsEXphYxcXUKK4urWFlYIfnMEiYuT2J1aQ1Lc8vE51+aW8bNi5NYW17H4uwSwZcXVnDzwgTWV9axML1IXN+VxVVcPz+O9RX2s4u/n61DW/DIt+/Frvu2I72YTJTLunOSLbeyPnH91ff+jtvnENwIYfzyJFekj3XjJHA+/VCQ9e+nlbAWVKPNgJTCRG6fQDgUxrUPbnIWVKPVgLTiZExdmwHAxrKvvX+Ds5jqzTqkl6ZgaizKIwzG3rvOFfnTGbXILE/FxJUpjl999zqyKlmuNWiQVZGG8cssZxgGV9+5xpVC0eg1yK7KwM1oOXOGYXDlnWvIqYlynRo51bc4AFz5+Rhyo3kclUaF3JpMzkIMsGXG8+rY1ZgyunralKsUyKvPFlQJvvyzMeQ3sEUGFUoF8huycY1XJfjyz29xWkEjvyEbY+9eF/BYN0VaQaNgSw6uEjwbFEWBpikUbskRlEu/8s415Ec5RVEo2JKDK+8IeUFDDmia5YWNubjCqzJ89RfXWLdbtMR9wZYcQRXiq+9eR35DDtvMC0BjXw1quyugUCig0ZFl7WXdHcmThqw7qljlWGecDXqzjuCJUVtobNcvMT6HHW/zsruGpY5PUYDda4XJtgmnKdg8Fpgk+l8kZAVA0RQsLrYSq1jxmX7QNA2L0yRpIQ6k+0EraJgdRkkLcVyGDwpllEv0d/CneaFQKWC2GyX7P/jTvFCqFDBYDXD4SO5L9kClUcFg0cHhJy3GvmQP1FoVDGYdnHGkxdiT6IJap4bepIVLogqxJ9ENtU4NrVELl4S91RPvgkavhtaggUeiP4orwQmtQQO1Tg13AjneGXBCZ9JBo1fDI2FhdsbZYTDroNaqkJSXALPdSPyOrLsrOREu62PrD1/9Y3zvuf/CxdktLrMgvEFR7BNxLE4u5oDQAivF+YlXq8uMOYLfSrZa3WZiBzjfoirFNVo11tc+hPOS0VKcn+yWOn++rVTq/PnJeKnxfIuqxWkiwj/8lqqSnGe7lWpfy6/nJdWelm8rlrIo838m1X6W/55SFmU+N1gNWBZZjB946xh2HSddZLLuvOREuKxPXP2nu/E7b7+OpoFavPiDJwgLLkBh5PWDMFj02NJbjexKsj/EvV8ehsGqR92eSuTXZxH8ni8chNFqQPWuMhQ2k/0b7v3iIRhtBlR0lKB0ayHJXx+CyW5E6bZCVHaQFt3RLw7B7DCiuDkfNbtJC+7ouSFYnCYUbslB/d5qgh87Nwiry4y82iw0D5AW3aO/dQA2jwXZVRloGSSr5B55ZT9sXisyy1Mlq+QOn+2Hw29DWkkKOiWq5B56sR/OgB0pBYmSN9eh53vgTnAiKS8eXSfJwn4H+fxJPQAAIABJREFUntkHT5ILCVlx2PPwDoIPnO6GL9WDQIZPsopuz6O7EJfugz/Vg/7TXQTf+3An4rP88Ca7Javodp3sQGJuPNyJTgw9R1p4f90ean8dJK80ZN0xvTzwZfz9f/kn7jXfvgmQFlO+ffTjcLGFV2xRJbjIonpbLrL48ntLAKTFV2xhFVt8b8fFFlexxVfKwso/BykLLP8zir8PMZeyuPJXguLvQ8zF11N8zNtxiqYA5lb/EwB4/Hsn2D70sj5xySsNWZ+6Hv/+CQw+uw8qjRJVO0uJ/hnrK+s4eKYXKo0K5e3FKN1WQPBDL/ZCrVWhZGsBKjqKCT78Yh/UOjWKmvNQ21Uh4hs49GIfNHo18htyiP4Z66sbGD7bD61Bg5yaTDSJNu/FuM6oRVZlOlqHhDerjbUNDL/UB71Ji/TSFGw/3CTiQQy/2AeDWY/UoiR0jLYKnpQ31oIYPtsHg1WP5PwE7Dy+XcCD60EMn+mDyW5EQnYcuk52CCal4HoIh870wewwIZDhx95Hdgj5RghDL/TC4jLDn+ZFz2O7BDfpUDCMwef2weaxwJvsRv/pLgEPB8MYfHYfHD4bPIlODDzZLajyGw6Fsf/pPXDG2eGKd+DAM3sFPBKOYODJbrjiHXD4bRh8rkcwCUXCEfQ93gVvkhs2rxVDzws5E2Gw79FdyKpIQ3ymHy/92ZPyhPEZlLzSkHXH9D/+r3/A1x/6LpbmlkHTFJwBB+deiikWA6dpCq54J1fgMKZYXJ2iKHgSXbh5aULAY3F7iqLgSXIJ3EsAYHGZMD/Jxshj/cL5snosmItWTpXidq+Vc3z5Uz0CdxPAJvCnr8+yPM3DFVCU5KleQQ91gE30xhxhsX7lfLkCDq4opBSP9Vjf7Pz43JfqwQ0R9yS5uKKRUp/fm+TCzQ/j0R7t4v+OyZfixo0LH43zzyWmk18fwY7ofhWFUgFZn57klYasT11//0f/yNVKikQYTFyZQm4ta0G1+6xIK0nmkqaRCIPxy5PIr2ctojaPBRllqVwilmEY3Lw0wfXksLjMyKpM5xK9DMPg5sUJzkJqdhiRU53BTRgAcOPCOIqa2DyI0WZAbm0WN2FwPJonMVj1yKvPEpTyvn5+HCWtbJ9rvVmHgoYcbkIAgOsfjHN9rnUmLQobc4X8/E2UbmPzLFqDBkVNedyEwY6/xTV6NUpa8rkJI8bLtheCoiiodWqUtOYLJuHr58dR3lbEcq0KpdsKBPzG+XGUtRWBoiko1UqUbisU3KRvXGDH0woaCpUCZdsLuQkjxsu2F3K8vK1IMAncvDiBsu2FUChpKJQ0yrcXcRMCx7cVQqFSgFbQKG8T8vFLkyjdVgilWgmKptBxrAUN+6pAUZQ8YXyGpbzbJyDr11sxW6vOqIVKTf5zi3GNQQOVhuQmB2u51Bo0UGlUBI/ZYrV6DdQS3BS1bGp0aqi1JOfeX6uGRqsmuNFmBEWx+Qy1XoobWK5RQSPFrXpQNBXl5F4Do1UPWkFDpVZBYyC5wWIATVNQqZXQGUkLs96sg0JBQ6lSQmvQkuPNeigUCijVCuiNJNeZdKAVNJQqxSbH10OhpEHRFHQmkutMOihUCoCBpMVaZ9JBqVIgEo5Ic6MWyuh4s9Ms+R3J+mxJDk/JumP6k7f+At96/He5ZC8/1BMTP9ls99kwc2P2l+J8Cys/FBSTzqDF6vLmnG9hdfjtmL4+I+S8Kq1S4/kWVkecHdPXhOP5lWelxvMtqlLvb7YbscBxcrzZaeJ2VUtxvu1W6vrxbb12n5VowsS3Bdu8VqJJks1j4RojSXMrZsfZn1ndFqLJFX+MlIX55NdHsPNeuRvf3ZAcnpL1qavrRDu+8/M30Dm6Fef++jlkEBZccInm2q4KZJZtwk1aVO0o5XZfC/iLfdCbdahoL0Z+PVkl99BZNhFdsrWAC03xdfAMm4guaspF2XbSonvwTC+MNgPy67NR2UladA++0AOjzYjcmkyi1hUADD7XA7PDhKyKdNTvrSL4gWf2wuI0Ib0sBY39NQQfeHoPrG4L0oqS0HKArKI7cLobdq8VyfkJ2HaokeB9T3TB4bchMSeA9qOkhbfn1E64Ag7EZ/kl6zjtfWQHPIkuxKV7ses+8ua9+4F2eJNd8KV40HWCLFG+6/g2+NO88CS5sPfhToLvuGcrAhk+uOKd6DlFWnhlffYlrzRkfWI6d/gt/I/v/wP3WmwJFVtMxVxsUeX3smDHCy2oYkupmIstpeLjiceLudhyKv59saX0dpxvV2U5hUiY4XHh+4ktvgoFjTDveGILr/j9WEsrj9M0IhH+eAgsvmLLcfTwnCVWfD7iMeLjid+TPV+hxfaZP3wYW3rJyVTWJy95pSHrruvR7xzH0VcPQKPXoLarAsXRpHJMwfUgRl4bhNagQdXOUpS3Cy22G2tBjJwbgs6oRXl7Map3lYnGhzBybhA6oxalWwuIJ/vgeggjrw9Cb9KhqCmPsNiGNkIYfX0QerMO+fXZxOY7lg/BYNUjtyaTsNiGgmGMvj4Eo82ArIo0dI62EnzkHLu5MKM0hdh8Fw5FMPLaIMxOE1ILk9D9YKeIhzHy2iCsbjOS8xPQI+qPEQ5HcPTVA7B5rEjIjkPfE7sFFt5IOIIjr+xnuwJm+jHwZLeQRyIYfmkAzjg7/GleHHh2n+AGH4kwGD7bD3eCE75kNw4+3yu4wTMRBgdf6IUnyQVPohPDZ/sEkwzDsCsrf6oHrngHDr88IJikGIbB/mf2obAxF+klyfjy/3xRnjA+B5JXGrI+Mf35t/4a33jke1zPCUecDdPXRDkGXg7BGbBzBQhj4vfM4NtRY+LnGFzxDkxeFXFemQxXvBOTV4UWYH5pC6nx/ByEK8GJSZGFmF8Gg2935TgvByHF+TkEqffnx/3d8Q5MiDg/RyB1ffh5JUnOy3tIXX9+3oRvF77Fb+VlpHI8/DFSOZiHf+cedIyw+1liKyVZd0fySkPWXdcP/+xHgiZF09dmUd7GribciS5kV6YL2oVOjc1wG/pc8Q7k1GQImixNjk2jcgfbU8MRZ0deXbagnenk1WlURbndZ0XBlhxuwmD5FLdasXksKGrOE9RCmrw6zXGLy4ySlnxBraXJK1Oo2V0OiqJgdrClSfi1nCauTKGmi+VGmwFl2wsFpcAnrkyhtrsCFE3BYNGjor1YUItq8uo0arsrQCto6M06VHaWCBLFEzGupKEzalG1o0yQiJ4cu8W1Bg2qd5YJjAgxrlAqoNapUbOrXJAonxqbQW1XBZQqBdRaFWp2lwtu8lPXZlCzuxxKtRIqjQq1XRWCRP50lKu1KijVStR1Vwgmmenrs6jeVQa1Tg2lSoGeUzuxpY9dWcgTxudHsuVW1qeqUJDNEURCYUGo4hZnY/jhUJiIlwNAKJoDiYTCYCTHs8cPByOSrUFjOY5wMCzJY+8fCUU2Ob8QGIZhuaikRuy4HJc6/kYITITl/HwG//2ZSGTT8eFgGEyYPTdxSQ+ORxhEwhGEw5ufH7PZ+FCYDTFRzCY8wl53ikI4GJIeH46AYRiiZEmMM5EIIhEGwfWQ5Hcs67MtOTwl6xPTX3737/CNh7+LlYVVUBQFZ8BOho944SV3ggMTV4Scb2F1JzoxcXnz8JIn0UXsMDfZDVic2Zzzw0dSO5T5FlYpzreVSnGb24LZKOfvtuY4L7wkNZ5vi5Xi/JCP1Ofjh4fciS5MiDkvJCUVPuOHzKQ4/2dS4TUBlwiPxcJTsu6+5PCUrLuutsNN+N67b6Ln1E688Y8vIaOU7LzW93gXNHo1KjpKkFqUtAnXoHRbITJKSYtu72O72d3WzXmSVXR7H90NnVGLgoYc5EV3p/PVc2ondCYtcmsyud3lfO17ZCf0Zh2yKtNR0pJP8L0Pd8Jg0SOjNAXlona1ALDn4U4YbWxDKXG7WgDoPtkBk92I5PwE1EpU2e16oAMWpwmJuQFJC++u+9tgdVsQyPRzoR6+dt63DXavFXHpPrTsJy28naNb4fDb4EvxSNZ5aj/aDGfAAU+iC9uGGwm+dbgR7gQnXPEOSYtv69AWeJPdcMTZ0THSQnBZnz/JKw1Zn5revP/b+G/f+Cvu9e0stQQXWVjFXGypVWlVCH4YF1l+xRZXwrIrssiKLcKE5Vb0eUhLrpILp0lz4eclLLeiz0NRlMAdJWXZ5VeRJSy5Ysvt7bjIsiv+mdiyCwC0kkYkdIs///8+hppd5H4XWZ++5JWGrM+cTn7tGO778mHoTDrU7alE6Tbhk3loI4T73hiG3qxD9a4y4sk8FAzj+FeG2SRyRzFqu4VP5uFgGPe9wfbnKNtWiC091QQ//pXDMNoMKG7OIzbPhUMsN9kNKNiSQ2yeC4ciOP6VwzA7TMirzUK76Mk5Ema5xWlCdlUGdoo2x0XCERx/4zCsbjMyy1OJ/haRcAT3fmkYNo8F6SXJ2PeI0GLLRBjc86VDsPtsSClIRN/ju4WcYTD6xYNwxNmRlBePgae6ifEj54bgincgISsOg6L+FQwDHH3lADxJLsRl+HDoTB/BD58dgC/FDX+qF8Mv9UOsgy/2wp/mhTfZjSOv7Cf4oRf6UNlZgoItOfjaj16TJ4zPoeSVhqxPTX/y1l/gm4/9Lvd0zy9JERN/9SBVpoLPpcqU8Dvp3ZZLlNHglymRen9+pz0pzi9TIsX5ORwpzs/R2LwWzN4UXh+j1cAVhZS6fnyL8O24VBkPfg5HqpOgxWnG/NTC5pz3M36+KKZT3zmONtF+F1mfDckrDVmfOb39tz8RhINmx+expZddDQQy/MhvyBaEm2ZvzqGxrwYUxZYBL2zMFfCZm3No6q8FRQHeJDeKW/K5CYHjA7WgaAruBCdKtxYI+Y05NO+vA0VTcAUcKG8r4iaM2Ps3768DTVNw+G2o7CjhJgyOH6gHraBh81hQtbOUmzD4XKGkYXWZUbO7XGARnr05h5YD9VCoFLA4TajbUymwAM/enEfLgXoo1UqYbEbU763iJozY9Ws5UA+VWgmj1YCGnmqBRXh2fB7N++ug0qigN+uxpbdGwOcmFtC8vw5qrQo6kxaNfbWCdrHzkwtoGqhje4IbtWjqr+UmDI7310Jr0ECj16B5f51gElmYWkRjXy10Ji00OjWGX+yX7G4o6/Ml2XIr664q5qxZmF6ATqIK68SVKTAMsDCzBGO0Yq2AX2X54uwSrIsWgk9enQYTYbA0tyzYE8LxsVt8eYHkU9dmEIkwWJ5fwfLCCsnHphEJR7CysCrYExLT9LUZhEMRrCyuEv2xAXbvQjgYxsriKhZnFgk+c2MWoY0QVrEmzW/OIbjB2oDFT/UAO3EE14OIhMNYmFqQ5BtrQdDBMOYn5wk+PzHP9linKKK/OQDMTc6zBSYZhljVAMD81AK7V4dhcPPiOFaX1qCWqCYs6/MjOTwl61PTP/zXH+KtE9/G3OQCaAUNd4KTaNITa5JE0xQ8yW6iiVCsiipFUfCleIgmR7EdzhRFwZ/mxbX3bwi534aZqEU1Lt1HcGfAgamoLTSQ4cPYe0LOt41Kcb7FNJDpx9i71wXck+jE+OUP4TxbrRT3Jrtw8+LmnN84Ser8+I2bJDmv8VNchg/XPoxLXL+4dC+uvX+T+O+YTn37Psle6LLuvuTwlKzPnLb0VON7772JQ2f68I1/O4f0kmTid3aMboVKo0RBYy4ScwIkv6cVaq0KefVZSC5IIHjHKMtzqjOQVkwev3OkFRq9BlmV6cgoIy3A7UebodVrkFGagqxKsspu29Fm6IxapBYlIbc2i+DbhhuhN2mRnJ+AgoZsCd4Eg0WPxJyAZBXerUNbYLTqEZ/pR+nWAoK3Dm2ByW6EP82L8jbS4ts0UAezwwRfipvbHc9XY18trG4zPIkuVEskoRt6qmHzWOAMOFDXXUnyfVVw+G1w+G2o30vyuu5KOOPssHutaBAZEWT9ekheaci6a/rW47+LP/rCn3KvtQYt1pZv5QzElk+tQSMoS3JbLrJ88pPgAGlh1eg1WBdxflVYfq8PqfFqnZoN5cS4yKJKjBdVeRVbiMWfUWwhBhW1uMa4yCIMCG230vyWjVhsEQaEtl+xBfgjcd4xVWolXvzT0yjbRpakl3X39ZleaVAU1UNR1M8oiopQFLXpSVIU1UZR1LsURX1AUdTpT/McZX3yGjk3hAe/MQKj1YC6PZUobxPeTCLhCB742jEYbQbU7C5H1c4ySW6yG1HZUYK6PcIn30iEwcmvH4PJYWQtuKLNb0yEwQNfOwaz04Tilny0DNaT/K2jsLjMKGzMxfYjTRLjj8LqNiOvLouocsswwIk3j8LmsSCnOgM7RVVuGYbBia8ehd1nQ2Z5GvY8RPafuO/Lw3DE2ZFekoKeR0X9Jxjg3i8dgivegdTCJAyc7ibGj7w+BHeCE0l5CTjw9F6SvzYIb7IbCdkBDL3QQ/DDL++HP9WDQKYfw2dJi+3w2X4EMnzwp3lx5OUBgh99ZT+29FajamcpvvXTL8kTxq+B7spKg6KobAARAL8D4FGGYYilAUVRCgDvAdgKYAzAvwIYYBjm5x92bHml8fnR//2l/4Zvn/597klYyqLJf3r9OJz/dM23k0pxqfH8p39JrlNhYzXKeRVvY+KvXswOI9cDPSb+6sfkMGJRxPkWX75d9qNyfhVhvp2X4zyLsBTnW4QNVgOW5z6M6wkzwOPfP4GtQ+ROc1mfPX2mVxoMw7zDMMy7t/m1CgAfMAxzgWGYDQB/CGD3bcbI+hzp5z98V7BjeWFqEduPNIGiKCTlxaOkNV8Q7liYWkTb0WZQNIWE7ABKtxcSvP1oM2gFjUCGHxXtxYJwzPzUItqPtYBW0PCneVG1o1TAF6YW0THSAoVSAW+yGzW7ywXhIpa3QqFSwJPoQl13BTdhAMDCNMuVaiVcAQfq91UJwl0L00voGGnF/2nv3sOjqs8Ejn/fcklIiCQhkAC5wYMgN2+g622FQr3AtvXS6pZtBYRKqbZ9cB/axbpVa0XKFmupFZRaCq3XB3m2RdcuihW3cjUgIYQkJORCQiCEO4GQBHj3j3MSZjJJOIFkZgLv53nmmTPznjnzzi/z5HfO+f3mPV26dqZn3zjGPHiL3+my4/XxiC7EJ8UyduJtflN8jx+qYsIj4+jarSuxvXsw7tv/HBAf/91xRER1pUdCDF95aLTfjLGqwycYP20ckdERxMR3545Jo/2mCFcdPsHdU50xm+5x0dw1ZYzfFOETR05w98NfJuqKbkT3iOKuh7/cKH6SOyePITo2iqiYbjy2YCpjJ97W7N/fdEzhPOW2H1Dq87gMCBx5A0RkOjAdIDU1cHDUdBw7MwpRVSqKK/lSp8B9mvyMQvSsUlGyny6RgV/f/C1FnD1zlsrSA01O4S3YUsjZM2c5UHaQ7rFRTcSLOHP6DAfLD9EjISYgvuuLIs7UOfG4xMApvoWZxZyuPc2hfYc50Kh4H0DhthLqak9zuOIoFY2K/wEUZZVQV1PHkcpjAcUNnXgptdW11NXUsbfRzDOAkuxSak7WUltdy95GM8sASnLKOHWihpqTNQEzzwBKc/c0dERl+U3E88obOpqyneUB8T0FexuONrLX5XL7AzcRnxQXsJ7puNrtSENEVovI9iZuXo8Wmiqw3+S5NFVdrKqjVHVUr169LjxpE1R3PTyW3qkJgDNImjyoL0XbSgCorjpFYWYJvdOcv2fnLp1IuaofuzKLAag5WcuuL4pJdOOdOncidUg/Cr4ocuLVteRvKaTPgN6AM6CcNjSZ/C1OvPZUHTszCukzINGJf0lIH5bMzs2FgFNCPe/zXfQdmHQuPjyFvIxdgFPSJHdTAf2u7AM4g9r9R6SSu6kAcEqO5GzMJ3lQo/jGfMAZj8nZsJOUwX0b2qP/1ankbDgX37E+j9QhyT7xNHI27ASc8ZQd6/JIHdKvIT7g6lR2rHfjCtnr8kgbluK3/R3r8s7F1+aR7hsfkUr2unMnALLX5pI+PLWFeB7pwxu9fu25+Jp31pGxKhNzaWm3Iw1Vvdh6x2VAis/jZCBw18Z0WP804XqW5PyG/1m8mhsnXM/Sn70VsPe6aPM8Pn79H4y88xrefH4Fpbl7/OIL1s/hH8s3cO3Y4az49XvszvGPv/DJz1m3MoOrbx/CyoWrKNlR5hef9+HPyFi1lSE3D2LVHz+hONs//tx7s8lcs4NBowaw5u21FG8v9Ys/vWIWOet3MuCaNNb99XOKsnb7xX/61kwKthSRNjSZzR9uC4j/eOlj7M7ZQ7+BSWz/LJc/bHvTLz7z1ensK9xP77QE8jcX8uqsP/nFf/DSNA7tPUJcUiy7c8p4+UdL/OLfmz+JqsMniInvTkXxfn4zY7FffOrz/0btqToioyM4sv8o86cu9ItPevoBEKFzl05UH69m7nd+6xef+MT9REZHoGed62/84sFfYy5t4Xx66nPgShHpD+wBvgUEVkAzHVpEtwjud6+NnTY0BVjfEEsZ3JeomG7c96MJAKQPTfGr5Np3YBLde0Rx7w+dwn+pjeJJ/XsTHRvNPY/d7cSHJPtNw01M60X3uGi+9n1nVlPOkHy/eK+UnlzRM4avfu8OAHZtLfabApvQL54eCTEN14MozS33m+Ia3yeO2F49GD/NKWy4r7jSb+A+LrEHcYmxDHF/D3K44qhf5dzYXlcQnxTLiNuc33ucOHrSrzLvFT1jiO8Tx3VjnZLtp2tP+w3cx8RFk9A3rqFk+5bV2/ym/XaPjaZXcs+G37NkfprtN2056opu9E5NYPANTsn57Wtz/Qbeu3WPJDGtF8NucUrO527K9xtYj4yOIDHdjvwvOaoa9BtwH86RRA1QAaxyn+8LfOCz3gScGVS7gCe9bHvkyJFqOq6sz3L038c8pctfWKl1tXUB8ez1eTpr7NP69ry/aG1NbUA8d1O+zhr3jL4xZ4XWnAqM79y8S39yx8/1z88u15rqmoB4wdYi/Y+7fqHLnn5Hq0+cCogXZpXoE+Of0yVPvqknq6oD4sXZu/Wn/zJHX5v9up48fjIgvju3TP/za3P11VnLtOroiYB4WX65PnXvPF30+B+16khVQLx81z595hu/0t/98A967NDxgPjeogp99sEXdMGjv9ejB44FxCt2V+pzE1/UF6e/oof3HwmIV5Yd0LnfWaDzpy3UQxWB8QPlh3Te5Jd03pSX9ED5oYD4oX2Hdf7Ul3XuQwu0cs/BgLgJX0CGevgfaz/uM8YYE95Tbo0xxnRM1mkYY4zxzDoNY4wxnlmnYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPLNOwxhjjGeX3C/CRaQSKAnBWycAgbWuw5/lHXwdNXfLO7iCnXeaqp63WNgl12mEiohkePkJfrixvIOvo+ZueQdXuOZtp6eMMcZ4Zp2GMcYYz6zTaDuLz79KWLK8g6+j5m55B1dY5m1jGsYYYzyzIw1jjDGeWadhjDHGM+s0LoCIPCAi2SJyVkSanRInIsUikiUiW0UkLC4n2Irc7xaRPBEpEJHZwcyxmXziReQjEcl37+OaWe+M295bRWRlsPP0yaPF9hORCBF5x41vFJH04GfZNA+5TxGRSp92/m4o8myU0xIR2S8i25uJi4j81v1M20Tk+mDn2BwPuY8RkaM+7f1UsHP04+WasHYLuMb5EGAwsAYY1cJ6xUBCqPNtbe5AJ5zrsg8AugKZwNAQ5/1fwGx3eTYwr5n1qsKgjc/bfsCjwCvu8reAd0KddytynwL8LtS5NsrpduB6YHsz8QnA3wABbgI2hjrnVuQ+Bng/1HnW3+xI4wKoao6q5oU6jwvhMfcbgQJVLVTVWuBt4J72z65F9wDL3OVlwL0hzOV8vLSf7+d5FxgnIhLEHJsTjn/781LV/wMOtbDKPcCf1LEBiBWRPsHJrmUecg8r1mm0LwU+FJHNIjI91Mm0Qj+g1OdxmftcKCWq6l4A9753M+tFikiGiGwQkVB1LF7ar2EdVT0NHAV6BiW7lnn923/DPc3zroikBCe1ixKO3+nWuFlEMkXkbyIyLJSJdA7lm4czEVkNJDURelJV/+pxM7eqarmI9AY+EpFcd6+iXbVB7k3t8bb73OyW8m7FZlLdNh8A/F1EslR1V9tk6JmX9gtJG3vgJa/3gLdUtUZEZuAcMY1t98wuTri2txdbcOpCVYnIBOAvwJWhSsY6jWao6lfaYBvl7v1+EflvnEP/du802iD3MsB37zEZKL/IbZ5XS3mLSIWI9FHVve5phf3NbKO+zQtFZA1wHc45+mDy0n7165SJSGegB+FxiuK8uavqQZ+HvwfmBSGvixWS73RbUNVjPssfiMhCEUlQ1ZAUYbTTU+1ERKJFJKZ+GbgTaHJ2RBj6HLhSRPqLSFecgdqQzURyrQQmu8uTgYAjJhGJE5EIdzkBuBXYEbQMz/HSfr6f55vA39Ud9Qyx8+beaCzg60BOEPO7UCuBSe4sqpuAo/WnO8OdiCTVj3eJyI04/7cPtvyqdhTqkfiOeAPuw9lzqQEqgFXu832BD9zlATgzTzKBbJxTQx0id/fxBGAnzl56yHPHOd//MZDv3se7z48CXnOXbwGy3DbPAqaFMN+A9gOeBb7uLkcCy4ECYBMwINRt3Irc57rf6UzgE+CqMMj5LWAvUOd+v6cBM4AZblyAl93PlEULsx7DMPcf+LT3BuCWUOZrZUSMMcZ4ZqenjDHGeGadhjHGGM+s0zDGGOOZdRrGGGM8s07DGGOMZ9ZpmEueiKSISJGIxLuP49zHae30fjNEZJK7PEVE+vrEXhORoW30Pve2tuKpiKxurkKwMV7YlFtzWRCRnwADVXW6iLwKFKvq3CC87xpglqq2eWl8EVmH89sJz78MFpHJQLKqzmnrfMzlwY40zOXiReAmEZkJ3Aa80HgFEUkXkVwRWeZTjC/KjY0TkS/EuT7KEp9fnv9SRHa46893n3tGRGaJyDdxfnw321hTAAACiklEQVT4hnsdhG4iskbc65iIyER3e9tFZJ5PHlUiMsctULdBRBKbyHUQUFPfYYjIUhFZJCKfiEihiIx288wRkaU+L10JTGyTFjWXJes0zGVBVeuAH+N0HjPVKfvdlMHAYlW9GjgGPCoikcBS4F9VdQROzbbvu6e77gOGues/1+g93wUygG+r6rWqWl0fc09ZzcMp9HctcINPVd5oYIOqXoNTq+yRJvK8FaeQna84d3uP4xQVfBEYBowQkWvdnA4DESISDhV1TQdknYa5nIzHKdcwvIV1SlV1rbv8Os5RyWCgSFV3us8vw7lwzjHgFPCaiNwPnGxFLjcAa1S1Up3S6G+42wSoBd53lzcD6U28vg9Q2ei599Q535wFVKhqlqqexSlB4buN/ThlY4xpNes0zGXB3dO+A+eqbY+3cAGexoN8StNltXH/2d8IrMC5KNT/tialFmJ1em6w8QxNV6Ouxqlf5avGvT/rs1z/2Hcbke7rjWk16zTMJc+tELoI57TUbuBXwPxmVk8VkZvd5YnAZ0AukC4iA93nHwI+FZHuQA9V/QCYiXOaqbHjQEwTz28ERotIgoh0ct/r01Z8rBxg4HnXasRtiyScSxEb02rWaZjLwSPAblX9yH28ELhKREY3sW4OMFlEtgHxwCJVPQU8DCwXkSycPfdXcDqD9911P8UZS2hsKfBK/UB4/ZPqlOV+AqdKbCawRb1f3AucsY7r6ktmt8JInPGS0618nTGATbk1poGIpAPvq2pLYx5hQ0QW4IxjrG7la1aq6sftl5m5lNmRhjEd1/NAVCtfs906DHMx7EjDGGOMZ3akYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPPt/4+W6FhppJ+AAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "from ctapipe.visualization import CameraDisplay\n",
@@ -426,32 +190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb2eed7630>"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGAVJREFUeJzt3XuYJXV95/H3BxBQEeQmojCMl9EsKOBug/FRYVeYDVk3QIwoeGF0jUSMy6pPzLIPxhhidr3Fja6IsK5hNCo6GGVQvAwDqNmIoVEER0QuGpkFYfCKclGc7/5xasKx7cuvZ/pcZvr9ep7z9KmqX1d9Ts88/emqOqcqVYUkSS22G3UASdLWw9KQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDS1qSS5P8qMkO/XN2y/Jx5PcmeQnSa5N8pIkz0zys+7x8yTVN/2zJEu69d3bTd+Z5O+T7Nu37jcm+bu+6SQ5Lck3unWuT7IqyZOH/bOQWlgaWrSSLAWeCRRwbN+iDwK3AAcAewInA7dX1Zeqapeq2gU4qBv78E3zqup73bxXdWMeD+wCvH2WGO8E/gtwGrAH8ATgk8Czt/wVSgvP0tBidjJwBXAesKJv/mHAeVX186q6v6q+VlWfme/Kq+rH9Arg0OmWJ1kG/DFwUlVdWlX3VdXdVfWhqnpzN+bZSb6W5KdJbknyxr7vX9rt7by0W/ajJK9IcliSa5L8OMm755tbms0Oow4gjdDJwDuArwBXJNmnqm6nVyRnJflfwD/27UHMS5I9gecAN84w5ChgfVX90yyr+XmXcx3wJGBNkqur6pN9Y54KLAOOAFYDnwWOBh4EfC3Jqqr6wua8Bmkq9zS0KCV5Br3DTx+rqquAm4AXdItPAL4E/BnwnSRXJzlsHqt/V5KfAHcCewH/eYZxewK3zbaiqrq8qq6tqo1VdQ3wEeDIKcP+sqrurarP0yuZj1TVHVX1/7rX8ZR5ZJdmZWlosVoBfL6q7uymP9zNo6p+VFWnV9VBwD7A1cAnk6Rx3adV1W7AwcDuwH4zjPsBsO8MywBI8tQklyXZ0BXRK+gVUb/b+57fM830Lo25pTlZGlp0kjwYeB5wZJLvJ/k+8BrgkCSH9I/tSuXtwKPonahuVlXXAm+id6hrusJZC+yXZGKW1XyY3iGn/bsiei/QWl7SgrM0tBgdD/wKOJDeSepDgX9F71DOyUnekuRJSXZI8jDgVODGqvrBZmxrJfAIfv3dWQBU1Q3Ae4CPJPm3SXZMsnOSE5Oc3g17GPDDqro3yeE8cAhNGglLQ4vRCuBvq+p7VfX9TQ/g3cALgV2BTwA/Bm6md+7jN37pt6iqXwDvond+ZDqndds9q9veTcDvAxd1y18JnJnkLuANwMc2J4e0UOJNmCRJrdzTkCQ1szQkSc0sDUlSM0tDktRsm7uMyF577VVLly4ddQxJ2qpcddVVd1bV3nON2+ZKY+nSpUxOTo46hiRtVZL8c8s4D09JkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSp2UhLI8kxSa5PcmPf/QP6l782yTeTXJNkbZIDRpFTktQzsg/3Jdme3j0ElgPrgSuTrK6qb/YN+xowUVV3JzkVeCvw/OGn1bhbvt0JQ9vWmo2rhrq9UVizcdWoI2hMjXJP43B6d0O7ubtRzfnAcf0Dquqyqrq7m7yCme+1LEkaglGWxqOBW/qm13fzZvIy4DMDTSRJmtUorz2VaeZNexvBJC8CJoAjZ1h+CnAKwJIlSxYqnyRpilHuaawH9u+b3g+4deqgJEcDZwDHVtV9062oqs6tqomqmth77zkv0ihJ2kyjLI0rgWVJHpNkR+BEYHX/gCRPAc6hVxh3jCCjJKnPyEqjqu4HXgV8DrgO+FhVrUtyZpJju2FvA3YBViW5OsnqGVYnSRqCkd5Po6ouBi6eMu8Nfc+PHnooSdKM/ES4JKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmO4w6gLQQ1mxctU1vTxoXloYW3PLtThjq9tZsXDXUbQ57e6Mwip+ptg4enpIkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzUZaGkmOSXJ9khuTnD7N8iOSfDXJ/UmeO4qMkqQHjKw0kmwPnAX8LnAgcFKSA6cM+x7wEuDDw00nSZrODiPc9uHAjVV1M0CS84HjgG9uGlBV3+2WbRxFQEnSrxvl4alHA7f0Ta/v5s1bklOSTCaZ3LBhw4KEkyT9plGWRqaZV5uzoqo6t6omqmpi77333sJYkqSZjLI01gP7903vB9w6oiySpAajLI0rgWVJHpNkR+BEYPUI80iS5jCy0qiq+4FXAZ8DrgM+VlXrkpyZ5FiAJIclWQ+cAJyTZN2o8kqSIFWbdRphbE1MTNTk5OSoY0jSViXJVVU1Mde4Ub7lVkOyfLsTRh1hoNZsXDXU1zjs7Y3CYviZrtm4aqjb21Z4GRFJUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc3m/HBfku2AQ4BHAfcA66rq9kEHkySNnxlLI8njgP8KHA3cAGwAdgaekORu4BxgZVV5gyRJWiRm29N4E3A28Ec15QJVSR4BvAB4MbBycPEkSeNkxtKoqpNmWXYH8DcDSSRJGlst5zS2B54NLO0fX1XvGFwsSdI4arnK7UXAvcC1gOcvJGkRaymN/arq4IEnkSSNvZbPaXwmyb8feBJJ0thr2dO4AvhE93mNXwIBqqp2HWgySdLYaSmNvwaeBlw79a23kqTFpeXw1A3ANywMSVLLnsZtwOVJPgPct2mmb7mVpMWnpTS+0z127B6SpEVqztKoqr8YRhBJ0vib8ZxGknOTPHmGZQ9N8p+SvHBw0SRJ42a2PY33AH/WFcc3eOAqt8uAXYH3Ax8aeEJJ0tiY7YKFVwPPS7ILMAHsS+9+GtdV1fVDyidJGiMt5zR+Blw++CiSpHHn7V4lSc0sDUlSM0tDktSs5SZMTwBeBxzAr9+E6VkDzCVJGkMtnwhfBbwX+N/ArwYbR5I0zlpK4/6qOnvgSSRJY6/lnMZFSV6ZZN8ke2x6DDyZJGnstOxprOi+vq5vXgGPXfg4kqRx1vLhvscMI4gkafy1vHvqQcCpwBHdrMuBc6rqlwPMJUkaQy2Hp84GHkTvAoYAL+7m/eGgQkmSxlNLaRxWVYf0TV+a5OuDCiRJGl8t7576VZLHbZpI8lgW6PMaSY5Jcn2SG5OcPs3ynZJ8tFv+lSRLF2K7kqTN07Kn8TrgsiQ3A6H3yfCXbumGk2wPnAUsB9YDVyZZXVXf7Bv2MuBHVfX4JCcCbwGev6XbliRtnpZ3T61Nsgx4Ir3S+FZV3bcA2z4cuLGqbgZIcj5wHNBfGscBb+yeXwC8O0mqqhZg+5KkeZqxNJI8q6ouTfKcKYsel4Sq+vst3PajgVv6ptcDT51pTFXdn+QnwJ7AnVOyngKcArBkyZItjCVJmslsexpHApcCvzfNsgK2tDQyw3rnO4aqOhc4F2BiYsK9EEkakNlu9/rn3dMzq+o7/cuSLMQH/tYD+/dN7wfcOsOY9Ul2AHYDfrgA25YkbYaWd099fJp5FyzAtq8EliV5TJIdgROB1VPGrOaBy5g8F7jU8xmSNDqzndP4LeAgYLcp5zV2BXbe0g135yheBXwO2B54f1WtS3ImMFlVq4H/A3wwyY309jBO3NLtSpI232znNJ4I/Efg4fz6eY27gJcvxMar6mLg4inz3tD3/F7ghIXYliRpy812TuNC4MIkT6uqLw8xkyRpTM12eOpPq+qtwAuSnDR1eVWdNtBkkqSxM9vhqeu6r5PDCCJJGn+zHZ66qPu6ctO8JNsBu1TVT4eQTZI0ZuZ8y22SDyfZNclD6V3i4/okr5vr+yRJ256Wz2kc2O1ZHE/vnU5L6N1TQ5K0yLSUxoO6u/cdD1zY3bHPD9hJ0iLUUhrnAN8FHgp8MckBgOc0JGkRyuZclSPJDlV1/wDybLGJiYmanPQNX5I0H0muqqqJucbNeT+NJLsBfw4c0c36AnAm8JMtSqihWb7dtv2h+jUbVw31NQ57e6OwGH6mazauGur2thUth6feT+/SIc/rHj8F/naQoSRJ46nldq+Pq6o/6Jv+iyRXDyqQJGl8texp3JPkGZsmkjwduGdwkSRJ46plT+NUYGV3biP0LlG+YvZvkSRti+Ysjaq6Gjgkya7dtG+3laRFquUyInsmeRdwOXBZkncm2XPgySRJY6flnMb5wAbgD+jdcnUD8NFBhpIkjaeWcxp7VNVf9k2/KcnxgwokSRpfLXsalyU5Mcl23eN5wKcHHUySNH5aSuOPgA8D93WP84HXJrkriSfFJWkRaXn31MOGEUSSNP5a9jQkSQIsDUnSPMxYGkkuTrJ0eFEkSeNutj2N84DPJzmju3OfJGmRm/FEeFV9LMmngTcAk0k+CGzsW/6OIeSTJI2Rud499Uvg58BOwMPoKw1J0uIzY2kkOQZ4B7Aa+NdVdffQUkmSxtJsexpnACdU1bphhZEkjbfZzmk8c5hBJEnjz89pSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmqapRZ1hQExMTNTk5OeoYkrRVSXJVVU3MNa7lHuHSvCzf7oShbm/NxlVD3eawtzcKo/iZauvg4SlJUrORlEaSPZKsSXJD93X3GcZ9NsmPk3xq2BklSb9pVHsapwNrq2oZsLabns7bgBcPLZUkaVajKo3jgJXd85XA8dMNqqq1wF3DCiVJmt2oSmOfqroNoPv6iC1ZWZJTkkwmmdywYcOCBJQk/aaBvXsqySXAI6dZdMZCb6uqzgXOhd5bbhd6/ZKknoGVRlUdPdOyJLcn2beqbkuyL3DHoHJIkhbOqA5PrQZWdM9XABeOKIckaR5GVRpvBpYnuQFY3k2TZCLJ+zYNSvIlYBVwVJL1SX5nJGklScCIPhFeVT8Ajppm/iTwh33T3j1QksaInwiXJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1G8md+7RtW7Nx1agjaAH476jpuKchSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJajaS0kiyR5I1SW7ovu4+zZhDk3w5ybok1yR5/iiySpIeMKo9jdOBtVW1DFjbTU91N3ByVR0EHAP8TZKHDzGjJGmKUZXGccDK7vlK4PipA6rq21V1Q/f8VuAOYO+hJZQk/YZRlcY+VXUbQPf1EbMNTnI4sCNw0xCySZJmsMOgVpzkEuCR0yw6Y57r2Rf4ILCiqjbOMOYU4BSAJUuWzDOpJKnVwEqjqo6eaVmS25PsW1W3daVwxwzjdgU+Dby+qq6YZVvnAucCTExM1JYllyTNZGClMYfVwArgzd3XC6cOSLIj8AngA1W1arjxtLVZs3G4/0WGvT1pXIzqnMabgeVJbgCWd9MkmUjyvm7M84AjgJckubp7HDqauJIkgFRtW0dzJiYmanJyctQxJGmrkuSqqpqYa5yfCJckNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVKzbe5zGkk2AP88oNXvBdw5oHUPw9aeH7b+12D+0dra88PgXsMBVTXnlcS3udIYpCSTLR9+GVdbe37Y+l+D+Udra88Po38NHp6SJDWzNCRJzSyN+Tl31AG20NaeH7b+12D+0dra88OIX4PnNCRJzdzTkCQ1szQkSc0sjVkk2SPJmiQ3dF93n2bMAUmu6m4StS7JK0aRdTqN+Q9N8uUu+zVJnj+KrDNpeQ3duM8m+XGSTw0743SSHJPk+iQ3Jjl9muU7Jflot/wrSZYOP+XMGvIfkeSrSe5P8txRZJxNQ/7XJvlm939+bZIDRpFzJg35X5Hk2u73zj8kOXBo4arKxwwP4K3A6d3z04G3TDNmR2Cn7vkuwHeBR406+zzyPwFY1j1/FHAb8PBRZ5/Pa+iWHQX8HvCpMci8PXAT8Nju/8fXgQOnjHkl8N7u+YnAR0ede575lwIHAx8AnjvqzJuR/98BD+men7oV/vx37Xt+LPDZYeVzT2N2xwEru+crgeOnDqiqX1TVfd3kTozX3ltL/m9X1Q3d81uBO4A5PxU6RHO+BoCqWgvcNaxQczgcuLGqbq6qXwDn03sd/fpf1wXAUUkyxIyzmTN/VX23qq4BNo4i4Bxa8l9WVXd3k1cA+w0542xa8v+0b/KhwNDe0TROv+DG0T5VdRtA9/UR0w1Ksn+Sa4Bb6P0lfOsQM86mKf8mSQ6n95fNTUPI1mper2FMPJre/4VN1nfzph1TVfcDPwH2HEq6ubXkH2fzzf8y4DMDTTQ/TfmT/HGSm+jtjZ82pGzsMKwNjasklwCPnGbRGa3rqKpbgIOTPAr4ZJILqur2hco4m4XI361nX+CDwIqqGupfjwv1GsbIdHsMU/8SbBkzKuOcrUVz/iQvAiaAIweaaH6a8lfVWcBZSV4AvB5YMehgYGlQVUfPtCzJ7Un2rarbul+qd8yxrluTrAOeSe+Qw8AtRP4kuwKfBl5fVVcMKOqMFvLfYEysB/bvm94PmLr3uWnM+iQ7ALsBPxxOvDm15B9nTfmTHE3vD5Mj+w4xj4P5/vzPB84eaKI+Hp6a3WoeaO8VwIVTByTZL8mDu+e7A08Hrh9awtm15N8R+ATwgapaNcRsreZ8DWPoSmBZksd0P98T6b2Ofv2v67nApdWd1RwDLfnH2Zz5kzwFOAc4tqrG7Q+RlvzL+iafDdwwtHSjfqfAOD/oHWNe2/2DrAX26OZPAO/rni8HrqH3DodrgFNGnXue+V8E/BK4uu9x6Kizz+c1dNNfAjYA99D7S+13Rpz7PwDfpnd+6Ixu3pn0fkkB7AysAm4E/gl47Kh/1vPMf1j3c/458ANg3agzzzP/JcDtff/nV4868zzzvxNY12W/DDhoWNm8jIgkqZmHpyRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDW3zusu8fCfJHt307t30QK5s2l2B9OTu+Uu6KwVsWva+hboiaZLjk7xhnt9zyUxXCpZa+JZbLQpJ/hR4fFWdkuQc4LtV9T+GsN3LgT+pqskBrPsf6b1v/855fM8KYL+q+quFzqPFwT0NLRb/E/jtJK8GngH89dQBSZYm+VaSld19Fi5I8pBu2VFJvtbdw+D9SXbq5r+5774Mb+/mvTHJn3T3mZgAPtTd9+DBSS5PMtGNO6lb3zeSvKUvx8+S/FWSrye5Isk+02R9AnDfpsJIcl6Ss5NcluTmJEd2Oa9Lcl7ft64GTlqQn6gWJUtDi0JV/RJ4Hb3yeHX1Ljk9nScC51bVwcBPgVcm2Rk4D3h+VT2Z3jXbTu0Od/0+vU/jHgy8aco2LwAmgRdW1aFVdc+mZd0hq7cAzwIOBQ5Lsumy7w8FrqiqQ4AvAi+fJufTga9Ombd7t77XABd1r/Ug4MlJDu0y/QjYKcm4XFFXWxlLQ4vJ79K7ydSTZhlzS1X93+7539HbK3ki8J2q+nY3fyVwBL1SuRd4X5LnAHdPXdksDgMur6oN1bs0+oe6dQL8Ath0B8Kr6N3waKp96V02pd9F1TvefC1we1VdW70rFq+bso476N1wS5o3S0OLQveX9nLgt4HXdFfMnc7Uk3zF9JeqpvtlfzjwcXo3h/rsfCLNsuyX9cDJxl8x/dWo76F3/ap+m67UurHv+abp/nXs3H2/NG+WhrZ53R3xzqZ3WOp7wNuAt88wfEmSp3XPTwL+AfgWsDTJ47v5Lwa+kGQXYLequhh4Nb3DTFPdBTxsmvlfAY5MsleS7bttfWEeL+s64PFzjpqi+1k8kt5tiaV5szS0GLwc+F5Vremm3wP8VpLpbrxzHbCiuxPjHsDZVXUv8FJgVZJr6f3l/l56ZfCpbuwX6J1LmOo84L2bToRvmlm9uxD+N3pXKP068NWqms9l378IPKUrgfn4N/TOl9w/z++TAN9yK/2LJEuBT1XVbOc8xkaSd9I7j3HJPL9ndfXuqS7Nm3sa0tbrvwMPmef3fMPC0JZwT0OS1Mw9DUlSM0tDktTM0pAkNbM0JEnNLA1JUrP/D36ums6OBsFpAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "CameraDisplay(subarray.tel[98].camera)"
    ]
@@ -469,45 +210,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAI4CAYAAABndZP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3Xl8nGW9///XNZN9b5YuSdp0pbTpkkLoQi0WUArCD44iIHqAAgJfROm3ehSPsqn0nO+RqkfEcxAQRSi1LHLgVAVrtSxSlha6L3Rv02xN2uyZZJbr98c9DV3SJcmk92TyfvK4H8l93zPX/bnTYeYz12qstYiIiIjEEo/bAYiIiIhEmhIcERERiTlKcERERCTmKMERERGRmKMER0RERGKOEhwRERGJOUpwRKRfMcasMMZ81e04RKR3KcERkQ7GmN3GmHZjTO4xx9cYY6wxZngPy+9ycmGMmWqM+ZMxps4Yc9AY874x5uaexNHF66caY5qMMX86U9cUkZ5TgiMix9oFXH94xxgzEUh2IxBjzAzgb8AbwGggB7gTuKwbZRljTHfe874ItAGXGGOGnKT8uNM5JiJnhhIcETnWM8CNR+zfBPzu8I4xJtMY8ztjzAFjzB5jzL2HEwdjzFxjzNvGmIXGmEPGmF3GmMvC5xYAs4BHwzUij4aPn22MWRaundlqjLn2iGs/DDxtrf0Pa22Nday21l4bfu4AY8zScCyHwr8XHhHrCmPMAmPMP4AWYOSRN2qM8YTj32OMqQ7fV+Yxf4+bgMeAdcBXjnn+bmPMPcaYdUCzMSbuBMe+a4zZYYxpNMZsMsZ8Pvz8xPB9TzyizIHGmFZjTN5p/nuJSCeU4IjIsd4FMowx44wxXuA64Nkjzv8CyMRJFj6Nkwwd2WQ0DdgK5AI/Bn5tjDHW2u8DbwFft9amWWu/boxJBZYBzwEDcWqO/ssYU2yMSQFmAC+eJFYP8BugCBgGtAKPHvOYG4DbgXRgzzHn5oa3C8P3k3bk840xw4DZwKLwdiPHux64HMiy1gZOcGwHTnKXCfwAeNYYM8Ra2wb8HvjnY8r7q7X2wEnuW0ROQQmOiHTmcC3OZ4EtwP7w8cMJz79aaxuttbuBn+AkEYftsdY+Ya0NAk8DQ4BBJ7jOFcBua+1vrLUBa+2HwEs4zUIDcN6jKk4UpLW21lr7krW2xVrbCCzASbqO9Ftr7cZw+f5jzn0F+Km1dqe1tgn4V+BLRzQt3Qiss9ZuAhYDxcaYKceU8Yi1dp+1tvVEx6y1L1hry621IWvtEmAbMDX82KeBLx/RfHYDzt9fRHpA7cMi0plngDeBERzRPIVTK5PA0TUhe4CCI/YrD/9irW0xxoBTM9KZImCaMabuiGNx4esfAkI4CdKWzp4cruX5GXApTkIEkG6M8YYTLIB9J7g2QH4n9xKHk5Dtx0lwngjfS7kx5g2cJquPjnhOZ+UfdcwYcyPwTWB4+FAazt8Sa+17xphm4NPGmAqcvkavniRmETkNqsERkeNYa/fgdDb+HPCHI07VAH6cxOSwYXxSw3PKoo/Z3we8Ya3NOmJLs9beaa1tAVYCV5+kvG8BY4Fp1toM4ILwcXOSax6pnOPvJQBUGWPOB8YA/2qMqTTGVOI0v11/TOfhzsrvOGaMKcJJkr4O5Fhrs4ANx8T4NE4z1Q3Ai9Za30liFpHToARHRE7kVuAia23zEceCwPPAAmNMevjD+5sc3UfnZKo4uqPvUuAsY8wNxpj48HaeMWZc+Px3gLnGmG8bY3IAjDGTjTG/D59Px+l3U2eMyQYe6OI9LgbmG2NGGGPSgH8DloT7zdyE0z9oPFAS3iYAKXRtFFcqTsJzIBz/zeFyjvQM8HmcJOd3iEiPKcERkU5Za3dYa1d1cuobQDOwE3gbp4PwU6dZ7M+BL4ZHPD0S7jdzCfAlnNqUSuA/gMRwDO8AF4W3ncaYg8DjwOE5af4TZwh7DU7n6Ne6eJtP8Ulz3C7AB3zDGJMEXAv8wlpbecS2K/z4m073AuH+Oz/BqY2qAiYC/zjmMWXAhziJ0FtdvAcR6YSx9mS1tyIiciYYY54Cyq2197odi0gsUCdjERGXhWeI/gJw7AgtEekmNVGJiLjIGPMjnE7HD4ebwEQkAtREJSIiIjFHNTgiIiISc/ptH5zc3Fw7fPhwt8MQERGRLli9enWNtfaUa7X12wRn+PDhrFrV2QhYERERiVbGmGPXlOuUmqhEREQk5ijBERERkZijBEdERERiTr/tgyMiIr3L7/dTVlaGz6e1Q6XrkpKSKCwsJD4+vlvPV4IjIiK9oqysjPT0dIYPH44x5tRPEAmz1lJbW0tZWRkjRozoVhlqohIRkV7h8/nIyclRciNdZowhJyenR7V/SnBERKTXKLmR7urpa0cJjoiIiMQcJTgiIiISc5TgiIhIVLDWUnaohQ376yk71EIkFoM2xnDDDTd07AcCAfLy8rjiiisAqKqq4oorrmDy5MmMHz+ez33uc6xfv56SkhJKSkrIzs5mxIgRlJSU8JnPfKbTa+zevRtjDPfdd1/HsZqaGuLj4/n6178OwNatW5k9ezYlJSWMGzeO22+/nddff73jOmlpaYwdO5aSkhJuvPHGTq+zYsUKMjMzO55zOJ4HH3yQhQsXdvlv89vf/rYjvmM1NTVxxx13MGrUKIqLi7ngggt47733unwNN2kUlYiIuK6+1c8z7+5hd00TBoPFMjw3jRumF5GZ3L1hwgCpqals2LCB1tZWkpOTWbZsGQUFBR3n77//fj772c8yb948ANatW8fEiRNZs2YNAHPnzuWKK67gi1/84kmvM3LkSJYuXcqPfvQjAF544QWKi4s7zt99993Mnz+fq666CoD169czceJE5syZA8Ds2bNZuHAhpaWlJ73OrFmzWLp0aRf/Cl331a9+lREjRrBt2zY8Hg87d+5k8+bNvX7dSFINjoiIuMpayzPv7qHsYAv5mcnkZyWTn5nMvoMtPPvunh7X5Fx22WX88Y9/BGDx4sVcf/31HecqKiooLCzs2J80aVK3rpGcnMy4ceM61jhcsmQJ11577QmvM3HixG5d51SeeOIJzjvvPCZPnszVV19NS0sL4CRcEyZMYPLkyVxwwQUdjy8vL+fSSy9lzJgxfOc73wFgx44dvPfeezz00EN4PE6aMHLkSC6//HIA/umf/olzzz2X4uJiHn/88Y6y0tLSuOeeezj33HP5zGc+w/vvv8/s2bMZOXIkr776aq/c78kowREREVftr2tld00TA9MTO0bOGGMYlJ7Irpomyut7NlHgl770JX7/+9/j8/lYt24d06ZN6zh31113ceutt3LhhReyYMECysvLe3ydsrIyvF4v+fn5Hefmz5/PRRddxGWXXcbPfvYz6urqunWNt956q6OJasGCBced/8IXvsAHH3zA2rVrGTduHL/+9a8B+OEPf8jrr7/O2rVrj0o21qxZw5IlS1i/fj1Llixh3759bNy4kZKSErxeb6cxPPXUU6xevZpVq1bxyCOPUFtbC0BzczOzZ89m9erVpKenc++997Js2TJefvll7r///m7db08owREREVfVtfgxmOOGBRtjMBjqWtp7VP6kSZPYvXs3ixcv5nOf+9xR5+bMmcPOnTu57bbb2LJlC1OmTOHAgQPdus6ll17KsmXLWLx4Mdddd91R526++WY2b97MNddcw4oVK5g+fTptbW1dvsasWbNYs2YNa9as4fvf//5x5zds2MCsWbOYOHEiixYtYuPGjQDMnDmTuXPn8sQTTxAMBjsef/HFF5OZmUlSUhLjx49nz55TL9T9yCOPMHnyZKZPn86+ffvYtm0bAAkJCVx66aWAU0P16U9/mvj4eCZOnMju3bu7fK89pQRHRERclZUSj8Ue1xRlrcViyUpJ6PE1rrzySv7lX/7lqOapw7Kzs/nyl7/MM888w3nnncebb77ZrWskJCRw7rnn8pOf/ISrr776uPP5+fnccsstvPLKK8TFxbFhw4ZuXedk5s6dy6OPPsr69et54IEHOibKe+yxx3jooYfYt28fJSUlHbUuiYmJHc/1er0EAgGKi4tZu3YtoVDouPJXrFjBX//6V1auXMnatWuZMmVKxzXi4+M7klSPx9NRtsfjIRAIRPxeT0UJjoiIuKogK5nhuWlUNbZ1JDnWWqoa2xiZm0Z+ZlKPr3HLLbdw//33H9f35W9/+1tHP5XGxkZ27NjBsGHDun2db33rW/zHf/wHOTk5Rx1/7bXX8Pv9AFRWVlJbW3tUZ+dIaWxsZMiQIfj9fhYtWtRxfMeOHUybNo0f/vCH5Obmsm/fvhOWMWrUKEpLS3nggQc6/j22bdvGK6+8Qn19PQMGDCAlJYUtW7bw7rvvRvweIkWjqERExFXGGG6YXnTcKKoRuWl8ZXpRRGZDLiws7BgpdaTVq1fz9a9/nbi4OEKhEF/96lc577zzun2d4uLio0ZPHfaXv/yFefPmkZTkJGsPP/wwgwcP7vZ1TuRHP/oR06ZNo6ioiIkTJ9LY2AjAt7/9bbZt24a1losvvpjJkyd3jBTrzJNPPsm3vvUtRo8eTUpKCjk5OTz88MNMmjSJxx57jEmTJjF27FimT58e8XuIFBOJeQb6otLSUnu4t7uIiETe5s2bGTdu3Gk/3lrL/rpW6lv9ZKUkkJ+ZpKUe+rnOXkPGmNXW2pOPp0c1OCIiEiWMMRQOSKFwgNuRSCxQgiMiJ+ZvdX7GJ7sbRyyzFtqbwZsAcT3vTCu9Z/369UfNigxOJ91Iz/D7+uuvc8899xx1bMSIEbz88ssRvU6sU4IjIscLhWDjS7Dj787+qIuh+PPg0biEiPK3wgdPQfVG8Hhh8vVQdL7bUckJHDnDcW+aM2dOxwzH0n16txKR41WuhY//Aun5zrbtNahc53ZUsefj152/a0YhJOfAR89CQ4XbUYnEBCU4InK8xiqnycTjdTYTD03dm/xMTqK+DJIywRiISwQMtB50OyqRmKAER0SOlzUMQn4ItDmbDUBW4amfJ12TMwZ8dRAKQluTk+ikDXI7KpGYoARHRI43cBxM+hL46p1t0vWQd7bbUcWe0RfByAuhqRJsEKbfCam5bkclEhPUyVhEjmeM8+E76sJP9iXyvPFQcj1M/pL+xr1owYIFPPfcc3i9XjweD7/61a84cOAA9913H6FQCL/fz7x586ipqeGFF14AnBFTh2c9vuWWW7j77rtPWP7kyZMZP348ixcv7jj27rvvMm/ePNra2mhra+O6666jqKiIn//85wBs2rSJsWPH4vV6ufTSSzn77LP59re/TUFBAT6fjzvuuIP58+cD8OCDD5KWlsa//Mu/nDCGQCDA4MGDue222/j3f//3juNLly7t0n0ePHiQJ554gry8PNrb27nvvvs6lreYO3cuV1xxBV/84hfx+/3cd999vPTSSyQmJpKSksIPfvADLrvssi7/+/Qaa22/3M4991wrIiK9Z9OmTV1/Uihkrb/N+RkB77zzjp0+fbr1+XzWWmsPHDhgd+/ebYcMGWL37dtnrbXW5/PZLVu2HPW81NTU0yp/06ZNdsKECTY/P982NTV1HD/rrLPsmjVrrLXWBgIBu3HjxqOeV1RUZA8cONCx/5vf/Mbedddd1lpra2pqbE5Ojt27d6+11toHHnjAPvzwwyeN449//KM9//zz7ciRI20o/Ldrb2/v8n0eea2PP/7Ypqen2/b2dmuttTfddJN94YUXrLXW3nPPPfbGG2/s+LtWVlbaJUuWnDTG7ujsNQSssqfxOa8mKhERiQ6NVfC3H8H/znN+Nlb1uMiKigpyc3M7Fn7Mzc0lPT2dQCDQsV5UYmIiY8eO7Vb5zz33HDfccAOXXHIJr776asfx6upqhgwZAjiLWI4fP/60y8zJyWH06NFUVJz+iLrFixczb948hg0b1rE+VGNjY4/uc8yYMaSkpHDo0KGjjre0tPDEE0/wi1/8ouPvOmjQIK699loA7rzzTkpLSykuLuaBBx7oeN7w4cP53ve+x4wZMygtLeXDDz9kzpw5jBo1iscee+y04zpdSnBERMR91sL7v4KWQ04n95ZDzn4PlxO65JJL2LdvH2eddRZf+9rXeOONN8jOzubKK6+kqKiI66+/nkWLFnW6cvbpWLJkCddddx3XX3/9UU1U8+fPZ+zYsXz+85/nV7/6VceK26dj7969+Hw+Jk2adFqPb21tZfny5VxxxRVHxdHT+/zwww8ZM2YMAwcOPOr49u3bGTZsGBkZGZ0+b8GCBaxatYp169bxxhtvsG7dJ1NMDB06lJUrVzJr1izmzp3Liy++yLvvvsv9999/2nGdLiU4IiLivqDfmQMoLfxhmjbQ2Q/6e1RsWloaq1ev5vHHHycvL4/rrruO3/72tzz55JMsX76cqVOnsnDhQm655ZYul/3BBx+Ql5dHUVERF198MR9++GFHbcf999/PqlWruOSSS3juuee49NJLT1nekiVLKC4uZuTIkUctzHkqS5cu5cILLyQlJYWrr76al19+mWAwCNCt+/zZz37G2LFjmTZtGg8++OBpxXCk559/nnPOOYcpU6awceNGNm3a1HHuyiuvBJxJE6dNm0Z6ejp5eXkkJSVRV1fX5WudjBIcERFxnzceMoZAU7Wz31Tt7Hvje16018vs2bP5wQ9+wKOPPspLL70EOB+y8+fPZ9myZR3HumLx4sVs2bKF4cOHM2rUKBoaGo4qZ9SoUdx5550sX76ctWvXUltbe9LyrrvuOjZu3Mhbb73Ft771LSorK087jr/+9a8MHz6cc889l9raWv7+9793nO/qfc6fP5+tW7eyZMkSbrzxxuNqn0aPHs3evXs7Vio/0q5du1i4cCHLly9n3bp1XH755Uc9/3CTlsfj6fj98H4gEDit+z1dSnBERMR9xsDUOyBlANTtdX5OvaPHo8u2bt3Ktm3bOvbXrFnDoEGDWLFixVHHioqKulRuKBTihRdeYN26dezevZvdu3fzyiuvdDQP/fGPf8SGm9e2bduG1+slKyvrtMqeMWMGN9xwQ8eIq5NpaGjg7bffZu/evR1x/PKXv2Tx4sU0NTX16D6/8IUvUFpaytNPP33U8ZSUFG699Vbuvvtu2tvbAaev07PPPktDQwOpqalkZmZSVVXFn//859O+XqRpmLiIiESH9EFw0X1Os5Q3PiJD55uamvjGN75BXV0dcXFxjB49mp///Ofccccd3HHHHSQnJ5Oamspvf/vbLpX75ptvUlBQQEFBQcexCy64gE2bNlFRUcEzzzzD/PnzSUlJIS4ujkWLFuH1ek+7/HvuuYdzzjmH733veyd93B/+8Acuuuiio2pDrrrqKr7zne/w05/+lB//+Mc9us/777+fL3/5y9x2221HHX/ooYe49957GT9+PElJSaSmpvLDH/6QyZMnM2XKlI6mtpkzZ3bpepFkbA87cPVVpaWldtWqVW6HISISszZv3sy4cePcDkP6sM5eQ8aY1dba0lM9V01UIiIiEnPURCUiInISCxYs6Jj597BrrrmG73//+2c0jrvuuot//OMfRx2bN28eN9988xmNo69QE5WIiPQKNVFJT6mJSkREROQISnBEREQk5ijBERERkZijTsYiIuI6ay3lzeWsP7CeurY6shKzmJg3kfzUfEwE5sOR/kc1OCIi4ipfwMeizYv4rzX/xcryleyo28HK8pX815r/YtHmRfgCp79Q5bHS0tKOO7Z161Zmz55NSUkJ48aN4/bbb+f111+npKSEkpIS0tLSGDt2LCUlJdx4442dlrtixQquuOKK444vXbqUKVOmMHnyZMaPH8+vfvUrFixY0FG21+vt+P2RRx7ptOwHH3yQhQsXHnd8wYIFFBcXM2nSJEpKSnjvvff4/Oc/T0lJCaNHjyYzM7Oj7HfeeQe/3893v/tdxowZw4QJE5g6daqrMwufaa7W4BhjngKuAKqttRPCx7KBJcBwYDdwrbX2kHFS+J8DnwNagLnW2g/Dz7kJuDdc7EPW2qPnlRYRkahkreXFj19k88HNx9XWWGvZfHAzL378Il8Z95WI1eTcfffdzJ8/n6uuugqA9evXM3HiRObMmQPA7NmzWbhwIaWlpxyocxS/38/tt9/O+++/T2FhIW1tbezevZuxY8d2DClPS0tjzZo1XY555cqVLF26lA8//JDExERqampob2/n5ZdfBpyEa+HChSxdurTjOd/97nepqKhgw4YNJCYmUlVVxRtvvNHla/dVbtfg/BY4donV7wLLrbVjgOXhfYDLgDHh7Xbgv6EjIXoAmAZMBR4wxgzo9chFRKTHypvLO01uAIwx5Kfms+XgFiqaKyJ2zYqKCgoLCzv2J06cGJFyGxsbCQQC5OTkAM7CkmPHjo1I2RUVFeTm5nYsyZCbm0t+fv4JH9/S0sITTzzBL37xi47nDBo0iGuvvRaAO++8k9LSUoqLi3nggQc6njd8+HC+973vMWPGDEpLS/nwww+ZM2cOo0aN4rHHHovIvZwpriY41to3gYPHHL4KOFwD8zTwT0cc/511vAtkGWOGAHOAZdbag9baQ8Ayjk+aREQkCq0/sJ44E3fC2hljDF7jZd2BdRG75vz587nooou47LLL+NnPfkZdXV1Eys3OzubKK6+kqKiI66+/nkWLFhEKhSJS9iWXXMK+ffs466yz+NrXvnbKmpjt27czbNgwMjIyOj2/YMECVq1axbp163jjjTdYt+6Tv+/QoUNZuXIls2bNYu7cubz44ou8++673H///RG5lzPF7Rqczgyy1lYAhH8ODB8vAPYd8biy8LETHT+OMeZ2Y8wqY8yqAwcORDxwERHpmrq2OhK8CSd9TII3gbq2yCQhADfffDObN2/mmmuuYcWKFUyfPp22traIlP3kk0+yfPlypk6dysKFC7nlllsiUm5aWhqrV6/m8ccfJy8vj+uuu67LC2ce6fnnn+ecc85hypQpbNy4kU2bNnWcu/LKKwGnZmvatGmkp6eTl5dHUlJSxJLBMyEaE5wT6Sy9tyc5fvxBax+31pZaa0vz8vIiGpyIiHRdVmIW7cH2kz6mPdhOVmJWRK+bn5/PLbfcwiuvvEJcXBwbNmyIWNkTJ05k/vz5LFu2jJdeeili5Xq9XmbPns0PfvADHn300ZOWPXr0aPbu3UtjY+Nx53bt2sXChQtZvnw569at4/LLL8fn+6Qj9+EmLY/Hc9Qq5R6Ph0AgELH76W3RmOBUhZueCP+sDh8vA4Ye8bhCoPwkx0VEJMpNzJtIwAY40bJB1lqCNsikvEkRu+Zrr72G3+8HoLKyktraWgoKOq3475KmpiZWrFjRsb9mzRqKiop6XC44I7+2bdt22mWnpKRw6623cvfdd9Pe7iSQFRUVPPvsszQ0NJCamkpmZiZVVVUxO7IqGufBeRW4Cfh/4Z+vHHH868aY3+N0KK631lYYY14H/u2IjsWXAP96hmMWOT0Hd0JzLaQNhAGReeMTOWOshQNboa0RsoZB+qAeF5mfms+47HEnHEVV3lzOuOxxDEkd0q3yW1pajupQ/M1vfpOysjLmzZtHUlISAA8//DCDBw/uctnLly8/quzFixfz4x//mDvuuIPk5GRSU1O73Yz00EMP8Z//+Z8d+6+88grf+MY3qKurIy4ujtGjR/P444+fsox7772X8ePHk5SURGpqKj/84Q+ZPHkyU6ZMobi4mJEjRzJz5sxuxRjtXF1s0xizGJgN5AJVOKOh/gd4HhgG7AWusdYeDA8TfxSnA3ELcLO1dlW4nFuA74WLXWCt/c2prq3FNuWM2/F3WLcEjHE+KM65CYpmuB2VyOmxFtYugV1/B+MB44Xz74a8s074lNNdbNMX8PHixy+y5eAWvMZLgjeB9mA7QRvk7Oyz+eJZXyQpLimSdyN9RE8W23S1Bsdae/0JTl3cyWMtcNcJynkKeCqCoYlEVjAAG16C9CHgTYCAD9b9HoZNdxIekWjXXAO73oDMYU6C03oINr4Ms+/pcdFJcUl8ZdxXqGiuYN2BdR0zGU/Km8SQ1CGayVi6JRqbqERijw06myf8v5wnHoJ+sCHnm7BItAv5w8l4ONnwxjuJeoQYY8hPyyc/7cRzu7jh9ddf5557jk7iRowY0THBXk8sWLCAF1544ahj11xzTcekgNIzSnBEzoS4RCiaCTvfhIRUaG+Gsy4Bj5Ib6SPSBkHOaKcPTnyK8xo+p/NlDI5kre3TNTBz5szpmOE40r7//e8rmTmJnnahUYIjcqZM+hJkDoX6fZA1XP1vpG/xeGH6nbDzDWipgYHFkF9y0qckJSVRW1tLTk5On05y5Myz1lJbW9vREbw7lOCInCneOBj5abejiF3Wwp53YPtfnRqz4s9DXmSmyZew+GQYe/oTxRcWFlJWVoYmVpXuSEpKOmqUWlcpwRGR2FC+Fj58GlLyoL0F3vkFXHQvpHd9+K9ERnx8PCNGjHA7DOmnonGiPxGRrqve6PQNSUyD5CwIBaFur9tRiYhLVIMjIrEhNRcCrU5TFdYZoZaY7nZUIuISJTgiEhtGXADVm6Bmm5PkjJwNeWe7HZWIuEQJjojEhvhkZ2bdpipnnqHUXE2iKNKPKcERkdjh8UJGdE0UJyLuUCdjERERiTlKcERERCTmKMERERGRmKMER0RERGKOEhwRERGJOUpwREREJOYowREREZGYowRHREREYo4SHBEREYk5SnBEREQk5ijBERERkZijBEdERERijhbblL7LWmgoh/ZmZ4HFxDS3IxKRaNNyEJprICXbWWFe+g0lONI3WQubX4WtfwbjdZKbT82H9MFuRyYi0aJqI7z3GISCYDxw7s1QeK7bUckZoiYq6ZsaK2Hra5BRCJmFEGiDjf/jdlQiEi2shdVPQ2IGZA6F5Gz46Bkn2ZF+QQmO9E2BVucbmcfr7Mcng6/e3ZhEJHrYELQ3QXyKsx+XBIF2CLa7G5ecMUpwpG9KH+K0qTeUO4lNcw0UTnU7KhGJFh6v855Qt9d5j6jfC4MnOImO9AvqgyN9U3wyzPy/sPl/ofUgjL0Mhs9yOyoRiSYl10PKAKjZBoWlcPblYIzbUckZogRH+q7UHCid63YUIhKt4hJh/FVuRyEuUROViIjgYfDNAAAgAElEQVSIxBwlOCIiIhJzlOCIiIhIzFGCIyIiIjFHnYxF5PTU73dGrKUNgrSBbkfTtx0eupxR4Ex3ICIRpwRHRE5t99vw0SJnckVjYNodMHii21H1TVv/DJtecZYY8Xhh5jzIGeV2VCIxR01UInJygTZYu8SpuckshKRM+OhZt6Pqm3z1sHmpU3OTWQhxyc7fVkQiTgmOiJxc0A82AN4EZz8uyVnB3Vp34+qLAm2AdWpvwPlb+ptcDUkkVinBEZGTS0iFQROhbg+0HIT6fc6s0ZoRtutScmDACOdv2HIQmiqg6FNuRyUSk9QHR0ROzhgovQW2LXM+mHPHwMgL3Y6qb/J4YcbX4OPXobEKBo3XEiMivUQJjoicWnwSjP//3I4iNiSkwoQvuB2FSMxTE5WIiIjEHCU4IiIiEnOU4IiIiEjMUYIjIiIiMUcJjoiIiMQcjaLq74J+KFvlzLCadxZkj3Q7IhERsRaqNjhrwGUMgcGTNPdUFynB6c9CQXjvcahcC5442BSCGXdpjSEREbdtfQ02vQyeeAj54ewrYPyVbkfVp6iJqj9rrHC+IWQNh8yhkJjpLAQoIiLuCYVg6x8ho9BZsyxzKHz8mlPjLqdNNTgiEjtCIWg96MwYnJSlKn3pw4597eq13FVKcPqz9HynOap8jfOBYIBzbnA7KpHuCbTB+09C9QbAwOjPQPHnleRI3+PxwNmXw4Y/ON0HQgFnJnFvvNuR9SlKcPozjwem3gblHzmdjHNGQ/YIt6MS6Z5dbzn9ybKGgw056z0NKoa8sW5HJtJ1Z81xmqcayiF9sPpGdoMSnP7OGw9Dp7odhUjPNVVBfIpTY2O8YDxO4i7SFxkDgyc4m3SLOhmLSGzIOxv8LeBvhbYGJ8HJLHQ7KhFxiRIcEYkNBefApC85Q2rjEmH6/4GMfLejEhGXqIlKRGKDMTD6ImcTkX5PNTgiIiISc5TgiIiISMxRgiMiIiIxRwmOiIiIxBx1MhaJBo1VztozbU0wbAYUlmoGXnFHMAA7lkP1Jme287Mvh8Q0t6MS6TIlOCJu8zXAWz+BgA/ikuCDJ5yJ6grPcTsy6Y82v+osupucDTUfQ91emPUtZ+ZzkT5Er1gRt9XthfZmSB8CyQMgMQPK3nc7Kumv9q6EjAJIzoKMoXBoF7QecjsqkS5TgiPitvhkZzE9G3L2Az5IynA3Jum/EjOc2aDBmTQR40ycKNLHKMERcVv2SBj+Kajf52xJmXDWpW5HJf1VyZch6IOGMmishInXqA+O9EnqgyPiNmNgyj87SU6wHTKHQkKK21FJf5UzCj7zoJPcJGVBxhC3IxLpFiU4ItHAGMge4XYUIo7kAc4m0oepiUpERERijhIcERERiTlKcERERCTmKMERERGRmKMER0RERGKOEhwRERGJOUpwREREJOYowREREZGYowRHREREYo4SHBEREYk5SnBEREQk5ijBERERkZijBEdERERijhIcERERiTlKcCS2tTXCoT3ga3A7EhHpDc21ULcX/D63I5EoE+d2ACK9pmY7vPtLCPrB44Wpd8Cg8W5HJSKRsn05bHgJMJCSDTPnQWqu21FJlFANjsQma+GDJyEuCTIKICENVv0aQiG3IxORSGg64CQ3aYMhsxB89bDxZbejkiiiBEdikw05b3gJ6c5+fCq0t0Cw3d24RCQy2hsBA954Zz8hHZoPuBqSRBclOBKbPF4YMhnq9zqJTcM+yBsLcYluRyYikZA2GJLSoakK2pud5CZ/ittRSRRRgiOx65wbYfgs8MbB0Blw3q1gjNtRiUgkJKTAzP8LuWMgLgGK/wnGXOJ2VBJF1MlYYldCCkz5ittRiEhvSR8MM+5yOwqJUqrBERERkZijBEdERERijhIcERERiTlKcEQktoRCzjxIItKvqZOxiMSGUMiZ6G3n38ATDxOvheHnux2ViLhENTgiEhv2roSPXwvPj5IJH/0ODu12OyoRcYkSHBGJDYd2Q0IqeOKcJTow0FTtdlQi4pKoTXCMMbuNMeuNMWuMMavCx7KNMcuMMdvCPweEjxtjzCPGmO3GmHXGmHPcjV5EzrjMoc6s1TYUXpIjBCk5bkclIi6J2gQn7EJrbYm1tjS8/11gubV2DLA8vA9wGTAmvN0O/PcZj1RE3FV0Poy8AOrLnJqbiddBzii3oxIRl/S1TsZXAbPDvz8NrADuCR//nbXWAu8aY7KMMUOstRWuRCkiZ543Dqb8M0z4orMW2eFFGEWkX4rmGhwL/MUYs9oYc3v42KDDSUv458Dw8QJg3xHPLQsfE5H+Jj5JyY2IRHUNzkxrbbkxZiCwzBiz5SSP7WwFxeMmwggnSrcDDBs2LDJRioiISNSJ2hoca215+Gc18DIwFagyxgwBCP88PESiDBh6xNMLgfJOynzcWltqrS3Ny8vrzfBFRETERVGZ4BhjUo0x6Yd/By4BNgCvAjeFH3YT8Er491eBG8OjqaYD9ep/EyHWQush8NVrdlgRkUgKhaDlILQ1uh1JTIrWJqpBwMvGGHBifM5a+5ox5gPgeWPMrcBe4Jrw4/8EfA7YDrQAN5/5kGNQMAAfPQNl7zsNfqNmw4RrwBOVebGISN/hb4X3n4DqzWAMjLsKxs5xO6qYEpUJjrV2JzC5k+O1wMWdHLfAXWcgtP5l3/uw5x0YMNypvdm+HPLGwZBJbkcmItK3bV8OVRshqwhCAdj0PzBwrPN+KxGhr+JyYs3VzoywxuMMuzUe8NW5HZWISN/XWAGJ6U7tjTfeeX9t1ftrJEVlDY5EiZxRsPVPTlWqDTnHMgvdjUl6xB8M8d7OWt7eXktTm5+xg9K5aNwgCrKS3Q5NTmJrZSPLN1dRXt9KXloiF549kIkFmYSb8aUvyhsLZR9AQhoE2pxEJyPf7ahiimpw5MQGTYCSr0CwzUlwSm+B7JFuRyXdFApZFr27h5c+3E8gGCIjKZ5NFQ38/K8fs6um2e3w5ARW7qjhsTd2UNngIzMpnkMtfn7zj938dXOV26FJTxR9CsZdCf5miEuA6V+DtIGnfp6cNtXgyIkZAyM/7WzS5+2saWLd/nqGDkju+OY/MD2JQy3tvPLRfuZ9ZoxqBKKMzx/k1bXlDMpIJDHOC0BmsofUBC+vb6xi6ogcMpM1qWGf5PHAuCucTXqFanBE+oktlY3EezzHJTFZyfGUHWqlsS3gUmRyImWHWgmEbEdyc1ic14MB9tSq5k3kRJTgiPQTXmOwx0/w7TDgUe1N1PEYOpmT/cjz+jcTORElOCL9RHF+JsGQJRQ6+hOzpqmdMQPTSEtUi3W0KRyQQlK8h5b2o2vX2gJBvB7DyLxUlyITiX5KcET6iaHZycwcnUtZXQsHm9tpagtQUdeK1wNXlkRw9Ibf50xedmArBP2RKzfatTU585rUbHdmqI2AhDgP15UOo67FT1WDj+a2ANWNPg40tvGFKQWkJCgpFTkRY/vp9PulpaV21apVbochckaFQpZNFQ28u7OWRl+AsYPTmTEyhwGpCZG5QHszvP0zqN8PWMgZA+d/HeISI1N+tGo5CG/9xFnWxIagoNQZdRihWb/317Xyj+01lB1qZVB6IjNH5zI8V7U30j8ZY1Zba0tP9Til/yL9iMdjmFCQyYSCzN65wN53oW7fJ7Nf12yFinUw9LzeuV602PYXaK2HzKHOfZd9ACNmOXOdREBBVjLXlg499QNFpIOaqEQkcvwt4Al/bzLGmZ014HM3pjOhLTyXCTj37fE6k7eJiGuU4Ij0JdHepDw4vE5ZUzU0VjpNU7lnuRvTmTBsqtM811ILjeXOFPzRvqZQtL+WRHpITVQifUF9Gax6ykkaBo6Hc26EpAy3ozregCKY9U3Y8XenFmP0xZA+yO2oet/giTDjLmdx2oRUOGtOdP77ADSUO6+lhnKnCe3cuZDUS02WIi5SgiMS7QLtsPJRCAYgowCqN8HaxTDtDrcj61zOKGfrb4ZMcrZoFgzAyl86I90yCqFmG3z4jNMRXCTGqIlKJNq1NYCvEVJynD4taYOg5mO3o5K+qL3RWbE6NdfpK5Q2yElyRGKQEhyRaJeYDnFJ4Gtw9ltqIavI3Zikb0pIg4QU8NU7+y01kKXRWRKblOCIRLu4RJjxNbABqN/n9GmZ8s9uRyV9kTcept8JWOe1lJLj9MERiUGa6E+krwgFwd/qdGLVGkTSE4dfS/EpEZuMUORM0UR/brJWH0ASeR4vJKa5HYXEAr2WpDdFyWegEpxIqtsHq37tzAEycDyce5PTf0JERCTWNVQ4n4EN5ZA71vkMTM5yLRzVTUZKoB3e/aWz4F5GoTOUd81it6MSERHpfYenIGg55HwG1m6Dj551NSQlOJHS1uCMcknJOWL4pYbyiohIP9De6Cw22zEFwWDXPwOV4ERKYjrEJTuJDoSH8g5zNyYREZEzISHNGQDhq3P2Ww64/hmoBCdS4hJh+v+BkIbyiohIP9MxBQFRMwWBholHmobyiohIf3UGpiDQMHG3aPiliIj0V1H0GagmKhGJKT5/kLZA0O0wRMRlqsERkZiwp7aZpWsr2FXbhMEwsTCTyycOISct0e3QRMQFqsERkT5v38EWfvn37VQ2+MjPTGZQRhIbyxv45YrtNPr8bocnIi5QgiP9W1sTVK6H6i3ORFXSJ/11cxVxHg/ZqQkYY/B6DIMzkmhoDbBq9yG3w5Puam+Byg1QvRmCSlSla9REJf1Xy0F46yfOTywMngRTbwev/rfoa7ZWNpLbSVNUemIcmysauPDsgS5EJT3ia4C3fgpNVYCFvLEw/S6IS3A7MukjVIMj/dfOFc7Mm1nDIHMYVK6Fmq1uRyXdkJzgxR8MHXfcHwyRmuh1ISLpsT3/gKbKT/7/rN4CVevdjkr6ECU40n+1N4M3/G3QGDAeCLS5G5N0y/mjcjjQ1MaR83qFQpbm9iBTR+S4GJl0m78VPPHO78Y4m5qppAuU4Ej/NXQqBHzQfMBZ/TYhHbJHuh2VdMOsMXmMHphGWV0rBxrbqGzwsb++lU+NzmHsoHS3w5PuyJ8CNghN1c4q1fEpkDPG7aikD9FMxtK/VW+G3e9AfBKM+Sykqa9GXxUIhtha1cjG/Q0kxHmYVJjJiNxUjGYU77tqd8CuN5yanNEXQ0a+2xFJFNBMxiKnY+A4Z5M+L87roTg/k+L8TLdDkUjJGeVsIt2gJioRERGJOUpwREREJOYowREREZGYowRHREREYo4SHBEREYk5SnBEREQk5ijBERERkZijBEdERERijhIcEekV1loafX6a2gJuh9KrrLXUt/ppaY/t+xTpazSTsYhE3O6aZl5Zs599B1vBWEYPTOeqknyGZCa7HVpEbalo4H/XllPd2IYFivMzuHJyPjlpiW6HJtLvqQZHRCKqvK6V/35jB7XN7eRnJZGfmcy+gy388m/bOdjc7nZ4EbO9uokn3tpJS3uQIZlJDMlIYmtlI/+9YgfNMV5rJdIXKMERkYj6+5ZqPMCAlASMMRhjyE1LpC0QYuWOGrfDi5jXNlSQmhhHRnI8xhg8HsOgjCTqWv18tPeQ2+GJ9HtKcKR7fPWwfTlsWwZN1W5HI1Hk46pGslISjjuemRzPlspGFyKKvEAwxK6aZrKS4487l5Lg5eOq2LhPiZCDO2Hrn2HX2xCInVrMaKc+ONJ1vgZ448fQXAvGOP/jfvoeSB/kdmQSBVIT42gLhEiIO/r7U3swxMCk2Oib4vUYkuO9+IOWhDhz1Ln2QIiMpOMTH+mnKjfAykfBeCHkh/2r4fyvg8frdmQxTzU40nXVm6G5BgYUQdYwCLTBvvfcjkqixMzRORxsbsNa23EsFLI0+gKcPyrXxcgixxjD+aNzqW70HXWfgVCI9mCIc4dnuxidRJWPX4fEDMgshKzhcGAL1Je5HVW/oBoc6TpjgCO/tdrwMRGYOiKH7dXNrCurI87jwWIJhiwzR+cwfkiG2+FFzEVnD2R3bTPbq5tI8HoIWQiGQlxaPJjhOSluhyfRwhg4IgnGoPfLM0QJjnTdwPFOc9ShXWA8kJgOw2a4HZVEiXivhxumF7GzJpfNFQ14PYbi/AyGZadgYuiNPSney+2zRrKtuomPqxpJivcyoSCT/MykmLpP6aGzL4d//BzqmsAGYchkyChwO6p+wRxZvdqflJaW2lWrVrkdRt/V1ggVayEUgsETIEVV8iIinarbCzXbnS+D+SXgVR+tnjDGrLbWlp7qcarBke5JTIfhn3I7ChGR6Jc1zNnkjFInYxEREYk5SnBEREQk5ijBERERkZijBEdERERijhIcERERiTkaRSUSw6y1lNf7qG7wkZIQx8i8VOK9+l4TC1raA+w80EwgZBmWnUJ26vHrf4n0Z0pwRGKUzx9k0Xt72FTegDEGC2QkxXHLzBEMzdZMu33ZR3sP8fyqffgDlsMziX/6rDwunzgEj0eTDIqAmqhEYtb/ri1nU0UDBVnJFGQlU5iVDBaeeGsnre3BnhVeXwbVW5xV5aNMWyCIPxhyO4xeU17XyqL39pKRFE/BgGQKBqQwOCOJv22u5oM9B90OTyRqqAZHJAY1twX4YPdBhmQkH7VsQEZyPPsPtbC5ooFzigZ0r/Ctf4ZNrzirIXuT4FPzomISs30HW1i6voIdVU14PFAyNIvLJgxhQIw13by/qxavx1kq4jCvx5CTlsDfNlczbUSOi9GJRA/V4IjEoKa2ABbng+9YxhgOtrR1r+CWg7D5f521dDIKnWPrX+h+oBGyv66VR/++nf0HW8jPSmJgehJr99Xzy79vp6kt4HZ4EVXZ0EZK/PHfTVMSvNQ2t9Nfl98ROZYSHJEYlJkcj9cYAp001YSsZVB6cvcK9rcCBjzhD9j4FPA1dD/QCFm2qRKvMeSkJWKMwesxDM5Moq61ndUx1mwzdEAyze3HJ22NbQGGaKFPkQ5KcERiUFK8l5mjc6mo9xEMOd/orbXUNreRnZrAWYPTuldw2kDIGOL0wWmtg+YqGHZ+BCPvni0VjZ2OIkpPjGfjfvcTsEiaOiIHYwxNvk+SnPZAiEPN7Xxm3CAXIxOJLuqDIxKjLp0wmPZgiHd31IIBG4KCAUl8ZXoRiXHeUxfQGW88nP8N2LwUmmvgrEth5KcjG3g3JMV78QdDeD1H35c/GCI1sZv3GqXy0hP56qdG8Nz7eymvawUDXmP4wjmFTCrMdDs8kahh+mt7bWlpqV21apXbYYj0uvoWPweafCQnxJEfo00Yf9lYyWsbKynM+qRTdShkKatr5bZZIxmfn+FyhJEXCIYoO9RKIGQpyEomOSG2EjmREzHGrLbWlp7qcarBEYlxmSnxZKbEux1Gr7rgrDw+rmpk54FmkhO8BEOW9mCI80flcPbgdLfD6xVxXg/Dc1PdDkMkainBEZE+Lyneyx2fHsWWigY2lDeQ4PUweWgWI3NTNfGdSD+lBEdEYkK818PEwiwmFma5HYqIRAGNohLpLdY6HXEbqyAUuzPrSj8XaIeGcmdUnUgUUQ2OSG8IhWDdYtj1NhhgYDFMvQ3iEt2OTCRyWg7CO49A0wFnf9K1UTGqTgRUgyPSO6o3wc43ILMQMoZC5XrY847bUYlE1oY/QHOt8zpPGwjrlji1liJRQAmOSG9oawTjCW8G4pL0xi+xp7kaEsND8L0JgIG22JpYUfouNVGJ9IasoU5y46t3FqX0t8LAs92O6ozz+YNsr26iqS1AblqiRjXFmsGTPll4tb0JElIhTbMpS3RQgiPSGzILYcZdsPFlCPrh3LkwaILbUZ1Re2tb+PXbO2luD2CtASzDslO4+VMjyEiK7Xl5+o2zLgUbhLJVzmt+0nVOkiMSBTSTsYhEnM8f5N/+tBmvMWQkf5LMVNa3cvaQDG6eOcLF6CIjGLLsrm2m0RcgOyWBodnJMTlLtEi00UzGIuKaj6saaW4LUjjg6FXLB2YksbG8gbqWdrJSjl8csyustZQ3l7Onfg8BG2BQyiBGZY0iztP7b2vVjT5++4/dVDf6AIO1lhF5adw0o4h01U6JRAUlOCIScc5K18fXDnuMwWOg0RfoUYJzyHeI57c+z97GvZjwfxZLWkIaV4+5mjEDxvQg+pMLhixPvb2bpjY/BVkpgJNs7attZskH+/jqrJG9dm0ROX0aRSUiEZeXnogzAdDRAsEQYMhO7X5y0+xv5qkNT1HZUkl+aj75afkMSRtCflo+XuPl6Y1Ps7t+d7fLP5VdNU3UNLWRk/rJnEbGGAZlJLGlsjFcqyMiblOCIyIRNzIvjYIBSVQ1+Djczy8QClFR72PWmFxSE7tfebyqchWHfIfIS847rs9LanwqqfGp/GnXn+it/oX1rYHOKqcw4dqphtZAr1xXRLpGCY6IRJzXY7h15khGDUyjvM5HRX0rBxrbmH32QC6dMLjb5Vpreaf8HbKTsk/4mIyEDMqbyqlqqer2dU4mOzUB20mGE7KWkKVHtVMiEjnqgyMivSIzJZ7bZo2ktqmN5rYg2WkJpPWg5gbAH/LT7G8mMzHzhI8xxmCMobG9kcGp3U+mTqQoO4XCASlUNfgYmJ6IMYaQtVTU+Zg8NEsJjkiUUA2OiPSqnLREhuWk9Di5AYjzxOH1eAmETtEMZCHB2zuJhsdjuGXmCIZlp1Be79ROVdT5mFSYyRfPLeyVa4pI16kGR0T6DI/xUJJXwtoDaxmYMrDTx/gCPlLiUyhIK+i1ODJT4rlz9iiqGtpo8PnJTk0gN00LqYpEE9XgiEifMiN/BiEbojXQety5YCjIgdYDXDj0wl6fD8cYw+DMJM4alK7kRiQKKcERkT5lcOpgvjLuKzS2N1LRXEGTv4kWfwvVLdVUNldyQeEFTB0y1e0wRcRlaqISkT5nbPZY5p87n7UH1rK+Zj3BUJApA6ZQOriU/NR8LZkgIkpwRKRvykzM5ILCC7ig8AK3QxGRKKQmKhEREYk5SnBE5IzzB535bE453PsMstbS4m+hNdDaa7Mgi8iZoyYqETlj9jft5+39b7OhZgNYiPfGM33IdKYNmXbSyft6kz/kZ03VGt7a/xaH2g4RsiEK0gq4oOACinOL1Z9HpI8y/fWbSmlpqV21apXbYUiUOtDYxvu7atld20xuaiLTR+VQlJPqdljd0hYIsr6sng/31gEwZWgWk4ZmkhjnPaNxbKzZyOIti4n3xJOdnI3XeGkPtlPbWktqQipfnfhVcpNzu11+a3uQD/ceZH1ZA/FxhtKiARTnZxLnPXFFtT/oZ9HmRWw9tJXspGxS41Ox1tLY3kh9ez3n55/PFSOviKokp9HnZ9XuQ2yuaCA10cvUETmMHZSOxxM9MZ6uUMiypbKRD3bX0twWpLggg3OLsiMyKaTELmPMamtt6Skfd6oExxhTCnwfKMKp8TGAtdZOikSgkWKMuRT4OeAFnrTW/r+TPT6qExxroWYb+OogIx8yY2B21LYmqNkKGBg4DuKT3Y7ohHbVNPP4mzsIhiypiXH42oO0BUNcfU4hM0d3/wPYDT5/kF+/vYvt1U1kJDkfGo2+AKMGpnHrp0aQFH9mkpz6tnp+uvqnZCZkkhSXdNz5g60HyUrK4q6Su7qVTDS1BfjvFduprPeRnhRPKGRpbAswuTCTf55edMIkZ/me5Szfu5yCtILjrhuyIcqbyvny2V9mQt6ELsfUGw42t/Po37fR0BogPTEOfzBEc3uQmaNzuPqcwqhKxE4lFLK89GEZ7+yoITUhjnivh8Y2P1kpCdw1ezQDonnJi5aDcHAneONh4HjnZ1/Wxz5zTjfBOZ00eRHwbWA9EOppYL3BGOMFfgl8FigDPjDGvGqt3eRuZN20eSlsWQrGONt5d0BBidtRdZ+vHt5cCM0HnP+RsobCp74JCSluR3acUMjy+/f3khTnJSPZedPKSIqnPRDifz7az4SCTDKT+86b2ardB9lR3cTQAckdH36ZyfFsr27ig90HmTUm74zEsaZ6DSEb6jS5ARiQNIDy5nL2Nu6lKKOoy+Wv2FpNZb2PwgGfvKayUuJZW1bPlPJ6Jg8dcNxz2oPtrCxfycCUgZ0mBh7jISMhgzf3vxk1TVV/XFdOc1uQgqxPviAMCFne2V7LlGEDGJWX5mJ0XbOzpomVO2opHJCCJ/y3zUiOp7Lex583VPDlaV1/HZwRjZXO+1l7k/N+NmgCTL8TvH241inWPnPCTqeT8QFr7avW2l3W2j2Ht16PrGumAtuttTutte3A74GrXI6pe9oa4eM/Oxl0VhEkZ8OG592Oqmf2feAkN1lFMGA41O2FynVuR9WpygYftc3tHcnNYQlxHkIWtlc3uRRZ97y36yADUhKO+nA2xpCdmsB7O2vPWBybD24mPT79hOeNMRgMexq699by3s6D5KUfPZuwMYb0xDhW7TnU6XOqW6ppC7WddM2q9IR0ypvKO501+UxrD4RYV1ZP3jGzJns8hvg4D+vK6lyKrHvW7qsnIc7TkdwclpeeyJp9dfiDUfl9GrYtg2C7836WVQTVG6F2u9tRdV+nnzkvuB1VRJxOyvmAMeZJYDnQdvigtfYPvRZV1xUA+47YLwOmHfsgY8ztwO0Aw4YNOzORdVUoAFgw4aYDTxy0N7saUo+F/ByVSxsPBP2uhXMywZDlxF/ULcFQ3+qz5g+G8HTyNcZrDP9/e3ceJVd5n3n8+6utq/dN3epdu0ACgQSN2AwGLNtgx8Z27NjYExPHsZ0zJslx4pl4OWcyZzI5J87GZOIlB8dkHE8SjJ3EJjEDNhgDBmQkzCqBQGhttaRe1PtSXcs7f9ySaKm7hbpV3bfq1vM5p6DrVnXpV7eqbj393ndJppfuuaRd+k1bQEIWIuMW9qWWymQI28zDWShkJFOzP0/nHMbZazq5MvlC68qljHM4YLauNmGb+3nmq6l0hvAsTyZkkHHe881L6ak3js8nWzwy+Xk8OycnRzIG6Tsn61xacD4BbAZuBt6TvfzKYha1AFduk9oAACAASURBVLMdpWZ8OpxzdznnOp1znQ0NS9M0P2/xGmjeDIMHYPQ4jByFtW/3u6rz07wZIlEYPuJdYhXeees8tLwqTkkkxGQyfdr2TDbYrKzPv9NqZ3NpWw0DYzMPvgPjU2xur1myOlZVrWJkauSs98m4DM3lzQt6/Etaa+gfm5qxfWQyyaVzPM/60nrAW79qLuPJcapiVZRF/X/d49Ewq5aVMzB++uvpnCORSrOxpcqnyhbmopYqJqbSM4bknxibYm1jxZJ3gj9nK6+D1KR3qmroMJQ1QN1qv6tauHgNNF8arO+crHNpwbnUObdp0Ss5P11A+7TrbUC3T7WcHzO4/BNQv9b7AC1bB21X+F3V+alqhuv/Kxx8EkJhWHEtlNf7XdWsYpEQt17awj89fYiqeJSqeJSJZJq+0QTXrVtGY9XsfUjy1TVrl7Hj4Am6BydOncLpHUlQWRrhmjVL12H68uWX80T3E6QyqVkXwRxNjlIeLWdNzZoFPf7bNjSyq3uI48OT1JfHSDtH32iCpur4nEGuLFrGlsYt/LLnl7MGK+ccJyZP8N417yVk+TFl2HsuaeGrj7xG70iCuvIYyXSGntEE6xoruKBp7lOA+WhDcxWrG8rZ1zdGQ0UJ0XCIE2NTpJ3j3ZsWFnSXRMN6uP7z0LUDomWw6nqIFeYISyCY3zlZ5zKK6pvAnfncYdfMIsCrwNuAI8AO4KPOuV1z/U5ej6IS3+05NsJDu49z8MQ4deUxbryggc6VdbM2qee7gbEpHtnTc6ovyuUrarnpgsYlH6XyyOFH+PGBH1Mfrz/VIuKcYzAxyGR6kk9c9AlW1yz8L+Ge4UkefrmHF44MEgmFuGp1HW+9oPGsQ46Hp4b55gvfZCgxRENpA+GQ12qQTCfpGe9hVc0qPr7x42ftp7PUugbGeejl47xydITSWJhr1tRz3bqGJRsRl0uTyTSPvdrLk6/3M5lMs6G5im0bl5/WiVrkTLkcJv4ysAbYj9cHJ1+Hib8L+F94w8Tvds79ydnur4AjsrScczzX8xwPH3qYwcTgqT43HVUd3LLyFtqr2t/8QRbB8NQwDx18iOd6nju1LRwKc1XTVdzQcQMl4ZKz/LaILLVcBpxZx+rl4UiqeVHAEfFHxmU4PnacRDpBRazivCb3y6Wx5Bj9E/0YRmN5o4KNSJ7K2Tw4hR5kRCS/hCxEc0X+9bEoj5ZTHi3gvhQicpr86DknIiIikkMFPPWiiBSzdCbNvqF9vDbwGqlMitbKVjbUbciLId0i4j8FHBEpOMfHjvOPL/8j/ZP9RENRQhbi6WNP8++hf+d9a9/H5sbCn2ZeRM6PAo6IFJShxBDfeulbOOdorWg97bZEOsF393yXeCTOhXUX+lShiOQD9cERkYLy9LGnmUhOUBufuYBmSbiE2pJaHtj/wIwZchdDIpVmaDyZv+smiRQxteCISMFwzrG9e/upZRZmUx4t5+jYUY6OHaWlomVR6kik0vx413GefL2PVMZREgmxbcNyrlvXUJCTQYoEkQKOiCyqdMaRTGcoiYTedMHNN5PMJEmkE9SH5w44ZkbIQowlF2fBQOcc3336MM91DdJUFScaDpFIpvnhs0cYn0rxrk2LE6pEZH4UcERkUUylMvxsTw+PvdbLZDJDfXmMd17UxJaOmgUHnUgoQjQUJZlJEg1F57yfc454ZHHWDTs2PMnzXYO01ZSeeh4l0TAtNaX8bE8v168/+/IQIrI01AdHRHLOOcc//eIgD7x0jIqSCK01paQyju9sP8BT+/oX/LghC3FF0xX0T8z9GOPJcapKqmgpX5yWlO7BScyYEdIiYe9wenx4clH+XRGZHwUcEcm5roEJXjwyRFttKSURbxHIipIIyyvj3P/iUaZSC++Uu7V5KxGLMDo1OuO2ZCZJ/2Q/2zq2nVo4M9fi0RDM0n/ZOUfGUZCLXooEkQKOiORc18A4MLOVoyQaJpHM0DOy8FaOZaXL+I2Lf4NkJsmR0SMMTA4wnBjm6NhR+sb7ePeqdy/qPDhrGiqIx8KMJVKnbR8YT9JUVUJL9eKcGhOR+dGJYhHJuVgkBMzsZ+Ocw526feE6qjr4g84/4OUTL7O7bzcpl6KjqoPNDZtnHT6eS/FomNuvXsndTxxgcCJJNGwk0xkqSiJ87KoV592RWkRyQwFHRHJu3fJKIiFIJNOUTDtlc2JsiraaUhoqzn+l7ngkzpbGLWxp3HLejzVf65ZX8oVbLuSFrkH6R6doqYlzcWs1ZTEdUkXyhT6NIotl5DjsewTSSVh5LdSt9ruiJVMVj/JrV3Rwz9OHMIOSSJiJZJryWJgPb20PRCtHdWmU69Y1+F2Gv5yD7ufg6PNQWgtrb4KSSr+rEgEUcEQWx/gJeOzPIZUAC8HhX8D1n4falX5XtmQuX1FLW20pzxw8Qf/YFCvry9ncXkNlfO7h3VJgDm2HZ/4eYhWQHIeeXXDd5yES87syEQUckUXR9ypMjULNCu/6cDcc+WVRBRyA5VVxTXwXZPsfg9J6iFd514cOw0h30b3PJT9pFJXIYghHveb7kzIpiJb6V4/IYojGIT3l/ewygIOwWm8kPyjgiCyG5RdD/VoYOAiDB6F8GXRc7XdVIrm18VZwKa/lZvAQrHwLVDb7XZUIoFNUIosjUgLX/p53qiqTgmXrIFbud1UiuVW7Em76b16Ij1V47/MAdCCXYFDAEVkskRg0Xex3FSKLq7zeu4jkGQUcEQmMnuFJDvSPEw4ZaxsrqC7ViC2RYqWAIyIFL51x/ODZLp58/eQinEY4BO/b0so1a5b5WpuI+EMBRyTg0hnHaCJFPBo6tfBl0Ow8cILHX+ujvbaMUMjrAzKVyvAvz3TRWlPKivpg9n8an0qRzjgqSiKBmDxRJJcUcEQCyjnHjv0neGDXMUYmU4RCsHVlPbdsajq/JQXSSTjyDEwMQP06WLY2d0Uv0CN7ellWUXIq3IC33lU0HGL7vn7/A45zcPQ5GDkGVa3QtOm8OuP2jSa477ludh8dBgfNNXFuvbSFtcs1i7DISQo4IgH11L5+vrfjMMsqS2ipKSWVzvDUvn6ODU/y229dQzi0gC/YTAZ23O0FnHDUGyG29TPQdlnun8A8nBibYnnlzPWtSmNh+kYTPlR0ht0/gFfu9+aISU/BRR+AC29Z0EONTCb5+iN7mUimaa6OY8DwZIq/fWwfd9y4lpXLgtlaJTJfmgdHJICS6QwPvHSMxqr4qdaaSDhES3Wcfb2j7O8bXdgDj/XAsee84cHVbVBWB3t+lLvCF6i9tpThyeSM7WOJFCv9br1JTcFrP4GaDm+fVbfDnvu9sLgAzxwcYHgyRWNlnJAZZkZ1aZTSaJgf7zqW4+JFCpcCjkgADYxNMZFME4+e3ufGzAiZcbB/fIGPbDBtgmacy4t5T7ZtbGR4MslkMn1q2/BEknDIuHK1z0OYZ+wfN+vdztWeYyNUlMxsfK8pi/JqzyjOnd/jiwSFAo5IAJVEwuCY9csu4xzlC+2DU9EIbZ0weMCbvXZyEDa85/yKzYENzdV8dGsHY1MpuocmODI4QSwS4tPXr2FZxcxTV0sqHIUL3vXGbL/DR7x9FlrY4bcyHmEqNbP1J5nKUB4Lq7OxSJb64IgEUHVZlPVNlezrGaOx6o0v+EQyTSQUYkNz1cIe2Awuux2aN3vhpm4V1K3OUdXn54pV9VzaXsvx4UnCIaOpKn5ap2NfXfhuqF0Boz3eUgaNGxb8UFtX1bHjwADpjDvVj8o5R89Igls2NeWqYpGCp4AjElC/elkbf/vo63QNTBCLGOm0A4PbtnZQXXYeE+CFI9B2ee4KzaFYJER7XZnfZcxk5o2cyoE1DRVs29DIT1/pIRzyTjkm0xnWN1Vy3bqGnPwbIkGggCMSUHXlMX7/7evZ3T3Mgf4xasqiXNpWQ73fp2zkvJgZ79rUzCVtNbx0ZIipdIYLmipZ11i5sJFxIgGlgCMSYPFomMtW1HLZilq/S5EcMjPa68rys7VKJE+ok7GIiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEjgKOiIiIBI5GUcnCZNIwcABcxltjJ6KhxyIis0qMwNARiJV765FptukloYAj85dOwi/uguMveR/U6ja49ve8D69I1tBEkoP9YxjGqobyWddPCoL+0QSHByaIho01DRUz1v+SIjd8FH5+J0yNeX8Qrn8nbLxVIWcJBPOII4vr2Itw7AWoWeF9SAcPwsGnYN02vyuTPOCc46GXj/Pj3cdxGcAgHDLet7mFq9cs87u8nElnHP/+Qjc/f7UXy65BGouEue2Kdja11fhdnuSL3T+E9JT3h2AmDa8+CO1XQlWz35UFnvrgyPylJr1gc/IvkFAUEsP+1iR546UjQ9z/4jEaK0porS2ltaaUurIY33umi/19Y36XlzNP7evjZ6/00FRdSktNGa01ZVTEIvzDUwfpGZ70uzzJF5NDEC31fg6FwUKQmvC3piKhgCPzV78WwiXewoHj/ZBJQvOlflcleeJne3qpLo0SCb9xeIlFQsQjYZ7Y2+djZbnjnOOnr/TQUFly2vIIpbEwITN2HDjhY3WSVzqu8o6TE4Mw3A1ldVDZ4ndVRUGnqGT+Khrhus95Ta3pJKy5CerX+F2V5Ine0cSs/W3KYmGOB6RlI51xDE+kaK0pnXFbPBoKzPOUHFh1vddqc+SXUFYLF/4KRON+V1UUFHBkYWpXwpWf8bsKyUMtNaV0D0xQWx47bfvYVIp1yyt8qiq3wiFjWUWM0URqRpibSKZpq9UaUZJlBquu8y6ypHSKSkRy6qYLGxlJJEmk0qe2jU+lSKYd164NRidjM2PbhuX0jyVIpjOnto9MJgmHjM6VdT5WJyKgFhwRybH1yyu57YoOfvBcN8n0FOCdtvmNq1cGqmXj8hW1DE0k+cnu46QzDoDK0gi/dd1q6s5ovRKRpaeAIyI5t3V1PZe019A1MEHIoK22jFgkWA3GZsbbNizn6jX1dA9OEAmFaKstPa1ztYj4RwFHRBZFPBpmbWMw+tycTVkswtrGSr/LEJEz6E8NERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcTfQnxW2sD3p2Q7gEmi+B6MzVoaVw9I4kOHRijJAZaxsrqIxH/S5Jzsf4CTi+C0IR7/MZK/e7IikgCjhSvIaPwmN/DslxcA7qVsK1n4No3O/KZJ4yGccPn+/midf6cHjrQkVCxvsva+Oq1fU+VycLMtYHj34FJkcAB1WtcP0fKOTIOVPAkeK1/zFIJ6FmhXd94CD0ver9pSgFZcfBEzy6p4e22jLCIQNgKpXhezsP01JdSkd9cBb5LBqHnoKpMajNfj4HD8Dx3dB+ha9lSeFQHxwpXi4NZtM2GLiMb+XIwv3slV7qK0pOhRuAWCRELBJi+/5+HyuTBXMOmPb5dKf+I3JOFHCkeK18C+Bg6DAMHoSK5bBsvd9VyQL0j01RFg3P2B6PhukbSfhQkZy39q0Qjr7x+SxfBg0X+l2VFBCdopLiVdMBb/0CHH0eIiXeATWmUxmFqL22lL7RBDVlsdO2jyVSXNZR61NVcl4qm+CGL0L3LyEUhbZOiFf5XZUUEAUcKW7Vrd5FCtrbNjTyzcf3UxoNU5JtyRmeTBIyUyfjQla5HC64xe8qpEDpFJWIFLyNLdXcdkU7o1Mpugcn6B6cIBwyPnX9ahoqS/wuT0R8oBYcEQmEravrubSjhmNDk4RDRnN16WmdjkWkuCjgiEhglETCrKjXPCkiolNUIiIiEkBqwcmlsT54/p9huBuWXwwX/6pmxRURkeIwfgKev8cb2t+wATZ90NeRqWrByZV0Cp78G+jbC+EYHHgcXrzX76pEREQWXyYD278OPa9434GHnvT+4PeRWnByZXLQa8GpbvOuVzbD0Rf8rUlERGQpJIa9sxfV7d71qlbfvwPVgpMrsXIIhb2FGwEmBqGi0d+aRERElkK0DMIl3vphAJNDvn8HKuDkSrQUOj/pvahDXV7fmy2/7ndVIiIiiy8Sgys+CVOjMHzE+4P/8tt9LcmcK87Fyzo7O93OnTtz/8CJUUiMQFmdN/2/iIhIsZgag8lhKK1dtEE2ZvaMc67zze6nPji5VlLhXURERIpNrNy75AEFHJFCMGMKgg94p0VF5mv8hPdeGurKi6G8IotFfXBE8l06BU99Ffpe84Zf7n8MXvie31VJIcqkvaG8vXvyZiivyGJRC45IvpschNHeN6YgqGqBY5qCQBYgMQzDR6e9l/wfyiuyWNSCI5LvzpyCIA+GX0qBipZ5LTd5NJRXZLEo4IjkuzOnIIiUwJb/5HdVcxs/Aa8/Cvsf90ZTFIuRY/D6I3DwSUhO+F3N7CIl0PmbMDWSN0N5RRaLhomLFIpCmIJgrB8e/Yp3KsQ5r3Xg+v8C8Sq/K1tcg4fh8b+AVAJcBupWw1s+l7+v08mhvPn8XhKZw7kOE1cLjkihKKmAqub8/kLq2uGFsJoVULsSxnrg+C6/q1p8rz8CjuzzXgUDB6F/r99VzS1Wnv/vJZHzpIAjIjnkZl51GV8qWVqzPMcibR0XyRcaRSVSZHpGJnmxa4jRRIrVyyq4oKmSWCRHf+u0dsLeh2HwoHe9rA6aLs7NY+ez1TfAkWdg8BC4NNR0QP3anD38+FSKF7uGODY8ybKKGJvaaqiKR3P2+CJBpD44IkVk+75+vv9MFwaEQ0YynaGlppRPXb86d1+YY33Q/SxYCFovh9Ka3Dxuvhs6Asde8jqFt12es9lcjwxOcNejrzM2lSIaCpHMOGLhEL913SpWN2jWdCk+WqpBRE7TMzLJ95/poqGi5LQWm6ODE/zo+aPcdmVHbv6h8mWw7u25eaxCUt3qXXIok3F856kDOKC15o3Zhkcmk3z7qQN8+V0bc9f6JhIw+mSIFIkXu4YwmPGF2FgV59nDg0wm0/4UJnM6MjhB3+gUtWWx07ZXxqOMJdLs6xv1qTKR/KeAI1IkRhMpwiGbsT0cMpxzJJLF0Bm4sEwm08x8xabfrtdMZC4KOCJFYtWycpLpmV+IY4kU1aVRKuM6Y51vllfHcUA6c3pfSecczjlaquP+FCZSABRw5Oz69sLTd8GOb3kjRKRgXdhURXNNKceGJk59YY4lUvSPTfHuS5oJzdK6I/6qike5fn0DRwYnSKS8U4jJdIauwQku76ilsUoBp6AdfQG2fwN++Q8w2uN3NYGjP9lkbgMH4Od/BZG4N5fJsRfghi9B5XK/K5MFiEVCfPr61fzH8908d3gQ56C6NMrHr17B5vYiGelUgN69qZmyWJif7emhf3SKaDjEtg2NbNvQ5Hdpcj6OvQhPfQ1KKiE95Y3Au+nLEK/2u7LAUMCRuR17EQhBeYN3ffAg9L2qgFPAquJRPnrlCt6/pY2pVIbKeEQtN3kuHDK2bVjOW9c3MJZIURoLUxIJ+12WnK9DT3tTCZTVe9eHDnszYDdf4m9dAaKAI3OLloFLej87512ipf7WJDlRGgtTGtOXZCGJhkPUnDGaSgpYSYW3dhl4x9ZMWktn5JgCjsyt4yo4vD3b98ZB44XQpL8uRETO27q3e6f9hw57XQDat0L9Or+rCpS8Czhm9t+BTwG92U1fcs7dn73ti8AngTTwu865B7Pbbwb+GggDf+ec+9OlrjuQYuVw3efhxD5vVtq61RDW9PAiIuetrA5u/JJ3Wioc846vIY37yaW8CzhZdzrn/mL6BjPbCHwEuAhoAR4ys/XZm78GvB3oAnaY2X3Oud1LWXBgRUqgcYPfVYiIBE+sHJZv9LuKwMrXgDObW4F7nHMJYL+Z7QW2Zm/b65zbB2Bm92Tvq4AjIiJSpPK1PewOM3vBzO42s9rstlbg8LT7dGW3zbVdREREipQvAcfMHjKzl2a53Ap8A1gDbAaOAn958tdmeSh3lu2z/bufNrOdZrazt7d3truIiIhIAPhyiso5t+1c7mdm3wT+I3u1C2ifdnMb0J39ea7tZ/67dwF3AXR2ds4agkSkQDkHB56AvQ9BJAYXfcAb+SciRSnvTlGZWfO0q+8HXsr+fB/wETMrMbNVwDrgaWAHsM7MVplZDK8j8n1LWbOI5IHu57wp7zNJmBiCp74Kw0f9rkpEfJKPnYz/zMw2451mOgB8BsA5t8vM7sXrPJwCPuucSwOY2R3Ag3jDxO92zu3yo3AR8VHPboiVQazCu54Y9uYYqWo++++JSCDlXcBxzv36WW77E+BPZtl+P3D/YtYlInmufBkkJ7xTVThv8rSSSr+rEhGf5F3AERFZkFVvhZ6XvfXSnIPVN0KD+uCIFCsFHBEJhmgcrvkdGO3xZtwuqwfTQqIixUoBR0SCIxRWnxsRAfJwFJWIiIjI+VLAERERkcBRwBEREZHAUR8cCa5MGg5th4EDUN0OK66BsN7yIoExNQb7HoOJE9B8CTRt8rsiySM62ktw7foBvPYgRMtg36MwfBg2f8zvqkQkF9JJePKrMLAfInHY/yhc8Slov8LvyiRP6BSVBFMmDft+CtUdULEcalfA/p9DKuF3ZSKSC8NHYPAg1KzwPuOldfD6T/2uSvKIAo4Ek4UgFPHWJQLIpLwhxBb2ty4RyY1Q1JvQ0WW865kUREr8rUnyigKOBJMZbPowjB6HwUMwchQu+lX1wREJiqoW6LjS+3wPHYL0FGx8r99VSR7R0V6Ca+U1UN3izWxbVg/1a/yuSERyxQy2fBzaroCpce80dEWj31VJHlHAkWCrXeldRCR4QiFYfpHfVUie0ikqERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRyRfJGcgIlBcM7vSqTYZdIwMQCpKb8rEVmwiN8FiAjw+iPw0r+Ay0DDBtj6WxAt9bsqKUZjffDU12C0ByIlsPXT0Hih31WJzJtacET8NtQFL9wL5Q1Q1QY9u+C1H/tdlRSrZ78DEyegug0ipfD0XZCc9LsqkXlTwBHx28QAWAjCMTCDWCUMHfG7KilWQ0egtM77uaQCUgmYGvW3JpEFUMAR8VtFkxdsEiOQTkJiCBou8LsqKVaNG2DkKGRSMNYLpTUQr/a7KpF5U8AR8VtFA1z1n71WnIkTsP5mWH2D31VJsbrkw9BymdcXp6IRrr4DwlG/qxKZN3NFOmKjs7PT7dy50+8yREREZB7M7BnnXOeb3U8tOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4mslYRIKj91XY/zhEYrDu7VDZ5HdFIuITBRwRCYa+vfDEnd7su5kUHH0ebvwSlNX5XZmI+ECnqEQkGI7shFDMW/KistmbfffEPr+rEhGfqAWn2DkHQ4dhagyqWiFe5XdFIgsTLYNM0vvZOe+iCeqkkI32erNJly/zJl2UeVHAKWbOwe4fwqsPerPoRkvhLZ+D6la/KxOZv1XXQ9dOGDrkrcq+/GJo3Oh3VSIL0/087Pgm4MABnZ+Atjed206mUcApZqM9XripaoVQ2Lu+61/hmt/xuzKR+SutgRu+4J2WCkWgfi2EdYiTAuQc/PLbUFrrtUwmJ71V3lu2eMdqOSf69Bez1KTXcnPyAxMt9RZ8FClUsTJoutjvKkTOTyYNqQkoq/euR0pgbMrrPK+Ac87UybiYVTZ553WHj8DEIIz3QfvVflclIlLcwhFouxIGD3rH5sGD0Hq5F3TknKkFp5hFSuDa34VX7ofxftjwK7DyLX5XJSIimz8K5fXQvw9WXgPrb/a7ooKjgFPsSmthy8f8rkJERKaLxGDDe/yuoqDpFJWIiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEjgKOiIiIBI5GUYnIm3MOjr3orYtT3QbL1oOZ31UVpkzaW+l8YgBqV0L9Gr8rEgkkBRwReXO7/g32/D9vCQSX9uboWH2D31UVHufg2f8LB58ACwMOrvgUtF3ud2UigaNTVCJydskJ2PsQ1KyAmg6obPEWaXXO78oKz8QAHN7+xr4srYeXf+h3VSKBpIAjImfnsqsZn7lN5u/Uvsye3jPTvhRZJAo4InJ2sTJY81YYOgRDXTDSDRe+R31wFqKsDto6YeCAty/HeuHCd/tdlUggqQ+OiLy5iz8EdWth9Lh3amX5RX5XVJjM4LLbYfnFMHEC6lZDwwV+VyUSSAo4IvLmQiF1hM2VcAQ6rvS7CpHA0ykqERERCRwFHBEREQkcBRwREREJHAUcERERCRx1MpbClUrAoV9AYggaN2rKexE5nXNw9DkYPAxVrdCyxeswL0VBAUcKUzoF278BPbshFINXfgRXfxaaNvldmYjkiz33w64fQCQO6QSsewds+qDfVckSUZSVwjR8BHr3QM1KqG6Fkmp49UG/qxKRfJHJwJ4HoLodqlqgugNef9hr+ZWioIAjhenMWXRdBkxvZxHJMsseJ04uheHwlsjQDNzFQqeopDBVtULTJdD9LITCXrjRlPcicpIZbHwfvHCPt3J7Jg0b3wuRmN+VyRJRwJHCFArD1k/B0echMQr1q6Gm3e+qRCSfrLnRO4U9fBQqGrzBCFI0FHCkcIUjWj5AROZm5q31pfW+ipI6LYiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IhIsGTS4JzfVYiIz7SauIgEQyYNu34Arz8M4Shs+jVYea3fVYmIT9SCIyLBcGg7vPYgVLZAvAae/Q4MHPC7KhHxiQKOiATDwAGIlkEoDJG4t220x9eSRMQ/CjgiEgzV7TA1Bi4D6SlvW1m9vzWJiG/UB0dEgmHFNTB8aJSLzQAACeJJREFUGA78HCwMmz4M9Wv8rkpEfKKAI7KU+l+HsV6oaIS61X5XEyzhCGz+GFz8QS/ghHV4y7lMBnpfhsQo1HRAVbPfFYnMSUcAkaWy96fw4r2AAQ62/LpG+SyGSInfFQSTc/DCP8O+xyAU8kLkNb8DDRf4XZnIrNQHR2QppJOw61+hstn7y7eiCV641/uLWKQQjPV6p/9qOqC6A6Ll8NK/+l2VyJwUcESWgsuAS0Mo22gaCoNLAZqQTgpEJo3X+mje9VAEMkk/KxI5KwUckaUQKYGV18HgQRg9DoOHYc3bvKAjUggqGmHZeu89PHIMxnthzTa/qxKZk/rgiCyVSz7sNe0PHYbaFdB+ld8ViZy7UBiu/G3Y/zhM9EPjRmja5HdVInPypQXHzD5kZrvMLGNmnWfc9kUz22tme8zsndO235zdttfMvjBt+yoz+4WZvWZm3zWz2FI+F5FzFgrDqrfA5tu8Ic0hNaBKgYnGYf3b4dKPQPMlYOZ3RSJz8usI+xLwAeCx6RvNbCPwEeAi4Gbg62YWNrMw8DXgFmAjcFv2vgBfAe50zq0DBoBPLs1TEBERkXzlS8Bxzr3snNszy023Avc45xLOuf3AXmBr9rLXObfPOTcF3APcamYG3AR8P/v73wbet/jPQERERPJZvrWRtwKHp13vym6ba3s9MOicS52xfVZm9mkz22lmO3t7e3NauIiIiOSPRetkbGYPAU2z3PRl59wP5/q1WbY5Zg9i7iz3n5Vz7i7gLoDOzk6NzxUREQmoRQs4zrmFjB/sAtqnXW8DurM/z7a9D6gxs0i2FWf6/UVERKRI5dspqvuAj5hZiZmtAtYBTwM7gHXZEVMxvI7I9znnHPAI8MHs798OzNU6JCIiIkXCr2Hi7zezLuBq4Edm9iCAc24XcC+wG3gA+KxzLp1tnbkDeBB4Gbg3e1+APwR+38z24vXJ+dbSPhsRERHJN+Y1ghSfzs5Ot3PnTr/LEBERkXkws2ecc51vdr98O0UlIiIict4UcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwIn4XICJ5qncPvPoAYLD+ZmhY73dFweMcHNoOB5+AeDVseA9UNvldlUggqAVHRGYaOAhP/DUMHobBQ9mfD/ldVfAcfhqe+XsY64Xju+Dxv4LJYb+rEgkEBRwRmal3DzigrN674LxtkltHdkJJNcRroGI5TI3BUJffVYkEgk5RichMJRXgUt4pFIBMCmIV/tYURPEaSE14P7uMd4mW+luTSEAo4IjITK2Xe6dPTrbaNF7kbZPcuuAW6H0Fhg57YXL1DVC70ueiRIJBAUdEZoqUwNV3wFC23011B4R1uMi5sjq48UswdMTb59VtYOZ3VSKBoCOWiMwuHIG61X5XEXzRUli21u8qRAJHnYxFREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHDMOed3Db4ws17goN91LKFlQJ/fRRQh7Xd/aL/7Q/vdH8W231c45xre7E5FG3CKjZntdM51+l1HsdF+94f2uz+03/2h/T47naISERGRwFHAERERkcBRwCked/ldQJHSfveH9rs/tN/9of0+C/XBERERkcBRC46IiIgEjgKOiIiIBI4CTkCY2YfMbJeZZcys84zbvmhme81sj5m9c9r2m7Pb9prZF6ZtX2VmvzCz18zsu2YWW8rnUqjM7L+b2REzey57ede02+b1GsjCaH8uLjM7YGYvZt/fO7Pb6szsJ9njxU/MrDa73czsf2dfixfM7DJ/qy8cZna3mfWY2UvTts17P5vZ7dn7v2Zmt/vxXPykgBMcLwEfAB6bvtHMNgIfAS4Cbga+bmZhMwsDXwNuATYCt2XvC/AV4E7n3DpgAPjk0jyFQLjTObc5e7kfFvwayDxpfy6ZG7Pv75N/SH0BeDh7vHg4ex2812Fd9vJp4BtLXmnh+j94x4rp5rWfzawO+CPgSmAr8EcnQ1GxUMAJCOfcy865PbPcdCtwj3Mu4ZzbD+zFe7NvBfY65/Y556aAe4BbzcyAm4DvZ3//28D7Fv8ZBNq8XgMf6yx02p/+uBXvOAGnHy9uBf7BebYDNWbW7EeBhcY59xhw4ozN893P7wR+4pw74ZwbAH7CzNAUaAo4wdcKHJ52vSu7ba7t9cCgcy51xnY5N3dkm4nvnvbX0nxfA1kY7c/F54Afm9kzZvbp7LblzrmjANn/N2a36/XIrfnu56Lf/xG/C5BzZ2YPAU2z3PRl59wP5/q1WbY5Zg+37iz3F87+GuA1Df8x3v76Y+Avgd9k/q+BLIzeu4vvWudct5k1Aj8xs1fOcl+9Hktjrv1c9PtfAaeAOOe2LeDXuoD2adfbgO7sz7Nt78Nr4oxkW3Gm37/onetrYGbfBP4je3W+r4EszNn2s+SAc647+/8eM/s3vNOCx82s2Tl3NHtqpCd7d70euTXf/dwF3HDG9p8tQZ15Q6eogu8+4CNmVmJmq/A6oj0N7ADWZUdMxfA6wd7nvJkfHwE+mP3924G5WodkmjP6F7wfr+M3zPM1WMqaA0b7cxGZWbmZVZ78GXgH3nv8PrzjBJx+vLgP+Hh2lM9VwNDJUyyyIPPdzw8C7zCz2uzp8ndktxUNteAEhJm9H/gboAH4kZk955x7p3Nul5ndC+wGUsBnnXPp7O/cgfeGDwN3O+d2ZR/uD4F7zOx/As8C31rip1Oo/szMNuM1Ax8APgOwwNdA5sk5l9L+XFTLgX/zxiEQAf7JOfeAme0A7jWzTwKHgA9l738/8C68TvXjwCeWvuTCZGb/jNf6sszMuvBGQ/0p89jPzrkTZvbHeMEf4H84587suBxoWqpBREREAkenqERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEpKCZ2Uoze8XM/s7MXjKzfzSzbWb2hJm9ZmZb/a5RRJaeAo6IBMFa4K+BS4ALgY8CbwE+D3zJx7pExCcKOCISBPudcy865zLALuDh7LpqLwIrfa1MRHyhgCMiQZCY9nNm2vUMWnNPpCgp4IiIiEjgKOCIiIhI4Gg1cREREQkcteCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4Px/uGHzFHgrkhUAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 576x576 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.peek()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$4.9235437 \\; \\mathrm{km^{2}}$"
-      ],
-      "text/plain": [
-       "<Quantity 4.92354368 km2>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.footprint"
    ]
@@ -521,210 +235,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam),\n",
-       " TelescopeDescription(type=SST, name=ASTRI, optics=ASTRI, camera=ASTRICam),\n",
-       " TelescopeDescription(type=LST, name=LST, optics=LST, camera=LSTCam)]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.telescope_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[CameraGeometry(cam_id='ASTRICam', pix_type='rectangular', npix=2368, cam_rot=0.0 rad, pix_rot=0.0 deg),\n",
-       " CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg),\n",
-       " CameraGeometry(cam_id='LSTCam', pix_type='hexagonal', npix=1855, cam_rot=0.0 rad, pix_rot=100.89299992867878 deg)]"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.camera_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[OpticsDescription(name=LST, equivalent_focal_length=28.00 m, num_mirros=1, mirror_area=386.73 m2),\n",
-       " OpticsDescription(name=ASTRI, equivalent_focal_length=2.15 m, num_mirros=2, mirror_area=14.56 m2),\n",
-       " OpticsDescription(name=MST, equivalent_focal_length=16.00 m, num_mirros=1, mirror_area=103.83 m2)]"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.optics_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "[$95^\\circ38{}^\\prime18.0015{}^{\\prime\\prime}$\n",
-       " $117^\\circ35{}^\\prime31.273{}^{\\prime\\prime}$\n",
-       " $15^\\circ56{}^\\prime32.527{}^{\\prime\\prime}$\n",
-       " $166^\\circ24{}^\\prime15.7253{}^{\\prime\\prime}$\n",
-       " $90^\\circ00{}^\\prime00{}^{\\prime\\prime}$\n",
-       " $78^\\circ42{}^\\prime54.1682{}^{\\prime\\prime}$\n",
-       " $101^\\circ17{}^\\prime05.8318{}^{\\prime\\prime}$\n",
-       " $16^\\circ19{}^\\prime25.416{}^{\\prime\\prime}$\n",
-       " $38^\\circ42{}^\\prime43.3493{}^{\\prime\\prime}$\n",
-       " $138^\\circ18{}^\\prime26.2816{}^{\\prime\\prime}$\n",
-       " $160^\\circ45{}^\\prime08.6066{}^{\\prime\\prime}$\n",
-       " $45^\\circ50{}^\\prime11.5818{}^{\\prime\\prime}$\n",
-       " $68^\\circ26{}^\\prime09.4249{}^{\\prime\\prime}$\n",
-       " $11^\\circ27{}^\\prime33.9556{}^{\\prime\\prime}$\n",
-       " $111^\\circ33{}^\\prime50.5751{}^{\\prime\\prime}$\n",
-       " $134^\\circ09{}^\\prime48.4182{}^{\\prime\\prime}$\n",
-       " $168^\\circ32{}^\\prime26.0444{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime43.7281{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime16.2719{}^{\\prime\\prime}$\n",
-       " $16^\\circ02{}^\\prime24.2016{}^{\\prime\\prime}$\n",
-       " $38^\\circ36{}^\\prime32.8491{}^{\\prime\\prime}$\n",
-       " $141^\\circ23{}^\\prime27.1509{}^{\\prime\\prime}$\n",
-       " $163^\\circ57{}^\\prime35.7984{}^{\\prime\\prime}$\n",
-       " $45^\\circ48{}^\\prime42.2049{}^{\\prime\\prime}$\n",
-       " $68^\\circ25{}^\\prime33.0227{}^{\\prime\\prime}$\n",
-       " $11^\\circ21{}^\\prime07.5916{}^{\\prime\\prime}$\n",
-       " $111^\\circ34{}^\\prime26.9773{}^{\\prime\\prime}$\n",
-       " $134^\\circ11{}^\\prime17.7951{}^{\\prime\\prime}$\n",
-       " $168^\\circ38{}^\\prime52.4084{}^{\\prime\\prime}$\n",
-       " $49^\\circ01{}^\\prime53.8821{}^{\\prime\\prime}$\n",
-       " $130^\\circ58{}^\\prime06.1179{}^{\\prime\\prime}$\n",
-       " $153^\\circ34{}^\\prime33.8961{}^{\\prime\\prime}$\n",
-       " $57^\\circ29{}^\\prime13.3129{}^{\\prime\\prime}$\n",
-       " $80^\\circ06{}^\\prime19.0782{}^{\\prime\\prime}$\n",
-       " $99^\\circ53{}^\\prime40.9218{}^{\\prime\\prime}$\n",
-       " $122^\\circ30{}^\\prime46.6871{}^{\\prime\\prime}$\n",
-       " $1^\\circ21{}^\\prime19.7674{}^{\\prime\\prime}$\n",
-       " $23^\\circ51{}^\\prime29.0911{}^{\\prime\\prime}$\n",
-       " $156^\\circ08{}^\\prime30.9089{}^{\\prime\\prime}$\n",
-       " $178^\\circ38{}^\\prime40.2326{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime26.1515{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime33.8485{}^{\\prime\\prime}$\n",
-       " $34^\\circ34{}^\\prime02.3914{}^{\\prime\\prime}$\n",
-       " $57^\\circ11{}^\\prime07.3317{}^{\\prime\\prime}$\n",
-       " $122^\\circ48{}^\\prime52.6683{}^{\\prime\\prime}$\n",
-       " $145^\\circ25{}^\\prime57.6086{}^{\\prime\\prime}$\n",
-       " $15^\\circ57{}^\\prime57.3762{}^{\\prime\\prime}$\n",
-       " $38^\\circ34{}^\\prime56.9335{}^{\\prime\\prime}$\n",
-       " $141^\\circ25{}^\\prime03.0665{}^{\\prime\\prime}$\n",
-       " $164^\\circ02{}^\\prime02.6238{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime25.2281{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime34.7719{}^{\\prime\\prime}$\n",
-       " $11^\\circ18{}^\\prime54.9244{}^{\\prime\\prime}$\n",
-       " $168^\\circ41{}^\\prime05.0756{}^{\\prime\\prime}$\n",
-       " $45^\\circ48{}^\\prime11.2618{}^{\\prime\\prime}$\n",
-       " $68^\\circ25{}^\\prime20.4612{}^{\\prime\\prime}$\n",
-       " $111^\\circ34{}^\\prime39.5388{}^{\\prime\\prime}$\n",
-       " $134^\\circ11{}^\\prime48.7382{}^{\\prime\\prime}$\n",
-       " $63^\\circ12{}^\\prime03.8214{}^{\\prime\\prime}$\n",
-       " $85^\\circ49{}^\\prime13.7063{}^{\\prime\\prime}$\n",
-       " $29^\\circ21{}^\\prime33.4806{}^{\\prime\\prime}$\n",
-       " $51^\\circ58{}^\\prime41.6293{}^{\\prime\\prime}$\n",
-       " $3^\\circ09{}^\\prime32.0002{}^{\\prime\\prime}$\n",
-       " $25^\\circ45{}^\\prime53.6564{}^{\\prime\\prime}$\n",
-       " $94^\\circ10{}^\\prime46.2937{}^{\\prime\\prime}$\n",
-       " $116^\\circ47{}^\\prime56.1786{}^{\\prime\\prime}$\n",
-       " $128^\\circ01{}^\\prime18.3707{}^{\\prime\\prime}$\n",
-       " $150^\\circ38{}^\\prime26.5194{}^{\\prime\\prime}$\n",
-       " $154^\\circ14{}^\\prime06.3436{}^{\\prime\\prime}$\n",
-       " $176^\\circ50{}^\\prime27.9998{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime24.8214{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime35.1786{}^{\\prime\\prime}$\n",
-       " $15^\\circ57{}^\\prime47.4141{}^{\\prime\\prime}$\n",
-       " $38^\\circ34{}^\\prime53.4825{}^{\\prime\\prime}$\n",
-       " $141^\\circ25{}^\\prime06.5175{}^{\\prime\\prime}$\n",
-       " $164^\\circ02{}^\\prime12.5859{}^{\\prime\\prime}$\n",
-       " $11^\\circ18{}^\\prime46.4095{}^{\\prime\\prime}$\n",
-       " $168^\\circ41{}^\\prime13.5905{}^{\\prime\\prime}$\n",
-       " $52^\\circ49{}^\\prime06.0105{}^{\\prime\\prime}$\n",
-       " $75^\\circ26{}^\\prime16.4206{}^{\\prime\\prime}$\n",
-       " $38^\\circ57{}^\\prime04.2653{}^{\\prime\\prime}$\n",
-       " $61^\\circ34{}^\\prime14.3105{}^{\\prime\\prime}$\n",
-       " $104^\\circ33{}^\\prime43.5794{}^{\\prime\\prime}$\n",
-       " $127^\\circ10{}^\\prime53.9895{}^{\\prime\\prime}$\n",
-       " $118^\\circ25{}^\\prime45.6895{}^{\\prime\\prime}$\n",
-       " $141^\\circ02{}^\\prime55.7347{}^{\\prime\\prime}$\n",
-       " $66^\\circ31{}^\\prime35.8563{}^{\\prime\\prime}$\n",
-       " $89^\\circ08{}^\\prime46.5312{}^{\\prime\\prime}$\n",
-       " $26^\\circ24{}^\\prime12.8535{}^{\\prime\\prime}$\n",
-       " $49^\\circ01{}^\\prime22.348{}^{\\prime\\prime}$\n",
-       " $90^\\circ51{}^\\prime13.4688{}^{\\prime\\prime}$\n",
-       " $113^\\circ28{}^\\prime24.1437{}^{\\prime\\prime}$\n",
-       " $130^\\circ58{}^\\prime37.652{}^{\\prime\\prime}$\n",
-       " $153^\\circ35{}^\\prime47.1465{}^{\\prime\\prime}$\n",
-       " $5^\\circ52{}^\\prime51.9148{}^{\\prime\\prime}$\n",
-       " $28^\\circ29{}^\\prime50.4816{}^{\\prime\\prime}$\n",
-       " $151^\\circ30{}^\\prime09.5184{}^{\\prime\\prime}$\n",
-       " $174^\\circ07{}^\\prime08.0852{}^{\\prime\\prime}$]"
-      ],
-      "text/plain": [
-       "<Angle [ 95.63833374, 117.59202028,  15.94236861, 166.40436814,\n",
-       "         90.        ,  78.71504671, 101.28495329,  16.32372666,\n",
-       "         38.71204146, 138.30730046, 160.75239071,  45.8365505 ,\n",
-       "         68.43595137,  11.45943212, 111.56404863, 134.1634495 ,\n",
-       "        168.54056788,  78.69548002, 101.30451998,  16.04005599,\n",
-       "         38.60912476, 141.39087524, 163.95994401,  45.81172359,\n",
-       "         68.42583965,  11.35210877, 111.57416035, 134.18827641,\n",
-       "        168.64789123,  49.03163391, 130.96836609, 153.57608224,\n",
-       "         57.48703137,  80.10529951,  99.89470049, 122.51296863,\n",
-       "          1.35549094,  23.85808087, 156.14191913, 178.64450906,\n",
-       "         78.69059764, 101.30940236,  34.56733094,  57.18536991,\n",
-       "        122.81463009, 145.43266906,  15.96593785,  38.58248153,\n",
-       "        141.41751847, 164.03406215,  78.69034114, 101.30965886,\n",
-       "         11.31525677, 168.68474323,  45.80312828,  68.42235035,\n",
-       "        111.57764965, 134.19687172,  63.2010615 ,  85.82047396,\n",
-       "         29.35930018,  51.97823035,   3.15888895,  25.76490456,\n",
-       "         94.17952604, 116.7989385 , 128.02176965, 150.64069982,\n",
-       "        154.23509544, 176.84111105,  78.69022816, 101.30977184,\n",
-       "         15.96317058,  38.58152291, 141.41847709, 164.03682942,\n",
-       "         11.31289154, 168.68710846,  52.81833625,  75.4378946 ,\n",
-       "         38.95118481,  61.5706418 , 104.5621054 , 127.18166375,\n",
-       "        118.4293582 , 141.04881519,  66.52662676,  89.14625866,\n",
-       "         26.40357041,  49.02287445,  90.85374134, 113.47337324,\n",
-       "        130.97712555, 153.59642959,   5.88108744,  28.497356  ,\n",
-       "        151.502644  , 174.11891256] deg>"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from astropy.coordinates import SkyCoord\n",
     "from ctapipe.coordinates import GroundFrame\n",
@@ -744,20 +284,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 0,  4, 22])"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_ids_to_indices([1,5,23])"
    ]
@@ -771,109 +300,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([-1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,\n",
-       "       16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,\n",
-       "       33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,\n",
-       "       50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66,\n",
-       "       67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,\n",
-       "       84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97])"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_index_array"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 0,  4, 22])"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_index_array[[1,5,23]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_indices[1]  # this is a dict of tel_id -> tel_index, so we can only do one at once"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[5,\n",
-       " 6,\n",
-       " 7,\n",
-       " 8,\n",
-       " 9,\n",
-       " 10,\n",
-       " 11,\n",
-       " 12,\n",
-       " 13,\n",
-       " 14,\n",
-       " 15,\n",
-       " 16,\n",
-       " 17,\n",
-       " 18,\n",
-       " 19,\n",
-       " 20,\n",
-       " 21,\n",
-       " 22,\n",
-       " 23,\n",
-       " 24,\n",
-       " 25,\n",
-       " 26,\n",
-       " 27,\n",
-       " 28,\n",
-       " 29]"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ids = subarray.get_tel_ids_for_type(subarray.telescope_types[0])\n",
     "ids"
@@ -881,21 +337,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,\n",
-       "       21, 22, 23, 24, 25, 26, 27, 28])"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "idx = subarray.tel_ids_to_indices(ids)\n",
     "idx"
@@ -903,45 +347,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<SkyCoord (GroundFrame): (x, y, z) in m\n",
-       "    [(   0.        ,    0.        , 10.),\n",
-       "     (   0.        ,  151.19999695, 10.),\n",
-       "     (   0.        , -151.19999695, 10.),\n",
-       "     ( 146.6559906 ,   75.59999847, 10.),\n",
-       "     ( 146.6559906 ,  -75.59999847, 10.),\n",
-       "     (-146.6559906 ,   85.59999847, 10.),\n",
-       "     (-146.6559906 ,  -85.59999847, 10.),\n",
-       "     ( 154.20500183,  238.47399902, 10.),\n",
-       "     ( 154.20500183, -238.47399902, 10.),\n",
-       "     ( 308.41000366,    0.        , 10.),\n",
-       "     (-154.20500183,  238.47399902, 10.),\n",
-       "     (-154.20500183, -238.47399902, 10.),\n",
-       "     (-308.41000366,    0.        , 10.),\n",
-       "     (   0.        ,  325.24200439, 10.),\n",
-       "     (   0.        , -325.24200439, 10.),\n",
-       "     ( 315.46801758,  162.6210022 , 10.),\n",
-       "     ( 315.46801758, -162.6210022 , 10.),\n",
-       "     (-315.46801758,  162.6210022 , 10.),\n",
-       "     (-315.46801758, -162.6210022 , 10.),\n",
-       "     ( 291.08499146,  450.15499878, 10.),\n",
-       "     ( 291.08499146, -450.15499878, 10.),\n",
-       "     ( 582.16998291,    0.        , 10.),\n",
-       "     (-291.08499146,  450.15499878, 10.),\n",
-       "     (-291.08499146, -450.15499878, 10.),\n",
-       "     (-582.16998291,    0.        , 10.)]>"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_coords[idx]"
    ]
@@ -955,23 +363,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[-20,~65,~16] \\; \\mathrm{m}$"
-      ],
-      "text/plain": [
-       "<Quantity [-20.,  65.,  16.] m>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.positions[1]"
    ]
@@ -986,865 +380,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>pos_x</th>\n",
-       "      <th>pos_y</th>\n",
-       "      <th>pos_z</th>\n",
-       "      <th>name</th>\n",
-       "      <th>type</th>\n",
-       "      <th>num_mirrors</th>\n",
-       "      <th>camera_type</th>\n",
-       "      <th>tel_description</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>tel_id</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>-20.000000</td>\n",
-       "      <td>65.000000</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>-20.000000</td>\n",
-       "      <td>-65.000000</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>80.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>-120.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>151.199997</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>-151.199997</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>146.655991</td>\n",
-       "      <td>75.599998</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>146.655991</td>\n",
-       "      <td>-75.599998</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>-146.655991</td>\n",
-       "      <td>85.599998</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>-146.655991</td>\n",
-       "      <td>-85.599998</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>154.205002</td>\n",
-       "      <td>238.473999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>154.205002</td>\n",
-       "      <td>-238.473999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>308.410004</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>-154.205002</td>\n",
-       "      <td>238.473999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>-154.205002</td>\n",
-       "      <td>-238.473999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>-308.410004</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>325.242004</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>-325.242004</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>315.468018</td>\n",
-       "      <td>162.621002</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>315.468018</td>\n",
-       "      <td>-162.621002</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>-315.468018</td>\n",
-       "      <td>162.621002</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>-315.468018</td>\n",
-       "      <td>-162.621002</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>291.084991</td>\n",
-       "      <td>450.154999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>291.084991</td>\n",
-       "      <td>-450.154999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>582.169983</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>-291.084991</td>\n",
-       "      <td>450.154999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>-291.084991</td>\n",
-       "      <td>-450.154999</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>-582.169983</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>MST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>FlashCam</td>\n",
-       "      <td>MST_MST_FlashCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>205.500000</td>\n",
-       "      <td>-158.899994</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>69</th>\n",
-       "      <td>-883.377014</td>\n",
-       "      <td>227.686996</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>70</th>\n",
-       "      <td>-883.377014</td>\n",
-       "      <td>-227.686996</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>71</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>944.301025</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72</th>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>-944.301025</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>73</th>\n",
-       "      <td>915.922974</td>\n",
-       "      <td>472.151001</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>74</th>\n",
-       "      <td>915.922974</td>\n",
-       "      <td>-472.151001</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>75</th>\n",
-       "      <td>-915.922974</td>\n",
-       "      <td>472.151001</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>76</th>\n",
-       "      <td>-915.922974</td>\n",
-       "      <td>-472.151001</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>77</th>\n",
-       "      <td>1100.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>78</th>\n",
-       "      <td>-1100.000000</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>79</th>\n",
-       "      <td>471.011993</td>\n",
-       "      <td>971.210022</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>80</th>\n",
-       "      <td>471.011993</td>\n",
-       "      <td>-971.210022</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>81</th>\n",
-       "      <td>706.517944</td>\n",
-       "      <td>849.808960</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>82</th>\n",
-       "      <td>706.517944</td>\n",
-       "      <td>-849.808960</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>83</th>\n",
-       "      <td>-471.011993</td>\n",
-       "      <td>971.210022</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>84</th>\n",
-       "      <td>-471.011993</td>\n",
-       "      <td>-971.210022</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>85</th>\n",
-       "      <td>-706.517944</td>\n",
-       "      <td>849.808960</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>86</th>\n",
-       "      <td>-706.517944</td>\n",
-       "      <td>-849.808960</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>87</th>\n",
-       "      <td>239.196991</td>\n",
-       "      <td>1109.734985</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>88</th>\n",
-       "      <td>239.196991</td>\n",
-       "      <td>-1109.734985</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>89</th>\n",
-       "      <td>956.787048</td>\n",
-       "      <td>739.822998</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>90</th>\n",
-       "      <td>956.787048</td>\n",
-       "      <td>-739.822998</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>91</th>\n",
-       "      <td>-239.196991</td>\n",
-       "      <td>1109.734985</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>92</th>\n",
-       "      <td>-239.196991</td>\n",
-       "      <td>-1109.734985</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>93</th>\n",
-       "      <td>-956.787048</td>\n",
-       "      <td>739.822998</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>94</th>\n",
-       "      <td>-956.787048</td>\n",
-       "      <td>-739.822998</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>1195.984009</td>\n",
-       "      <td>369.911987</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>1195.984009</td>\n",
-       "      <td>-369.911987</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>-1195.984009</td>\n",
-       "      <td>369.911987</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>-1195.984009</td>\n",
-       "      <td>-369.911987</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>ASTRI</td>\n",
-       "      <td>SST</td>\n",
-       "      <td>2</td>\n",
-       "      <td>ASTRICam</td>\n",
-       "      <td>SST_ASTRI_ASTRICam</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>98 rows × 8 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              pos_x        pos_y  pos_z   name type  num_mirrors camera_type  \\\n",
-       "tel_id                                                                         \n",
-       "1        -20.000000    65.000000   16.0    LST  LST            1      LSTCam   \n",
-       "2        -20.000000   -65.000000   16.0    LST  LST            1      LSTCam   \n",
-       "3         80.000000     0.000000   16.0    LST  LST            1      LSTCam   \n",
-       "4       -120.000000     0.000000   16.0    LST  LST            1      LSTCam   \n",
-       "5          0.000000     0.000000   10.0    MST  MST            1    FlashCam   \n",
-       "6          0.000000   151.199997   10.0    MST  MST            1    FlashCam   \n",
-       "7          0.000000  -151.199997   10.0    MST  MST            1    FlashCam   \n",
-       "8        146.655991    75.599998   10.0    MST  MST            1    FlashCam   \n",
-       "9        146.655991   -75.599998   10.0    MST  MST            1    FlashCam   \n",
-       "10      -146.655991    85.599998   10.0    MST  MST            1    FlashCam   \n",
-       "11      -146.655991   -85.599998   10.0    MST  MST            1    FlashCam   \n",
-       "12       154.205002   238.473999   10.0    MST  MST            1    FlashCam   \n",
-       "13       154.205002  -238.473999   10.0    MST  MST            1    FlashCam   \n",
-       "14       308.410004     0.000000   10.0    MST  MST            1    FlashCam   \n",
-       "15      -154.205002   238.473999   10.0    MST  MST            1    FlashCam   \n",
-       "16      -154.205002  -238.473999   10.0    MST  MST            1    FlashCam   \n",
-       "17      -308.410004     0.000000   10.0    MST  MST            1    FlashCam   \n",
-       "18         0.000000   325.242004   10.0    MST  MST            1    FlashCam   \n",
-       "19         0.000000  -325.242004   10.0    MST  MST            1    FlashCam   \n",
-       "20       315.468018   162.621002   10.0    MST  MST            1    FlashCam   \n",
-       "21       315.468018  -162.621002   10.0    MST  MST            1    FlashCam   \n",
-       "22      -315.468018   162.621002   10.0    MST  MST            1    FlashCam   \n",
-       "23      -315.468018  -162.621002   10.0    MST  MST            1    FlashCam   \n",
-       "24       291.084991   450.154999   10.0    MST  MST            1    FlashCam   \n",
-       "25       291.084991  -450.154999   10.0    MST  MST            1    FlashCam   \n",
-       "26       582.169983     0.000000   10.0    MST  MST            1    FlashCam   \n",
-       "27      -291.084991   450.154999   10.0    MST  MST            1    FlashCam   \n",
-       "28      -291.084991  -450.154999   10.0    MST  MST            1    FlashCam   \n",
-       "29      -582.169983     0.000000   10.0    MST  MST            1    FlashCam   \n",
-       "30       205.500000  -158.899994    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "...             ...          ...    ...    ...  ...          ...         ...   \n",
-       "69      -883.377014   227.686996    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "70      -883.377014  -227.686996    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "71         0.000000   944.301025    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "72         0.000000  -944.301025    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "73       915.922974   472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "74       915.922974  -472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "75      -915.922974   472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "76      -915.922974  -472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "77      1100.000000     0.000000    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "78     -1100.000000     0.000000    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "79       471.011993   971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "80       471.011993  -971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "81       706.517944   849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "82       706.517944  -849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "83      -471.011993   971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "84      -471.011993  -971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "85      -706.517944   849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "86      -706.517944  -849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "87       239.196991  1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "88       239.196991 -1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "89       956.787048   739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "90       956.787048  -739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "91      -239.196991  1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "92      -239.196991 -1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "93      -956.787048   739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "94      -956.787048  -739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "95      1195.984009   369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "96      1195.984009  -369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "97     -1195.984009   369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "98     -1195.984009  -369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
-       "\n",
-       "           tel_description  \n",
-       "tel_id                      \n",
-       "1           LST_LST_LSTCam  \n",
-       "2           LST_LST_LSTCam  \n",
-       "3           LST_LST_LSTCam  \n",
-       "4           LST_LST_LSTCam  \n",
-       "5         MST_MST_FlashCam  \n",
-       "6         MST_MST_FlashCam  \n",
-       "7         MST_MST_FlashCam  \n",
-       "8         MST_MST_FlashCam  \n",
-       "9         MST_MST_FlashCam  \n",
-       "10        MST_MST_FlashCam  \n",
-       "11        MST_MST_FlashCam  \n",
-       "12        MST_MST_FlashCam  \n",
-       "13        MST_MST_FlashCam  \n",
-       "14        MST_MST_FlashCam  \n",
-       "15        MST_MST_FlashCam  \n",
-       "16        MST_MST_FlashCam  \n",
-       "17        MST_MST_FlashCam  \n",
-       "18        MST_MST_FlashCam  \n",
-       "19        MST_MST_FlashCam  \n",
-       "20        MST_MST_FlashCam  \n",
-       "21        MST_MST_FlashCam  \n",
-       "22        MST_MST_FlashCam  \n",
-       "23        MST_MST_FlashCam  \n",
-       "24        MST_MST_FlashCam  \n",
-       "25        MST_MST_FlashCam  \n",
-       "26        MST_MST_FlashCam  \n",
-       "27        MST_MST_FlashCam  \n",
-       "28        MST_MST_FlashCam  \n",
-       "29        MST_MST_FlashCam  \n",
-       "30      SST_ASTRI_ASTRICam  \n",
-       "...                    ...  \n",
-       "69      SST_ASTRI_ASTRICam  \n",
-       "70      SST_ASTRI_ASTRICam  \n",
-       "71      SST_ASTRI_ASTRICam  \n",
-       "72      SST_ASTRI_ASTRICam  \n",
-       "73      SST_ASTRI_ASTRICam  \n",
-       "74      SST_ASTRI_ASTRICam  \n",
-       "75      SST_ASTRI_ASTRICam  \n",
-       "76      SST_ASTRI_ASTRICam  \n",
-       "77      SST_ASTRI_ASTRICam  \n",
-       "78      SST_ASTRI_ASTRICam  \n",
-       "79      SST_ASTRI_ASTRICam  \n",
-       "80      SST_ASTRI_ASTRICam  \n",
-       "81      SST_ASTRI_ASTRICam  \n",
-       "82      SST_ASTRI_ASTRICam  \n",
-       "83      SST_ASTRI_ASTRICam  \n",
-       "84      SST_ASTRI_ASTRICam  \n",
-       "85      SST_ASTRI_ASTRICam  \n",
-       "86      SST_ASTRI_ASTRICam  \n",
-       "87      SST_ASTRI_ASTRICam  \n",
-       "88      SST_ASTRI_ASTRICam  \n",
-       "89      SST_ASTRI_ASTRICam  \n",
-       "90      SST_ASTRI_ASTRICam  \n",
-       "91      SST_ASTRI_ASTRICam  \n",
-       "92      SST_ASTRI_ASTRICam  \n",
-       "93      SST_ASTRI_ASTRICam  \n",
-       "94      SST_ASTRI_ASTRICam  \n",
-       "95      SST_ASTRI_ASTRICam  \n",
-       "96      SST_ASTRI_ASTRICam  \n",
-       "97      SST_ASTRI_ASTRICam  \n",
-       "98      SST_ASTRI_ASTRICam  \n",
-       "\n",
-       "[98 rows x 8 columns]"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel_string = \"LST_LST_LSTCam\" # an LST with LST structure and LSTCam camera\n",
     "df = subarray.to_table().to_pandas()\n",
@@ -1853,29 +391,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'LST_LST_LSTCam': Int64Index([0, 1, 2, 3], dtype='int64'),\n",
-       " 'MST_MST_FlashCam': Int64Index([ 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,\n",
-       "             21, 22, 23, 24, 25, 26, 27, 28],\n",
-       "            dtype='int64'),\n",
-       " 'SST_ASTRI_ASTRICam': Int64Index([29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,\n",
-       "             46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,\n",
-       "             63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,\n",
-       "             80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,\n",
-       "             97],\n",
-       "            dtype='int64')}"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "g = df.groupby('tel_description')\n",
     "g.groups"
@@ -1883,181 +401,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Int64Index([0, 1, 2, 3], dtype='int64')"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "g.groups[tel_string]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>tel_id</th>\n",
-       "      <th>pos_x</th>\n",
-       "      <th>pos_y</th>\n",
-       "      <th>pos_z</th>\n",
-       "      <th>name</th>\n",
-       "      <th>type</th>\n",
-       "      <th>num_mirrors</th>\n",
-       "      <th>camera_type</th>\n",
-       "      <th>tel_description</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>-20.0</td>\n",
-       "      <td>65.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>-20.0</td>\n",
-       "      <td>-65.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>80.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>-120.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>LST</td>\n",
-       "      <td>1</td>\n",
-       "      <td>LSTCam</td>\n",
-       "      <td>LST_LST_LSTCam</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   tel_id  pos_x  pos_y  pos_z name type  num_mirrors camera_type  \\\n",
-       "0       1  -20.0   65.0   16.0  LST  LST            1      LSTCam   \n",
-       "1       2  -20.0  -65.0   16.0  LST  LST            1      LSTCam   \n",
-       "2       3   80.0    0.0   16.0  LST  LST            1      LSTCam   \n",
-       "3       4 -120.0    0.0   16.0  LST  LST            1      LSTCam   \n",
-       "\n",
-       "  tel_description  \n",
-       "0  LST_LST_LSTCam  \n",
-       "1  LST_LST_LSTCam  \n",
-       "2  LST_LST_LSTCam  \n",
-       "3  LST_LST_LSTCam  "
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.loc[g.groups[tel_string]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : LSTs\n",
-      "Num Tels : 4\n",
-      "Footprint: 0.05 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "      LST_LST_LSTCam    4    1 ..   4\n"
-     ]
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$0.045238934 \\; \\mathrm{km^{2}}$"
-      ],
-      "text/plain": [
-       "<Quantity 0.04523893 km2>"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAI4CAYAAABndZP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3X+U3XV97/vXOzPJJCH8CCT8DBAQREE0eFLUWnupWqnVBe2911ZPT0vVe2mtVWtv7xGlv1dZ99Ryjh7be9ui9dReqa21Wlz0VKvc4jq2Ag0/yg8RQUEIBAg0/JL8muRz/5hNOsgkBMhkz/7k8VhrVvb+7u/+7vc338nMM9+990y11gIA0JN5wx4AAGBPEzgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BA8wJVXVHVb12huUfqKrbq+qxqlpbVX85WH7TYNljVbWtqjZNu/6Bvb8HwFwyPuwBAHamqs5J8tNJXtta+1ZVHZ7krCRprZ0ybb3Lk3yytfaxoQwKzDnO4ABz2fcl+WJr7VtJ0lq7t7V20e7csapeUFVfraqHq2p9Vf3ZrE4KzCnO4ABz2RVJPlJVdyf5hyTXtta27eZ9/68kf5PkVUkWJnnp7IwIzEXO4ABzVmvtk0neleTMJF9Jcn9Vnbebd9+aZGWSw1trG1tr/zg7UwJzkcAB5rTW2sWttdcmOSjJzyf57ao6czfu+t4ki5NcW1XXV9V/mM05gblF4AAjobW2tbX2V0muT/Ki3Vj/7tba25IckeTdST5eVcfM8pjAHCFwgLlkflUtnPbxv1XVG6pq/6qaV1WvT3JKkiufbkNV9ZNVdWRrrSV5aLB4cjaHB+YOLzIG5pL//j3Xb06yIcknk4wl+U6Sd7TWvrob23pFkg9X1f5J1iU5t7V2z54cFpi7auo/NwAA/fAUFQDQHYEDAHRH4AAA3RE4AEB3ungX1bJly9rKlSuHPQYAMMuuvvrqB1pry59uvS4CZ+XKlVmzZs2wxwAAZllVfWd31vMUFQDQHYEDAHRH4AAA3eniNTgA7Fu2bt2atWvXZtOmTcMehVmycOHCrFixIvPnz39W9xc4AIyctWvXZv/998/KlStTVcMehz2stZYHH3wwa9euzXHHHfestuEpKgBGzqZNm3LIIYeIm05VVQ455JDndIZO4AAwksRN357r8RU4AEB3vAYHgK611rJ2w8Zcd9dD2fD4lixdvCCrjj4oK5YuchaoY87gANCtTVu35U//6Y58+MvfzFdvW5/b7nssX71tfT785W/mT//pjmzauu1Zb3vJkiVPWXbLLbfkjDPOyKpVq/LCF74w5557br74xS9m1apVWbVqVZYsWZKTTjopq1atys/8zM/MuN3LL788b3zjG5+y/NJLL81pp52Wl7zkJTn55JPzx3/8x7ngggt2bHtsbGzH5Y985CMzbvs3f/M3c+GFFz5l+QUXXJBTTjklL37xi7Nq1apceeWV+fEf//GsWrUqJ5xwQg488MAd2/6nf/qnbN26Needd15OPPHEvOhFL8rpp5+ev/u7v3uGf4OzyxkcALrUWsunrrozN97zcI466Mlna1prufGeh/Opq+7Mz37/nnsn1rvf/e68973vzdlnn50kueGGG3LqqafmzDPPTJKcccYZufDCC7N69epntN2tW7fm3HPPzVVXXZUVK1Zk8+bNueOOO3LSSSfl/PPPTzIVXNddd90znvlrX/taLr300lxzzTWZmJjIAw88kC1btuRzn/tckqnguvDCC3PppZfuuM95552XdevW5cYbb8zExETuu+++fOUrX3nGjz2bnMEBoEtrN2zMjXc/nKMOfOpTUVWVow5clJvueTh3P7Rxjz3munXrsmLFih3XTz311D2y3UcffTSTk5M55JBDkiQTExM56aST9si2161bl2XLlmViYiJJsmzZshx55JE7Xf/xxx/PRz/60fz+7//+jvscdthh+Ymf+IkkyTve8Y6sXr06p5xySn7jN35jx/1WrlyZD3zgA3nFK16R1atX55prrsmZZ56Z5z3vefmjP/qjPbIv0wkcALp03V0PZXysdnp2pqoyryrX3vnQHnvM9773vXn1q1+d17/+9fnQhz6Uhx7aM9s++OCDc9ZZZ+XYY4/NW97yllx88cXZvn37Htn26173utx11115/vOfn1/4hV942jMxt912W4455pgccMABM95+wQUXZM2aNbn++uvzla98Jddff/2O244++uh87Wtfy6te9ar87M/+bD7zmc/kiiuuyK//+q/vkX2ZTuAA0KUNj2/JxNjYLteZGB/Lhse37LHHfOtb35qbb745b3rTm3L55Zfn5S9/eTZv3rxHtv2xj30sl112WU4//fRceOGFedvb3rZHtrtkyZJcffXVueiii7J8+fL85E/+ZP70T//0WW/v05/+dF760pfmtNNOy0033ZSvf/3rO24766yzkkyd2XrZy16W/fffP8uXL8/ChQv3WAw+QeAA0KWlixdk87Zdv4h48+S2LF28YI8+7pFHHpm3ve1tueSSSzI+Pp4bb7xxj2371FNPzXvf+9586Utfyl//9V/vse2OjY3ljDPOyG/91m/lD/7gD3a57RNOOCF33nlnHn300afcdvvtt+fCCy/MZZddluuvvz5veMMbnvTD+p54SmvevHk7Lj9xfXJyco/tTyJwAOjUqqMPyuS2ltbajLe31rK9tZx2zEF77DG/8IUvZOvWrUmSe++9Nw8++GCOOuqo57zdxx57LJdffvmO69ddd12OPfbY57zdZOqdX7feeutub3vx4sV5+9vfnne/+93ZsmXq7Ne6devyyU9+Mo888kj222+/HHjggbnvvvuG+s4q76ICRkZrLfc+silr7tiQ+x/ZlP0mxnPaMUtzwqFLMjbPzzPhyVYsXZQXHXXg1LuoDnzqu6jufnhjXnTkgTnqoEXPavuPP/74k15Q/Mu//MtZu3Zt3vOe92ThwoVJkt/7vd/L4Ycf/oy3fdlllz1p25/61KfywQ9+MD/3cz+XRYsWZb/99nvWTyP9zu/8Tj784Q/vuH7JJZfkXe96Vx566KGMj4/nhBNOyEUXXfS02/jVX/3VnHzyyVm4cGH222+//PZv/3Ze8pKX5LTTTsspp5yS448/Pq985Suf1Yx7Qu2sbEfJ6tWr25o1a4Y9BjCLJrdtz2evvTtXfvvBjM2bl0Xz52XrtpYtk9tzxEEL87ZXHpel++3ZpxqYu26++ea88IUvfNr1Nm3dlk9ddWduuufhzKvKxPhYNk9uy/bWcsqRB+Ytpx+ThfN3/Todhmem41xVV7fWnvZ99s7gACPhb29Yl69968GsOGhR5n3P2Zr7H92cj/6Pb+c9rz0xE+O+WfFvFs4fy89+/8rc/dDGXHvnv/0k49OOOegpPxuHvggcYM57eOPW/I9bH8hRM8RNkhy6/0TWbng8N9/zSFYds3QIEzKXVVVWLF2cFUsXD3uUJ/niF7+Y973vfU9adtxxx+34AXvPxQUXXJC/+qu/etKyN73pTTt+KOC+QOAAc94t9z6S1touX2ezZGI8V9z+rwJnH9JaG+kzMGeeeeaOn3C8p51//vkjHzPP9SU03kUFzHmPbZrMvKf5RrZgfF4e2bh1L03EsC1cuDAPPvjgc/4myNzUWsuDDz6448Xaz4YzOMCcd8Ci+dn+NN/INm/dnuX7T+xyHfqxYsWKrF27NuvXrx/2KMyShQsXPumdZM+UwAHmvJMO3z/zqjK5bXvGx2Y+8fzdLZP5/uct28uTMSzz58/PcccdN+wxmMM8RQXMefsvnJ/XvPCw3PPQxmzb/uQzOa213Pvwphx98OKcdPj+Q5oQmGucwQFGwg+ffFgmt2/P5besT2XqNTeT27dnclvL8cuX5KdfcWzm7+TsDrDvETjASBibV3nji4/MK44/JP+y9qGsf3RLFi8Yy4tXHJhjDl480u+mAfY8gQOMlEOWTOTVLzhs2GMAc5zzuQBAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3Rlq4FTVQVX1mar6RlXdXFWvqKqDq+pLVXXr4M+lw5wRABg9wz6D81+TfKG19oIkL0lyc5LzklzWWjsxyWWD6wAAu21ogVNVByT5wSR/kiSttS2ttYeSnJ3kE4PVPpHkx4YzIQAwqoZ5Buf4JOuT/LequraqPlZV+yU5rLW2LkkGfx46052r6tyqWlNVa9avX7/3pgYA5rxhBs54kpcm+cPW2mlJvptn8HRUa+2i1trq1trq5cuXz9aMAMAIGmbgrE2ytrV25eD6ZzIVPPdV1RFJMvjz/iHNBwCMqKEFTmvt3iR3VdVJg0WvSfL1JJ9Pcs5g2TlJLhnCeADACBsf8uO/K8nFVbUgybeTvDVT0fXpqnp7kjuTvGmI8wEAI2iogdNauy7J6hlues3engUA6Mewfw4OAMAeJ3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4MPXCqaqyqrq2qSwfXj6uqK6vq1qr6y6paMOwZAYDRMvTASfKeJDdPu/67ST7UWjsxyYYkbx/KVADAyBpq4FTViiRvSPKxwfVK8uoknxms8okkPzac6QCAUTXsMzgfTvIfk2wfXD8kyUOttcnB9bVJjprpjlV1blWtqao169evn/1JAYCRMbTAqao3Jrm/tXb19MUzrNpmun9r7aLW2urW2urly5fPyowAwGgaH+JjvzLJWVX1o0kWJjkgU2d0Dqqq8cFZnBVJ7hnijADACBraGZzW2vtbaytaayuTvDnJ/9da+6kk/5Dkfx2sdk6SS4Y0IgAwoob9GpyZvC/JL1fVbZl6Tc6fDHkeAGDEDPMpqh1aa5cnuXxw+dtJTh/mPADAaJuLZ3AAAJ4TgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdGdogVNVR1fVP1TVzVV1U1W9Z7D84Kr6UlXdOvhz6bBmBABG0zDP4Ewm+T9aay9M8vIk76yqk5Ocl+Sy1tqJSS4bXAcA2G1DC5zW2rrW2jWDy48muTnJUUnOTvKJwWqfSPJjw5kQABhVc+I1OFW1MslpSa5MclhrbV0yFUFJDt3Jfc6tqjVVtWb9+vV7a1QAYAQMPXCqakmSv07yS621R3b3fq21i1prq1trq5cvXz57AwIAI2eogVNV8zMVNxe31j47WHxfVR0xuP2IJPcPaz4AYDQN811UleRPktzcWvsv0276fJJzBpfPSXLJ3p4NABht40N87Fcm+ekkN1TVdYNlH0jyn5J8uqrenuTOJG8a0nwAwIgaWuC01r6apHZy82v25iwAQF+G/iJjAIA9TeAAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3xoc9wFy2eXJbtm5rWTR/LGPzatjjAMCc1lrLxq3bUqksnD8vVcP73ilwZnDng4/n8m/enxvWPpwkmZg/Lz9wwrK84nnLcuCi+UOeDgDmlslt23PNnRvyD99Yn/WPbU6SHHHgwvzQSYdm1dEHZd4QThIInO9x7Z0bcvEV38mC8bEcfsDCzJtX2Ty5LZfdfF/W3LEh7zjjeTlkycSwxwSAOWHrtu25+Irv5F/uejhL95ufIw9cmCR5dNNk/t8r7sg37zskP7H66L0eOU/7GpyqWl1Vn6uqa6rq+qq6oaqun+3BqupHquqWqrqtqs6b7cdLkgce25xPXXVnDlkykeX7T+w4GBPjYznyoMV5fMtkLr7yzrTW9sY4ADDn/eNtD+T6tQ/n6IMXZf+F81NVqaocsGh+VixdnCu+/WCu/s6GvT7X7pzBuTjJ/5nkhiTbZ3ecKVU1luT/TvLDSdYm+eeq+nxr7euz+bhr7vjXJMnC+WMz3r5syUS+8+B3s3bDxhx98OLZHAUA5rzJbdtz+S33Z/n+EzO+3mZeVQ7ZbyKXfeO+/Ltjl+7Vszi78y6q9a21z7fWbm+tfeeJj1me6/Qkt7XWvt1a25LkL5KcPcuPmRvvfiQHLNz5a2yeOHh3/evjsz0KAMx5Dzy2Jd/dsm2nJwaSZMnC8Tzw2JY8smnrXpxs987g/EZVfSzJZUk2P7GwtfbZWZsqOSrJXdOur03ysukrVNW5Sc5NkmOOOWaPPOi2tj3zduMV35PbPUUFANtby+6ck6kke/tb5+4EzluTvCDJ/PzbU1QtyWwGzkx/X0/6q2mtXZTkoiRZvXr1HvlrO37Zklz9nQ1ZtGDnJZpMvTIcAPZ1B++3IGPzKlu3bc/8sZmfFNq0dVsWLRjLAQv37vuadufRXtJaO3XWJ3mytUmOnnZ9RZJ7ZvtBX378Ibni2w9mcvv2jM976oF6ZOPWLN1vQY5fvmS2RwGAOW/h/LF8//OW5SvfvD9HHTTza1Pvf2xz3njqERnfSQDNlt15tCuq6uRZn+TJ/jnJiVV1XFUtSPLmJJ+f7QddsXRRXvOCw3L3ho15fMvkjuWttTz42OZ8d8tkfuplx/qhfwAw8EMvODSHHbAw9zy0MZPb/u29SFu3bc/dGzZm5cGL88oTlu31uXbnDM4PJDmnqm7P1GtwKklrrb14toZqrU1W1S8m+WKSsSQfb63dNFuP94SqyutPPTyHLFmQv//6vbnnoY2pSrZvb3neoUvyxhcf6d1TADDNkonxvOOME/KFG9flqts35IlXlMyryquevyyvO/nwXb4IebbU0/1Ml6o6dqble+GdVLtt9erVbc2aNXt0m9u2t6x7eGO2TG7PAYvmZ5kf7gcAu/TdzZNZ/+jU+5EOO2Dh076m9dmoqqtba6ufbr2nPYMzl0JmbxqbV1mx1NkaANhd+02MZ7+JufFLEvw2cQCgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgO0MJnKr6var6RlVdX1Wfq6qDpt32/qq6rapuqaozhzEfADDahnUG50tJXtRae3GSbyZ5f5JU1clJ3pzklCQ/kuT/qaqxIc0IAIyooQROa+3vW2uTg6tXJFkxuHx2kr9orW1urd2e5LYkpw9jRgBgdM2F1+C8LcnfDS4fleSuabetHSx7iqo6t6rWVNWa9evXz/KIAMAoGZ+tDVfVl5McPsNN57fWLhmsc36SySQXP3G3GdZvM22/tXZRkouSZPXq1TOuAwDsm2YtcFprr93V7VV1TpI3JnlNa+2JQFmb5Ohpq61Ics/sTAgA9GpY76L6kSTvS3JWa+3xaTd9Psmbq2qiqo5LcmKSq4YxIwAwumbtDM7T+IMkE0m+VFVJckVr7edbazdV1aeTfD1TT129s7W2bUgzAgAjaiiB01o7YRe3XZDkgr04DgDQmbnwLioAgD1K4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3Rlq4FTVr1RVq6plg+tVVR+pqtuq6vqqeukw5wMARtPQAqeqjk7yw0nunLb49UlOHHycm+QPhzAaADDihnkG50NJ/mOSNm3Z2Un+rE25IslBVXXEUKYDAEbWUAKnqs5Kcndr7V++56ajktw17frawbKZtnFuVa2pqjXr16+fpUkBgFE0PlsbrqovJzl8hpvOT/KBJK+b6W4zLGszLEtr7aIkFyXJ6tWrZ1wHANg3zVrgtNZeO9Pyqjo1yXFJ/qWqkmRFkmuq6vRMnbE5etrqK5LcM1szAgB92utPUbXWbmitHdpaW9laW5mpqHlpa+3eJJ9P8jODd1O9PMnDrbV1e3tGAGC0zdoZnGfpvyf50SS3JXk8yVuHOw4AMIqGHjiDszhPXG5J3jm8aQCAHvhJxgBAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANCdoQVOVb2rqm6pqpuq6oPTlr+/qm4b3HbmsOYDAEbX+DAetKp+KMnZSV7cWttcVYcOlp+c5M1JTklyZJIvV9XzW2vbhjEnADCahnUG5x1J/lNrbXOStNbuHyw/O8lftNY2t9ZuT3JbktOHNCMAMKKGFTjPT/Kqqrqyqr5SVd83WH5Ukrumrbd2sOwpqurcqlpTVWvWr18/y+MCAKNk1p6iqqovJzl8hpvOHzzu0iQvT/J9ST5dVccnqRnWbzNtv7V2UZKLkmT16tUzrgMA7JtmLXBaa6/d2W1V9Y4kn22ttSRXVdX2JMsydcbm6Gmrrkhyz2zNCAD0aVhPUf1NklcnSVU9P8mCJA8k+XySN1fVRFUdl+TEJFcNaUYAYEQN5V1UST6e5ONVdWOSLUnOGZzNuamqPp3k60kmk7zTO6gAgGdqKIHTWtuS5D/s5LYLklywdycCAHriJxkDAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHeG9XNwAJ6Vrdu259vrv5tHNm3NxPi8HL98SZZM+FIGPJmvCsDIuPbODfmba+/OY5snp35xXSXzqvIDJy7P6190eOaPOSkNTBE4wEi4+jsb8skr7siyJRNZsXjxjuWT27bn8m/cn0ce35p//7JjMm/eTL+zF9jX+O8OMOdtntyWz16zNofuvzCLFzz5/2XjY/OyYumiXHPXhtz+4HeHNCEw1wgcYM775r2PZdPWbVk4f2zG26sqC8fH8rVvPbiXJwPmKoEDzHnrH92UebXrp572mxjLuoc37qWJgLlO4ABz3sT4WLa3tst1Jre3LBif+QwPsO8ROMCcd+JhS5IkbReR8+imyaw+9qC9NRIwxwkcYM479ICFOeXIA3LvI5tmjJxHNm7NogVjecnRS4cwHTAXCRxgJPzk9x2TFUsXZ+2GjXl449Zs3bY9j2+ZzN0PbczWbdvzv//A8X7gH7CDrwbASNhvYjw//z89Lzfd83C+eusDWf/Y5iyaP5Y3nHpEXnrM0hy4eP6wRwTmEIEDjIwF4/Ny2jFLc9oxnooCds1TVABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHeqtTbsGZ6zqlqf5DvP4C7LkjwwS+PMJfvCfu4L+5jYz97Yz77sC/s5l/bx2Nba8qdbqYvAeaaqak1rbfVg0UVlAAAGlklEQVSw55ht+8J+7gv7mNjP3tjPvuwL+zmK++gpKgCgOwIHAOjOvho4Fw17gL1kX9jPfWEfE/vZG/vZl31hP0duH/fJ1+AAAH3bV8/gAAAdEzgAQHe6DpyqelNV3VRV26tq9bTlP1xVV1fVDYM/Xz3ttsur6paqum7wcehwpt99O9vPwW3vr6rbBvt05rTlPzJYdltVnbf3p35uquovpx2jO6rqusHylVW1cdptfzTsWZ+LqvrNqrp72v786LTbZjy2o6iqfq+qvlFV11fV56rqoMHy3o7nSP+725mqOrqq/qGqbh58LXrPYPlOP39H1eDrzQ2D/VkzWHZwVX2pqm4d/Ll02HM+F1V10rRjdl1VPVJVvzRyx7O11u1HkhcmOSnJ5UlWT1t+WpIjB5dflOTuabc9ad1R+NjFfp6c5F+STCQ5Lsm3kowNPr6V5PgkCwbrnDzs/XgO+/+fk/z64PLKJDcOe6Y9uG+/meRXZlg+47Ed9rzPYT9fl2R8cPl3k/xub8ezt39337NvRyR56eDy/km+OfgcnfHzd5Q/ktyRZNn3LPtgkvMGl8974vO3h4/B5+29SY4dtePZ9Rmc1trNrbVbZlh+bWvtnsHVm5IsrKqJvTvdnrOz/UxydpK/aK1tbq3dnuS2JKcPPm5rrX27tbYlyV8M1h05VVVJfiLJp4Y9y162s2M7klprf99amxxcvSLJimHOM0u6+Xf3vVpr61pr1wwuP5rk5iRHDXeqversJJ8YXP5Ekh8b4ix72muSfKu19kx+W8Cc0HXg7Kb/Jcm1rbXN05b9t8Hpt18bfAMdVUcluWva9bWDZTtbPopeleS+1tqt05YdV1XXVtVXqupVwxpsD/rFwVM3H5926runY/i93pbk76Zd7+V49nzMdqiqlZk6S37lYNFMn7+jrCX5+8HLG84dLDustbYumYq9JHP+pQ3PwJvz5P9AjszxHPnAqaovV9WNM3w87f+MquqUTJ0O/7lpi3+qtXZqpr5xvirJT8/O5M/Ms9zPmeKs7WL5nLKb+/yWPPkf37okx7TWTkvyy0n+vKoO2JtzP1NPs59/mOR5SVZlat/+8xN3m2FTc+4YTrc7x7Oqzk8ymeTiwaKRO567MHLH7JmqqiVJ/jrJL7XWHsnOP39H2Stbay9N8vok76yqHxz2QLOlqhYkOSvJXw0WjdTxHB/2AM9Va+21z+Z+VbUiyeeS/Exr7VvTtnf34M9Hq+rPM3Va+c/2xKzPxbPcz7VJjp52fUWSJ56a29nyOePp9rmqxpP8z0n+3bT7bE6yeXD56qr6VpLnJ1kzi6M+J7t7bKvqo0kuHVzd1bGdk3bjeJ6T5I1JXtMGT/6P4vHchZE7Zs9EVc3PVNxc3Fr7bJK01u6bdvv0z9+R9cTLG1pr91fV5zL1PeK+qjqitbauqo5Icv9Qh9xzXp/kmieO46gdz5E/g/NsDN6h8bdJ3t9a+8dpy8eratng8vxMfbG9cThT7hGfT/LmqpqoquOSnJjkqiT/nOTEqjpuUOhvHqw7al6b5ButtbVPLKiq5VU1Nrh8fKb2+dtDmu85G3yxfMKP598+H3d2bEdSVf1IkvclOau19vi05T0dz17+3T3F4Kn8P0lyc2vtv0xbvrPP35FUVftV1f5PXM7Ui+NvzNRxPGew2jlJLhnOhHvck86Qj9rxHPkzOLtSVT+e5PeTLE/yt1V1XWvtzCS/mOSEJL9WVb82WP11Sb6b5IuDuBlL8uUkH937kz8zO9vP1tpNVfXpJF/P1Gn/d7bWtg3u84tJvpip/fx4a+2mIY3/XHzvc8NJ8oNJfruqJpNsS/LzrbV/3euT7TkfrKpVmXoq444Mnk7d1bEdUX+QqXeEfWnwsrcrWms/n46OZ2ttspN/dzN5Zaaezr+hBj+yIckHkrxlps/fEXZYks8NPkfHk/x5a+0LVfXPST5dVW9PcmeSNw1xxj2iqhYn+eE8+ZjN+PVorvKrGgCA7uyTT1EBAH0TOABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDjISqWllV36iqjw1+h9XFVfXaqvrHqrq1qkb2t6kDe57AAUbJCUn+a5IXJ3lBkn+f5AeS/EqmfnIuQBKBA4yW21trN7TWtie5Kcllg1/MeUOSlUOdDJhTBA4wSjZPu7x92vXt6fx36wHPjMABALojcACA7vht4gBAd5zBAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDv/P+dlKcIa9+JfAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 576x576 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lsts = subarray.select_subarray(\"LSTs\", df.loc[g.groups[tel_string]]['tel_id'])\n",
     "lsts.info()\n",

--- a/docs/examples/InstrumentDescription.ipynb
+++ b/docs/examples/InstrumentDescription.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,9 +43,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : MonteCarloArray\n",
+      "Num Tels : 98\n",
+      "Footprint: 4.92 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "      LST_LST_LSTCam    4    1 ..   4\n",
+      "    MST_MST_FlashCam   25    5 ..  29\n",
+      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
+     ]
+    }
+   ],
    "source": [
     "subarray = event.inst.subarray\n",
     "\n",
@@ -54,9 +70,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<i>Table length=98</i>\n",
+       "<table id=\"table48074305264\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>tel_id</th><th>pos_x</th><th>pos_y</th><th>pos_z</th><th>name</th><th>type</th><th>num_mirrors</th><th>camera_type</th><th>tel_description</th></tr></thead>\n",
+       "<thead><tr><th></th><th>m</th><th>m</th><th>m</th><th></th><th></th><th></th><th></th><th></th></tr></thead>\n",
+       "<thead><tr><th>int16</th><th>float64</th><th>float64</th><th>float64</th><th>str5</th><th>str3</th><th>int64</th><th>str8</th><th>str18</th></tr></thead>\n",
+       "<tr><td>1</td><td>-20.0</td><td>65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>2</td><td>-20.0</td><td>-65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>3</td><td>80.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>4</td><td>-120.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>5</td><td>0.0</td><td>0.0</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>6</td><td>0.0</td><td>151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>7</td><td>0.0</td><td>-151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>8</td><td>146.65599060058594</td><td>75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>9</td><td>146.65599060058594</td><td>-75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>89</td><td>956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>90</td><td>956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>91</td><td>-239.19699096679688</td><td>1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>92</td><td>-239.19699096679688</td><td>-1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>93</td><td>-956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>94</td><td>-956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>95</td><td>1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>96</td><td>1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>97</td><td>-1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>98</td><td>-1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=98>\n",
+       "tel_id        pos_x        ... camera_type  tel_description  \n",
+       "                m          ...                               \n",
+       "int16        float64       ...     str8          str18       \n",
+       "------ ------------------- ... ----------- ------------------\n",
+       "     1               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     2               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     3                80.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     4              -120.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     5                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
+       "     6                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
+       "     7                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
+       "     8  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
+       "     9  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
+       "   ...                 ... ...         ...                ...\n",
+       "    89   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    90   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    91 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    92 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    93  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    94  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    95  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    96  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    97 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    98 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.to_table()"
    ]
@@ -70,9 +149,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<i>Table length=3</i>\n",
+       "<table id=\"table48080417512\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>description</th><th>name</th><th>type</th><th>mirror_area</th><th>num_mirrors</th><th>num_mirror_tiles</th><th>equivalent_focal_length</th></tr></thead>\n",
+       "<thead><tr><th></th><th></th><th></th><th>m2</th><th></th><th></th><th>m</th></tr></thead>\n",
+       "<thead><tr><th>str18</th><th>str5</th><th>str3</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th></tr></thead>\n",
+       "<tr><td>LST_LST_LSTCam</td><td>LST</td><td>LST</td><td>386.7332458496094</td><td>1</td><td>198</td><td>28.0</td></tr>\n",
+       "<tr><td>MST_MST_FlashCam</td><td>MST</td><td>MST</td><td>103.83055877685547</td><td>1</td><td>84</td><td>16.0</td></tr>\n",
+       "<tr><td>SST_ASTRI_ASTRICam</td><td>ASTRI</td><td>SST</td><td>14.562566757202148</td><td>2</td><td>2</td><td>2.1500000953674316</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=3>\n",
+       "   description      name type ... num_mirror_tiles equivalent_focal_length\n",
+       "                              ...                             m           \n",
+       "      str18         str5 str3 ...      int64               float64        \n",
+       "------------------ ----- ---- ... ---------------- -----------------------\n",
+       "    LST_LST_LSTCam   LST  LST ...              198                    28.0\n",
+       "  MST_MST_FlashCam   MST  MST ...               84                    16.0\n",
+       "SST_ASTRI_ASTRICam ASTRI  SST ...                2      2.1500000953674316"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.to_table(kind='optics')"
    ]
@@ -86,9 +194,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : SCTels\n",
+      "Num Tels : 69\n",
+      "Footprint: 4.92 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
+     ]
+    }
+   ],
    "source": [
     "tab = subarray.to_table()\n",
     "sc_tels = tab[tab['num_mirrors'] == 2]['tel_id']  # select tel_id of entries where the mirror type is SC\n",
@@ -105,9 +227,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : SCTels\n",
+      "Num Tels : 29\n",
+      "Footprint: 1.06 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "      LST_LST_LSTCam    4    1 ..   4\n",
+      "    MST_MST_FlashCam   25    5 ..  29\n"
+     ]
+    }
+   ],
    "source": [
     "gtab = tab.group_by('num_mirrors')\n",
     "sc = gtab.groups[0]\n",
@@ -124,9 +261,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel = subarray.tel[5]\n",
     "tel"
@@ -134,54 +282,142 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$103.83056 \\; \\mathrm{m^{2}}$"
+      ],
+      "text/plain": [
+       "<Quantity 103.83055878 m2>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.optics.mirror_area"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "84"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.optics.num_mirror_tiles"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$16 \\; \\mathrm{m}$"
+      ],
+      "text/plain": [
+       "<Quantity 16. m>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.optics.equivalent_focal_length"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.camera"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[-0.028867999,~-0.072168998,~0.057735,~\\dots,~-0.54848301,~-0.50518101,~-0.54848301] \\; \\mathrm{m}$"
+      ],
+      "text/plain": [
+       "<Quantity [-0.028868  , -0.072169  ,  0.057735  , ..., -0.54848301,\n",
+       "           -0.50518101, -0.54848301] m>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.camera.pix_x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb32234f60>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsnXeYVdW5/z/r9N7P9N47M8PA0HvvXXoXERETTYwmGrFEY6JGjTFG0343vd7E1JvE1JubYjSKFUE6DAwM03vZvz9OYe+zN0KMCpj9fR54OOdz9tn7nBn2u961vut9hSRJ6NKlS5cuXRcjw6W+AF26dOnSdeVIDxq6dOnSpeuipQcNXbp06dJ10dKDhi5dunTpumjpQUOXLl26dF209KChS5cuXbouWnrQ0KVLJiFEjhBCEkKY/s33OSSEmPZOXZcuXZeL9KCh6z9W0Rt7txCiI/YHSHuPzu0RQjwshDgSPff+6OPQe3F+XbrervSgoes/XfMlSXLF/gAn3u0TCiEswDNAOTAL8ABjgCZg5Lt9fl26/h3pQUOXrreQEGKTEOI1IUS7EOKAEOIaGQsJIX4qhGgRQpwVQvxJCCH/P1UthNgjhGgVQnxHCGGLPr8eyAIWS5L0qiRJQ5IkNUqSdLckST+PvvctQog3o+d9VQixWHbejUKIPwshPhM99wEhxJjo80eFEI1CiA3vxfej6z9PetDQpeut1QjMI5INbAI+I4SojbKbgGNAGEgGPgrI6/KsIJJJ5AJVwMbo89OAX0qS1PEW530TGA94gTuBrwshUmW8HtgDBIFvAt8GRgAFwFrgMSGE61//uLp0vbX0oKHrP10/io7WW4QQP0qEkiT9TJKkN6WI/gD8isjNHKAfSAWyJUnqlyTpT5KymNujkiSdkCTpLPAToDr6fBBoeKuLkiTpe9FjhyRJ+g6wD+XU1UFJkr4iSdIg8B0gE7hLkqReSZJ+BfQRCSC6dL2j0oOGrv90LZIkyRf9sygRCiFmCyH+Gp1+agHmALHF6k8D+4FfRaeIbkk4/KTs311AbOTfRCTYnFdCiPVCiBdiAQ2okJ0X4JTs390AkiQlPqdnGrrecelBQ5eu80gIYQV+ADwAJEuS5AN+DggASZLaJUm6SZKkPGA+cKMQYupFvPVvgJlCCOd5zpsNPAXsBILR874cO68uXZdSetDQpev8sgBW4DQwIISYDcyIQSHEPCFEgRBCAG3AYPTPhfQ14CjwAyFEiRDCIIQICiE+KoSYAziJrI2cjp5nE5FMQ5euSy49aOjSdR5JktQO7AK+CzQDq4GnZS8pJJI1dAB/AR6XJOn3F/G+vUQWw18Hfk0k4PydyPTT3yRJehV4MPqep4BK4M/vyIfSpevflNCbMOnSpUuXrouVnmno0qVLl66Llh40dOnSpUvXRUsPGrp06dKl66KlBw1dunTp0nXR+rfKP1+OCoVCUk5OzqW+DF26dOm6ovTcc8+dkSQpfKHXve+CRk5ODv/4xz8u9WXo0qVL1xUlIcThi3mdPj2lS5cuXbouWnrQ0KVLly5dFy09aOjSpUuXrouWHjR06dKlS9dFSw8aunTp0qXroqUHDV26dOnSddHSg4YuXbp06bpo6UFDly5dunRdtPSgoeuy1pnjTTxy7ZP89afPafKmhmYeve6L/PlHf9fkzada+OzOL/KnH/xVk7ecbuVzu77M77+j3a6iramdxz/wFX77zT9p8vbmDp648av8+r/+gFabgY6WTp788H/xy6/8TpN3tnXx1Ee+zs+f+g1DQ0Mq3tXezZc++k1+8sSvNHl3Zw9fvf3b/OixXzA4qO7/1NPVy/+74zv88JGfMTig5r3dvXz97u/z/Yd+wkD/gIr39fTxzXt/yHc+9WP6+/rVvLefb9//I75133/T16vmut5/et/106irq5P0HeHvD/3yK7/jc7u+RE9nLwAjZlVz148/gskcKWTwm6//kUd3PEV3Rw8AtdMqufvpW7DYLAD87tt/5uFrvkBXezcA1ZPLuevpW7A7bQD86Qd/5cGtn6eztQuAyvGl3PPTW3G47QD834+f5YHNn6O9uROA8rHF3POTW3H5Il1a//az5/jUxs/R1tQOQEl9IZ/46a14gm4Anv2fF7h/3aO0nonworp87vnprfiTvAD887cvce/qR2hpbAWgoCaXe356K8FUPwB7/vgqn1j5Gc6ebAEgb1g2dz99C0mZkVbhr/zfXu5e8SBNJ5oByKnI5O6nbyElJwmA1/++j7uWPcjpY00AZJWmc/fTt5CWnwLAvucPcOfSBzh1+DQAmcVp3Pmjm8ksTgfgzRcPsXvJpzl5sBGAtIIU7vrRzWSXZQJw6JWj3LHofk68GWlNnpqXzO4ffpi8qux/+Wet69JLCPGcJEl1F3rd+66MiK4rX//41YuU1hfw/G9ejAcMgGd/+QJ9Pf28+PtXKB5RwPPP7IkHDIDnf/MS3R09vPy/r1NQm8sLv30pHjAAXvjdK3S2dvH63/aRV5XNC797OR4wAF7602u0NbWz77kDZJVlsOcPr8QDBsArf95LS2MrB/YcJqMoNf76mF7/2z6aGpo58toxUvKSeeXPr8cDBsAb/3iTM8eaOLH/JElZIV79vzfiAQNg/z8PcurwaRqPnCGY6uP1v+2LBwyAAy8e5uTBRppPtuANe9j77P54wAA49PJRTuw/SVtTOy6fk33PHYgHDIAjrx3n6N4TdLV3Y3Pa4ueL6ejeExx57Tj9vQOYLCYO7DkcDxgAJ/af5NDLR5EkEAIOvXwkHjAAGg6c4sCew3rQeJ9LDxq6Lhsd2HOYz93wZfb84VV8SV6Ss0Oq19w+/5Ps+eOreENuUqMjZrnuXvEQL/7+FdwBF5nFaSp+/7rP8sLvXsblc5JdnqHiD279PC/89mUcHjv5w9Q3v0ev+yL/fOYlHG47BbW5Kv7EjV/l+d+8hN1lo6guX8W/eOs3eP7Xe7A5rJTUF6r4f+3+Ds/9ag9Wu4XyMcUq/s17f8jzv96D2WqiYlypin/vgad57td7MFlMVE1Q8/9+9Of88zd7MJqMVE0qV/GfPvErnn/mJQwGwbDJ6rbkv/zyb3n+mZcQQlAzRW9b/p+oSzo9JYT4MjAPaJQkSfUbKIQQwCPAHKAL2ChJ0vNv9Z769NSVq3tWPsQfvvsXxXPekJvWM+0IIUjJDdNwoFHJwx5aT7cBkemRhgOnFNyX5I2P5tPykxUjYwB/spfmU+fngVQfZxsio/20ghRO7D+p4KE0P2eio31Nnh7gzPGz5+cZQc5Es4H0whSO71PypMwgjUebznt8UlaIxiNnzsuTs0OcOvwWPCfMqUOnz/v5U3KT4tmG1vebmpcU/5kUDs/jo9+4gYwidbDWdfnrYqenLvVC+FeBWW/BZwOF0T/bgM+/B9ek6zLSoutnY7GZqZ5STp7GyH/R9bOx2i1UTSijUGPkv3DnLKwOKxVjSygeUaDiC66bhc0ZGfWXjVaP7BdcOzOSNYzIp3JciYrP3T4Dh8dOQU0u1Roj97nXTMfpdZBblc3waVUqPufqqZGspyyDupnVKj5ry9RI1lSSzqh5w9V88xQ8ITfpBSmMXqD+/z594yR8SV5S85IZt6RezddPxJ/iIzk7zPhlo1R8yprxBNP8hDODTFo5VsUnrxxLKCNAKD3AlntX6wHjP0CXfCFcCJED/PQ8mcYXgN9LkvSt6OO9wCRJkhrO9356pnHl6qmbv8Z3H3g6/tjmsNLTdW5Nw2gyKhxAVoeF3q6++GOD0cDQ4DmHkdVuobf77XOL3UKfnBsEQ0Pn/r9YbGb6es45hoRBIMm42Wam/6241Uy/zHEUSawlYv8lzVYT/b0yR5MAAXFuspgY6Evg4tw5zBYT/X1KR5T8MxrNRgb7B8/PE77vyHMGBgeGVP+OafcPP8zYRSPRdeXpSsk0LqR04Kjs8bHoc7reh7r6U+v4wBPbcPocjF00kpFzaxV8cGCQnZ/dgsvvpH5urermNDQ4xM7HIrxuZjXjl4/S5O6Ai9ppVUxePU7Fr39sC56gm+pJ5czYMFHJhyR2PrYZb9hD5fhSZm+ZquDSkMTOx7bgS/JQNrqIedunq/lnN+NP9lIysoBF1yuTbEmS2PHIZgKpfgqH57HsxvnKL0iCaz+ziVB6gPzqHK66eaGKb39wA+HMILmVWaz66GKN73gtydlhssoyWPfxZSq+9f41pOQmkVmSxoa7rlLxTfesIq0ghbSCFDbds0rF25ra+ert3+ZLt36D7o5uFdd15etyzzR+BtwnSdL/Rh8/A9wsSdJzCa/bRmT6iqysrOGHD19ULxFdl5l+9NgvePJD/xUfHcvXK2KSj859SR5aGhP5udG5L+yhJeF4eXagdbzVZqG3p++855dnP1rvL+dax9tdtrjjS4s73Da62qM85KH1TAL32Olq645yt8KdBeD02OmMck/QrXB3ATh9Djpbus7LXT4nHS0Rx5g74KL9bIeCu/3OuKNM/u84lx0TSPVz148/QrGGIUDX5af3S6ZxDMiUPc4ATiS+SJKkJyVJqpMkqS4cvmC3Ql2XkYaGhvjj9/9C65k2Xv7f1xTTKa2n25i+fiJCQGZJGjVTKxXTOS2NbczYMBFhEKQXpjJ8RpViOqfldBszNkxCGARp+cmMnF2jmE5qaWxjxsZJGIwGknPC1M+rjQeM2PlnRnlSVojRC+oU02Utp9uYtWkyRpORUEaQsYtHKnjr6TZmbpqM0WwkkOpj/NJRCotwa/R4k8WEP9nLxBWj4wEDoPVMG7M2TcFsMeENe5i0cmw8YER4OzM3TsZiM+MJupm8alw8YEBk1D9z4yQsdgtuv5Opa8bHA0aMz9gwCZvTitPnYNq6CfGAAdB+tiPOHW4b09dNVASJ9uZOpq+biMNtw+6yMWPDJEWQOdvQzOFX5BMFut4Putwtt08DO4UQ3wbqgda3Ws/QdWXp1b++wWM7v8i+5w/i8jk1LbaHXonsC2g60YzVYdXmQxJnG5pxeuwqfvjVYxF+sgV3wKXJhwaHaDnVSmt0051cR14/ztDgEK2n2xR7KuLHv36cwYFBWk+30nyqRcWP7T3BYP8gbU0dnG1oVvGjb5xgoG+AtqZ2xZ6L+PH7TtDfN0BHc2fchSXX8Tcb6OvpZ6B/kDPHm1T8xIFT9HX3MdA3QOPRMyrecPAUPZ29CAGNh9X85MFGerv6EALFno44P9xId0dv/LW63v+61JbbbwGTgBBwCrgDMANIkvRE1HL7GBGHVRewSZKkt1zl1hfCrxzdtfwB/vSDvymei1lUjSYjqblJHNunHCOEMgKcOXYWg9FAWkEKx/YqE8+YRdUQzT6OJvKoRdVgEGQUpXHk9eMKHrOgCiHILEnjyGtKHrOgCiHIKk3n8KvHFFxuS80uy1Bxue01uzxTNRKX226zyzM4/Iry+IzCFI7tO//xmcVp8c+sdf4L8azS9PhnvhDPKsvgSCKXPVc5vpQPf+U6UvOS0XX564qYnpIkaZUkSamSJJklScqQJOlLkiQ9IUnSE1EuSZJ0nSRJ+ZIkVV4oYOi68jV17QRMZiNlo4tIL1Jv3pu2dgImi4mSkQVklqjtnVPWTMBsNVNYl09Oeaaarx6PxWYmvzqH3KosNV81DqvdQm5VFgU1agvvpKvGYnVYyS7PoHB4ngYfg81lI6s0nZKRaovvhGWjsbtsZBSlUjaqSMXHLx2Fw+MgLT+FSo3Ne+OWjsLlc5KSm8SwiWUqPmbRCNwBF0lZIWqmVqr5whF4gm7CGUFqp6stwPVzh+MNewim+Rk+c5iaz6nFn+wlkOKjfnaNio+YWU0g1Yc37GHxrjl6wHgf6pIvhL/T0jONK0dfue1bfPPeH8Yf2902umVz+gaDQVGkz+620y0rC5JoYZUvMl8UF0JRRFCLyy2wNpeNHhlPtMDanFZF2ZNEC6yKo7S4Wh1WeruU3Gg0MBjjCRZhUNpiNbnMVptoEQYwmY0MRHmiBRiUtl6VBRilrVjr+I996wNMukq9v0PX5acrItPQ9Z+tTfes4gNf2IbL72T80nrqZihHtkNDQ+x6fCvugIsxC0dQn2DBlYYkbvj81XiCLurnDmfs4pEqvuvzV+MJuqmbWc3EFaOVXIpwb9hN7bRKpiRYcCVJYtfjV+NL8lA9uZwZGyYpP4AE1z++FX+yN2LB3TpVzR/bSiDFR9mYYuZfO0P1Hex4ZBPBND8lIwtYsmuOil/7yCZCGYGIBfem+Wr+0AbCmaGIBfcjC1X8mgfWk5wdJrcyi9W3LVXxrfevJSU3ieyyDNbdobbgbrl3NWkFKWQWp7HxrpUqvuHOq8goTiO9MIVNn1DzWBXgR3c8pXKC6boypWcaui6Zvv3J/+Yrt30rvmHO5XfSIbdwJozUVRbPC3GUI3ktLt+gpjo/ypG4NjfFS4rL7apxLhupu3wOOmTuJVCO/uV2WE3udSgKLIIyu3B4HHS1JXDZBki5HTcmefbjcNsVBR4TeWImmPhcYqYWec9zFmKXz8ndT39Es2aWrksvPdPQdVlqoH+AX375t5w53sQbz72p2GHd0dzJ/GtnYDAaKKjJZfj0KsX0UntzJ/N3zMRgNJBXlc2IWdWa3GgykFOeyah5wxU7vNubO1lw3UyMZiOZJemMWThCsaO5o7mTBdfNwmQ2kl6Yyvgl9fGAEeMLd87CbDWRlp/MxOWjFT0oOlpi3ExyTphJK8cqdmx3tHSxcOcsLDYzSVkhpq4er5gu6oxyq8NCKD3A9PUTlby1iwXXzcTmsBJM9TNjwyTFdFRXWxcLdkTKnvhTfMzaPFmxY76zrZv510bKnnjDHmZvmaKYLutq72be9hk4vQ48QTdzrp6m4N3tPczdNh2X34nL72TutumKINLd0cOcqyNlT5xeB/O2z1BYiDtaOjn2hm5+vNJ1uVtudb2P9PwzL/HZ657i2BsN2JxWkrPVe2pe+N0rDA0OcfT14wz0qxdRX/ztyxG+97hmU6M9v3+FwYEhju1rwGBSj4le/P0rDPYP0vDmSSw2s4q/9MdXGegf5OTBU9hdNjX/w6v09w5w8tBpnF6Hir/8v6/T39tP45Ez8b4aibyvp5/TR89w9A3VliNe+b+99Hb10dd9liOvHVPx1/66j56uXnq6ejmswV//+366O3ro7ujh4EvqPRJ7n90f3evRzYGXjqj4G/94M57NvPnCIRXf/8+D8Wxr/wsHVfzNFw7F92rse+5NFdd15UvPNHS9Z3r6c7+IjzR7Ons5/OoxUvMiDYMsNjNZpRkcjVpge7v7OPTyUdIKIg4qs9VMdnlG3CLb3zvAwZeOkF6YCkSmkXIrsuIW0YG+AQ68eDheHt1oMpBbmRW3sA70D/LmC4fIKolUpTEYDeQNy+Zg9EY6ODDE/n8eJLssUj5dGAT5w3LiN9qhwSH2PS/jAvKrc+M3WmlIYt9zB8ipyIzzghoZlyI36NzKcw6uwtpc9j9/MM73PvumojdFYW0e+547EH+89+/7yR+Wc44Pz+ONf5y7Ue99dj/51Yk84XgVVx4vd5AVDs9j77P7FcfLy8MX1uay91n58W8qikiOmFWt6ejSdWVJDxq6Lqnq5w2P3rBzCGcG1HxObfyGn5SlzkxGzqnBaDaSU5FJSo6aj5hVjcliIqssg7R8deYyfOYwTBYTmSVppBekqvmMYZitZjKKUsks1uYWm5m0ghSyStVl0WqnVWG1W0jJS9a0ANdMrcTmsJKcE9ZsXjRscgV2l42krJDiBh9T1cQy7G47ofSApkW4cnwpTo+DQKqfIg2LcMW4Elw+J74kL8Uj1OU+yscU4w648IY8lGr0/yitL8ITdOMOuCjVqBJcPLIQb9iDy+dkwvIxJGWpN3DqurKkL4Tres/0tbu+x9fu/F58Wilx4TfRApu4cJxogVUtLCcsjKsWli/EUS6cay08yxfOtbh84VxeJ+ocP7dwrsXltlathWmL1Rzvxa21MC23wGotTMsX1rW4fGFdyyIsf+7t8Ju/upPp65WFIHVdHtIXwnVddlr38eXsenwrLr+TiSvGUD1JWaMyYoHdhjvgYtziempnVKn549vwBF2MXjCCkXOUFlwkuOHxiMV25Jxaxi4cqcm9ITd1M4cxQaN/xM7HtuANe6iZUqGy4ALs/OwW/MleqiaWMX2D+ua349FNBFJ8VIwtUVtwgR2PbCSQ6qdUowouwPaHNhJKD1A8Ip9Fu9StZq55cD3hzCCFtXks++A8Fd/2qXUkZ4fJG5bNisQquMCWT0aq2OZUZLLqVnUV3I2fWEVafgrZZRms0aiCu373CjKKUskoTmP97hUqvvb2ZWSVpJNekKJp0W1v7uDha77AfWsfUbSi1XXlSM80dL1n+urt3+Ybn/hB/HHiSDtxM96/zAXAuWxFzZWZitZIX55pqEb6CZlK4mZDUGYiWpmAgmuM9OWZimozIcrNelojebnFV4vLN+BpbSaUZyJamwXl3GKz0NeTwO1m+rr7Va+NSW4Btjms3Pnjj1Crr3NcFtIzDV2XhXq6evnhIz+j4cApDr2idOt0tXWz7Kb5GE0GyseWMDxhc19XWzfLPzQfk9lI6agiRs6pUR//oQWYzCaKR+QzesEIxfRWV1s3K25eiNlqpqAml3GLRyIfI3W1dbP8wwswW83kVWUzacUYhUW3q72bq25eiMVuIac8kykrxymCVnd7Nys+vBCr3UJmSRrT1k1QWHi723tYcfNCbE4r6YWpzNw4Wck7eljx4QXYXTbS8pOZvXWqwuLb09HDig8twOG2k5KTxNxt0xRNk3o6e1l203ycHjvhzBDzr52hsPj2dPay/Kb5uHxOQhkBFl43S7Fju7erl6UfnIc74CKQ6mPR9bMVN/ne7j6WfmAu3pAbX7KXxTfMVfC+nj4W75qDL8mLL+xhyQfmxgNGhPez6PrZ+FN8eIIult04X2EB7unq5WRC+1hdl7+Mu3fvvtTX8I7qySef3L1t27ZLfRm6gP97+lk+Nude/vC9v/DTL/ya/r5+VX+GM8fP0tHcScupFkCirUnJm4430362I8qhLaF/xNmGZtqa2qN9MSRVf4mzDc20nmmP971I7F/RcqqV1tNttJ5uQ5JQ9cdoaWyLvOZMG5IkqfpvtJxpo/lUK+1NHUhDkqoSbuuZds42tNB+tiNSTTeBt53toOlEM+3NnQwNDMX7lcfU3twR+Y5aOhnsH1TxztYuTh87S1dbFwN9A2re1sXpo010tXXT39uv4t0d3TQePkN3Rw+9PX20JPCezl5OHjpNT2cvvV29quvv7erl5MHGiA24U4N399Fw4BS93X10tXervr/R8+s0a3jpeu915513NuzevfvJC71OzzR0vWv6xZeeic9b9/f2c3zfybhF1e62kVuZReORSDnu/r4Bju1tILciYkG1Oa3kDcuOl+Me6B/k6Osn4g4jq8NCfnVOvBz34MAgR147HregWu0WCmtzaTgQ4UODQxx+9Rj5UYeR2WqiaHgeJ96MVIwdGpI49MpRCmojNzCTJZK9HI9W2ZUkOPTy0bgDyWQ2UjKygONvxLjEwZeOUBRtOGQ0GSipL1RU4T340pF4n3KD0UDpqMK4xRjgwJ7DlNRHuDAIykYXKarsHthzmNJRhTJerKhCe2DPYUpHR4ogChFxPsmr5B7Yc5iyMeccTuVjijn08rm9HAf3HFHyscVxC3Ls+svHvjUvG1McnQaE8jFFCn7o5aOUjSmK8/FL61XZo67LX3rQ0PWeqnRUIUII0vJT8ATV/S2KRxYgDILUvGS8Yc95eUpOEr5kdf+LohH5GIwGwlkh/Mk+9fHD86JNlcIEUv3q4+vyMJqMhDOCBNPUFuCC2jyMZiPBtAChdDUvrM3FZDERSPWTlBlU8fzqHMxWM4EUH8nZSSqeV5WDxWbGn+wjJUfNcyuzsdot+MIeUvM1eHkmVocVT9CtaTHOLsvA7rLhDrjie1zkyipNx+624/I7ydDgmcXpODx2nF5HfA+Mghel4fTasbvtZJVkqHhGYRouvwOb00bF2FJ8Gj1MdF3e0hfCdb1r+vYn/5uv3P7t+DqBJ+hSTj+JaCXbOFe3H5UvHF+Qh9yq6Sv5wrAWl1tctd5fbnHV5LLFXk0uWxjWap8qbw+ryWWL2VpcvpiuVRtLvhivxeVmAK3aWHKuZVGW2461LMjyY7SMBzc+tV3Va13XpZG+EK7rkmvlLYu59jMbcfkcTLxqDOVjSpQvkOC6RzfFq9wOm6TuD3HdI5tx+Z2MWTBCs//DdY9uxh1wUT+3lhGz1FMdOx7eiCfoom7GMMYsUP9/2P7QJjwhN7VTKxm3tF7Fr/nMBrxhD8MmlTNp5Rg1f3ADviQvFeNKmLp2vJo/sAF/io+y0cXM3DRZxbd+ai2BVD8lIwqYu01twd1y3xpC6ZEqt/N3zFTxTZ9YSTgzSF51tmaV3I13rSQpO0RuZRbLblRXyV13x3JScpPIKstguYZFd+3ty+JVblfdorborrp1CRlFqaQXprBGo4ruVR9eSFZpOql5yay/Y7mKt51t55PrHuW2+fdxTKOsiq7LT3qmoetd0+c/+FV++MjP4o8TLaDyLEGLy+2v7wo3CEXBRPmoH9QWX7ldFNSbERMtqokWX6vdTK/MXZTYj0NlUU2w+Mo37ml9Rq1+F/J+HJpc9jMwW0yKHu2gtADLszYtLu/tEeeyY+R24Zjk12QyG9n9ww9TP3c4ut576ZmGrkuijpZOvn739zn86lFOHDipYD2dvay9fRkmi4nhM6qonValyc1WM9VTKlSLpD2dvaz7+HIsNjOVE0oZnZA59HT2svbjy7HYLZSPLWZcQn+Nns5e1t2xHKvDQkl9IRNXKDOHnq4ItzmtFNXlMXW1MnPo7epj3R3Lsbts5NfkMCNhc19vdx/r7liGw20ntzKLWVumKCy+vd39rLtjOU6vg+yyDOZtm6HgfT39rP34Mlw+J5nFaSzcMUsRtPp7+ll7+zLcARdpBSks3jVHERT7ewdYc9tSPCE3KblJLP3gvHjAiPFVH12CL+whOTvM8g/NVwTt/r4BVt66GF+yl3BmkKtuXqiwAA/0DXDVRxYRTPMTTPOz8pZFCj44MMh6lW4KAAAgAElEQVSKmxcSyggQSPGx6tbFiiAz2D/I8pvmk5QVwpfkZfXHliiC2ED/II1H9Q1/l7v0TEPXO6bffut/efyGL9N6pj2ymJwZ4OTB04rXeMMeWk+3YTAaSM4Oxd1NMfmSPLQ0tmEwCJJzk2h4U+nj96f4aD7ZgsEgSMlLjvfbjimY6qepoTmy2F6QHO+3HVOsB3mEp8TdUYkcIKMoVVXKO5wZ5HT0xqbFYz3IATKK01Q9zJOzw3FHmLxfd0wpOWFOHjo/l/cg1+T5yfHvTIvLe5RrXf+FeHphavw7k/87Jvkx8n7n8eOLUuOOM/m5Ytr1+NXM365uVqXr3Zeeaeh6z/XMN/4Y3ycxODDIqUNn4kXwvCE3+cNy4vskhgaHaDjQGLeYugMuCmtz4z7+oSGJhjdPxS2mLp+Dorp8mk+2xPmJ/Scpi1pMnV4HJSMLaGpoBiIW2OP7TsYtona3jdJRRfGAEOENVIyLcpeNsjHnOMCxNxqonBBpGGR1WCgfWxIPGDFeFeN2C5XjS+MBA+DY3hMMm1QOEM+OYgED4KiMm60mhk0qjweMGK+eEuEms5Fhk8rjASORG00GqqdUKILs0b0nqJkaKdViMEa4/CZ97I0GqmW8RoPXTKlEGESET61UBInj+xqonlKBMAiEQVAztUIRZI7vO0n1lAoMRkOUV8YDBsCJ/SepnlyB0WRECMH09RNV2aGuy0960ND1rkmSpHjPDG/Yi81lVb0mZiv1hjzYNPpXJOckIQR4Qh7s7vNzd8CFw21X8+wwwiDwBNw4NI5Pyopwl9+J06Puj5GUGcJgELh8Tlwa/TNCmSEMRgNOrwOnT4OnBzCaDDg8Djx+dX+NUHoAo9mIw23HHVBbkIOpAUwWE3a3HU9IfXwwNYDZYsLusmv27/Cn+DFbzdhdNnwaFuZAsg+L3YLNYcUbVttf/cleLFZzxAasYY/1J3mx2ixYbRb8SWqLsy/sxWq3YLaY8KeouTfsweqI8NTcZBwe9c9Q1+UlfXpK1zumH3zmp3zp1m/EF1N9yV7VDmN57SN/sle1Q1m+MKrF5YvFsakqueSL0VpcvtityWWL5VpcbnHV5LJ6VFpcbjv1J/toPqXkctuq1ueXt5TV4vKWtrGpPgWX2Xa1uNw2HJtKVHCZbdkb8qj6fsuf07I4+8Ke+K57LYvyDZ/fxrxr1C4yXe++9OkpXe+5ln5wHpvuXYXDbWfiijGKBjwxXX3/GhweO+OXjopPPSn4J9fi8NgZvaCOivElGsevxel1UD+3lmGTy1V8831rcPkc1M0YRp2GRXfLJ9fg8jupmVpJvcZu5C33rcYdcFE1sUzTorv53lV4gm4qxpUwQcOiu+melXjDHkpHFTFphdqiu/GulfiSPBSPKGDqWnUV3Q13rsCf4qOgNpcZGhbddXcsI5jmJ29YNnM0quiuuW0ZoYwAORVZzNNYG1h162KSskJklaaz8Dp1Fd0VNy8kOSdMRlEqS25QW3iX3zSf1Lxk0gpSWHaT2sK7+IY5pBemkpKbxIoPqy28C66fRWZJGknZIVbeoubNja3csfhT3Djx4+x7/oCK67r00jMNXe+YPrPtCX7+xWfijxMtqnJ7JqgtqomWTovdQp+MJ1o2Ey2qF+QJllA1V1qA5VkRqC28iRbWC/FEC2/i51XxhO8rVn4j9n9Wm5+z+GpZXOXn0LLIym3IiZ8nwg0MDQ2dl8u/Q2EQIEkKh1gil3/exGs2GAS3fedGxi9Vl7DX9c5LzzR0vSc6e7KZp27+Gm889yZnTpxVsL7ufjbevRKLzcLo+XXUJFhse7v72HTPKqx2CyPn1DBi5rCE4/vYfO8arA4rw2cMY/R85e9zX08/m+9dhc1ppWZKBeMTFlEjfDU2l42qiWVMumqMim+5bw12t53ysSVMSbDY9vf2s+W+1Tg8dkpHFTJj46QEPsCW+1bj9Dooqstj9pYpKr75vtW4/E4KanKYf61y5D/QN8DmT6zCHXCRW5nF4utnK3n/IJs/sQpvyE12WQZLb5yn2Bcy0D/IxnsimUtmcRrLPzRfcYMe7B9k490r8Sf7SC9MYeUtixQ36cGBQTbsXkEwzU9qXhKrP7ZEsW9laHCI9XcsJ5wRJDk7zLrbl8UDRoyv/fgykrJChDODrNu9XBF0pSGJ1R9dSkpOEsH0AOvvukrFV966mLT8ZPwpPjbevVIR5IaGJM4mTO/puvTSMw1db1s//+IzfOGm/0dXezdCCELpAVVjndgcvhCCUEZA4T4C5Ry+3K4ak3wOPik7ROPhBO530d4c4XI7a0zyefPknDCnDiVYgEPuuONLi8vn/VNyk+IFEs9xb7yya0pOEicPKbl8XUPr+GCqj6aGt+BpfppONF8U17r+UEaQM9GfiRYPZwTjPzOt7y8pM0Tj0TNRHuJUwvcv/5lp/fzk7ym3K18s3/nZLZrTaLreeemZhq53XX/6wV/iTYokSaLpZDNVEyOlQGLd5WKLvpIkcfpoU3wdItadTl6rqPHIGWqmRRryBFJ9lI4qVNRaajx8Jl5KxJfkoWxMUTxgAJw6fDrek8Mb9lAxrkSx0Hrq0GnqotmMJ+iiakKZopT6qUOnGTGrGojUaRo2qVyxUHzyYGN8w6HT46BmSoWiFPjJQ+e4w2OndlqVYiH85MFG6udGug3aXTaGTx8WDxhxHu1GaHNaqZtZHQ8IMT5qbi1CRKb2RsyuUfBTh05TP7cWYRBYbGZGzq6JB4wYHzU30pPdbDVRP6dWEeRPHY4cbzRF+dzaeMCI8DPUzx2O0WzEZDExam6tIkg0HjlD/ZxaTBYTRrORUfOGK4LQ6aNNjJxdg9lqwmgyaPIRs2uw2MwYjAbmXzuTySvHouvykh40dL1zkiLrBBCZrxdGoXqJ1WYBInPXBqP6189sjR5vNmlyS5Qbz8PNVlOEmwwYtXjs/Kbzn18IgdFkxGhSc5PZFOFmw/mPN0SON2gdbzFF9j2YDBjNRjW3Rj6XwWjQPr/VjDAaIseb1MebLWYMhujxGu9vtBgxRPddaJ7fYkIIA0IYMJlNGp/fgEEIBGC0qLnRbIxygUnr/GZj9P3Fed7fiDAYEAIs0eCi6/KSPj2l623rx5/7JU/d/LX4YrZ8qgQAEbW4Ri2swXQ/TcebFe8ht7jKd2PHJK/SKp9KiUluYdXi8ukvremPC3F5ZVgtLp8+0+Ly6TEtLp8e0+Ly6TGtzye33cqnorR5gDPHlN9vIMUXXzfQ+v5jO+xB4+eb8JwWl79nINXH2QblGoX8muTXElNsekqSpLgRQNe7I316Ste7rnnbp7Pqo0uwOiyMXzqKnPJMBRcI1ty2DKvDythFI+INkuRae/sybE4r9fOGxxsYybXmtggfMauGEg2L7prblmF32aidVknFOLVFd9XHlmB32xk2uTy++1qu1bctxeGxUzG+RFULCyJVXJ1eB2Vjihg5W23RXXnrYlx+J8UjC1QL9QBX3bwwstt9eB5jNXY7r7h5IZ6Qm7xh2UxYPlrFl920EF+Sh9zKLCavUlt0l944D3+Kl6zSdKatU1fZXXLDXAKpfjKK05i5YZKKL7x+NqH0AGkFycxKWMgHmL9jJuGsEKl5SZr7J+ZeM53knCSSs8MsuFZdhXfWlimk5icTzgiwcOdsFZ+xYTIZRakE0wOaFt+zDc18ZMZdXDv8Zl78wysqruu9l55p6Hrbum/tI/z2m/8bf5xokU20tCZaUFU8ocpqouU10aJ6QZ7wfokW1QvxxPdLtKgmvj7RspvIDSYDQzKeaImVV6TVOp/BKBgalGSPlZbXRAurFkc6Z9mV22c1j0+oAixE5K/Ya2ID/9gtRMU1LLeJ51Cf89w1JVqMAW752i6mrlEHR13/vvRMQ9e7ooYDp3j4mi+w54+vqnbzDvQNcPX9a7E5bUxYNoqqhJF9f+8A2x5Yj91lY+zikQxP2HzX3xflbhuj5g+nfq5yZD/QN8D2hzbgcNsZMauGMYtGqPmD6yOL0NOrVCP3gf5Btj+0AafXQfXkciavHqfJXT4nleNLmbFeWcV2cGCQax/agDvgomxMMbMTNtcNDgxxzYMb8ARdlIwsZG7CyHwoyr0hN4XD81h0nXLkPTg4xDUPrMeX5CW/OoelH5irPH5Q4upPryOQ4iOnIku1eU4akrj6/rUE0/xkl2Ww6tbFKr75vlWEMgJkFKex5rYlan7vapKyQqQVpLA2of+FJMHGO68iJSeJlNwkNtx1lSIgSBKs372CtPxkkrPDbPrEKhLHpGtvW0pGUSrhzCBbP7lWtU9j1a2LySpJJ5Qe4Or715A4qE38ndP13kvPNHRdtH748M/44q3fiI/uE+eghUFgtpji2YPWHLY8u9Di8jUOrTlyBddYI5GX+QimBWg6cf41Eq05fPkahyb3OemMlvHQ4vI1kGB6gCYVd9ERdXxpXZ+89IbW55d3P9Ti8tIfWlxuEQ6k+jnb8FZc/fORW4i1yqT4U7w0n4wcr1XmRH5O+bm0uFYZkx0Pb2KxRrMpXf++9ExD1zuuv/38OcV0UNvZDuqiFtX0olSKhucpppuaT7Yyan6koU5qfjKlowoV/GxDS7xUR0pumPKxxYomSU0nmuPZRFJ2iMoJpUp+vDm+ThDKCDBsUnk8YESOP8u4JZFSH8E0PzVTKuIBA+DM8bOMj5YC8Sd7GT69SmEBPnP8LBOWjkKISM2kupnD4gEjkXuCbkbOrlG0U206fpYJy0YjDAK330n93Np4wIhd34RloyMFD30ORs+vU9RqajrRzMTlozEaDTi9dsYsHKFol9t0opkJy0ZjNBmwu22MXTRScZNtOtHMhOWjMZlN2JxWxi2uV9ykzzY0M2HZKMxWEzaHlfFLE3kLE5aNwmIzY7VbmLBslCJINJ9sYfzSUVjsFiw2c5SfO775VCvjltRHChJaTUxcPloRpFoaWxm7uB6b04bJouatp9sYu2gkdpcNk9nIig8tUG2w1PXeS+1506XrIiVJEl3Rm2xvVy9Wu0XFYzfRvu4+Vdc3gPboTbi3u1/VVQ5QHC8PWDHFbuJ9Pf0X5H0aPNYTu6+3n96ePjVv7USSIlNnfT0a79/WFeX9ipIoCj4k0d8/qFjviamrvYuhwSEG+gbolXUNjB/f3s3QkER/36Ciq2BM3R3dDA1KDPQP0tPVo+bt3QwODiIGoKdTi/cw0D+INCQpAu659++hv28Ag0EoAq6cx36uWsf3dPYy0DfA0JAU39Oj5D0M9PUzODCozbt66e8bYHBgkLamds2fsa73Vvr0lK6L1i++9AxP3PT/6GrrxmA0EEzzKyyiBqMBh9tOR0snBoMglBFU7RB2+Rx0tHQhhCApK6TagRyzsAohSM4Oq3ZYe4NuWqPz2lo7pL1hN62nIzw1L0mjydO5KRF5Q6OY5FMq8oZGcS6bkknLT+ZEApdPCWlx+ZSW1vvLLahax8ttuVo8KStI45Gm835++Q5src8v3zWuxeXfudb3fyEuvyatHeryc2rtMI9NTw30D2ju89D19qVPT+l6xzV17QQW7pyN2Wpm9II60vKTVa9ZvGsOZpuZ+rnDyShOU/ElH5yHxWamblY12eUZKr70A3Ox2C3UTqskd1iW+v1vmIPVbqF6cgUFGlV0F++ai9VhpXJCGcUjClR80a7Z2JxWyscUxxs4ybXw+tnY3TZK6gupHFeqPv66WTjcdorq8jQtvAt2zMTpdZBfnaOqtQUwb/sMXD4nuZVZjJyltvDOu2Y67oCLrLIMRs1T98qes3Ua3pCbjOI0xiwcoeKztkzFl+QhrSBFs9DfjI2T8Cd7SclNYsJyNZ++fhLBVD/J2SEmrVRX6Z26Zjyh9AChjICmi2nKqnEkZYUIpvmZvm6iik9YPoaU3CQCKT5maFiAxy8dRWp+Mr4kr6qWF0R2nd8w7ja2VtzIX36iDw4vhfRMQ9dFa/fST/Pn//57/HGiZVa+SA1qy6rVYVVMwSRaThOr4l6QJ1atTbD8JlpcE6vqJlpSEz+Pmlvok01hJVpSVVVxEyytie+faDdNtAAnVq1VVc1N4OqqtygssFpVb+Wf8YI8wVIcee7cz+BCPPH7SLxmraq5ci4ijuHoXxHd+NR2Zm9Rl4jX9a/risg0hBCzhBB7hRD7hRC3aPCNQojTQogXon+2Xorr/E/WwZePcO+ah/n7L/4Zby4UkyTBtk+vw+GxM3nVONXmusH+QXY8vBGHx87EFaOpmVKu5o9uxul1MHbxSEYkjLwH+wfZ+dnNkUXiBXXxRfU4Hxhk56ObcfmcjJxdoxpZDw0MsfOzm3H7nQyfMYyJK5QW3KHBIa5/bAvugIvqyRVMXTdBxXc+tgVPyE3VxDJmbpqk5EMS1392C96wh/IxxczdNi2BD3Hdo5vxJXkpHVXI/ITNb9KQxI5HNuFP8VFUl8+SDyottpIkce1nNhJM9VNQk8uymxao+DUPbSCUHiCvKouVtyRYbCW45tPrCWcGyS7PZM1tS0nU1k+uITknTGZJOusTLLYAm+9dTWpeMulFqWy4e6WKb7z7KtILU0jNT2bTJ1ar+Prdy8ksTiMlN4mtn1qr4mtuW0p2WQZJWSG2fXqdiq+8dTG5lVmEM4Js/8xGRcAA4tUAdL13umSZhhDCCLwBTAeOAc8CqyRJelX2mo1AnSRJOy/2ffVM453TN+75Af9153fjo79EC2SkLpCIjyQTeaSGkyE+UtSyUMpH11qd5OTZihaXj961LJwX4vLsR5ufy260uDy70uJyC7AWl5dB0fp8Drc9vkCs9f3JLcJaXN7pT6uTntwirNVJT14mRW731eLyf8ckf095ReI4l12T/FpikncCdPocdLZ0Kfi1D21kScJ+Fl1vT1dCpjES2C9J0gFJkvqAbwPqVl66Lple+N1LiumCno4exi+LjObzq3MorM1XTA91NHfE58FzK7MoHV2kmC5pPd3G5NWRqqXZZRlUTihVTMe0NLYxZU1kw11mSRrDJpcrprdaGtuYunY8QkB6YQq106oU0z0tja1MXzcBISILrnUzhqn5+okIgyA5J8zIOTWK6bIYNxgMhDODjJpXq5gOa2lsZcaGiRiMBkLpAcYsHKGYjotxo8lAINXH2MUjFY6iCJ+E0WzEn+xl/NJRipFyS2MbMzdOwmQ24g17mLhitMJR1Hq6jRkbJmG2mPAEXUy6aozCIhzjFqsZt9/J5FXj4gEDoO1MO9PXT8Rqt+D0OZiyerziJt3W1M60dROxOqw4PHamrZ2gCAJtTR1MWzsBu8uG3W1T8fazHUxdMx67247NaWX6+omKINTe3MGU1eNxeh1Y7ZYIlwWxjuZOJq8ci8vvxGK3MGPDJEU72c6WLiZdNRZ30IXFZmb9HSuYe40yu9P17utSBo104Kjs8bHoc4laKoTYI4T4vhAiU4MjhNgmhPiHEOIfp0+f1nqJrndA0pDE0dePA5E9Ct2d6umqI69FeNOJZk0L5dHXTwBw9mSL4oYX07Eobz7ZqhpVAhzbewJJiuwBSBy1AhyN8pbT7efnQxKtp9tUo26A4/saGBoaoq2pg7Yz6uOP7zvJ0OAQ7Wc7VFkDwPH9pxgcGKKjuVOTn3jzJIP9g7Q3d6r6g0f4KQb6B+ls6VRtrANoOHiK/r4BOlu744UE5Tp5qJG+3n662ntUGwcBTh1upLe7j662bs4cb1LxxiOn6e3qpbu9m9NHz6j50TN0d/TQ09GjKJse0+ljTfR0dNPT2atyPgGcOdZEV3s3vd19KuccRH5vOlu76OvuUznnAJoaztLZ0kVfTz8HXz6synx0vfu6lNNTy4GZkiRtjT5eB4yUJOl62WuCQIckSb1CiO3ACkmS1JYKmfTpqXdOv/n6H3nixq/SeqYds9VMINWnsEgazUbcPictp9swmY2EM4I0yC2WAvxJEQuryWwknBU6r4XVaDKSnBPmxP6TCh6rsmowGkjNS+b4vgYFj1lUDQZBWkEKx95Q8phF1WAQpBemcnTvCQWP2TqFEGQUp8WDYkwxi6oQgsyStHhQjCklJ8zJ6HeSVZqu4nKLaVZZBkdePabgcttsdlkGhxN5QUr8O9Hi6YUpHN938rzvn1GUGv9ONHlxGsei30lWaQZHXlPyzOK0+Hem9fkyS9Lj35n83zFllaRzJMZl7xXnsnNmFKVx7I3z8/SiVI4n/Hy3P7iBxTfMob+3H6vdiq63rytheuoYIM8cMgDFb4wkSU2SJMXy/6cAtQdR17umsYtGMGX1eIwmA7XTKglnBBXcYDAwbV1kOmbYlAqScsIKLhCR6RiTkcqJZaTlqS26semY8nHFZBSmqvj0jZMwWUyUjS4iq1SdiE5fPwmz1URJfSE5FWqL7rS1E7HYzBTV5ZOnUWV32roJWO0WCmpyKKxRW3inrBmH1WEhtypLswrv5DUTsDmt5FRkUlKvtvBOXjkOu8tGVmk65WOKVXziVWNweOxkFKVSOV5t8Z24fAxOr4O0/GRNi++EpaNx+Z2k5CRRO7VSxccurscdcJGUFaJuxjAVH7NwBN6wh1BGgBGzq1V89II6fEkeAqm+eIMouUbNHU4gxYc/2cvoBer7zcg5NQTTA3jDHsYsUlf5rZtRRTgziCfoZtwSNa+dVklydhi336lpIT5x4CQ76j7CxqJd/Obrf1TVqtL1zutSZhomIgvhU4HjRBbCV0uS9IrsNamSJDVE/70Y+IgkSW/ZZV7PNN45fWzevfz95/+MP060lMoXcUFt+ZQv4oLaUimvAwVqC+sFuWyRGdQWVhVPqJr6r3MUFlab06baZS2/hkQLcuJ3kGhBBqVNONFiDEoLqyaX2WYTLb4Xw+XGg0SLr5qbVTu05c8lWq5VPOH3BZS26URL9cVwvT3s29dln2lIkjQA7AT+B3gN+K4kSa8IIe4SQsS8hbuEEK8IIV4EdgEbL83V/ufo1b/s5fYFn+QP3/uLquyF0WjgmgfW4/Q6mLZuIqX1yv4WkgQ7HtmE0+dg8qpxlI9XWnCHBofY9bmtuPxOJiwfTc3UCiUfktj1+NW4/E7GLR4Zb70q5zd8/mrcARej59cxaqHy91saktj1+avxBF2MmF3D+GjdqXPXJ3H941vxhNwRC+5VYzS5N+yhZkoF0xI2r0kSXP+5rfiSvFRNUFtwAa5/bCv+ZC/lY4uZc7V6kfa6RzbHW9ku2KG+uV338CaC6X6K6/I1XUHbH9pAOCOoacEFuOaB9SRlh8irylZVuQXY9ql1pOQkkXMeC+6W+1aTmp9MVmk663dfpeKbP7GS9MJUMopS2Xi3mq/fvYLMknTSClLYcp/agrv248vILssgJTeJq+9XW3BX3bKI3MoskrPDXPPgehVf8eEFFFTnEM4Mcu1nNqi4VqkWXe+s9M19uuJ66iNf57uf/nH8caKF0mQxMdg/GB+JJ3KD0YA0JJ2XCxEZzceyBZVFM8ql83GUI/W3w+UjbS0uH/26/U7aEyygcouwJpeNpLUspPLR/QW5zC4bkzw70eLy7EZux71YLs/uEjNJUGZfiZlk4jGJmWIit7ls9CTUq5Jfk1amJudamdr2Bzew9IPz0PWv67LPNHRdfnrtb28oHg/0DcRLQVSMLaawNlcxZ9zT2cPMjZMRAkpGFVI6ulDBO5o7mbN1KkIIikbkUzWxTDG91H62gznbIrygNpeaqZWK6aX2sx3M3TYdYRDkVWVTN3OYYnqr/WwH866ZjsEoyCnPoH5OjYrP3z4do9FAZkkaoxfUKXY8t5/tYN61MzCajKQXpjB20QjFdEl7cyfzr52B0WwkLT+Z8UtHKSzC7c2dLNgxC7PFREpOmIkrRiumazqaO1mwYyZmq4mkrBCTV41VTAfFuMVmJpQeYOra8UreEuV2C8FUH9PXT1TcJDtaItdndVjxJ3uZsXGS4ibb2drF/O0zsLtseMMeZm2arOLzrpmOw2PHE3Qze8tUxU2+q62budum4fQ6cAdczLl6qmK6rqu9mzlbp+L2u3D6HMzdNl0RZLrbe5i1ZQrugAun18Hca5S8p6OHmZsm4w17sLvtzNs+QxHEejp7mbEhUvbE5rQx/1ol7+3qZfr6iQRS/dicVrZ9ej0Ld+pTU++2jLt3777U1/CO6sknn9y9bdu2S30ZV6T+56u/o/HwOZuk0Wig7WwHHS2ddEaLFMotjsIg6Gzrov1sB11t3ZHXJ9hYuzt6aGtqj3CTIV5MMKbezj5az7TR1daNyWxUbW7r6+6jpbGNrvaeKFfaWHt7+mk51UpXezdmi0nVv6G/Z4Czp1robu/BZDGp+j8M9A1wtqGZno4eTFazyuY62D9I04lmujt6MFvNqv4TA/0DEftxRy9mq1nVv2JwYIgzx87S3dGDxaLmQ4MSp4820dPVi8VqVvXnkKRIvaXerl7MVpOKI6Dx8Gl6u/rOy08dOh09Xv3+wiA4eTBiwzVZjCpuMBpoOHCKvu4+TGb1+xtMRk68eZL+nn6MJoOKmywmTuw/SX9vP0ajmputJo6/0cBA3wBCoPp+zDYTx/Y2MNCvzS1WM8feOMFA3yASEhVjS/AE3Oj613XnnXc27N69+8kLvU6fntIV1x+//xce/8BXaDrRjN1lw5fkVVQ5NVvN+MIeTh9rwuawEkjzKyyysU1vjUfOYLVbCGeGVBbK5OwQpw6fwWIzk5wdVlkwYxZVs9VMal6yygIaqwxrtphIK0zh8CvaFlWjyUBmSTqHXj6q4OmFqRzf14DBaCC7LIODLx1R8JgFVRgEuRVZHNhzWMFjtlIhIK8qmzdfVPKYLfV8PKc8g0PRa86vzuHNFw4peUVm/JoLanLZ/8+DCp5bmRW/Zi2eV5Udv+a3w+XXdCGudf3yY7R5Dvv/GXkub1g2BxK+H/nx8mvV4rlVWRzco/z5bfvUOhbfMIeezl5cPie6Ll769JSuf1nDJpUzYnYNwiAoHV2EL6wcsRkMgrsz3a0AACAASURBVPq5tRgMguL6AgIpXgUXQjBq3nAMBkFRXT6BNJ/qHGMWjsRgNFBYm0c4M6ji9fPqMJgM5A/LJjk7pOKj59dhNBvJqcwiJTdJxUfNG47JbCSnIou0/BT1+8+txWQxkV2WQbqGxbd+Ti1mq4msknQyS9RVekfOrsZiM5NelEZWqbpKb92sGix2C6n5KZoW4OEzhmF1WEnNSya/KkfFa6dXYXPZSM4OU6BhAa6dVonDbSecGaRweJ6KV0+uwOGxE0zzUzxCbREeNqkcp9eBP8VHSYKRAaByfCkuvxNf2KNZBbhiXAmeoBtP0K2qNQZQOroIb9iDO+DUtBCX1hfhT/bi8jk1LcTFI/IJpPpxeBxUT65Q8cLheQTTAzjcNmo0LMZHXjvOtqqbWF+wkx899gsGBwdVr9H170nPNHTFdfP0u/jnMy/FHydaMhMXbhMtk4kLs4kW28SF10SLrIoLoVgjSaw9lFjlVbWwm7Cw/i/zhM/g9NrpbFUu/Moru2otHJtMRgaitlBNbjYx0D9wXi63vWotLFus5nhzqUSLMCh/hhfiWgvPcluvFrc5rPHmUFoWYPkxiVWGI/ycbVnLAiz/zBfiWhbhax5Yz7Ib56PrwtIzDV0XpWf/5wVunPRx/uerv6O/L8GzbzZFLLY+BzM3TlaNfIXBwI6HN+HyOZm6dgIlo5T9K6QhieujFtvJK8dSNbFMxXc9HrHQTlg2itppypGjJEnc8ESEj12ktuBKUsxi62bUvOGMTqiCiwQ3PH41npCbEbOqGbe0XsV3RS22tdOqVBZcOGexrZ5cwTSN/hDXfXYL/mQfleNLmbVpsorveHQzgVQ/5WOKmbNNbcHd8fBGgml+SuoLWaCxv2D7gxsJZwQpqstnqYYFd9sD60nKCpFfncPyD6ktuFvuX0tyTjhaBXeRiseq2GaXZbBaw4K78a6VpBemkFmSzrqPq6vgrr1jGZnFaaQXprLxLnUV3DUfi1SxTctPYdO9q1R81a0Ri21KbhJbNCy4y29aQP6wHJKyw1z9KXUV3CU3zKVweCRrvfYhtQU3cR+Irn9fF8w0hBAGYBiQBnQDr0iSdOotD7qE0jONi9ejO57iJ0/8Kv44MVNI3LyVONJPzDQSR+qJm/ESR9IXk2nAuc12To+DzrbzZyKq90+w+KpG8gmZhtZIX55pXJBrWFDlG9DsbruqvLw8E9HKBOQb5LS43AKslQmYbWb63yKTkI/etSysCq6RKcif08wkZJmIVqYgvyb5tWpyjc2E8u8ksR8J6JnGv6J/O9MQQuQLIZ4E9gOfBFYBO4BfCyH+KoTYFA0ouq5QHXhJucgoSVLc4lo3c5gqsxjoG2DBjpkYDIKaaZWqOfGezl4WXT8bg0FQNbFMlVl0tXWz5ANzMZgMVIwrUW3u62ztYukH52I0GSgbXcSIWdWKoNDZ1sWym+ZjMhspGpFP/bxa1fsvu3E+JrOJgtpcxiwaqQhaXW3dLP/QfMxWE3nDshm/ZJQiaHW1dbPsQ/OxWM3kVGQy6aqxium1CF+IxW4hszSdKavHKXl7N8s/tACr3UJ6USrT109U7Fjubo+c3+a0kpafwsyNk+MBAyJOs2U3zcfuspGSm8TsrVMVO6q7O3pYftP8yJpGVoi526YpbpI9nb0su3E+Tq+DcEaQ+dtnKG7CPZ29LP3gPFx+J8E0Pwuum6W4ifd29bLkhrm4Ay78KT4W7Zyt5N19LNo1B2/Igy/Jw+JdcxRBore7j4U7Z+FP9uINuVnygbmKvuZ9Pf0s2DGTQKoPd8DF/2fvvcPkuM4z39/pnOP05JwDMDMYDAY55xwGIBKRQQAkwSAGiRQpBolKVCZX9l3ttdf23Wyvvbb3+q591155LVmmIjMJksg5Y4DJHWr/qO6aqjoFAqBAiSLme555gO63T3d1dXedc77v/d63+zPLDJNYcjDJ8n0LyCuJEYj4WfvociM+lGTpnnkkyuL4Qj7WPbrCMIkmh1Ms3j2XgsoE3qCHB7+/m9UPLWE0bm98mMnuC8DvA3sV03ZECJEPbAK2AH/88R3eaPwmI5VM85O/+hlKRuHNH71LtMBY6M6kMvz4v/2UTEbh7R8fIF4cNeBKRuHHf6Hi777yvmWh+0d//gqZVIYDPztIQaVc6P7RX/yUdCrD+784RGG1XOj+0Z+/QiqZ5tCrRxislQvd//yXPyWVTHH49WPSqhXgx//tZySHUhx587jB1S8XP/mrnzM8lOTY2ycQCAn/l7/6KcMDw5w8cAqHwy7j//3nDA0Mc+r9M7g9Lgl/5f/9JYN9Q5w+dBZPQBbY+9n/9ysGegcZ6B3kvZ99ION/+yr91wbovzbAuz+V8Z//3av09fTT19PPWz85IOG//J+v03u5j97Lfbz5o3ck/Ff/6w2t4fH1f3pbwl//x7c0ufLXfvimjP/vdzTa86v/8IaEv/njdzVa8y//5+sS/tZPDmi03J//7asS/s4r72se6T/9H7+S8AM/+0AT1fy7P/lHxs5oprLFUhx7ND5iXHenoCjKRkVR/rd5wshi5xRF+a6iKKMTxu9wbPjcao2BFIoHiRdHuZTtYxjsG+LS6SsUZy/Mwaifgqp8jSc/NDDMuWMXKK1XGUj+sI/ShmLOn1B/0MODSU59cEYTGfSFvFS0lGly2cmhJCcOnKaiWWUgeQMeqsaWaz/45HCK4++eonKM+oP3+N1Ut1VwJquim0qmOfbOSarGqgwlt89NbXuVphibTqU5+vYJqtsqADU1UtdRpVGEM+kMR946Tk17JaCmPurH12gqqpmMwuE3j2k+5A6Xg4bOGk0xNpNROPzGMY3B5HDaaeiq1aTfFUXh0OtHNZFDu8NOY1etphKrKAqHXjtKfZbhZLPbaJpUZ1CxPfjaURq6anV4vYFCfPDVI9puz2YTNE824odeO0rTJBUXQtA8pd5AMVbx+hF8cr2BwnrotaMGBlXzlAYDRfbQ68do0uOT6zn8uhFvnlyvpRmbJ9cbxh9+w4g3TTLiR948TvPkemy2HF5nwI++dZymSSN448RaA/7uK+/zL//9FwwPDlvK0I/GR4sbppeEEHYhxAohxINCiEdyf7+JgxuNjzdq2itpzF6UyptL8Yd9Btxmt2l4aWOxxHsXNqFddMoaiwnGAqZXUHEhoLSuiHCe3HSVu2gU1xQQyQ9LeNNEFS+qLiBaIFN4mybVI2yCwsoEsSIZb+yqw2YX5FckiBfHZHxCLXa7arqUVyrjDRNqsTvs5JXESJTLO6OGzhocTjux4hgF5QkJrx9fg9PlIFYUsaQI13dU43Q7iBaEKbJQAa4bV4Xb6yKSCFFisbOqaavA7XMRygtRXCtTiKvHVuDxewjFA5TWyxTiqjFleAMeglE/ZY2yinBFcxm+kJdA1E+FhcpwRVMpgYgPf1hdFJijrLGEQMSHN+ixpCCX1qvfG4/fQ3WrjJfUFRGKB3H73JYqxcU1BYQToaxSsUxRPvzGUXY1P8y2ugf4D1/5c41pNhofPW6mEP43wCDwBqDt5xVFef7jPbSPFqOF8JuPR2Y+wxv/NJKicHmcJIdSWh3BbO/pcNrJpDNancCM2+w2UJTr4rnH5OoAVri+cGxlP6ovvn8kXFdYtsL1xVar49MXcy1xnQqrlbaVvlhshesLx5a4rjBspV2lp7Ba4frCsZV9qr5Yb0VB1pMBfCEf/VeNuD/kpU/DZeKA/jmtCvuBiI/e7DFZUYz178mqsK/XA7Mq7O/6yibJS3001LidlNtSRVHWKIryrKIoz+f+bsMxjsZvIf7xv/wz947/LH/5/f8hNT65PC52fmUT/rCPhTtmU2VaGTqcDu55cQv+sI/5W2ZS22FsLhNCsO/b2zWV28ZJcvPY/S+pFN2Z6yZbNofd//JOAlE/U1d30TZHbv6673s7NZXb8QtbLfAdBGMBuhaPY+JS2f/hvu9u11Rup66aIOH3fmcb4USI9tljmLFWVuHf9+3tRPJDtM5oZvamaRK+95tbVZXbKQ3M3ypTdPd8cwuxoihNk+pYtGuuhO/6+t3Ei6PUd9awfN98Gf/qZk3ldtUDiyV851c2kF+eR1VrOd0PyRTdbV/aoKncWlF0tz67TlO5Xf85maK7+em1msqtlUruhidXU9ZYTHFtIVueWSvhdz2+koqWMgqr8i1Vctd8ZrmmcrvjBZmiu2r/Ymrbq0iUxdn1tc0SvvzehdR31hAvibHnRZnCqydGjMZHi5vZaXwd+HtFUf7uQx/4CYnRncb142tbX+Lv/90/abfNzWr6VTLIK0UzJfJGfhqSH4bOKwLklabkt3ED3KySaqb4mleiZoqvhJsovla4/vei3xWoOAa/DWmlK0CA1oxoRVE1+G3cALf0y7DbSH8YrlP5taKwGvEP99Ow8ssw4BZ+GfrX1L+WJW7lp6F7T+bvw83goyq414/budP4F+AvhBADQoirQohrQoirNxw1Gp+4MFup2ux2Vj+wGLvDxtTVXdRki8a5UBSF7s8sw+6wM3l5Jw0m57rkUIr1n12Jw2lnwpJxjJlmlI0Y7B1i45OrcTjtdCxoZdwcI8V2oHeQTZ9fg8PloH3OGDoXtkv45qe6cboctM5slii2gznc46RlaoPkDDfYN8TmL3Tj8jhpnFgn7RwG+4bY/HQ3bq+L+s4aZm+cZlLxHWLzF9bi8bupHVfFvLuN/hqD/er4XBF/4Y45hklpqF8d7wt6qWgpZcnueejXaEMDw2x+uht/2EtZYzHL711ouMjl8EDET0ldESvvX2TAhweTbHpqDcFYgKLqAlY/tESbMHL4xs+vIZQXpKAiwdpHlhku0smhJBueWE0kP0SiLM66R5eb8BTrP7eKaGGEvJIYd312pWGSSA2nuOvxlcSLo8QKI2x4YpURT6ZZ99hy8krjRArCbHxytWGSSifTdH9mGfnleYTzQmz6/Bojnkqz+qElFFblE4oH2Px0t2ESzKQzrNy/iOKaAoJRvyW+/N6FlDYU4w/7eOwP77P0KBmNW4ub2WkcAlYBb1gxqT5pMbrTuH48OOXzvPMv72u3PX4PDqed3it9qhhhQYjzxy5quMvjxO1zc+1Sb7aYG+XsUZ1HuMNOIOKj58I1HE47eaUxzhw+b3jNSH6YK+d6sDvs5JeZPMQZ8Qi32W0UViY09lMuYkVRLp2+jM0mKKwukD3Ei6NcPKXiRTWFsod4SYwLJy8hhKCkzsJDvDTO+RMXVby+SPPLzkXOQxysPa5zHuKgkgFy7KlcFFbla4wvvV/2zeJF1QWaaKSVB7feY9wS13mMW+F6j3Gr49d7jFu9f73HuP7/VriVx7f+OXNikgZcd8z692KJ686FFV7ZUsbjf3Q/9eNlTa7RuL07jfeBN38XJozR+PDY/qWNGsU1XhwlrySqdYAnh5L0XurTKK7RQpXtkyvEJodTXD57RaOwRvJDlDUW05OVQk8l05w7dpG6LEU1nBekurVckzJPp9KcPnyO+k61DhKMBahpr9SkyjPpDKcOnqWhS/1BByI+6jqqNSnyTEbh1AdnNIqpP+yjYUKNRgHOZBROvn+apskq7g16aOyq1Tj/iqJw4r3TtExR2V7egIemSfUaRVhRFE4cOEXLVNXH2+1z0TylQZswAI4fOMXYrBuh2+uiZWqjYRI9/u4pxs5Qd1suj5Mx0xq1CQHg2LsntYZHp9vB2BlNMj5LxR1OO60zmw0qw8ffPUnb7BYNb5vVYrhI6nG7w0777BbDRfb4uydpnz0GIUQWH6NNGLnjb5/dghACm91G+5wxhkn2+IFTtM8Zg7AJhE2ouG6SOHHgFG2zr4+ffO80bbNbsNltCKHi+kno5PunaZvVgt1hH8F1k9ypD87QNrMFh1Ptj2mf3WLED56ldWYzDpfaftY2y4gfees4P//b1xjoHeDMEePiZTRuPm5m0jgN/FAI8eQo5fZ3O/LL4hRUqrTQeHEMp8dpwIUQGi00XhTF7TU1p2WprwCxwihun9y8VpjFo4UR3H6PhOeUZ6MFYbxBa1wIdYfiC1ngtQUIgWrcE/LKeHUhwiYI54UkCjFAYWUBwiYIxQPWeFUBNpsgFA8StJDWLijPx2a3EYj6CUYt8IoEdocNf8RPKC5TjPPL4tiddvxhH+F4yALPw5HD82Q8URLH4bKr0vUJa9zpcuAJuC0pzPHiKE63A7fPZUlhjhfHtB2mFR4rjOD2uHB7XcQLo9a4z43b4yJeZIEXRPD43TjdDksKtGq45MbpcpBXIuPh/BAev0fFS+Xm0XAihDfgwe60WzaXvv+LQ2yvf5CdjQ/xbz737yTZl9G4cdxMeupZq/s/qQyq0fTU9eOhqU/x9k9G3PncPhfJoZSWJw8nQvScHylXOd1OMumMVoyM5IcMJknqinBEFC6XisqFEAKH065JXZhxMBZOrXB9MTZaEJZMlvSFTytcX0y2wvXFbEtcVwy3wvXF+khBmCtmXEdhtRqvJxNE88NcNr1/PUXV6vzoKahWuJ6CGk4EJRMsPa3X/PmDkVYcygtKJlv6+6wozOG8oLYbDcb8XLtkpADrX9PKPleP+yN++kz2tvr3bEURvhG+/YsbLFlgd2LctvSUnmY7Srn93YpMJsPf/Jv/ybb6B/jPL/6lBdPExZZn1uINeli0czalDcbmMKfLwbbn1+MNepm3ZaYkx2Cz29j5lU34Ql5mb5xGzbhK6Rh2f20zvpCXmesm09gl55L3fkOl8E5d3cWYbGpIH/d8Yyv+sI/Jy8dLWlagmu4EIn66Fo+jw8Jf4Z4X7yYQ9TN+fisTFo+T8F1f30wwFqB9zhgmL5d/L7u+uplQPEjrjGamre6S8B1f2Ug4L0TL1AZm3SWr5O748gYi+SEaJ9UxZ+N0Cd/+pQ1EC8LUd9Ywf/ssCd/2/HriRVFqx1WxeLdM0b37C+vIK4lR3VrB0r0yRXfT090kyuJUtJSx8n6ZorvhidUUVCQoayxh9YOyTtNdn11JUXU+JXVFrHtUFv5b+8gyimsLKaopYN3jMoV39UNLKW0oprAyn41PrpHwlfcvpLy5lPzyPEuV3WX75lM1tpxEaZytz8oqu4t3zaGmvZJ4cZStz98l4Qu3z6JufDXRwoilCu9o1v3W47o7jaxY4cuKokgCMkIIP7AeGFIU5d9/vId4azG60xiJ57q/wY//4qfabbMKq5lSaqbImv0RzBRYM6XT/HxmSqaZQmqmXJpxM2XTTAk2UzJvFTdTMs3vx4ybKcdmiq+ZwirjRgqrmeJrVmk14+bzaab4WlFc9TRjK4qr/hitKK76c6D3DsmF/j4riqv+Oc3nw3xMVuP170nYBCiKgYGmPydmfxUwnlPz+QS49zvbWWPRz3Inxu3Yafwe8AUhxDtCiD8VQvyeEOIPhRD/BPwzEAT+7DYd72h8DHHhxEXDbZfXybpHV+B0OZizaZok62Cz29jwxCqcbicz75qiFbVzkckobH66G5fbybQ1k2iebNwZJIdSbHvuLlweJ5NXdNI2y7gzGBoYZvuXNuDyuJi4tIPOBW0SvuNLG3F7XXQuaqdriXFnMDwwzM4vb8TtczFu3lipOW94YJgdL2zE43fTNquZGSb/DHX8JjwBD2OmNTLH1Jw3PJhk55c34g16aJ5cz/wtM4zvbzDJji9vxBfy0jChhkW75pjef5KdX9mIP+KjtqNK8s9IDqXY8eVNBKJ+qlvLWXH/IsMFLDmcYscLGwnGAlS2lLL6oSUGPDWcYvsLGwgnQpQ1lrD20RUGim8qmWb7F9cTyQ9TUlfE+s+uMuDpZJptz68nVhihqKaAjU+uMVzE06k0W59bR7wkRmFlPpue6jZcxNOpDHc/s5ZEWZz88jzufmadYRLJpDNsemoN+RUJ8kpibH3+LsMklMkobHxS1TuLFUXZ9vxdhkksk86w/rMrKa4tJFoQYfuXNhgmQSWjsPbRFZQ2FBNJhNjxwgbDJKooCqsfXkpFcymheJAdL2w0TMKKorBy/yKqxpYTjAV46j8+PDphfIS4mZpGAOgEilD9NN5RFEWWz/yExOhOYyT2T3yCAz87qN32BjwoGYXB/iHsDjuR/JDGPgJ1pS9sgsG+IWx2G7HCiMY+AnVV53I76b82gM0miJfENMVRUFeC3oCH/qvWOIx4dgghSJTFDewkGMmxCyHIL49z9qg1DlBQmdAEDnOhz7EXViY4Y8L1OXI93TUX+hy4Fa6vS+T8zA14lkJ8vfE5ijBAUVW+REGOF8e4eEo954XV+ZwxPX9eaYwLJy5d9/lzFOLr4fllcc4dvz6eKI9rtGur85tfkce57GeipxvnQn+fnq6cC/1nkiiLS9+PwqqERtu2xkeOOUenvj4e5cLJywZcf84Lq/L53J88wJipsjLBnRi3s6bRqyjKDxVF+Y+Kovy3T/KEMRrG2Pft7dpuoaSukLySmFb0TafSDPYNaT7SRdX5FFbla+mlTDpD7+U+TSW1oDJBWUOxlt7KZBQun+3RKKr55XlUt1ZoRd1MRuHCiUtaHSJeEqNufLVG8VUUhXPHLmg+0bHCCA1dtdqEoCgKZ49eoD3bEBjJD9M0qd6gxXT2yHnNkyNXV9AXas8cOU/HfFVqJBQPMnZao6HQe+bwOcYvUPFg1E/rzGZDIfnM4XN0LlR3Q/6wj7ZZLYZC9ulD5+hcpOK+kJf2OWO1CSM3fsJitWHRG1A9rfWT9OnD51RPdiHw+N2Mn9+mTRgAZw6do2tJB0II3D4XnQvatAkj9/xdS1RPd5dH3Z2d1+0uVbwDm92G0+NkwqJ2bcKQcLeDrsXjDH06Z4+cZ+KSDuwOGw6Xg4lLOrQJA+Ds0fN0LR6H3WnH7rQzcUmHYRI5d+wCXYvH4XA5sDtsTFzaYZjEzx+/yIRF7TjdDmz2LH7YAvc4EVl/ev0kd+HkJToXtGmLnYlLzPhlxi9ow+NzI4Sga8k4wyR95vA5Xv2HN7l2uZcjb42oA4/Gh8eoidKnODw+N26f6tngcrsQNtPHLRjBPS5VcNCEe/y58U7sFv4R3oBKi3W6HJZ4brzTbY3nxjuugxvHy19XT8CbHW//0PEOlx27U7aP8WRpwXaXQ+P/6yN3fhwuu8b/N4z3uhFCzb07XRavn8XtTjtOy/EuEGptwOmW8dwF0e6wSxRpALfHhc0msDkELrcF7nVhEwK73YbLwt/D5XFis9kQNpvl8zuzuM0mPhwXAtf1cLsNIaxf3+lWcXW8NW63q6/vMlPAAYfbic2h9n24vPLrO1wO7E6b4buuj3deeZ9tdQ+wt/0xvrvvB5pXyGhcP26Ynvpdi9H0lLpKF0JI6SmP3006mSY5nEIIQSQ/ZFg5uzwuFEUhOZRECEG0IKz5a4B6YbTZbVqxOFYU0Qx1QE1PudxOrZgdK45y6ZQxPaAvlutTNbnQF9ut0g96iqo+VXOzuJ52mVcal+o+esvbRGmM86bxeoqrPhWUC336zOr59bRUK1xPUbU6fn16zer86NNrVrg+vRYviXHRjOvSa1afjx7PdevrQ3+f/rG50D+nFQVZn56zohDrj9lMATe/Z/251HDdObXCtzyzjq3PySysOyFuZ0f4aPyORCqZ4k+/+VdsKNnDHz3znyQmitvnZt2jqh3p/K0zJX8Hl8fJ+s+uxO1zM2fTNErqjP4NdoedTZ9fg9vnZtb6qVp3eS5sNht3f2Etbp+b6d2TLP0Rtjy7Do/fw5SVEzQDI33c/cw6vAEPE5d20DixVsafXYc36GHCwnYtNWbAv7AOX8jLuLljaZshU3Tv/sJaLdVkRdHd/PQa/GEfY6Y1MmGRTNHd/NQaAlE/zZPrmbRsvIRvelLVgmqYUGOporvhyVWE8oLUdVQxo1tW0V3/xGrCiRDVbZXM3iir6N71+AqiBWEqx5Qx11SoB5UCGyuKUt5UwoJtsspu98NLySuJUVpfzGJTIR9g1QOLyS/Po7imkKV7ZArvyvsXUVCZoLAqnxX3LZTwZfvmU1RdQH55HqstVHiX7J5LSV0hidI43RY6UAt2zKKssYR4cdSS4jt/ywwqW8qIFkYsVXrnbJpGdWsFkfwQ65+QVXpnrptC7bgqwnkhNjw5KpH+UeJmCuH1wONABTp7WEVR5G/cJyDu5J3Gk4tf4Od/+5p220yhlW6bKLTm22YKrVnV1UzJNVNazRRWMyX11m8bKavSbRNl1UxRveXbJgqr+baZwnoj3ExZNVNc9Qq1Vo83U1LNt80qvrf6eJXSOkJJtcZHKK3SbRMFWL6tyvxe7/bNHqPx8YJM+vrjpXNqum1WXt7/8i5W3r+IOzFu507jT4FfAk+jTh65v9H4hIW5m9cb8LDhiVW4vS4W7ZhNeaNxZ+B0O9n89FrcPnXnUWVSubXZbGx9bj1un4s5G6dq1qO5yKQVdrywEbfPzQwLf4zkUIp7vn43Hr+bqau7GGda2SeHktzzoopPXt7JhEVtEr7nG1vwBjx0LRknNd8lh1Lc880teINexs9vY9oaI8U2NZxizze3qjuPOWOYvWGqJe4P+xg7o4m5m43Nd6lkmr3f3Eog4qdlagMLdxrXSelkmr3f3EIw6qdxYi1L7plngW8lFA9Q31nNctPKPJ1Ks+ebWwnnBalpr2S1aeWdTmXY840tRPLDVLVWsPYR48o7k85wz9fvJlYYoaK5jA2mlXUmnWH31zYRL45S1ljMRtPKWsko7PzKJhJlcUrqitjyhXUGiq+SUT/f/IoERdUFbH12naEHQskobH1+PYVV+RRUJtj+pQ2GC7qiqOme4ppCEmVxdnzZjCts+nw3pfVF5JXE2P31zdLueMMTqyhvKiVWFOWeF+82jAdY99gKqsaUEy0Is+cbW6Xxqx9eSk17JeFEiL3f3GKYMED156gfX00oHuTZP3/sjp0wbiVuZqfxC0VR5H34JzTu5J3GfZ2f5f1fHtZuewMekkNJUsk0QgjC+SGDzIXb5yKTJHaeygAAIABJREFUyozUOApCXD4zgjuzhdXcat9cw7A5bDgc9uvWOMC4O4kXRbl4+qPXOKxy8PqGxY9SAzHWOGRcX8Owwo01jBvhFjUOHUXYsoahr3FYvD99jSNeEuWiiWKqrwtYnV+99MlHqmEURrS6l1UNQ/+diBZEJK9u/XfCSkblRjUO/TmJJEJcOX/9GoeVDIr+nEcLwjzx7x6yTFveCXE7dxp/LYS4TwhRJISI5f5uwzGOxm2Oz/xgn5bnr26tIK80rqVLFEUhnUxrFNjKljKKqgq0dI6iKAz1DWsU1/KmUsoaiw3pod4r/RqFtaS+mJrWSkP6qef8VU2qo6imkIauWkM66+Lpy5onRmFVgubJ9Yb018VTl5m8XF2f5FfkMWZqoyFddvHkJSavVOsEeaUxWmc0GTrcL5y8xJRsHSFeHKV9dovBJOrCiUuaFEi0MMy4uWMNWkQXTlzSdiuR/BDj57cZ7FIvnLjE9DUTEUK9AHUuajdQgPV4MKZKmxjxi0zvnoSwCfwRHxOXdhguYhdOXGL62knY7LasdEqnoVB74eQlZqydhN1hxxf0MmXlBMPu8uLJy0zP4p6Ah6mrJhgushdPXWZ69yQcLgcev5tpq7sMi4gcnhM0nLZmomESuHT6MtPXTMTlceLyOJnePdFAlLh85grT1kzE5XXhdDuYvnaSYRFx+ewVpq7qwu1z4XA5mLF2kmERcflcD1NWTcATUCX7Z6ybbKAgXznXw5QVnXiDHuwOOzPWTjJMolfOX2Xy8k58IR82u03Cr164xsRl4wlE/CO4bpK+fLaHN//pHS6ducw7r4xYCIyGMWSOnxzbsv/qU1IKIFcxR+O3GoN9Q9pFWGUwGXeRiqJoF+GhwWEcJgqqgqI54Q0NDGGzm1RmMyN4cnCYtIniqCho4nzJoWFJkgLQairJoRSpZErC+7XnT5FKyXju+VNDKZJJ+fn7dc9vdp1T8dz4NKnhpIRrzz+cJmmF9w6iKFl80ALvG8GHh2R8sG8QJaNO4FbjB/uGyKQzpJIpyXVPff0h0qk0qWRKcvUDGOobIpNOk04Khgcsnr9/UPtcLMf3D5FKprFnFIYHhiR8sH84u3PFUM/Sxg8Mk06mUBT1WCR8cJh0Mk06nZH8vQGGB5KkhlNqH5HJP1wdnySdTJNJp63HDyZJJ1URzoE+eXxycJjkcFLFLZ7/zR+/y3/9zn+n/9oAszZMZc+LW0hYqOneyTFKuf0URCqZwuF0SOkpX8hLJpUZ6QBPhAwru1wPQ64DPFoYMaR/XB61N2Ogd1DtEC+KGtIrdocdt891/Q5wAf6Qmv65Xgd4IOKj90r/R+8AjwW4msULK/MlnwR9eseqA/rGHeIjtE7rDvCwltLTGyblQp/SsRpv6BC3wPXpE6vnN3SIW3SQJ8ryOH/8wnXfn75r2+r86ju8rTrsDR3gum7xXOg/E8sOcd0x3Qi36hDXnzOr9J/+nFml9/TjrdKnm5/qZvuXZKHDT2PctvSUEMIphHhQCPFn2b/9Qgi5i2Y0fuMx2D/EH33hP9Gd2Mn/9cgfSUU+t8/Nkj3zcLoczNowhXiJ0d/A5XGy/N6FOF0OpndPIr88z4DbHXZW7l+M0+1g6qouiquNFF2b3cbqB5fgdDuZtLyT0nqjSi4KdD+yDJfHSdfSDomiC7D2keW4PE7GL2ylqrVCxj+zDLfXRce8VmrHVUl492eW4fa5aJvVonW362PNw0vx+N2Mmd5E86R6GX9oCZ6Ah6bJ9ZrBkj5WP7gUb9BLQ1et1r2uj1X7F+MLe6nrqKJjnpwLX3n/QgIRPzVtlUxYKFN4l9+7kGA0QOWYMiYtk3+vS/fMJxQPUt5UwpSVMoV32Z75hBMhSuuLmL5GpvAu3j2HaEGY4poCZq6bLOGLds0hVqQabs21UOGdv20meSUx8svzmHu3TPGdt2UG+WV55JXGWbh9toTP3jiVgsoEsaIIC3fK+My7plBUU0C0MMLiXbKK7/S1kyipKyKSCLHUpOUFMHVlF2UNxYTzgizfK+OTlo2noqWMYCzA8nsXSPiExR1Ut1UQiPpZsX+0CH4zcTOF8P8bcAJ/nL1rC5BWFGX3x3xsHynupJ3GIzOf4Y1/eke7babU6ovAAJ6Ax7DlN6veun1uhvqvr3prptSan89MkTU/n5mSaqbs3kj19oa4pGrrNKRoJPwGqra3jN9A1VZSzTWr2propLKqrVHF1Xw+zRRY8/kyU2DN50MIEMJGJnN9VVv9e7BWtdWp3tpGnmsEH3lNK9Va/TELkU2w6lVt9aq3AkAYGF/SOTOd0xudc/Nn9tDv72GZheT8pzFuZyF8gqIo2xRF+Yfs3w5AXvKMxm88+q4aDWX8YT+bnlqDN+Bh+b0LKa0vNuAen5st2ea4xbvnUjHG6I/hdDnY8YKq8rpg+yzqOoxlK5sQqj9G0MPczdNpzupS5SKTzrDvWyrFddb6KZLKbSqZ5r7vbscX8jK9eyLjs0X1XKSTae5/aQf+sI8pKycwcWmHJR7IFpGnmJrn0qk097+0k0DET+fCdmaumyLh+1/eRTAaYNzcsczeaKTgZtIZ7n95F8F4gLZZLczfNkvC97+8k1BekDHTGiWV20xGYf9LOwknQjRPrmf5voXS+Pu+t4NIfpiGrlpWmfwrlIzCfd/bQawwQl1HtUSxVRSFfd/eTrw4SnVbJes/t0oav/db20iUxqkaW86mz68xjYd7XtxCfnke5U2l3P3sWgnf9fXNFFblU9pQzLYvrsccO17YSHFNAcW1hex4QU7bbH1+PaX1RRRV57Pra5skfMszaylrLKGgIsGeb2zBvGbd9Pk1VLaUkSiLs/db28xlOdZ/bpVK8iiJce93d0h+GGsfWUZdRzWxoij3v7RDouiufmgJDRNqiBaE2f/STglfft9CmifVE8kP8cJfP3HHTBi3Ejez0/glsE5RlIPZ29XAnymK0vGhA39LcSftNPZ1PM7BV49ot71Bj1oIzf4QzDIJHr+b4YHhEdzk1ObyOEkl09d18nM47SgK13Xys9lUb+kRJz9Z5kG/0rN26hvZrVg54elX95a4bjdk6eSn2/18FKe+Gzr56XZnVu9Pv/uzxn30X8059cnnzx/20tejjrdy2tO721nhegqxFQVV755n5cSnryEF4wGuXew14rox+nqUhuteMxAN0HvZiOu/s3pJl1zoabWBsI9ekxOf/j3rz6U2XnfOfUGPRpzIhf4zDUT8fO5PHrDs/P80xu3caTwO/C8hxA+FEP8I/APw6K97gABCiEVCiANCiA+EEE9Y4G4hxH/O4q8IISpvx+t+WuLJf/8QHfPVPHrLlAbySuKG9IgQQqPANk6so7CqwOifkExrP4j6zhrKGksM6YahgWGmZimqteOqqG6rNKQz+q70M32tmkevaq2goavWkC7pOX+NWRvU1X5FSxljpjYaUgNXzvUwK7vaL2sspnVmsyG9deVsD7M3qXhJXSHtc8YY0kFXzvYwd/N0hFALmh3zWw3ps8tne5iXxQsqE3Quajekyy6f7WHelhkIm1qk71rSYWDkXD7bw/wtM7DZbOSVxJi0fLyMb52RJQlEmLJygiGdd+WcOt7usBEtCDN1dZchXXjlXA/zt87E4VRl6mesnWS4yF05d5X522bicDkI5QWZuW6yNmGo5/cq87fOxOl2EowFmLV+isEOtef8VeZtnYnL4yQQ8TN7w1QDhfjqhWvM2zIDt8+FL+RlzqZpBrvVqxevMffu6Xj8brxBL3M3T9cmDIBrF3uZu3k63oAHj9/NvLtnGCaZa5d6mbNxGr6gF7fPxbwtMwyTVO/lXmZvmIo/7MOVlbbRL3J6r/Qxa/0UAlE/Lo+T+VtnGvowenv6mbluMqF4AKfbyYJtMw2TZP/VfqZ3TyKcCOFw2pm/baZhku6/Nsi0NROJFoSxO+0s2DbLsAjovdLHu6+8z9mj5/nF/z+itHCnxw0pt4qi/L0Qog5oAATwrqIoMtftFkMIYQe+D8wHTgA/E0L8laIob+setgu4rChKrRBiA/B1VMfA0UCVrj57RGWbnD9xUVKpTacznMkyRy6evCSplGYyGY1ZcuHkJXwhrwFX0hlOvn9aHX/qEqF40DheUTT80unLRAvDxvGKwsn3VPzK2SuWKrWn3j+j4ueu4rZQMT31gXp8Peev4Qv5JPzkB2dQFOi5cI1QLCjjB8+iKHD1Yq+0qgU4ffAsSkbh2qVerl26JuGnDp0jk8lw7XKftKoGVR49k87Qe6XfUiH1zJHzpFMZ+nr6uXpefv6zR86TSqbpvdwnNbZp+HCKvivW+LljF0gOJUmn0oaeiVycP3aB4UG1wdMSP36Rof5hhE1IjX2g9o4M9g0hBBLzCNT7BrPUVrN4I6i9OQNZmrEVfunMFfqvDaBkFIk5BWrvR//VATLpjDV+roe+nn7SqYzE7AJ1Yu670kcqmeasiVkH6sR67XIf6WSa04fPSvhrP3yLP/3WXzE8mGTC4nHc/70dlNQWSY+7k+LD7F7nKIryD0II2dgXUBTlz3+tFxZiMvCcoigLs7efzD7vV3WP+dvsY34ihHAAZ4CE8iE5tTshPTXQN4jX72HvuMc49NpR7f5AxI+iKPT19OP2ugjGAoYfui/oxWa30XulD5fHSTgRMlAY3T43Lo+Ta5d6cbqdxAojBn8Ep8uBL+Sl58I1HE47eSUxww/VZrcRigW4cv4qDqedRFlcopDmUi52h538ijxOHzT+UHNdxTa7jaKqfE5+cMaA5yisNpugqKZQm7RykaNV2myC4tpCTrxnxHPKtUIISuuLOH7glBHPUlSFEJQ2FHP83ZMGPL8iwbnsOSlrLJFwPW21rKmE4+8YcT2FtLyphGMmvKimQDsnVnhxTSGnDp657vOX1BZq58xqfEldkXbOrPDS+iLtnFm9v9KGYk5kz1lZQ7F0/vS4/v+5KGss5vi7p6TXGsFHXlN/rLkobyzhWBYvri3klOn7oX9P+nNpiVtQmPW4FUV5wxOr2fUVuVbzaYjbkZ7KSWQut/hb9msfIZQAeueTE9n7LB+jKEoK6AGkThshxB4hxM+FED8/f15ebXxa4trlXr7/4B/SnbeT7+791wahNVDZSLM2TMXmsDFpeSfhRMiAOz1O5myaht1hp2tJB7HCiAF3OO3M2zIDu8POhEXtxEuMjf82h435W2did9oZP7+N/IqEdIwLd87G4bTTPmcsRdUFEr5491wcLgetM5sprZNXbEt2zcHpcjB2ehNljeavAyzaORun20nzlAYqW8okfOGO2bg8Thon1lHdVinhC7bPxu11Ud9ZY0nhXbB9Fh6fm9pxldR3yhTe+Vtn4PG7qW6toGlinYTP2zIDb8BD5ZgyxkyRVXjnbp6OL+SlrLGEsdNkFd7ZG9V0TUldEe2zx0j4rA1quqaopoCOua0SPnPdFEKxgJqOM9npAkzvnkg4ESK/PI+uxTIFeOrqiUTyQ2o6ziKXP3XFBGJFEeLFUUsK8OQVncSLo0QKwlr3vT4mLhlPoixOJBFiuoXK74RF7eRX5BGKB5mxTsY75rdSVJ1PMBpg9vqpEt4+eywldUX4Iz5LleDWGc2UNRTjD/kkrTGAlqmNVLSU4Q16mHe3jI/GzRXCqxRFOXyj+275hYVYByzMUXeFEFuALkVRHtA95q3sY05kbx/MPkbe52bj07zTkOxbTZRYvY4SyJRYM26mxJopui6Pi+HB4eviZvqi+XjMlE6ziq6Zsmk+XjOFVRpvwj0BN4O9I+/HTKc0q/aqFNYRVddbxzFQWM0UYvMxmM83Qn2NDxuvP0dmii8YVVvNlGgwfgZmSjQYKa5WuJ7iav68wUhxNdNdzWPMFGDza1rh+vdsVqg141YUYP05EbYsPVd3ydPTtq3G6z8Tm03w8L/ea9lP8mmI21kI/68W9/3ZrR+SFCcA/VKxFDh1vcdk01NhQE6s3iFhln0IxYJsemoNvpCXVQ8spqjGuLL3Bb1sff4ufCEvy/ctoKzRSMF1e13s+PJG/GEfi3fNoca0Mnc47dzz4t34wz4WbJ9Fg3nlLQT3fmc7/rC6ajN7LasU1V0EIj5mrZ9K+5wWCX/w+7sJRP1M757IhIXGlXEmo/Dg791DMOpnysoJdC3rsMZjASYu7WDaaqPKrZJRePD3dhOKB5mwSKbgKorCA7+3m3BekI65Y6WVp4YnQrTNapH8KRQFHvhXu4kUhBkzrVFSuQXY//JOYoURmic3yM1lCtz/0k7ixVEaumpZbaLgAtz33e3kZa1yrfwj9n1nO4myODVtldz12ZUSvvebWyioyKNqbDmbn+6W8HuyFNuK5lK2PLtOwnd9dRPFNYWUNRSz7UtyOXH7F9dTWl9MSW0hO7+8UcK3PHcX5U0lFFUXcM+Ld0v45qe7qRxTRkFlgr3f2CLhG55YTXVrBfnleez7zjYJv+uxFdR1VJNXGuf+7+6Q8DUPLaWhq5Z4cZT9L++SKLwr7l9E86R6YoUR9r+8Uxq/dO98xkxtJFIQ5kt//eSndsK4lfiwmkYj0AK8iFF3KgQ8riiK3B57Ky+sTgLvAXOBk8DPgE2Koryle8z9wFhFUfZlC+FrFEX5UFutT/NOY2/7Yxx6faSGYW7O09MlQV4ZmymQbq+L4cGktpI24063g9RwegQ3USztDjtKJqOt9s3jhRAIwXVxMK7urHD9StmKAqpfCVuN169+Q/EAV03FbH0zl55OOoKPrIStxutXulavfyNcv9K1xHUrXT1dNhf6z9iKourxe7RCtXmnCcbdmxWup6Wad5rm+26Ee4NeTdsrF/rXNO8kze/J/H2+GVz/mzA3g4IqLHnt0ofhI5+J2+vi8T/ab9lZ/2mI27HTaECtXUQw1jM6gHt+3QPM1ij2A38LvAP8F0VR3hJCfFEIkVtS/QEQF0J8ADwCSLTcOyme+4vHNRXWiUs7pJqD060qjwKMmztGqikIm2DGXeoXvnVmM2WNJYbmqHQqzZxN00DAmGmNVLdWGPDh/mHmZd3imibX0TChxpAe6uvpZ9HO2QghaJhQy5hpjQb82qVeFu2agxAqhbd9doshHXDtUi9L7pmHsAlq2iromN9qSG9dvXhNwyvHlDFhUbuB4nvtUi9L987DZrdR3lTKxKUdhnTJ1Yu9LNs7H7vdRkl9EZNXTDB0/1691MuyffOxO+0U1xQwdXWXIV1z9WIvy/ctwOG0U1iVz/S1kwzpomuXelm2bwEOl4P88jxm3jVFwpfvW4DT7SCvNM7sDdMMF6kc7vK4iBdHmbt5uiFd1Xu5j2X75uP2uYkWRJi3ZYbhItl7pY9le+fj8buJ5IdYsG2WNmHkPp+le+bhDXoI5QVZuGO24SLd19PPkt1z8QW9BGMBFu2aY+hj6L86wOLdc/GHfQQifhbvnmuYJPqvDrBo5xwCUT++kJcl98wz4APXBli4YzaheABv0MPSPfMMk9RA7yDzt80inAjhCXhYtne+YRIc7Bti/paZRArCuH1ulu2T8bmbpxMriuLyulh+7wLDImpoYJjZG6eRVxLLSugs0CaMHD5r/RQSZXk43Q5W3LvAMIkPDQzzwa9+raz8pyKuS7lVFOUvgb8UQkxWFOUnH8eLK4ryN8DfmO57Rvf/QUDeM9+hUVRVwLN/9hhnjpyjsDKfveMeM+CpZIp3f/oBAIdfP4Y7K0iYi3QyzYFXVPzIm8fxR4wU1kw6w9s/eQ8UOPrWcUJ5xkJ6JqOoOHD8nVMSxRYF3vzRuyiKwvEDJ8krkdVB3/7nAygKnPrgDPkVeRL+1j8fQMkonHj/tGHC0cb/RMVPHzonUYzV53+PTDrD6UNncLnlr/fb//Ie6XSGc0cv4PV7JPydf3mfdDLNuWMXCET8Mv7K+6SSaS6cuChRkAEO/PQDUsMpLpy8xBkLCue7P/uA5FCKS6cvc/rQGQl/7xcHGR4c5tKZpMQcA/jgl4cZ6h9ieGBIozPr4/1fHdLUjo8fOCnhB187ysC1QQauDXLsnRMSfuiNY9ru9ehbxyX8yJvHtAv9kTePyfjbx7Xd0GHdrjgXx945qe3WDr4m48cPnNR6Lawu0MffO0XPuR4UBYM4Zy5OfnCGy2cuoyjw3s8PSvjpg2e4ePoySkbhwM8+kPFD57h46hKZdIZ3firjo/Hh6anPKoryohDiZaRMICiK8uDHfXAfJT7N6Slz/N0f/5AfPP4n9Fy4hj/swxf0Grjw/ogPp8vJlXM92upRT6H1Bjx4Ax4unbmCN+AhnAgZKIYuj4tgzM/FU5fx+NzEiiKc0lEYHU470YII509cxO11kVcalyiSOeVSl8dJfnmeRLEsqMjj7NELON1OCisTEoUzp0LqdDkoqimQKapZ2qTDaaekroijbxsvhDkKqt1hp6yxmCNvGi+EJXWFnHz/DDa7jYqmUg6bLoQ52qjNJqgcU25ID8IIhfR6eI7CKYSgqrXcQJEGqGgu5ejbJxBCUN1WYejwB9X35Ej24l3TXinhVWPKtWO2xMeWc/iND8FbK7SL+43w6rYK6fj199W0VUgTQU1bJQdfU5+zurVCOj/616xqLefw68dMeAUHXz0qvRer8ZVjyqTPV4/nzrX5+A69fhRFUSwpyNWtFRx+4xiKolA7ropH/s0+SV7n0xK3Iz2VU8L7OfALi7/R+C3HhEXtdC5oQwhom9Us7RycLicTFrUjhGDsjEaCsYABd7gcTFzSgRCClqkNhE07C7vDxqSl4xE2QdOUeqIFRoqusAkmr5iAzSZomFhHvMiooguqCqnNbqNhQg2JMnlnMXV1FzaHjbqOKgoqZQrv5BUTsDts1LRXWlJ4p6ycgMNpp2psOcW1hRbjO3E4HVS2lEpaXACTlnXicDkobyqhrEmm+E5aOh6X20lpQ7GlSu/EJeNxeZwU1xZS1Vou4V1LOnD7XBTVFFDTXinhnYva8fjdFFQmLC9GnQvb8AY9FFQkLCnAHfNb8QW9JEpjNJrseAHGzR2LP+wjXhKzVPltn91CIOonWhCmxYIi3D6rhVA8SCQ/TOv0JgkfO72JcCJEKB5k7EyZQtwytYFoQZhgLGBJIW6eVE+sKEIg4qNjjqwS3NhVT15pDH/YpxmA6aOhs4b8sjjeoIfOhe0SXjuumsLKfLwBj6aOoA/1e5WPx+eia4msjDR5eScvv/JVHv2D+/j+z772qZ0wbiVuyU9DCGEDAoqiyK2vn5C4k3Ya93c9YdiCmwuJ5sKo3nrVCjdTNs24mVLpj/jouzKSkzaropoLq0IYFUmtcBihuMo46FVNrXAhRmi4vrCPflNhV0+BtSr86gvzVoVd/Xu0xHW0UTNRAYyFe2vcoZlTWRWGHS47qeH0dXGX26mZP1kVhp0ep2b+5PG5GDRRfPWFe4kijPE7YkXx1ReTrQrL+te0ovjqj/mGuAUFWE/71p8rS9xhJ2UyCtN/pg6nncf/7f3M2XRn9GvcTj+N/yCECAkh/MDbwAEhxOM3GjcaH3+Yne8CET9bnl2HP+xjxf2LKKkzrrw9AQ/bv7QBf9jH0r3zKWsyrrxdbie7v343/oiPRTvnSCtjh8POvm9tIxDxMX/rTAv/CsH+rMrsnE3TGDPNSMFVFIUHshTbmeumSBTcHMU1GPMzbfVEOk0UXEWBB39/N8F4gMkrOulaNk7CH/i93YTiAboWj7NsLnvg+yrFtnNBG9MtWDAPfH8XkUSIcXNkCi7A/pd3ESkI0zqzmQUmFVyA+7+3k2hhhDFTG1l8j0zPvPd7O4gVRWmaVM+yfbK/w33f3Ua8JEbDhBpWPyRTcO/9lkqxre2oYu0jco/tPS/eTUFFguq2CkkFF2D311SKbeWYMjY+JVNwd35FVbEtbyphyzNrJVyl2BZRWl/MdgsV3C3P3kV5Y4mqgvtlWQV301PdVLSUUVRdwO6vb5bwDU+oKrYFlaoKrjnWPbac2nFVJMrz2PutrRK++sElNHTWkFca497vyBTcFfctpGliHfHiKPe9JONL7plHy9RGYoURvvTXT94xE8atxM00972qKEq7EGIzMB74HPALRVHkveInIEZ3Gr+5nYYZ/13Yaeh3EjfaafhDXvo+dKchq6h+3DsN/er6RjsNb8DNQO+H7DQsdiKGncJH2WnoxnwcOw39e/5oO40R2q/+XOdCv9Nwuhw89of33TETx+1s7nNmnfpWAX+pKEoSi8L4aPzm44W/foJFO2ZjswlmrZ8i1QQcLgfzt85ECJWiW9pg3FkIm2DxrjmqGu6iNqrGGHPy6VSapXtUimvH3LFSTn1oYIgV9y3CZhO0zmqhZYpxZ9HX08/qB5ZgswnGTG+ifXaLjD+0BJvdRtPkesYvaDVMKn09/XR/Zhl2h42Grlq6lnRI+JqHl+Jw2qnrqGLS8k4D46q/p5+1jy7D4XJQ01bBtDUTDRTfvp5+1j6i4lVjypixbrIRvzqgOQuWN5Uwe8NUw6TYf7Vfw0vri5h793RDR3P/tQHWProct89FcU0B87fONFCE+68N0P2ZZXh8boqq8lm0Y7bhIjbQO8jaR5bjDXjIr0iweNdcw0VyoHeQ7s8swxfyklcaZ+meeQZf8oHeIdY8vFStaRRHWb5vgcGXfLBviNUPLSEQ9RMrjLDivoWGi/xQ/xCrH1ySrWmEWLV/kWGSGB4YZuX+RWpNIy/IqgcXGyaZoYFhVty3UKtprHloqSEdlhxKsnzfAmJFUQIRP90PLzVMYsmhJEv3zCevRK1pdD+yzDBJJodTLN49l/zyPHxBL2sfXW5QJEgNp1m4Yw6FVfl4Ah7WPrLM0CeSSqZYsG0WRTUFuH1u1j26wpBuTA6npML4aID9ueee+9AHPP/88w7UDvBLwFeff/75CmDpc889928//sO79fjBD37w3J49e37bh/EbCW/Aw5SVE1hx30Lmb53F//iDv+fS6RElU7vTzpnD5xnsG+Jv4YzOAAAgAElEQVTymSsoKIaVtd1u4+zR8wz0Dqo+1wLDzsFms3H++AX6rw5w+VwPQmDgvQshuHjyEn09/Vw524OwITWnXT57hd4rfVw514MQQmqOu3Kuh2uXeuk5fxUhkPwdrpzv4erFXq6evwoCg3Q2qOq3PReucfXCNYRNSP4RPReu0XP+Klcv9iIEkj/F1YvXuHIuhwvJ3+La5V4un1GPUQgk/4xrl/u4fOaKRjM14309/Vw8dZneK/0gVNVWffRfU/G+nn4URbHAB7lw4mL2c1MkpdqB3gHOH7+oKsFmMtL4wf5hzh27wMC1QTJpWel2eGBY+w6kkmlpfHIwyZnD5xjsGyI5nJLxoSRnDp1jqH+Y5JCMp5JpTh08y/DAMEODw9L5SafSnPrgDMODSYb6hyQ8k1VaTg4lGewblPxTlIzCiQOnSA6n6O8dkD5fUDj+7klSwyn6rw4YpNUBECoNOJ1M09vTJ31/Wmc00z5HLuB/GuP5558//dxzz/3gRo+74U5DUZSXFEUpURRliaLGUUA2+x2N31rkWE8bn1xDoiyevS9IIOLXLoL91wbou9JPQVZkMBQPEikIaxeRgd5BrpzrobBK9QEPRv0kyuKaXPZg3xDnT1zSGEr+sI/imgKN4js0MMzpQ+c0n3BfyEt5U4lG8R0eTHLivdOalInH76aypUyj+CaHkhx/9xQVTSpDye1zUTW2XFMpza36ciKFbq+LmrZKTfE1lUxz9K0TVI1Vd0tOt4Pa9kqNApxOpTny5nGqsz7kDpeDuo5qjQKcSWc4/MYxqrN1HIfTTv34ak2RNZNROPT6MWqyIod2h436zhpNkTWTUTj02lHqOlQ8xxjLUTwVReHgq0eoG6+yb4RN0NhVy9G3jHhuNydsgsaJdYZeiA9+dUSrI9lsgqZJdQaK6cFfHTEwqJom1Rl6JT741REaJ6q4EIKmSfUGCuzBV4/QqBNhbJpcr9FlLfFJdQYK7sFXj9A0yYjrKbyHXjtK06Q6LQ3ZNNGEv37MML7RhB9+/RiNE+uw2dTxDV21BvzIG8dpnFiXTWNCfWe1EX/rOI1ddVp/jxk/9vYJGrpqsTvsAIyd0SS5O47GzRXCw0KIb+dUZIUQ3wLkrqfR+K1Hw4QaGiaoF4Wa9ip8QaM/ht1h136UVWPL8Zv8KewOO82T60FA5ZhyAiYKr80mVFqmgPLmUonCK4RgzLRGhBCUN5ZIFF6AsdObETZBWWMJkfywhLdMb0TYBKV1RURNKrwALdMaVdn0mgJiRTLePKUBm91GcU2h1DGv4vXYHXaKqvK1CdaAT6rD7rSTX5EgUS5TgJsn1WVl3/MorMyX8MaJ9TjdDhKlcQqrZIpw44RanB4neSUximpkinBDZw1ur4tYYYQSCwpxXUc1bq+LcH7YkkJcO64KT8BDJD9MWYNMIa5pq8Qb8BCMB6iwoBhXt1bgC3kJxQOWFOOqseUEsh3h5nQmqGZbwVgAf9hH1dgKCS9vUr833qDHkoJc1lBCJNsRXmuBl9YXE0qEcPvc2gRswOuKiBVFcXtd2m9BH+r3JorL46ShS1Yp7lo0jn/96jd45s8e49s//CIVzbKS8p0eN1MI/6/Am8AfZ+/aArQpimLps/HbjjupEG4Oc2H8ZrSn9DnsG2pPmXC7w0YmrVwXv93aUx8J1xWmb6RNZYXri60fRVvKgJu0wcBYTLbSlrqR9pQBv5H2lIkiDcZiuRWFWF94tir864v5VvapRu0powoyGMkIVoX5G+K692SlEmzQnrLA9efU43Pzuf/nAUn48k6J21kIr1EU5VlFUQ5l/54HRjtcPoGhZIyyzr6Qj63P3YU/7GPZvgWSf4Xb52bHlzepKre751LRYlxZOl1Odn8tq3K7bZbkP2Gz29n3bZWCO3fzdBosmsvuy1JwZ62fKqnggkphVVVuJ9E2S24Ou/+lnQRjqsrteAt/iP0v78qq3I5n4hK5eWv/SzsJxYN0LmxjyirZ/+G+7+1QVW7njdV0u8x4JD9E++wWy1TFvu9sJ1oQZuz0RubdPUPGv7VNVbmdUs/CnXMkfO83t2gqt8v3zpfwe76+hbzSGPXjq1lx/0IJ3/21zarKbXslax6WKbo7v7yBgooEVa3lrHtkuYRve349hdWqyu2GJ1ZL+Nbn7qK4tpCyxmI2PyXjm57uprShmJK6QkuV3A1PrKK8qZSimgK2PS9rja57bAWVY1WVWyuV3O7PLKWmTVW53fVVmaK7av9i6jqqSJTGuedFmYK7bN8CTeV27zdkfMnuuTRPVhsMn/uLx+/YCeNW4mZ2Gj9BVbX9Ufb2VOCbiqJ8IqUe7+SdxsPTn+atHx/Qbt/IT8NMwTXjt+qnYaaQ3qqfxo38Mm4V//X9NEBP8b2Rn4bVSlj/Hm/kl3FD3ILCavDTsPLb0H0GlrjBT8NhEHAEk5+GFX4jPw3dGP1zjeA6Pw0TZdt8zObvkxm39MO4oV/GCEXYZrfx2B/cx/ytRgn8OyVu507jXuD7QogjQoijwL8C9v66Bzgatz9e+Osn6X54KU63k0U7Zks5cYfTwYr7FmJz2JjWPVHaWYDaHGV32JiyopPaDuPOIp1Ms/bR5diddiYu7aBpslGWYmhgmPWfXYXDaWf8wjZaTbISA72DbPz8GhwuB+PmjmX8vFYZf3K16uw3q1mSdRjoHWTz09043U7GTGtk8opOCd/01BpcHidNk+uYvsa4ahzsG2Lz0924vC4aJtQwc/0UA4V3sG+ITU+twe1zUTuuijmbpkv45i+sVZ372iqYv3WWYVIa7Bti81PdeAMeKlrKWLRrjuEiNdQ/zOanu1WSQGMJS/fMk/BNn+/WnPuW37vAiA8Ms+mpNQSifoprCli5f7HBlGh4MMnGJ1cTzDr3rXloieEiOzyYZMMTqwjnBUmU5dH9mWUGinByKMX6z64kkh8mryTGuseWGy7yyaEUdz2+glhhhFhRlLseX2mYJFLDKdY+upx4cYxoQZgNT6wyTDKpZJruzywjURonnAhl8ZFJLJ3KsPqhJRRUJAjFg2z6/BrDJJdOpVm5fxGFVfkEYwE2PmXEM+kMK+5dqDr3hX1semqNYZLNpDNqU2tjMb6Ql81PdxsowqrQpSwyORrGuGkZESFECOCTLCECd/ZOIxc5D3HZ6c+Lw2Hj2uWcR3iY88cvaLjb58Llcek8wsOcPTqC6z3CnS4H8eIYZ46MCBwKmyCcF+LKuR7VQ7wszhmTR3isMMKlM1ewO+wUVOQZBBAB4kVRLp6+jM1uo7AqX/KAjpfEuJj1ALf0CC+NceHEh3iEl8U5f/zidT3C8yvyOHc05xFepLGnclFQkdAYYVYe2jf0AM8KMF4Xv5FHuM4Xu7ypVFKqvRUPcEtc7wFu8f70vuCWuO4+a4/wD8f1x2TpEW7AVbHJ6+F6P3VrvED6/m15Zh1bn/tQy55PbdxOGZG4EOIl4IfA/xJCfE8IIdNORuMTEznJ721f3EBZtqEvr0Rd/eWKgsODSfp6+ijPMmhiRVESZXlaITc5lOTK+atUjlHZI9GCMEU1hVqfRHI4xfmTF6luUxky4USIyuYyjeKbSqY5e/i8RkENxYNUt1ZoFN90SuXv5xgwgaif2nFVXDytUnwz6QynPjijUVADET9146u5eFI1bsxkFE6+f1qro/hCXhom1HDhxAh+4r3TNGbZYt6Ah8auWs4fVynCqnz7KZUthppaappUz7nsJKkoCsffPUXLFBV3+9w0T24wqAQff/ckLdk6jdvromVqg0El+Ng7JxkzXcVzu6PTh4z42KwIoMPlYOyMJm3CyOG53ZrDaad1RrNhEj32zgkNt9lttM5sNlxkj71zktZZLRreNrPZMImquDpe2ARts1oMF/Hj756kbVYLQghsNkH77BbDJHv8XfX4chTXtlkthknkxIFTtM1qwWYTCCFomy3jrTNVNl1uvH4SO/n+aVpnNmsUWBk/Q+uMJuwO9TLWOrPZgJ86eIaxM5pwuFSJ/LEzmkz4WcZMa8TpdgIwadn4OzY1dStxM+mp/wScB7qBtdn//+eP86BG4/ZEUXUBhVll2ERZHLfXZcBtNhsltWpxPFEaw+Mz4sJmoyRbPI+XxPCY/Dlyq3WAeHEUT8CIA5Rk8WhhGF/IK+G5SS1aYI2XNqjjI/kh/GGfhJc1FCMERBIh/Bb+F6W1RQibIJQXJGCiCIO6mhU2QSgelCjEoK7sbTYboZifcJ4FXlOAzW4jEPVbUoyLqwqwO2wEo34iCZliXFiVj91pxx/2EbWgIBdUJHC47PhCXtm/JIu7PE78YR8xC4pyfnkeLo8TX9BDrFimIOeX5eH2ufAFvcSLZZXiRGkcl8+F2+e2pDAnSuN4/B48fjeJUnktGS+O4vk/7L13mBzXeeb7VnXOOU5PzjnngEkAJiDMAJgEzACDMEMSBMEABjATBEmToAJFUZKtsJKu7bXXe++15fV12HXc+9iy1/KKtgLFgDwIk3PsUPtHdReq6tQQFAUSpFTv80Bgz29OdXU1VKfO973n+wwaqHVqySrHDp8NerMOap0a7gSS27026E1aqDUqyf4rNo8VBoueLa2fTFqgrW4LDBY9lCoFfBIW6NKthfjOz76M1/77szj7p6clKynLEuqjJML/jWGYUtHPfvRRljF3Q3J46pYeqHqSa8oEsE/TG6sbXPLY4jILdsCqtSqEgmEuji7mSpUCDAMuTi7mNE2BVtBcHFzMAWHy3Oo2Ezt4+YlRq9tC7NDmJz4lOc/CKsX5iVEpzk9mfxzOt5VK81u1j6Q432wgdX0MFh2W51kudX35ZgaL00TsoDda9ezudABmp4nYgc+3oEq11+XbiqUsxvyWuFIWY/4xpSzE/HMyWA1YFlmI+Z+Zfy2kuJSFmH9NTTYDnvz9B1HeRrrufhN1JxPhf0dRVD9FUXT0Ty+A/+9XP0VZn7TEDwQavQYHnu2BzqRF+7EWIlGu0qhw6Ewv9CYdth1qRGKOcPOXUqXEkZf7oTfp0DLYgNTCJAGnaBrHXj0AvVmHxr4ayf4PI68PQW/RoX5vFXKqyf4NI+dYi2/N7nLkN5D9G0ZfH4LRqkdVZwmKW8j+C6OvD8JoM6BsexHKt5MW3WPnBmGyG1HSWoCqnaUEP/rqAZgdRhQ25qJWwqJ77NUDMDtNyK/PxpZe0kB45JX9sLrMyKnOQFM/adE98nI/bB4LMivSJEMhh17sh91nRXppCtokLLoHz/TBEWdHalESdkhYdIee74Er4EBSXjx2399G8APP7oM70YWEnAD2SFTRHXiyG95kN+Iz/dgrUUW377Fd8Kd54U/zou/x3QTf+8hOBDJ88KW40f8kadHd81AnErLj4Ely4cAzZJXd3fe3ISkvHu54Bw5KWHh33LMVKYWJcMbZcegMWUW3/VgL0ktTYPdZMXyW5NsONSKzPA02jwVP/cHD8oTxMfRRVhqLYHeAx2wUCgCx6Z9hGIZck99FySuNW3qs9Qze/tufcq/FFlz+Uy9AVjUVb8YSVzUVW0zFlkzx8fj2TpYLLaZiS+XtuPh8xJbK23KRpZjkQouq2OIrrsIqtvgSXGTxFVuWCS66nixnEPu/LGFxpQAK4Lj4eostwlIWVpqmEYnu95GywPKvkZSFlT+Gf6xb/NZ7UjQFMLc+j/icKTpqd+Zxvm1XbImWuibiysr8a05RFB759n1oOyxXRQLu4EqDYRgTwzA0wzCq6B86+jPTZ23CkCXU2T89jaHneqA369B1oh0JWeKVgwK9j+6GUq1EY18tUgvFZR8o9J/uhkqjRP3eKqJ/RigYxoFn9kGlUaFmdzny6oQrg43VDRw80wu1VoXKHSUoEa0M1lc2MHy2D2qtCmVtRShvLyL5SwNQ69Qo2ZpPrAw2VjcwfLYfGr0ahU25xOa8jVV2vEavQX59Nhr7aoR8bQOHX+qHzqhFTnUG0T9jYy2Iwy8NQGfSIrMiDduGhTeX4HoQh1/qh96sQ3pJMtqPtUjwARiseqQUJmLHvVsFN7DgRgjDZ/thshmQlBePrgfahXw9hOEX+2B2GJGQFYc9D3UIbrChjRAOnemDxWVGIMOHnlO7BDwcDOPgmV7YPBb4Uz3ofbxLMKmFQ2EMPdcDu88GbxK7MuDf5MOhCAaf2wdnnB3uBCcOPLNXMElEwhHsf3ovXPEOuAIODD67TzDJRCIRDDzZDU+iCw6/DUMv9AgmKSbCoPex3fCleGDzWHHwTK9gkmMiDHpO7UJcug9WtwXDZ/sFFmCGYVcu8Zl+mJ0mHD7bT+wT2f1AO5KipU2Gz/YLJmmGYTDFa48s66Ppl+rc93mQvNIgFQqGoFQpcbLmKbzzz+9zP48ltteW16FQKmDzWDAVdScBbG8GpVqJlcVV0AoaDp9N0INcoVRAo1djZWEVNE3BEWfn3EkxxUpb0DQFZ8CBiStTAh6Li1MUBXeCU+BOAm7FwCmKgjvRifFLIs6LgfPtrjHxY9xSnJ9XiPUb5ytmEd6U+2yYiTq+pLjDb+OKPvLttDE54+zcNZca7wo4uGsuyaMW4s14rEc7y90C9xZwy2K82fXhc0+yG+Mi7k1yc7ZrT5KL+H68yS7cvDhJHCsmX7IbN6LHlOLeFDdn23bFOwUWcfFn5l8LjvOuOf9ax3ToTB8GnyWbTf0m6k7mNGR9zqVUsZbD0dcPchZYb7IbrngnF14Kh8JYXljhVhOeRCf8aV5uh3ckHMH81AJX8NAZsCMxJ8AlGiMRBtPXZ5Fby+YpHH4b0oqTuVpIkQiDiStTXJ7C5rUioyyVS6QyDIPxy5OcBdTqNiOrIo1LmjIMg/FLkyiM9uSwOE3IrsoQJHJvXpzgylibHUbk1mYKEsU3L06gpJVd7RhtBuTXZwsS0TcujHN9qA0WPQq25AhKid+4MI7SbSzXm3UobMrlJowYj3Ub1Bm1KGrO4yYMALhxfhzlbexqSmvQoLglX3ATu3HhFtfo1CjZWiCYpFnOxuDVWhXKthUKbpIxTtEUVFoVyrYXCibpGxcmUNHOcqVaifK2IsFN+ubFCZS3FYFW0FCoFAQf53MljYr2YsE+nfFLkyhvK4JCpWB5RzE3YQDAxOUplG0vglKlAEVTqGgv5iYMPldplCzvKBbs85m8OoXSbYUsp4CK9iLBJDl5dRqlWwug0aujPWKKBJP01LUZlLQWQGvQgKIotByoR9tRMm8k68Ol3AxQFPXnAI4zDHPp0zsdWZ+k9CYd9NHKtjqjlkiUAxTHtUYt54+/hSkYLAZuvEIl4gBni9XqNVB+HG5mj6/RaTh/vXA8y9U6NVSSnD2+WquGSq0iuN6sA0VRUGvVkse/xVWcf1/AjTr2pqyR5jrTLa7WqgmuNWhBK2go1UrCAg0AOqPuNlwDhVIBpVoJ9WacZm/qGh1pgdYYouNVSmj0JI+dH62gNuHR742S5hq9BgolDSbMSI/XR697MAytUUuO16mhUCrAhBloDdJcpVYhEmagNZIWbbVODaVKgeB6CDoTyQsbc/HY9+7H1Ng0siSq3Mq6vTYNT0VdUi+BrW57Ltqx7zMvOTy1ucThKY1ejUgoguBGCBRFweo2C5rgqDRKABSXzOWHagCAVtJQKhVcstjuswqaQAFCi2tst7eA85Ll/FBOTPx6UrHd4JtxqfAD33b5cTi/iqoU59tGpTjflirF+RZUKc63zUpzM+an2NWU1PXjh+ekrr/VY+EaG/FDbTHZPBbu34T4+wfYFWOs8ZIU5/+bkLIY889JkvM+k5TF+Lac92/G7rPhqd9/EIWNwg6Sslj9yuEphmH+CEAxADOAH1EU9ShFUY/E/tzBc5V1l6TWqtH7RBc0ejVahxq4BksxKVVK7H+qG1q9Bs3767gGSjHRNI3BZ3ugNWiwpbdGsn/CwRd6oTVoULenEmnFSQQffrEPOqMW1bvKJKvkHjzTC51Ji8qOEm53tpjrzTqUbitEfgNZJffgC73Qm/Uobs5DsUQHtoPP93ChqLK2IoIPPbsPRpsBeXVZqOosIfjgs/tgshuRXZWO2q4Kgu9/eg/MThMyylNRv7eK4ANPdcPiMiOtJFmyim7fE12weSxIKUhEyyDZq7rvcbYWVFJuPLYeIl1APY/uhCPOhoTsOLSPtBB874OdcMU7EJfuQ+doK8G7TnbAk+SCP9WDXcdJC+/u49vhTXHDm+TG7hMk33HPNvjTvXAnOCUtvG3HWhDI9MMZcKDnFFmFd/twExJzAnD4bZIW39ahLUjOT4DNa0X/EyRv6q9FalESrG4zHvnWvfKEcQf0oYlwiqLUAE4D2A92FzhnjYiWSP/MSV5pbK5nd72Kf/6zf+Nei6vCil+LLbXi1+Kqq+LXYsuqSqsS9KgWW0rFFlWxJVXMxfZK8e+LOfFaVHX1l+Viy6rY4iq2rIq52LIqPh6toBAJMzwuPJ54/G1fiyywYgux+LXYEhsrF8K9FnOp36eENmS+LZntt0Jx50RRrGd4s9+X/ozCa0ReM+E1ffh37kHHCDk5yroDKw2KotoAvA1AD6Ak2lPjTOzPHTxXWZ+Snv9/HsW9XzwUrUDazdWViolW0Bh8bh80ejVaDtQjvUTYNoVhgEMv9kGj16CxrwY5oif/4EYIR17ZD41eg/q9VVzdI46vBTHy2iC0Bo1kf4zgehAj5wahM2pR2VmCyh2lJH99CDqjFmXbi4gn++BGCKOvD0Fv0qGkJR9beoSb70IbIYy+fhB6sw4FjTlo3l9P8Hu+cBAGix55dVnYeqhRYvwQjFYDsqvT0SGy2IaDYYy+PgST3YjM8lTsuHcbwUe+MASzw4S0kmTiyTwcCmPk3BAsLjNSChOx9+GdIh7BsdcGYfNYkJQbj55HhTwSjuDYawdg97Eri/4nuoQ8EsGRVwbgjLMjkOHDftHmukiEweGXB+COd8Kf6sXQcz0CCy/DsG4jT5IL3iQXDp3pE/IIg6Hne+FL8cCd4MTw2QHBDR8ADjy9F3FpXjgDdhx+ZUAwiTEMg4HT3YjP9MPht+HYqweI8b2P7kJiTgA2jxUj5wYFEwQA7HtkJ1IKEmF1mTH6+iCxD4XoES7rl9aH5TT+fwD3Mgzzs0/3lH41ySuN24thGFAURfTfUGvVYBgGwfUgKIqCzWsR5CiUKiVoBcWtHsQxdIqmoNGquR4dUjF2/mrldjmM2+YgohVtN+N8u2pM/DIbUpyfo5Di/BzFx+H8HIUk58XlXQE7JkWfjx/3dwYcxD4DAZe4fjaPFbPj7Hcqdf35OQqH347p68Lx/LyHVI6Ef0ypHAn/nPjvJcl5+RSO875zqRwI/5pIlWE5/NIA9j/1mWw6etd1J3Ia9Z+3CUPWR1Ns5/EDbx3jqqQmZMchLt3LhX8YhsHK/CpnYQ1k+pGYGxCEm+anFrnVgj/Ni/SSFEFTp+nrsyhvZy2ivhQ3sirSBOGt6euzqIz2zHAnOpFTnSEIj01dm0FVdLXhincgry5LUEtoamyG2/Dn8NtRsCVHwCfHplGzmy0FYvdZUdSUJ2gyxedWtwXFLfmCWkiTY9Oo7a4ARbEl30u3FghqLU2OTaO2i+UmhxFl24sIXrenEhRNwWgzoLy9WFALanJsGnXdFaAVNAwWPSo7SwSJ3MmxGdTtqQStoKE361C1o0xwk5wam0ZddyVoJQ1tNC8k4NfY8QolDY1ejZrd5dyEEbv+dXsqoVQpoNapUdtVIbiJT1+fQV13BZQqJVQaFWq7KgSTwPSNWdR2V3BOs7o9lYJJaObGLGq7KlinmkqJ+j2Vgkls9uYcanaXQ6NnHU/1e0V8fB7Vu8o4R1b93krBQ8LcxDyqdpRCZ9KC5vg0jy+gqrMURqsBtILGznu3SZZekfXLaVPLraxff22sBbkyG8H1IFeiOiYGEHApi2nM+RRcDxIlJYQ8JM2jxw9thAQNhSR56EN4MESEIgBwkxg7nuQbq+sfOn59ZQMMwyAcCiEkNX49yoNhoitd7PyYCMvDEnwjet3CoTBCGyQPrgfBRKI8GJLgG2DCEURCYUE+RzCeYUNP4t3SMR6JMEA4IsgXcXwjBIaJAAy9yfhb1y24Jj0+EomAYSLYkDh+aIP9dxEOR4iugiwPg4lEEIkw0jwYRiQUAbPJ+Ny6LDz63eOYHZ9HUm48wWX98pJ3hP8GiwhP6dSgaQpry+ugaQp2n03w5KdUK6FSK7G6tMZyv03w5EfRFHRGLVYWVkFRFJwBcod4LDxEURRc8eQOcX54SGqHMD/8I7UDmV9lVZLfwR3kUpwfcpHi/JCNFOeHd6Q4P3xzW57kwk3R5+eHb/gNpWLi76r2JDoFTbgA4Q5z/n/HxD+mK8GBySvC75//nUqF5/jfmVR4js+lwm/8a+JL8eD0751EThXpupNFSt4RLuuXlkqtRNeJdqg0KtTvqyL6EygUNPY82MHWmuqq4HptxERRFPY9shNqrQrVO8uQkE22k+15bBfUWjXKO4qRnE8++fU8ugsanRpl2wuRVpRM8lM7odFrUNySJ1lFd9+pndAaNChozOEaLAn4IzugNWqRV5eFvGgDJb72PrwDOpMW2VUZkvbMPQ92QG/WIaMslailBbDtcg0WPdJKkrnd3XztPtEOo82A5IJEVHWSVXZ33d8Gk8OIxNx4ySq7O+7dBovThPgsP1FrK8atbjPiMnzY0kdaeDtHt8LutcKf6iFqbQFA+9EWOPx2eJJcaBkiq/BuG26EK94Bd4IT2yQK/bUMNcCd6IIzYEf7EdLi23KgHt4UN+w+GzokLL6NfbXwp3lh81gIIwEANOyrRnymHxaXGTuPbyd4bVcFEnMDMDtMGDk3KE8Yn4DklcZvsF7q/xL+4Y9+yL0WV7UVV5kVV8kVW2q1eo0gpyG2qIotuWJL6+24uGqt2MIqPh+iKu5tuNjSK7Z33paLLL9EVVwxF41XqpSCEJS46q34ehBVbwkOYVVb0fUSn6Nk1SyuMSwAACAASURBVFveOUpVvRVUtZWoeksraUS4qrfC6yE+J7G9VvyZpKri8v+Nia8XAJz8+gh2Skw+skjJKw1Zt9VT//khnPr2ffCnejB8tp/oj0HTNI68PACdUYvWoQZklQs33zEMMHJuCDqTFk0DtVxr05jCwTDu/dIw9CYdGvZVEf0vQsEwjr9xGHqzDrVdFcTmulAwjONfOQyDRY+qHaWo3in89xwOhnH/m0dgsOhR3lZEbJ4Lh1hutBpQurUAjaL+FuFQGMffPAKjzYCiply0DgmfvCPhCO5/8whMDiPyG7Kx/UgTyb9yBGanCTk1megUJVkjEQb3v3kEFpcZWZXp2CWy2EbCERx/4zBsHgsySlOw56FO0fVlcM+XDsHusyKtOAk9j+0i+RcPwRFnQ3J+AvpEFluGAUbPDcEVcCAxJx4HniZdQ8deG4Qn0YX4TD8GJfpXHHl5AN5kN+LSfRg+00fwQy/2wZ/qhS/FgyOvDBD84PM9CGT44Uly4ehrBwh+4Om9SMgOwBXvxOjrQwTvO92NpLwEOOPsuOcLByF+xu05tROphUlw+G2478uHiNI4fOODrDsjeaUhi9OppufxH//wc+61SqNEJMxwT59ii6NCSYOiKO5JUMwpin165jr18UpW3HqPW0/vUhZL/upAkvNWH1KcX6ZEyuLJtwDz7ai3uBZry2ubcv7qTOr9+RZgqfF8C7DUeH4ZEynOzwFJWVBNNiMWZ5einLSgmuwGLM6w46XKcPDLnEhxvoWYn0/iOG+MNDdhfjLayc9uxJKoEyD/M0l1+hNwXlfCmI69Oii5k1wWKXmlIeuX1iPfupezsKYWJSEpN14QrlhZXEVNNM6eUpCItJIUQThkcWYRddE4e1JuPLKrMgThmLnxeTREu93FZ8Uhry5LEO6ZHZ/nel7EZfhQ0JgrCCfNjs+jaT+7WvClelDcnCcIV82Oz6N5oBYUxSZkS7cWCJpAzd6cQ8v+elAUm/AtbysSWIBnx6OcpuCMs6Oyo4SbMGK89UADaJqG3WdF1c5SQThvdnweLQcaQCtoWN0WVO8uF1iAZ8fn0DpYD4WShsVpQm13heBJeHZ8Hq2DDVCoFDA7jKjfV8VNGHyuVCtgtBnQ0FMtuInOTcyj5UA9VGolDFY9GvtquAmD5QtoOVDP9gw369DYX8tNGAAwP7mA5v310OjU0Bm1aB6oE7R7jXGtQQOtUYvm/XUCC/HC9BKaBmqhM2qh0bEbRPmTzML0Ehr7a6E3sT3BWwbruQkDAJZmlrCltwZ6ix5qjQqtgw2CSXBpdhkNPdUw2gxQqZVoHRLxuRXU762C1W2BSqNC/+lu7Douh6butGTLrSxOU9dmOGfK7Pg8jFa98BciDI/PweIS9uBiGHB8bnIBtIJ8Jon1Y1iYWoBaS1p4Y6W2F6YWoZeoUjoeLbW9OL0Es91Ijr88CYYBFmeXJEMTNy9PgGHYG4z4qRQAxq9OgYkwWJ5f4cq6C/kkIpEIludXBTfcmCavTiESjmBlcZV4agaAiavTCIciWF1aI/pvA8Dk2BTCwTBWl9axILF7efLaNEIbYaxhnXjqB9i9E6xNliFWFTG+sRZEKBgmVn0AMHOT5RRNYUa0KgLYvRexiVhcnBBg/92sr7I2ZPHGPwCYG5/D6vIamGgpfbHmJxewvryOSDiCKdHGwhhfXVxFOBQhnFMAkF2ZjlPfuQ+LM0vwJrkJLutX110JT1EUZQdbyyoJwCUAvQzDEP+CKIoKA/hJ9OUVhmF2iX9HLDk89fH1SONz+Mn/fId7rdaqoNGpsTi7DKVKAYffLrBoKpQKGCx6LEwvsjzOTlhcrS4z5iYXoFAq4Ip3kBbVaMiFVtDwJrlw/bx0EySapuBN8eD6BzeFPGphpSgK/jQPrr0v5LFdzRRFIS7di7H3bgg43/YZyPCRnNf4Jz7Tj6vvXhdwvu1UivMtovFZflz9hZDzmxhJcX6TofisOFz9xTUh5zUZkuL+NA+ufzC+6fnFpXu5axbI9GPsw3iGH2PvCTn/mkldP/7P4tJ9uPa+kMdn+nD13RvRc/US3y//mvhTvbh+fnOenJ+Ax79/QtJ1J+v2+qyHp04D+BuGYdIB/E30tZRWGYYpiv657YQh685KoVRg26FGKJQKlLcXwZXgFHCKptB2pBlKlQLFWwvgSyaf7NqPtUCpUqCoOQ8BkUWX5a1QqpUo2JKDQKZfcrxKo0Refbbk5iyWq5BdnYEUiSq77UeboNapkFWZhrRi8may/XATNHoNMspSJC2824cboTVokFachKxKsv/C1kON0Bq1SM5PQE5NJsmHtkBv0iExNyBZhbdlqB4Giw6BTD+KmsgqvE3762C0GuBP86I02iCKr+aBOpjsRvhS3FwDKL4ae2phdprgSXKhooOs0tuwrxpWlxmueAdhNACAuj1VsHktcPhtqO0mLcC13ZWw+22w+6yo3UNagGt2lcMVcMDqtqB+H8krO0vhTnDC4jSjsbeG4GXbi+BNdsPsMEpWAS5pLYQ/zQujzYC+J7rkCeNT0N1aabwLoJFhmBsURfkA/D3DMMT/4yiKWmIYhoxBfIjklcbH1xePfh1/+d2/417zk7gAaVnVm3RcZz+AtNiKq+aKLZtiC6/YsnlbLqq6ezsutnTejvOT6ABp6RRbksUWWDEXv4fYYgyKPUaMi6+3+DNKcYWC5nbWi6sKA8LvQGwhBoQWV3EVYjEXf9/in4ktwIDQdixlAeafs5QFWK1RcTvLpSy+D7x1DLsk9m/Iur0+6ysND8MwNwAg+vdmwUctRVE/oijqnymK6trkd2TdIZ36znE8919PIbUoCfd9eZiockvTNEajVWBbhxq41q8xMRGGs8g2DdRxda1iCocieOCtozBa2SRuaavwyTkSjuDk147BaDOgrrsCFe1FJP/6MZjsRlTtLOXqRknx8rYi1O8TWnCZCIOTXzsGs8OE0q0FxJMrE2Fw8hsjsDhNKGrKw9aDDULOMHjga0dhdZtR0JCD9qMtBD/x1aOweSzIrcnEjnvIJOz9bx6B3WtFVmU62X+CAU68eRQOvw0ZZamS/Sfue2MYroADacXJ6H2MdAWNfvEg3AlOpBQmYv/pboKPnBuCN8mFxNx4DD67l+BHXz0AX6oHCVlxOPQCabE9/PIA4tJ9iEv34fDZfoIfPNOL+Ew//KkeHH2VtNgOPrcPiTkBeJPdGD1HWmwHntyD5PwEuBNduPeLBwne+8RupBYlwRXvwH1fHiY4f5KX9cnoE1tpUBT11wC8EuhpAN9nGMbK+91ZhmFsEsfwMwxznaKoFAB/C6CFYZjzEr83CmAUABISEkovX758pz7Gb7Qe3/oifvw3P+FeK1UKRMIRboOW2EJJK2iAYXjcRCR7+U+HUpz/dCnF+U+vkpz3pCvF+U/P0vzW07cU5z/dS1lI+RZgKc5fffBLosTE3yApyXmrL76dNia+BVjKospf/RmtBiLZz19d8u2+t7geKwvsz/h24Zj4PzOYdVjmrVTFxxSvZMXnLF6pirl4JQoA93zhIPY9QjZzknV73fWVBsMwrQzD5En8+QGA8WhYCtG/JzY5xvXo3xcA/D3YToJSv/dNhmHKGIYpc7lcn8jn+U3U498/geb9dQAF5FRnIK0kRbCjd2VxDVsPbgEoIKsiDdlV6QK+OLOEtiPNoCgK6SXJKNiSIwgnLEwvov1YCyiKQmpREoqb8wThCI7TFJLzE1C6rVAQ7liYXkTHSAtoBY2EnAAq2osF4RKWt4JW0Ahk+lG1o1QQblmYXkTnPa1QKBXwp3lRvbtcEK5ZmF5E5+hWKFQK+FLcqNtTKQgHLUwvYcc9W6FUK+FOdKJhX7XAArwwvYTO0a1QqZVwxTuwpa9GEK5anGHHq7UqOOLsaN5fJ9hRz3GdGjavFS0HGgQ3ycXZJXSOtkKj18DqtmDrwS0CC/DS7DI6R1qhNWhgcZqw7VCj4Ca8NLeMjmMt0Bm1MNkN2H64SXATX55bQfvRZujNOhitBrQdaeYmDIDdONd2pBkGiw56sw7tR1sEk8jywiq2DzfBaDNAZ9Ki/ViLYBJaWVjFtkONMDuM0Bq06BxpFUxyq0traB1qgMVlhkavQeeokK8traFlsB6ugAN6kw5Hf+uAZPdAWXdWd8ty+6cADgF4Nfr3D8S/QFGUDcAKwzDrFEU5AdQCOPepnuVvuC7+5Ap+8b8+ABjg6i+uweK2CDjDMPjFv7wPMMDYezdg94kXiwx+/sN3wTAMxt6/AXcCOaG/88P3wDAMrn9wExGJRPo7//IemAiD6+dvElV4Wf4+IuEIxi9OQK0mLby/+F9RfmkCOoNGgn+AcCiMiStTMFoMBH/vRx8gHAxj8uo0zHYTwd/90XmENkKYvjaDcc8kwT/48QUEN0KYvj7L2Y35ev/HF7GxFsTMjVnOJSUY//ZFbKxuILgexI0LNwl+/t8vY31lHRur64QzCQAu/OQy1pbXsba8jrH3rxP84k+vYnVpDRRFEc4rALj88zFuIrkixd8Zw/L8avR3rxL86rvXuBv95Z+RfOy961icWQbDMLjwkysEv/7BTSxMLYBhgAv/QUYQ0otT8NBv34PVxVXYPFaCy7rzuluJcAeAPwKQAOAKgB6GYWYoiioD2/jpGEVRNQB+B2yLWRrAGwzDfOd2x5YT4XdOj7W8gLf/7lZLFZVaCbPThOnrs9Do1HD47QILJE3TcPhtmBybhlqrgiveQVhgYxZVlUYFT6KTsGjGqqSq1Ep4U9ykRTVaxVSpUsCf5sOVd8YEPGZRVSgVCGT4cPnnQh6zddIKGglZcbgkupHFLKY0TSExJx4Xfyq8kcUspDRNITE3HhdFN7qYBZSi2NWR+EYXs8VuxhNzAtw5pxYm4vy/b85TChNxQcST8uJx6adXNx3P55Lj8xNwKfqZpHhyfgL3mVMKEnDhP4SfP7kgERejn4n/uzGlFCRyn1mS896Tf65SPKcmE6e+fR8SsuIg61fXXQ9PfZgYhplmGKaFYZj06N8z0Z//iGGYY9H//ieGYfIZhimM/n3bCUPWJytaQaN2dwVomkJOTSbsftGTHQXURpsKZVWmwxlwEMeo31sFWkEjsyIVnkRy5VG3l20alFaaQlTZBcA1DUopSoI/zUPw2mjToOT8BAQySItvze5yKNVKJOXGIyGbvNnU7C6HWqNCQnYAiblkld6qneVQa1WIy/AjuYC0+FbtKINGp4Y/zYuUQpJXdpZAa9DAl+JBemkKwcvbi6EzauFNciNTVOsLAMraiqA36eBOcCJbwgJctq0IBosOzoAdOdWkBbi0tQBGqwF2vw15ddkEL2nOh9lhhM1jQUE9aREubMqDxWmC1WVGYSNpES5oyIbVbYbZYUJxM1kFOK8uC3avFUabASWtpIU4tzoTjjg7DBY9SreRVYKzqzLgindAb9Zh+3CT5Hcs65OVXHtK1qb62oP/CX/y1b/gXosTo+KqrOLEqNgSKU58ii2ut+Pi47MOWIqzwBLjRRZYqcQr/z0ILrLAii3GgNDCejsuriIMCBP7Uolfvi1VivMtrGIL8Ufh/MS+uEoxy9XYWGPzMIRFWPQzKQswP/EvxfnnJGURFnAJi/CJrx7F7vvlPMad0Gd6pSHr86H7v3IEr/7VM8ivz8bD37wXGaXCzW8UTeH4G4dhtBrQcqAe2aL+FUyEwQNRC21jXy3Rn4KJMHjwGyMw2Qyo31tFbF5jIgwe/O0RmOxG1Owu51rHcpwBTn79GMwOIyo7SQsuwzA4+fURmJ0mlLcVoUFkwQXY0tkWlxklrQVoGqgTQoblVrcFRU15aBVZcAHg/jdZi21+fTbajjRL8COw+6xRCy7ZavT4G4fh8NuQVZGG3Q+0E/y+Lw/DGXAgozQFex/uJPjoFw7CleBEalESeh8j97+OvD4ET5ILyfkJ6Jew4B75rf3wpbiRmBPAfokquMMv9SMuzYv4LD8OvtBL8KEzvQhk+tkquC+RFtzBZ/YhITvAWnB/i7TgDpzuRnJ+ArxJboy8Nkjw3sd2IbUwEe5EJ+75AmnRleomKOuTlbzSkPWR9VTHy/jXv3ybey3enCVeiRArBTEXbZYjOcBfSUhxirrVo0HKAspf7Xwczl8pSHLeNZDi/JWE1EqHbxGWWqnwn66lxvOf3nUmHVYXP4RLrFT4KwV+RV9uPM9CLN7syI65tRKQ5LzVi9RKhW+bFfdLEZ8zf2NfTPd/5Qi6JCZbWb+85JWGrDuu0793Ep2jW0HRFAqbcomY+trSOnYd3w6KppDfkI0CUdmM5bkVdD3QzuZEqjNQ3JIn6H+wPLeC7pMd0ZxHGkq3FxF8z4MdUCgVSC9NQUVHicDiuzy/gu6HOqBUKZBalISa3eWC8Njy/Ar2PNzJ5jTy4lG/p5LkD7E8ISeALb3Vgh3sy/Mr2PvwDqi1KgQy/WgaqBVMmizvhFqrgj/Ni5bBeoFFeGVhFXsf3gGNns1pbD20RfCkvLLIcq1BA3eiC21HmgXhmJWFVex9qBM6oxbOgAMdx1oE4Z7VxVWus6DDb0PnaKuQL61xnQVtXit23rtNcBNfW15D1wPtMNmNsLot2Hl8u+Amvr6yjt33t8HsMMLiNGH3iTZBuGt9hf3+LS4zTHYjuh5oF4S71lc3sOPebbC5LTBaDeg+2SGwEG+sbqBztBUOvw0Gix57HuoUTHIb60G0H2uBP80Li9PENliSq9h+6lK88MILd/sc7qi++c1vvjA6Onq3T+PXUv/23/8Df/zmn2N5fgXzkwugaEqw+YwChdnxeSzNLWNhchEURRGb42Yn5rE0u4z5qQVQNM31645pYWoBC9NLWJhaBE3TmJ8SVmqdn17AwtQiFqcXQSkootLr0swS5iYXWE5TRKXXxZllzE3MY3FmOcqFlV6X5lYwNz6PxZkl0DRN9K9YmlvG7M05LM0ugaYpgq8srmHmxiyW55ZBURTRv2N1cQXT12exPLcCiiIrxa4tr2FqbIZbUYj5+soGJq9OY2VhFQyAmRsivraBiStTWF1cA8MwBA+ub2D88hTWltYQiURIvhHCzYsTWFteRyQUId4/HArjxoUJrK9sIBwMEzwUCuPG+XFsrG4gFAwRPBKO4Pr5m9hYCyK4HiSuDxNhcO39GwiuB7G+ukFc320HG/HofzqOXfdtR15dNmhafu69Uzpz5syNF1544Zu3+z35isv6yPrB1/6Cqwi7tryOm5cm4U9lHUx6sw5xGT6uCu7ayjrG3rvOuVt0Ri0Sc+K4iq8ba0Fc/cU1xEeLFGoNGiTlxXNVboPrQVx5Z4zrM67RqZGcn8BVbA1uhHD5Z2NIjBYxVGtVSC1M4iy8oWAYl356Fcl5CQDYME9qURJXpTUcCuPiT64gOT/K1UqklyRzexUi4Qgu/MdlpEQdUkoVu7rheITB+X+/jNSiJADsTvaMslRuL0IkwuD825e4Iom0gkZmWSou/Yy1yzIMgw9+fIkr1ULTFDIr0jgLKssvcg4rmqaQVZEmsOh+8L8vckUWKYpCVmWawCL7wf++iMxyIT//tjQHgKzKdJx/+9It/uOLyKxI4/E0fPDji5vzijSc/zF//CVBkcesCuH4829fQlZlGhemzCwX8gv/flnAy9uKULWzFCq1CgaJPTWyPh3Jk4asjy2KolDQkAOKAhJz42FxkpvfWE4hIScAq2hzIAAUNuWCoinEZ/ph95Kbswq35ICiKQQyfHD4iUozKGjIBq2g4E/zwhmwEzyvIQsKBQ1fihvueNICnF+fDYVKAU+SC24JC3BeXRaUKgU8iS74JPoz5NZmcju+YxMoXzk1mVBplHAF7IiTqPKbXZUOtVYNh9+GQAZZ5Te7Mp3bER4vsR8hszwVWoMGVreZm2D5Si9Nhc6ohcVpQlJuAslLUqA36WB2mJCcR1YRTitKgsGih8luREpBEsFTCxJhtBlgsBq4CZSv5LwEmBwmGMw6pJWQFuPEnHiYnSbojFpklJE8ITseFpcJOqMGZduL4I53Er8j69OVnAiX9ZH13Wf+AH/wW3/M5RnEtZFoBQ0mwtziNgMWeWUfKIoCRYHLQ4h57BixPAO/FSl7AHYD4aYcwtpV0vxWYluqthM/MS11fnwuVduJn3iWGs/nUrWf+Mng23OyvSk/MS2VmOdzqcS6zqDB6odxnm1YKnHP/5mUxZh/TKnaUXqLHivRc5ayCMsW209OciJc1h3X4ZcG8OYPX0bVjlI89Z8fEoQ2AHZSOP4V1oLbNFBH9JdgGAYn3joKo82ALb3VyN9Cbh478dZRmGwG1HVXorhFtPmLAR742lGY7EZU7ypDeTvZH+L+rx6B2WFERXsxqneR/R9OfPUozE4TyrYVom5PBcGPf+UwLC4zipvz0NhP9m84/pVhWN0WFGzJQetgPcHv+dIwbF4L8mozsW24ieD3fvEQ7D4bsqsy0DHSQvDRLwzBEWdHRlkqdt5PlvgefX0QrngH0kqS0X2yg+BHXtkPd6ITKQWJ2HeKLNx35OUBeJPdSMqLR98TZJXcgy/2wZ/qQUJOAP1PkhbdwWd7EMjwIZDhw+Cz+wi+/+k9iM+Kgz/Ni0MSFt2+x3cjMTcAX4obh8+SVXR7T+1Ecn4CPEkuHH1lP8HFpdBlffqSVxqyPrae7z6Hf/rBv3KvxRZcsQVUvNlP/CRK05TADSW2iBJcNF5s8RWPF1t8SQ7wLb5iCypFsf8Tew+pJ2H+Z5TaLMfnUhZVISf7cfBXUlIWVv53ILWZjm8Bvh2X2kzH/xl/4+AtfquKsFQ/Dv57SvXTuB1/6LdH0TlK7neR9atLXmnI+sR1+vdOoufRnVAoFSjbXoS82iwBX11cRd8TXVCoFChuyUdxc56Ir6H/yS4oVQoUNuaibLuwbMTq0hoGntoDlVqJvLosVHaWEuMHnuyGSqNCTnUGakWb+1aX1rD/qT1Qa1XIrEhDw74qgYV3dWkN+5/eA7VOjfSSFDT21wn42vIa9j+9Fxq9BimFiWgZbBBMSmvL6xh4ag+0Ri2S8uKxbbhRMCmuraxj/1N7oDNqkZAdh7ajzQK+vrKOgae6oTfrEMjwofOerSK+gYEnu2Gw6OFP9WDX8e2CKsDrqxvoP90Fo80Ab7IbXQ+0C26yG2tB9D3RBbPDBHeCE3se7BRYgDfWguh9fDcsTjOccXbsfXiHgAfXg+h9bBesbgvsPit6Tu0UTCLBjRD2ndoJu88Km8eC3sd2CSaJ4HoIex/eAYffBovLjL4nugSTVDgYxp4HO+CKd8DsNKH/NMl3n2hHUl48XPEOPPn7D8oTxmdAsuVW1sfWP/7xv+APX/sBVhdXMXl1CgwDIsZ/4/xNrCysYmpsGpEIQ/Dr529ieX4VU2MzYCIRIsdw88I4luaWMXVtBpGwBL80gaXZZUxfn0E4zBAW3/HLk1iYXsLsjVmEQ2GCT1yZxMLUImZvziEUChMW4MmxacxPLmBuYgGhjRDmRXxqbBpzE/OYm1hAcCNEWICnr89gdnwe81OLCK4HCT5zfRYzN+ewML2EjdUNgs+Oz2H6+iwWZ5extrJO8ol5TF+bwdLcMlaX1gg+P7WAyavTWJ5fwcriKsEXphYxcXUKK4urWFlYIfnMEiYuT2J1aQ1Lc8vE51+aW8bNi5NYW17H4uwSwZcXVnDzwgTWV9axML1IXN+VxVVcPz+O9RX2s4u/n61DW/DIt+/Frvu2I72YTJTLunOSLbeyPnH91ff+jtvnENwIYfzyJFekj3XjJHA+/VCQ9e+nlbAWVKPNgJTCRG6fQDgUxrUPbnIWVKPVgLTiZExdmwHAxrKvvX+Ds5jqzTqkl6ZgaizKIwzG3rvOFfnTGbXILE/FxJUpjl999zqyKlmuNWiQVZGG8cssZxgGV9+5xpVC0eg1yK7KwM1oOXOGYXDlnWvIqYlynRo51bc4AFz5+Rhyo3kclUaF3JpMzkIMsGXG8+rY1ZgyunralKsUyKvPFlQJvvyzMeQ3sEUGFUoF8huycY1XJfjyz29xWkEjvyEbY+9eF/BYN0VaQaNgSw6uEjwbFEWBpikUbskRlEu/8s415Ec5RVEo2JKDK+8IeUFDDmia5YWNubjCqzJ89RfXWLdbtMR9wZYcQRXiq+9eR35DDtvMC0BjXw1quyugUCig0ZFl7WXdHcmThqw7qljlWGecDXqzjuCJUVtobNcvMT6HHW/zsruGpY5PUYDda4XJtgmnKdg8Fpgk+l8kZAVA0RQsLrYSq1jxmX7QNA2L0yRpIQ6k+0EraJgdRkkLcVyGDwpllEv0d/CneaFQKWC2GyX7P/jTvFCqFDBYDXD4SO5L9kClUcFg0cHhJy3GvmQP1FoVDGYdnHGkxdiT6IJap4bepIVLogqxJ9ENtU4NrVELl4S91RPvgkavhtaggUeiP4orwQmtQQO1Tg13AjneGXBCZ9JBo1fDI2FhdsbZYTDroNaqkJSXALPdSPyOrLsrOREu62PrD1/9Y3zvuf/CxdktLrMgvEFR7BNxLE4u5oDQAivF+YlXq8uMOYLfSrZa3WZiBzjfoirFNVo11tc+hPOS0VKcn+yWOn++rVTq/PnJeKnxfIuqxWkiwj/8lqqSnGe7lWpfy6/nJdWelm8rlrIo838m1X6W/55SFmU+N1gNWBZZjB946xh2HSddZLLuvOREuKxPXP2nu/E7b7+OpoFavPiDJwgLLkBh5PWDMFj02NJbjexKsj/EvV8ehsGqR92eSuTXZxH8ni8chNFqQPWuMhQ2k/0b7v3iIRhtBlR0lKB0ayHJXx+CyW5E6bZCVHaQFt3RLw7B7DCiuDkfNbtJC+7ouSFYnCYUbslB/d5qgh87Nwiry4y82iw0D5AW3aO/dQA2jwXZVRloGSSr5B55ZT9sXisyy1Mlq+QOn+2Hw29DWkkKOiWq5B56sR/OgB0pBYmSN9eh53vgTnAiKS8eXSfJwn4H+fxJPQAAIABJREFUntkHT5ILCVlx2PPwDoIPnO6GL9WDQIZPsopuz6O7EJfugz/Vg/7TXQTf+3An4rP88Ca7Javodp3sQGJuPNyJTgw9R1p4f90ean8dJK80ZN0xvTzwZfz9f/kn7jXfvgmQFlO+ffTjcLGFV2xRJbjIonpbLrL48ntLAKTFV2xhFVt8b8fFFlexxVfKwso/BykLLP8zir8PMZeyuPJXguLvQ8zF11N8zNtxiqYA5lb/EwB4/Hsn2D70sj5xySsNWZ+6Hv/+CQw+uw8qjRJVO0uJ/hnrK+s4eKYXKo0K5e3FKN1WQPBDL/ZCrVWhZGsBKjqKCT78Yh/UOjWKmvNQ21Uh4hs49GIfNHo18htyiP4Z66sbGD7bD61Bg5yaTDSJNu/FuM6oRVZlOlqHhDerjbUNDL/UB71Ji/TSFGw/3CTiQQy/2AeDWY/UoiR0jLYKnpQ31oIYPtsHg1WP5PwE7Dy+XcCD60EMn+mDyW5EQnYcuk52CCal4HoIh870wewwIZDhx95Hdgj5RghDL/TC4jLDn+ZFz2O7BDfpUDCMwef2weaxwJvsRv/pLgEPB8MYfHYfHD4bPIlODDzZLajyGw6Fsf/pPXDG2eGKd+DAM3sFPBKOYODJbrjiHXD4bRh8rkcwCUXCEfQ93gVvkhs2rxVDzws5E2Gw79FdyKpIQ3ymHy/92ZPyhPEZlLzSkHXH9D/+r3/A1x/6LpbmlkHTFJwBB+deiikWA6dpCq54J1fgMKZYXJ2iKHgSXbh5aULAY3F7iqLgSXIJ3EsAYHGZMD/Jxshj/cL5snosmItWTpXidq+Vc3z5Uz0CdxPAJvCnr8+yPM3DFVCU5KleQQ91gE30xhxhsX7lfLkCDq4opBSP9Vjf7Pz43JfqwQ0R9yS5uKKRUp/fm+TCzQ/j0R7t4v+OyZfixo0LH43zzyWmk18fwY7ofhWFUgFZn57klYasT11//0f/yNVKikQYTFyZQm4ta0G1+6xIK0nmkqaRCIPxy5PIr2ctojaPBRllqVwilmEY3Lw0wfXksLjMyKpM5xK9DMPg5sUJzkJqdhiRU53BTRgAcOPCOIqa2DyI0WZAbm0WN2FwPJonMVj1yKvPEpTyvn5+HCWtbJ9rvVmHgoYcbkIAgOsfjHN9rnUmLQobc4X8/E2UbmPzLFqDBkVNedyEwY6/xTV6NUpa8rkJI8bLtheCoiiodWqUtOYLJuHr58dR3lbEcq0KpdsKBPzG+XGUtRWBoiko1UqUbisU3KRvXGDH0woaCpUCZdsLuQkjxsu2F3K8vK1IMAncvDiBsu2FUChpKJQ0yrcXcRMCx7cVQqFSgFbQKG8T8vFLkyjdVgilWgmKptBxrAUN+6pAUZQ8YXyGpbzbJyDr11sxW6vOqIVKTf5zi3GNQQOVhuQmB2u51Bo0UGlUBI/ZYrV6DdQS3BS1bGp0aqi1JOfeX6uGRqsmuNFmBEWx+Qy1XoobWK5RQSPFrXpQNBXl5F4Do1UPWkFDpVZBYyC5wWIATVNQqZXQGUkLs96sg0JBQ6lSQmvQkuPNeigUCijVCuiNJNeZdKAVNJQqxSbH10OhpEHRFHQmkutMOihUCoCBpMVaZ9JBqVIgEo5Ic6MWyuh4s9Ms+R3J+mxJDk/JumP6k7f+At96/He5ZC8/1BMTP9ls99kwc2P2l+J8Cys/FBSTzqDF6vLmnG9hdfjtmL4+I+S8Kq1S4/kWVkecHdPXhOP5lWelxvMtqlLvb7YbscBxcrzZaeJ2VUtxvu1W6vrxbb12n5VowsS3Bdu8VqJJks1j4RojSXMrZsfZn1ndFqLJFX+MlIX55NdHsPNeuRvf3ZAcnpL1qavrRDu+8/M30Dm6Fef++jlkEBZccInm2q4KZJZtwk1aVO0o5XZfC/iLfdCbdahoL0Z+PVkl99BZNhFdsrWAC03xdfAMm4guaspF2XbSonvwTC+MNgPy67NR2UladA++0AOjzYjcmkyi1hUADD7XA7PDhKyKdNTvrSL4gWf2wuI0Ib0sBY39NQQfeHoPrG4L0oqS0HKArKI7cLobdq8VyfkJ2HaokeB9T3TB4bchMSeA9qOkhbfn1E64Ag7EZ/kl6zjtfWQHPIkuxKV7ses+8ua9+4F2eJNd8KV40HWCLFG+6/g2+NO88CS5sPfhToLvuGcrAhk+uOKd6DlFWnhlffYlrzRkfWI6d/gt/I/v/wP3WmwJFVtMxVxsUeX3smDHCy2oYkupmIstpeLjiceLudhyKv59saX0dpxvV2U5hUiY4XHh+4ktvgoFjTDveGILr/j9WEsrj9M0IhH+eAgsvmLLcfTwnCVWfD7iMeLjid+TPV+hxfaZP3wYW3rJyVTWJy95pSHrruvR7xzH0VcPQKPXoLarAsXRpHJMwfUgRl4bhNagQdXOUpS3Cy22G2tBjJwbgs6oRXl7Map3lYnGhzBybhA6oxalWwuIJ/vgeggjrw9Cb9KhqCmPsNiGNkIYfX0QerMO+fXZxOY7lg/BYNUjtyaTsNiGgmGMvj4Eo82ArIo0dI62EnzkHLu5MKM0hdh8Fw5FMPLaIMxOE1ILk9D9YKeIhzHy2iCsbjOS8xPQI+qPEQ5HcPTVA7B5rEjIjkPfE7sFFt5IOIIjr+xnuwJm+jHwZLeQRyIYfmkAzjg7/GleHHh2n+AGH4kwGD7bD3eCE75kNw4+3yu4wTMRBgdf6IUnyQVPohPDZ/sEkwzDsCsrf6oHrngHDr88IJikGIbB/mf2obAxF+klyfjy/3xRnjA+B5JXGrI+Mf35t/4a33jke1zPCUecDdPXRDkGXg7BGbBzBQhj4vfM4NtRY+LnGFzxDkxeFXFemQxXvBOTV4UWYH5pC6nx/ByEK8GJSZGFmF8Gg2935TgvByHF+TkEqffnx/3d8Q5MiDg/RyB1ffh5JUnOy3tIXX9+3oRvF77Fb+VlpHI8/DFSOZiHf+cedIyw+1liKyVZd0fySkPWXdcP/+xHgiZF09dmUd7GribciS5kV6YL2oVOjc1wG/pc8Q7k1GQImixNjk2jcgfbU8MRZ0deXbagnenk1WlURbndZ0XBlhxuwmD5FLdasXksKGrOE9RCmrw6zXGLy4ySlnxBraXJK1Oo2V0OiqJgdrClSfi1nCauTKGmi+VGmwFl2wsFpcAnrkyhtrsCFE3BYNGjor1YUItq8uo0arsrQCto6M06VHaWCBLFEzGupKEzalG1o0yQiJ4cu8W1Bg2qd5YJjAgxrlAqoNapUbOrXJAonxqbQW1XBZQqBdRaFWp2lwtu8lPXZlCzuxxKtRIqjQq1XRWCRP50lKu1KijVStR1Vwgmmenrs6jeVQa1Tg2lSoGeUzuxpY9dWcgTxudHsuVW1qeqUJDNEURCYUGo4hZnY/jhUJiIlwNAKJoDiYTCYCTHs8cPByOSrUFjOY5wMCzJY+8fCUU2Ob8QGIZhuaikRuy4HJc6/kYITITl/HwG//2ZSGTT8eFgGEyYPTdxSQ+ORxhEwhGEw5ufH7PZ+FCYDTFRzCY8wl53ikI4GJIeH46AYRiiZEmMM5EIIhEGwfWQ5Hcs67MtOTwl6xPTX3737/CNh7+LlYVVUBQFZ8BOho944SV3ggMTV4Scb2F1JzoxcXnz8JIn0UXsMDfZDVic2Zzzw0dSO5T5FlYpzreVSnGb24LZKOfvtuY4L7wkNZ5vi5Xi/JCP1Ofjh4fciS5MiDkvJCUVPuOHzKQ4/2dS4TUBlwiPxcJTsu6+5PCUrLuutsNN+N67b6Ln1E688Y8vIaOU7LzW93gXNHo1KjpKkFqUtAnXoHRbITJKSYtu72O72d3WzXmSVXR7H90NnVGLgoYc5EV3p/PVc2ondCYtcmsyud3lfO17ZCf0Zh2yKtNR0pJP8L0Pd8Jg0SOjNAXlona1ALDn4U4YbWxDKXG7WgDoPtkBk92I5PwE1EpU2e16oAMWpwmJuQFJC++u+9tgdVsQyPRzoR6+dt63DXavFXHpPrTsJy28naNb4fDb4EvxSNZ5aj/aDGfAAU+iC9uGGwm+dbgR7gQnXPEOSYtv69AWeJPdcMTZ0THSQnBZnz/JKw1Zn5revP/b+G/f+Cvu9e0stQQXWVjFXGypVWlVCH4YF1l+xRZXwrIrssiKLcKE5Vb0eUhLrpILp0lz4eclLLeiz0NRlMAdJWXZ5VeRJSy5Ysvt7bjIsiv+mdiyCwC0kkYkdIs///8+hppd5H4XWZ++5JWGrM+cTn7tGO778mHoTDrU7alE6Tbhk3loI4T73hiG3qxD9a4y4sk8FAzj+FeG2SRyRzFqu4VP5uFgGPe9wfbnKNtWiC091QQ//pXDMNoMKG7OIzbPhUMsN9kNKNiSQ2yeC4ciOP6VwzA7TMirzUK76Mk5Ema5xWlCdlUGdoo2x0XCERx/4zCsbjMyy1OJ/haRcAT3fmkYNo8F6SXJ2PeI0GLLRBjc86VDsPtsSClIRN/ju4WcYTD6xYNwxNmRlBePgae6ifEj54bgincgISsOg6L+FQwDHH3lADxJLsRl+HDoTB/BD58dgC/FDX+qF8Mv9UOsgy/2wp/mhTfZjSOv7Cf4oRf6UNlZgoItOfjaj16TJ4zPoeSVhqxPTX/y1l/gm4/9Lvd0zy9JERN/9SBVpoLPpcqU8Dvp3ZZLlNHglymRen9+pz0pzi9TIsX5ORwpzs/R2LwWzN4UXh+j1cAVhZS6fnyL8O24VBkPfg5HqpOgxWnG/NTC5pz3M36+KKZT3zmONtF+F1mfDckrDVmfOb39tz8RhINmx+expZddDQQy/MhvyBaEm2ZvzqGxrwYUxZYBL2zMFfCZm3No6q8FRQHeJDeKW/K5CYHjA7WgaAruBCdKtxYI+Y05NO+vA0VTcAUcKG8r4iaM2Ps3768DTVNw+G2o7CjhJgyOH6gHraBh81hQtbOUmzD4XKGkYXWZUbO7XGARnr05h5YD9VCoFLA4TajbUymwAM/enEfLgXoo1UqYbEbU763iJozY9Ws5UA+VWgmj1YCGnmqBRXh2fB7N++ug0qigN+uxpbdGwOcmFtC8vw5qrQo6kxaNfbWCdrHzkwtoGqhje4IbtWjqr+UmDI7310Jr0ECj16B5f51gElmYWkRjXy10Ji00OjWGX+yX7G4o6/Ml2XIr664q5qxZmF6ATqIK68SVKTAMsDCzBGO0Yq2AX2X54uwSrIsWgk9enQYTYbA0tyzYE8LxsVt8eYHkU9dmEIkwWJ5fwfLCCsnHphEJR7CysCrYExLT9LUZhEMRrCyuEv2xAXbvQjgYxsriKhZnFgk+c2MWoY0QVrEmzW/OIbjB2oDFT/UAO3EE14OIhMNYmFqQ5BtrQdDBMOYn5wk+PzHP9linKKK/OQDMTc6zBSYZhljVAMD81AK7V4dhcPPiOFaX1qCWqCYs6/MjOTwl61PTP/zXH+KtE9/G3OQCaAUNd4KTaNITa5JE0xQ8yW6iiVCsiipFUfCleIgmR7EdzhRFwZ/mxbX3bwi534aZqEU1Lt1HcGfAgamoLTSQ4cPYe0LOt41Kcb7FNJDpx9i71wXck+jE+OUP4TxbrRT3Jrtw8+LmnN84Ser8+I2bJDmv8VNchg/XPoxLXL+4dC+uvX+T+O+YTn37Psle6LLuvuTwlKzPnLb0VON7772JQ2f68I1/O4f0kmTid3aMboVKo0RBYy4ScwIkv6cVaq0KefVZSC5IIHjHKMtzqjOQVkwev3OkFRq9BlmV6cgoIy3A7UebodVrkFGagqxKsspu29Fm6IxapBYlIbc2i+DbhhuhN2mRnJ+AgoZsCd4Eg0WPxJyAZBXerUNbYLTqEZ/pR+nWAoK3Dm2ByW6EP82L8jbS4ts0UAezwwRfipvbHc9XY18trG4zPIkuVEskoRt6qmHzWOAMOFDXXUnyfVVw+G1w+G2o30vyuu5KOOPssHutaBAZEWT9ekheaci6a/rW47+LP/rCn3KvtQYt1pZv5QzElk+tQSMoS3JbLrJ88pPgAGlh1eg1WBdxflVYfq8PqfFqnZoN5cS4yKJKjBdVeRVbiMWfUWwhBhW1uMa4yCIMCG230vyWjVhsEQaEtl+xBfgjcd4xVWolXvzT0yjbRpakl3X39ZleaVAU1UNR1M8oiopQFLXpSVIU1UZR1LsURX1AUdTpT/McZX3yGjk3hAe/MQKj1YC6PZUobxPeTCLhCB742jEYbQbU7C5H1c4ySW6yG1HZUYK6PcIn30iEwcmvH4PJYWQtuKLNb0yEwQNfOwaz04Tilny0DNaT/K2jsLjMKGzMxfYjTRLjj8LqNiOvLouocsswwIk3j8LmsSCnOgM7RVVuGYbBia8ehd1nQ2Z5GvY8RPafuO/Lw3DE2ZFekoKeR0X9Jxjg3i8dgivegdTCJAyc7ibGj7w+BHeCE0l5CTjw9F6SvzYIb7IbCdkBDL3QQ/DDL++HP9WDQKYfw2dJi+3w2X4EMnzwp3lx5OUBgh99ZT+29FajamcpvvXTL8kTxq+B7spKg6KobAARAL8D4FGGYYilAUVRCgDvAdgKYAzAvwIYYBjm5x92bHml8fnR//2l/4Zvn/597klYyqLJf3r9OJz/dM23k0pxqfH8p39JrlNhYzXKeRVvY+KvXswOI9cDPSb+6sfkMGJRxPkWX75d9qNyfhVhvp2X4zyLsBTnW4QNVgOW5z6M6wkzwOPfP4GtQ+ROc1mfPX2mVxoMw7zDMMy7t/m1CgAfMAxzgWGYDQB/CGD3bcbI+hzp5z98V7BjeWFqEduPNIGiKCTlxaOkNV8Q7liYWkTb0WZQNIWE7ABKtxcSvP1oM2gFjUCGHxXtxYJwzPzUItqPtYBW0PCneVG1o1TAF6YW0THSAoVSAW+yGzW7ywXhIpa3QqFSwJPoQl13BTdhAMDCNMuVaiVcAQfq91UJwl0L00voGGnF/2nv3sOjqs8Ejn/fcklIiCQhkAC5wYMgN2+g622FQr3AtvXS6pZtBYRKqbZ9cB/axbpVa0XKFmupFZRaCq3XB3m2RdcuihW3cjUgIYQkJORCQiCEO4GQBHj3j3MSZjJJOIFkZgLv53nmmTPznjnzzi/z5HfO+f3mPV26dqZn3zjGPHiL3+my4/XxiC7EJ8UyduJtflN8jx+qYsIj4+jarSuxvXsw7tv/HBAf/91xRER1pUdCDF95aLTfjLGqwycYP20ckdERxMR3545Jo/2mCFcdPsHdU50xm+5x0dw1ZYzfFOETR05w98NfJuqKbkT3iOKuh7/cKH6SOyePITo2iqiYbjy2YCpjJ97W7N/fdEzhPOW2H1Dq87gMCBx5A0RkOjAdIDU1cHDUdBw7MwpRVSqKK/lSp8B9mvyMQvSsUlGyny6RgV/f/C1FnD1zlsrSA01O4S3YUsjZM2c5UHaQ7rFRTcSLOHP6DAfLD9EjISYgvuuLIs7UOfG4xMApvoWZxZyuPc2hfYc50Kh4H0DhthLqak9zuOIoFY2K/wEUZZVQV1PHkcpjAcUNnXgptdW11NXUsbfRzDOAkuxSak7WUltdy95GM8sASnLKOHWihpqTNQEzzwBKc/c0dERl+U3E88obOpqyneUB8T0FexuONrLX5XL7AzcRnxQXsJ7puNrtSENEVovI9iZuXo8Wmiqw3+S5NFVdrKqjVHVUr169LjxpE1R3PTyW3qkJgDNImjyoL0XbSgCorjpFYWYJvdOcv2fnLp1IuaofuzKLAag5WcuuL4pJdOOdOncidUg/Cr4ocuLVteRvKaTPgN6AM6CcNjSZ/C1OvPZUHTszCukzINGJf0lIH5bMzs2FgFNCPe/zXfQdmHQuPjyFvIxdgFPSJHdTAf2u7AM4g9r9R6SSu6kAcEqO5GzMJ3lQo/jGfMAZj8nZsJOUwX0b2qP/1ankbDgX37E+j9QhyT7xNHI27ASc8ZQd6/JIHdKvIT7g6lR2rHfjCtnr8kgbluK3/R3r8s7F1+aR7hsfkUr2unMnALLX5pI+PLWFeB7pwxu9fu25+Jp31pGxKhNzaWm3Iw1Vvdh6x2VAis/jZCBw18Z0WP804XqW5PyG/1m8mhsnXM/Sn70VsPe6aPM8Pn79H4y88xrefH4Fpbl7/OIL1s/hH8s3cO3Y4az49XvszvGPv/DJz1m3MoOrbx/CyoWrKNlR5hef9+HPyFi1lSE3D2LVHz+hONs//tx7s8lcs4NBowaw5u21FG8v9Ys/vWIWOet3MuCaNNb99XOKsnb7xX/61kwKthSRNjSZzR9uC4j/eOlj7M7ZQ7+BSWz/LJc/bHvTLz7z1ensK9xP77QE8jcX8uqsP/nFf/DSNA7tPUJcUiy7c8p4+UdL/OLfmz+JqsMniInvTkXxfn4zY7FffOrz/0btqToioyM4sv8o86cu9ItPevoBEKFzl05UH69m7nd+6xef+MT9REZHoGed62/84sFfYy5t4Xx66nPgShHpD+wBvgUEVkAzHVpEtwjud6+NnTY0BVjfEEsZ3JeomG7c96MJAKQPTfGr5Np3YBLde0Rx7w+dwn+pjeJJ/XsTHRvNPY/d7cSHJPtNw01M60X3uGi+9n1nVlPOkHy/eK+UnlzRM4avfu8OAHZtLfabApvQL54eCTEN14MozS33m+Ia3yeO2F49GD/NKWy4r7jSb+A+LrEHcYmxDHF/D3K44qhf5dzYXlcQnxTLiNuc33ucOHrSrzLvFT1jiO8Tx3VjnZLtp2tP+w3cx8RFk9A3rqFk+5bV2/ym/XaPjaZXcs+G37NkfprtN2056opu9E5NYPANTsn57Wtz/Qbeu3WPJDGtF8NucUrO527K9xtYj4yOIDHdjvwvOaoa9BtwH86RRA1QAaxyn+8LfOCz3gScGVS7gCe9bHvkyJFqOq6sz3L038c8pctfWKl1tXUB8ez1eTpr7NP69ry/aG1NbUA8d1O+zhr3jL4xZ4XWnAqM79y8S39yx8/1z88u15rqmoB4wdYi/Y+7fqHLnn5Hq0+cCogXZpXoE+Of0yVPvqknq6oD4sXZu/Wn/zJHX5v9up48fjIgvju3TP/za3P11VnLtOroiYB4WX65PnXvPF30+B+16khVQLx81z595hu/0t/98A967NDxgPjeogp99sEXdMGjv9ejB44FxCt2V+pzE1/UF6e/oof3HwmIV5Yd0LnfWaDzpy3UQxWB8QPlh3Te5Jd03pSX9ED5oYD4oX2Hdf7Ul3XuQwu0cs/BgLgJX0CGevgfaz/uM8YYE95Tbo0xxnRM1mkYY4zxzDoNY4wxnlmnYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPLNOwxhjjGeX3C/CRaQSKAnBWycAgbWuw5/lHXwdNXfLO7iCnXeaqp63WNgl12mEiohkePkJfrixvIOvo+ZueQdXuOZtp6eMMcZ4Zp2GMcYYz6zTaDuLz79KWLK8g6+j5m55B1dY5m1jGsYYYzyzIw1jjDGeWadhjDHGM+s0LoCIPCAi2SJyVkSanRInIsUikiUiW0UkLC4n2Irc7xaRPBEpEJHZwcyxmXziReQjEcl37+OaWe+M295bRWRlsPP0yaPF9hORCBF5x41vFJH04GfZNA+5TxGRSp92/m4o8myU0xIR2S8i25uJi4j81v1M20Tk+mDn2BwPuY8RkaM+7f1UsHP04+WasHYLuMb5EGAwsAYY1cJ6xUBCqPNtbe5AJ5zrsg8AugKZwNAQ5/1fwGx3eTYwr5n1qsKgjc/bfsCjwCvu8reAd0KddytynwL8LtS5NsrpduB6YHsz8QnA3wABbgI2hjrnVuQ+Bng/1HnW3+xI4wKoao6q5oU6jwvhMfcbgQJVLVTVWuBt4J72z65F9wDL3OVlwL0hzOV8vLSf7+d5FxgnIhLEHJsTjn/781LV/wMOtbDKPcCf1LEBiBWRPsHJrmUecg8r1mm0LwU+FJHNIjI91Mm0Qj+g1OdxmftcKCWq6l4A9753M+tFikiGiGwQkVB1LF7ar2EdVT0NHAV6BiW7lnn923/DPc3zroikBCe1ixKO3+nWuFlEMkXkbyIyLJSJdA7lm4czEVkNJDURelJV/+pxM7eqarmI9AY+EpFcd6+iXbVB7k3t8bb73OyW8m7FZlLdNh8A/F1EslR1V9tk6JmX9gtJG3vgJa/3gLdUtUZEZuAcMY1t98wuTri2txdbcOpCVYnIBOAvwJWhSsY6jWao6lfaYBvl7v1+EflvnEP/du802iD3MsB37zEZKL/IbZ5XS3mLSIWI9FHVve5phf3NbKO+zQtFZA1wHc45+mDy0n7165SJSGegB+FxiuK8uavqQZ+HvwfmBSGvixWS73RbUNVjPssfiMhCEUlQ1ZAUYbTTU+1ERKJFJKZ+GbgTaHJ2RBj6HLhSRPqLSFecgdqQzURyrQQmu8uTgYAjJhGJE5EIdzkBuBXYEbQMz/HSfr6f55vA39Ud9Qyx8+beaCzg60BOEPO7UCuBSe4sqpuAo/WnO8OdiCTVj3eJyI04/7cPtvyqdhTqkfiOeAPuw9lzqQEqgFXu832BD9zlATgzTzKBbJxTQx0id/fxBGAnzl56yHPHOd//MZDv3se7z48CXnOXbwGy3DbPAqaFMN+A9gOeBb7uLkcCy4ECYBMwINRt3Irc57rf6UzgE+CqMMj5LWAvUOd+v6cBM4AZblyAl93PlEULsx7DMPcf+LT3BuCWUOZrZUSMMcZ4ZqenjDHGeGadhjHGGM+s0zDGGOOZdRrGGGM8s07DGGOMZ9ZpmEueiKSISJGIxLuP49zHae30fjNEZJK7PEVE+vrEXhORoW30Pve2tuKpiKxurkKwMV7YlFtzWRCRnwADVXW6iLwKFKvq3CC87xpglqq2eWl8EVmH89sJz78MFpHJQLKqzmnrfMzlwY40zOXiReAmEZkJ3Aa80HgFEUkXkVwRWeZTjC/KjY0TkS/EuT7KEp9fnv9SRHa46893n3tGRGaJyDdxfnw321hTAAACiklEQVT4hnsdhG4iskbc65iIyER3e9tFZJ5PHlUiMsctULdBRBKbyHUQUFPfYYjIUhFZJCKfiEihiIx288wRkaU+L10JTGyTFjWXJes0zGVBVeuAH+N0HjPVKfvdlMHAYlW9GjgGPCoikcBS4F9VdQROzbbvu6e77gOGues/1+g93wUygG+r6rWqWl0fc09ZzcMp9HctcINPVd5oYIOqXoNTq+yRJvK8FaeQna84d3uP4xQVfBEYBowQkWvdnA4DESISDhV1TQdknYa5nIzHKdcwvIV1SlV1rbv8Os5RyWCgSFV3us8vw7lwzjHgFPCaiNwPnGxFLjcAa1S1Up3S6G+42wSoBd53lzcD6U28vg9Q2ei599Q535wFVKhqlqqexSlB4buN/ThlY4xpNes0zGXB3dO+A+eqbY+3cAGexoN8StNltXH/2d8IrMC5KNT/tialFmJ1em6w8QxNV6Ouxqlf5avGvT/rs1z/2Hcbke7rjWk16zTMJc+tELoI57TUbuBXwPxmVk8VkZvd5YnAZ0AukC4iA93nHwI+FZHuQA9V/QCYiXOaqbHjQEwTz28ERotIgoh0ct/r01Z8rBxg4HnXasRtiyScSxEb02rWaZjLwSPAblX9yH28ELhKREY3sW4OMFlEtgHxwCJVPQU8DCwXkSycPfdXcDqD9911P8UZS2hsKfBK/UB4/ZPqlOV+AqdKbCawRb1f3AucsY7r6ktmt8JInPGS0618nTGATbk1poGIpAPvq2pLYx5hQ0QW4IxjrG7la1aq6sftl5m5lNmRhjEd1/NAVCtfs906DHMx7EjDGGOMZ3akYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPPt/4+W6FhppJ+AAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%matplotlib inline\n",
     "from ctapipe.visualization import CameraDisplay\n",
@@ -190,9 +426,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb1f185c18>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGAVJREFUeJzt3XuYJXV95/H3BxBQEeQmojCMl9EsKOBug/FRYVeYDVk3QIwoeGF0jUSMy6pPzLIPxhhidr3Fja6IsK5hNCo6GGVQvAwDqNmIoVEER0QuGpkFYfCKclGc7/5xasKx7cuvZ/pcZvr9ep7z9KmqX1d9Ts88/emqOqcqVYUkSS22G3UASdLWw9KQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDS1qSS5P8qMkO/XN2y/Jx5PcmeQnSa5N8pIkz0zys+7x8yTVN/2zJEu69d3bTd+Z5O+T7Nu37jcm+bu+6SQ5Lck3unWuT7IqyZOH/bOQWlgaWrSSLAWeCRRwbN+iDwK3AAcAewInA7dX1Zeqapeq2gU4qBv78E3zqup73bxXdWMeD+wCvH2WGO8E/gtwGrAH8ATgk8Czt/wVSgvP0tBidjJwBXAesKJv/mHAeVX186q6v6q+VlWfme/Kq+rH9Arg0OmWJ1kG/DFwUlVdWlX3VdXdVfWhqnpzN+bZSb6W5KdJbknyxr7vX9rt7by0W/ajJK9IcliSa5L8OMm755tbms0Oow4gjdDJwDuArwBXJNmnqm6nVyRnJflfwD/27UHMS5I9gecAN84w5ChgfVX90yyr+XmXcx3wJGBNkqur6pN9Y54KLAOOAFYDnwWOBh4EfC3Jqqr6wua8Bmkq9zS0KCV5Br3DTx+rqquAm4AXdItPAL4E/BnwnSRXJzlsHqt/V5KfAHcCewH/eYZxewK3zbaiqrq8qq6tqo1VdQ3wEeDIKcP+sqrurarP0yuZj1TVHVX1/7rX8ZR5ZJdmZWlosVoBfL6q7uymP9zNo6p+VFWnV9VBwD7A1cAnk6Rx3adV1W7AwcDuwH4zjPsBsO8MywBI8tQklyXZ0BXRK+gVUb/b+57fM830Lo25pTlZGlp0kjwYeB5wZJLvJ/k+8BrgkCSH9I/tSuXtwKPonahuVlXXAm+id6hrusJZC+yXZGKW1XyY3iGn/bsiei/QWl7SgrM0tBgdD/wKOJDeSepDgX9F71DOyUnekuRJSXZI8jDgVODGqvrBZmxrJfAIfv3dWQBU1Q3Ae4CPJPm3SXZMsnOSE5Oc3g17GPDDqro3yeE8cAhNGglLQ4vRCuBvq+p7VfX9TQ/g3cALgV2BTwA/Bm6md+7jN37pt6iqXwDvond+ZDqndds9q9veTcDvAxd1y18JnJnkLuANwMc2J4e0UOJNmCRJrdzTkCQ1szQkSc0sDUlSM0tDktRsm7uMyF577VVLly4ddQxJ2qpcddVVd1bV3nON2+ZKY+nSpUxOTo46hiRtVZL8c8s4D09JkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSp2UhLI8kxSa5PcmPf/QP6l782yTeTXJNkbZIDRpFTktQzsg/3Jdme3j0ElgPrgSuTrK6qb/YN+xowUVV3JzkVeCvw/OGn1bhbvt0JQ9vWmo2rhrq9UVizcdWoI2hMjXJP43B6d0O7ubtRzfnAcf0Dquqyqrq7m7yCme+1LEkaglGWxqOBW/qm13fzZvIy4DMDTSRJmtUorz2VaeZNexvBJC8CJoAjZ1h+CnAKwJIlSxYqnyRpilHuaawH9u+b3g+4deqgJEcDZwDHVtV9062oqs6tqomqmth77zkv0ihJ2kyjLI0rgWVJHpNkR+BEYHX/gCRPAc6hVxh3jCCjJKnPyEqjqu4HXgV8DrgO+FhVrUtyZpJju2FvA3YBViW5OsnqGVYnSRqCkd5Po6ouBi6eMu8Nfc+PHnooSdKM/ES4JKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmO4w6gLQQ1mxctU1vTxoXloYW3PLtThjq9tZsXDXUbQ57e6Mwip+ptg4enpIkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzUZaGkmOSXJ9khuTnD7N8iOSfDXJ/UmeO4qMkqQHjKw0kmwPnAX8LnAgcFKSA6cM+x7wEuDDw00nSZrODiPc9uHAjVV1M0CS84HjgG9uGlBV3+2WbRxFQEnSrxvl4alHA7f0Ta/v5s1bklOSTCaZ3LBhw4KEkyT9plGWRqaZV5uzoqo6t6omqmpi77333sJYkqSZjLI01gP7903vB9w6oiySpAajLI0rgWVJHpNkR+BEYPUI80iS5jCy0qiq+4FXAZ8DrgM+VlXrkpyZ5FiAJIclWQ+cAJyTZN2o8kqSIFWbdRphbE1MTNTk5OSoY0jSViXJVVU1Mde4Ub7lVkOyfLsTRh1hoNZsXDXU1zjs7Y3CYviZrtm4aqjb21Z4GRFJUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc3m/HBfku2AQ4BHAfcA66rq9kEHkySNnxlLI8njgP8KHA3cAGwAdgaekORu4BxgZVV5gyRJWiRm29N4E3A28Ec15QJVSR4BvAB4MbBycPEkSeNkxtKoqpNmWXYH8DcDSSRJGlst5zS2B54NLO0fX1XvGFwsSdI4arnK7UXAvcC1gOcvJGkRaymN/arq4IEnkSSNvZbPaXwmyb8feBJJ0thr2dO4AvhE93mNXwIBqqp2HWgySdLYaSmNvwaeBlw79a23kqTFpeXw1A3ANywMSVLLnsZtwOVJPgPct2mmb7mVpMWnpTS+0z127B6SpEVqztKoqr8YRhBJ0vib8ZxGknOTPHmGZQ9N8p+SvHBw0SRJ42a2PY33AH/WFcc3eOAqt8uAXYH3Ax8aeEJJ0tiY7YKFVwPPS7ILMAHsS+9+GtdV1fVDyidJGiMt5zR+Blw++CiSpHHn7V4lSc0sDUlSM0tDktSs5SZMTwBeBxzAr9+E6VkDzCVJGkMtnwhfBbwX+N/ArwYbR5I0zlpK4/6qOnvgSSRJY6/lnMZFSV6ZZN8ke2x6DDyZJGnstOxprOi+vq5vXgGPXfg4kqRx1vLhvscMI4gkafy1vHvqQcCpwBHdrMuBc6rqlwPMJUkaQy2Hp84GHkTvAoYAL+7m/eGgQkmSxlNLaRxWVYf0TV+a5OuDCiRJGl8t7576VZLHbZpI8lgW6PMaSY5Jcn2SG5OcPs3ynZJ8tFv+lSRLF2K7kqTN07Kn8TrgsiQ3A6H3yfCXbumGk2wPnAUsB9YDVyZZXVXf7Bv2MuBHVfX4JCcCbwGev6XbliRtnpZ3T61Nsgx4Ir3S+FZV3bcA2z4cuLGqbgZIcj5wHNBfGscBb+yeXwC8O0mqqhZg+5KkeZqxNJI8q6ouTfKcKYsel4Sq+vst3PajgVv6ptcDT51pTFXdn+QnwJ7AnVOyngKcArBkyZItjCVJmslsexpHApcCvzfNsgK2tDQyw3rnO4aqOhc4F2BiYsK9EEkakNlu9/rn3dMzq+o7/cuSLMQH/tYD+/dN7wfcOsOY9Ul2AHYDfrgA25YkbYaWd099fJp5FyzAtq8EliV5TJIdgROB1VPGrOaBy5g8F7jU8xmSNDqzndP4LeAgYLcp5zV2BXbe0g135yheBXwO2B54f1WtS3ImMFlVq4H/A3wwyY309jBO3NLtSpI232znNJ4I/Efg4fz6eY27gJcvxMar6mLg4inz3tD3/F7ghIXYliRpy812TuNC4MIkT6uqLw8xkyRpTM12eOpPq+qtwAuSnDR1eVWdNtBkkqSxM9vhqeu6r5PDCCJJGn+zHZ66qPu6ctO8JNsBu1TVT4eQTZI0ZuZ8y22SDyfZNclD6V3i4/okr5vr+yRJ256Wz2kc2O1ZHE/vnU5L6N1TQ5K0yLSUxoO6u/cdD1zY3bHPD9hJ0iLUUhrnAN8FHgp8MckBgOc0JGkRyuZclSPJDlV1/wDybLGJiYmanPQNX5I0H0muqqqJucbNeT+NJLsBfw4c0c36AnAm8JMtSqihWb7dtv2h+jUbVw31NQ57e6OwGH6mazauGur2thUth6feT+/SIc/rHj8F/naQoSRJ46nldq+Pq6o/6Jv+iyRXDyqQJGl8texp3JPkGZsmkjwduGdwkSRJ46plT+NUYGV3biP0LlG+YvZvkSRti+Ysjaq6Gjgkya7dtG+3laRFquUyInsmeRdwOXBZkncm2XPgySRJY6flnMb5wAbgD+jdcnUD8NFBhpIkjaeWcxp7VNVf9k2/KcnxgwokSRpfLXsalyU5Mcl23eN5wKcHHUySNH5aSuOPgA8D93WP84HXJrkriSfFJWkRaXn31MOGEUSSNP5a9jQkSQIsDUnSPMxYGkkuTrJ0eFEkSeNutj2N84DPJzmju3OfJGmRm/FEeFV9LMmngTcAk0k+CGzsW/6OIeSTJI2Rud499Uvg58BOwMPoKw1J0uIzY2kkOQZ4B7Aa+NdVdffQUkmSxtJsexpnACdU1bphhZEkjbfZzmk8c5hBJEnjz89pSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmqapRZ1hQExMTNTk5OeoYkrRVSXJVVU3MNa7lHuHSvCzf7oShbm/NxlVD3eawtzcKo/iZauvg4SlJUrORlEaSPZKsSXJD93X3GcZ9NsmPk3xq2BklSb9pVHsapwNrq2oZsLabns7bgBcPLZUkaVajKo3jgJXd85XA8dMNqqq1wF3DCiVJmt2oSmOfqroNoPv6iC1ZWZJTkkwmmdywYcOCBJQk/aaBvXsqySXAI6dZdMZCb6uqzgXOhd5bbhd6/ZKknoGVRlUdPdOyJLcn2beqbkuyL3DHoHJIkhbOqA5PrQZWdM9XABeOKIckaR5GVRpvBpYnuQFY3k2TZCLJ+zYNSvIlYBVwVJL1SX5nJGklScCIPhFeVT8Ajppm/iTwh33T3j1QksaInwiXJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1G8md+7RtW7Nx1agjaAH476jpuKchSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJajaS0kiyR5I1SW7ovu4+zZhDk3w5ybok1yR5/iiySpIeMKo9jdOBtVW1DFjbTU91N3ByVR0EHAP8TZKHDzGjJGmKUZXGccDK7vlK4PipA6rq21V1Q/f8VuAOYO+hJZQk/YZRlcY+VXUbQPf1EbMNTnI4sCNw0xCySZJmsMOgVpzkEuCR0yw6Y57r2Rf4ILCiqjbOMOYU4BSAJUuWzDOpJKnVwEqjqo6eaVmS25PsW1W3daVwxwzjdgU+Dby+qq6YZVvnAucCTExM1JYllyTNZGClMYfVwArgzd3XC6cOSLIj8AngA1W1arjxtLVZs3G4/0WGvT1pXIzqnMabgeVJbgCWd9MkmUjyvm7M84AjgJckubp7HDqauJIkgFRtW0dzJiYmanJyctQxJGmrkuSqqpqYa5yfCJckNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVKzbe5zGkk2AP88oNXvBdw5oHUPw9aeH7b+12D+0dra88PgXsMBVTXnlcS3udIYpCSTLR9+GVdbe37Y+l+D+Udra88Po38NHp6SJDWzNCRJzSyN+Tl31AG20NaeH7b+12D+0dra88OIX4PnNCRJzdzTkCQ1szQkSc0sjVkk2SPJmiQ3dF93n2bMAUmu6m4StS7JK0aRdTqN+Q9N8uUu+zVJnj+KrDNpeQ3duM8m+XGSTw0743SSHJPk+iQ3Jjl9muU7Jflot/wrSZYOP+XMGvIfkeSrSe5P8txRZJxNQ/7XJvlm939+bZIDRpFzJg35X5Hk2u73zj8kOXBo4arKxwwP4K3A6d3z04G3TDNmR2Cn7vkuwHeBR406+zzyPwFY1j1/FHAb8PBRZ5/Pa+iWHQX8HvCpMci8PXAT8Nju/8fXgQOnjHkl8N7u+YnAR0ede575lwIHAx8AnjvqzJuR/98BD+men7oV/vx37Xt+LPDZYeVzT2N2xwEru+crgeOnDqiqX1TVfd3kTozX3ltL/m9X1Q3d81uBO4A5PxU6RHO+BoCqWgvcNaxQczgcuLGqbq6qXwDn03sd/fpf1wXAUUkyxIyzmTN/VX23qq4BNo4i4Bxa8l9WVXd3k1cA+w0542xa8v+0b/KhwNDe0TROv+DG0T5VdRtA9/UR0w1Ksn+Sa4Bb6P0lfOsQM86mKf8mSQ6n95fNTUPI1mper2FMPJre/4VN1nfzph1TVfcDPwH2HEq6ubXkH2fzzf8y4DMDTTQ/TfmT/HGSm+jtjZ82pGzsMKwNjasklwCPnGbRGa3rqKpbgIOTPAr4ZJILqur2hco4m4XI361nX+CDwIqqGupfjwv1GsbIdHsMU/8SbBkzKuOcrUVz/iQvAiaAIweaaH6a8lfVWcBZSV4AvB5YMehgYGlQVUfPtCzJ7Un2rarbul+qd8yxrluTrAOeSe+Qw8AtRP4kuwKfBl5fVVcMKOqMFvLfYEysB/bvm94PmLr3uWnM+iQ7ALsBPxxOvDm15B9nTfmTHE3vD5Mj+w4xj4P5/vzPB84eaKI+Hp6a3WoeaO8VwIVTByTZL8mDu+e7A08Hrh9awtm15N8R+ATwgapaNcRsreZ8DWPoSmBZksd0P98T6b2Ofv2v67nApdWd1RwDLfnH2Zz5kzwFOAc4tqrG7Q+RlvzL+iafDdwwtHSjfqfAOD/oHWNe2/2DrAX26OZPAO/rni8HrqH3DodrgFNGnXue+V8E/BK4uu9x6Kizz+c1dNNfAjYA99D7S+13Rpz7PwDfpnd+6Ixu3pn0fkkB7AysAm4E/gl47Kh/1vPMf1j3c/458ANg3agzzzP/JcDtff/nV4868zzzvxNY12W/DDhoWNm8jIgkqZmHpyRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDW3zusu8fCfJHt307t30QK5s2l2B9OTu+Uu6KwVsWva+hboiaZLjk7xhnt9zyUxXCpZa+JZbLQpJ/hR4fFWdkuQc4LtV9T+GsN3LgT+pqskBrPsf6b1v/855fM8KYL+q+quFzqPFwT0NLRb/E/jtJK8GngH89dQBSZYm+VaSld19Fi5I8pBu2VFJvtbdw+D9SXbq5r+5774Mb+/mvTHJn3T3mZgAPtTd9+DBSS5PMtGNO6lb3zeSvKUvx8+S/FWSrye5Isk+02R9AnDfpsJIcl6Ss5NcluTmJEd2Oa9Lcl7ft64GTlqQn6gWJUtDi0JV/RJ4Hb3yeHX1Ljk9nScC51bVwcBPgVcm2Rk4D3h+VT2Z3jXbTu0Od/0+vU/jHgy8aco2LwAmgRdW1aFVdc+mZd0hq7cAzwIOBQ5Lsumy7w8FrqiqQ4AvAi+fJufTga9Ombd7t77XABd1r/Ug4MlJDu0y/QjYKcm4XFFXWxlLQ4vJ79K7ydSTZhlzS1X93+7539HbK3ki8J2q+nY3fyVwBL1SuRd4X5LnAHdPXdksDgMur6oN1bs0+oe6dQL8Ath0B8Kr6N3waKp96V02pd9F1TvefC1we1VdW70rFq+bso476N1wS5o3S0OLQveX9nLgt4HXdFfMnc7Uk3zF9JeqpvtlfzjwcXo3h/rsfCLNsuyX9cDJxl8x/dWo76F3/ap+m67UurHv+abp/nXs3H2/NG+WhrZ53R3xzqZ3WOp7wNuAt88wfEmSp3XPTwL+AfgWsDTJ47v5Lwa+kGQXYLequhh4Nb3DTFPdBTxsmvlfAY5MsleS7bttfWEeL+s64PFzjpqi+1k8kt5tiaV5szS0GLwc+F5Vremm3wP8VpLpbrxzHbCiuxPjHsDZVXUv8FJgVZJr6f3l/l56ZfCpbuwX6J1LmOo84L2bToRvmlm9uxD+N3pXKP068NWqms9l378IPKUrgfn4N/TOl9w/z++TAN9yK/2LJEuBT1XVbOc8xkaSd9I7j3HJPL9ndfXuqS7Nm3sa0tbrvwMPmef3fMPC0JZwT0OS1Mw9DUlSM0tDktTM0pAkNbM0JEnNLA1JUrP/D36ums6OBsFpAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CameraDisplay(subarray.tel[98].camera)"
    ]
@@ -210,20 +469,463 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAI4CAYAAABndZP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3Xl8lOW99/HPNZPJHpKQBLKx73uQCIhVUauotVpr1WIr4lJ7Wqu+OH1OtZvahed1Wmlt1T7HqqfFWqVorUcPbaWIBVzRYNn3JZCQhZB9z0zmev64QyQQlmzcyeT79jWvZK77nuv+3ZPI/HKtxlqLiIiISCjxuB2AiIiISHdTgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCIiIhIyFGCIyIiIiFHCY6I9CvGmDXGmLvdjkNEepYSHBFpZYzJNcY0GWOSTyjfaIyxxpjhXay/w8mFMWamMeZvxpgKY0yZMeYjY8wdXYmjg9ePMcbUGGP+dq6uKSJdpwRHRE50AJh/7IkxZgoQ5UYgxpgLgLeBtcBoIAn4BnB1J+oyxpjO/Jv3JaARuNIYk3aa+sPOpkxEzg0lOCJyoheABcc9vx34w7Enxph4Y8wfjDElxpiDxpgfHEscjDELjTHvGmOWGGPKjTEHjDFXtxxbDFwEPNXSIvJUS/l4Y8yqltaZXcaYm4+79mPA89ban1lrj1rHBmvtzS2vTTTGrGiJpbzl+8zjYl1jjFlsjHkPqANGHn+jxhhPS/wHjTFHWu4r/oT343bgaWAz8JUTXp9rjHnQGLMZqDXGhJ2i7CFjzD5jTLUxZrsx5oaW10e03PeU4+ocZIypN8aknOXPS0TaoQRHRE70ITDAGDPBGOMFbgH+eNzxJ4F4nGThEpxk6Pguo1nALiAZ+Dnw38YYY639PvAO8C1rbay19lvGmBhgFfASMAin5ej/GWMmGWOigQuAP58mVg/we2AYMBSoB5464ZzbgHuAOODgCccWtjwubbmf2ONfb4wZCswFXmx5LOBk84HPAQnW2sApyvbhJHfxwI+APxpj0qy1jcCfgK+eUN9b1tqS09y3iJyBEhwRac+xVpwrgJ3A4ZbyYwnPd6211dbaXOAXOEnEMQettc9aa5uB54E0YPAprnMtkGut/b21NmCt/QR4FadbKBHn36jCUwVprS211r5qra2z1lYDi3GSruMttdZua6nff8KxrwC/tNbut9bWAN8Fvnxc19ICYLO1djuwDJhkjJl+Qh1PWGvzrLX1pyqz1r5irS2w1gattcuBPcDMlnOfB249rvvsNpz3X0S6QP3DItKeF4B1wAiO657CaZUJp21LyEEg47jnRce+sdbWGWPAaRlpzzBgljGm4riysJbrlwNBnARpZ3svbmnleRy4CichAogzxnhbEiyAvFNcGyC9nXsJw0nIDuMkOM+23EuBMWYtTpfVv457TXv1tykzxiwA/h0Y3lIUi/NeYq1db4ypBS4xxhTijDV64zQxi8hZUAuOiJzEWnsQZ7DxNcBfjjt0FPDjJCbHDOXTFp4zVn3C8zxgrbU24bhHrLX2G9baOuAD4MbT1PdtYBwwy1o7ALi4pdyc5prHK+DkewkAxcaYOcAY4LvGmCJjTBFO99v8EwYPt1d/a5kxZhhOkvQtIMlamwBsPSHG53G6qW4D/mytbThNzCJyFpTgiMip3AVcZq2tPa6sGXgZWGyMiWv58P532o7ROZ1i2g70XQGMNcbcZozxtTzON8ZMaDn+HWChMeY/jDFJAMaYacaYP7Ucj8MZd1NhjBkIPNLBe1wGLDLGjDDGxAL/F1jeMm7mdpzxQROBrJbHZCCajs3iisFJeEpa4r+jpZ7jvQDcgJPk/AER6TIlOCLSLmvtPmttTjuH7gNqgf3AuzgDhH93ltX+GvhSy4ynJ1rGzVwJfBmnNaUI+BkQ0RLD+8BlLY/9xpgy4Bng2Jo0v8KZwn4UZ3D0mx28zd/xaXfcAaABuM8YEwncDDxprS067nGg5fzbz/YCLeN3foHTGlUMTAHeO+GcfOATnETonQ7eg4i0w1h7utZbERE5F4wxvwMKrLU/cDsWkVCgQcYiIi5rWSH6i8CJM7REpJPURSUi4iJjzE9wBh0/1tIFJiLdQF1UIiIiEnLUgiMiIiIhp9+OwUlOTrbDhw93OwwRERHpgA0bNhy11p5xr7Z+m+AMHz6cnJz2ZsCKiIhIb2WMOXFPuXapi0pERERCjhIcERERCTlKcERERCTk9NsxOCIi0rP8fj/5+fk0NGjvUOm4yMhIMjMz8fl8nXq9EhwREekR+fn5xMXFMXz4cIwxZ36BSAtrLaWlpeTn5zNixIhO1aEuKhER6RENDQ0kJSUpuZEOM8aQlJTUpdY/JTgiItJjlNxIZ3X1d0cJjoiIiIQcjcERERHXWWvJL69nY14F5XVNJEaHkzUkgczEKLUCSaeoBUdERFzV4G9m6fu5/Oqt3by7t4S9xTW8u7eEX721m6Xv59Lgb+503bGxsSeV7dq1i7lz55KVlcWECRO45557WLlyJVlZWWRlZREbG8u4cePIyspiwYIF7da7Zs0arr322pPKV6xYwfTp05k2bRoTJ07kt7/9LYsXL26t2+v1tn7/xBNPtFv3o48+ypIlS04qX7x4MZMmTWLq1KlkZWWxfv16brjhBrKyshg9ejTx8fGtdb///vv4/X4eeughxowZw+TJk5k5cyZ///vfO/gO9l1qwREREddYa1n20SG2FlSSkdC2tcZay9aCSpZ9dIiFc7pvJtb999/PokWLuP766wHYsmULU6ZMYd68eQDMnTuXJUuWkJ2d3aF6/X4/99xzDx999BGZmZk0NjaSm5vLuHHj+P73vw84CdfGjRs7HPMHH3zAihUr+OSTT4iIiODo0aM0NTXx2muvAU7CtWTJElasWNH6moceeojCwkK2bt1KREQExcXFrF27tsPX7qvUgiMiIq7JL69n6+FKMuJP7ooyxpARH8W2gkoOV9R32zULCwvJzMxsfT5lypRuqbe6uppAIEBSUhIAERERjBs3rlvqLiwsJDk5mYiICACSk5NJT08/5fl1dXU8++yzPPnkk62vGTx4MDfffDMA3/jGN8jOzmbSpEk88sgjra8bPnw43/ve97jgggvIzs7mk08+Yd68eYwaNYqnn366W+7lXFGCIyIirtmYV0GY15yydcYYg8cY/nWootuuuWjRIi677DKuvvpqHn/8cSoquqfugQMHct111zFs2DDmz5/Piy++SDAY7Ja6r7zySvLy8hg7dizf/OY3z9gSs3fvXoYOHcqAAQPaPb548WJycnLYvHkza9euZfPmza3HhgwZwgcffMBFF13EwoUL+fOf/8yHH37Iww8/3C33cq4owREREdeU1zUR4fWe9pyIMC/ldU3dds077riDHTt2cNNNN7FmzRpmz55NY2Njt9T93HPPsXr1ambOnMmSJUu48847u6Xe2NhYNmzYwDPPPENKSgq33HILS5cu7XR9L7/8Mueddx7Tp09n27ZtbN++vfXYddddBzgtW7NmzSIuLo6UlBQiIyO7LRk8F5TgiIiIaxKjw2lsPv0g4sZAM4nR4d163fT0dO68805ef/11wsLC2Lp1a7fVPWXKFBYtWsSqVat49dVXu61er9fL3Llz+dGPfsRTTz112rpHjx7NoUOHqK6uPunYgQMHWLJkCatXr2bz5s187nOfa7Og3rEuLY/H0/r9seeBQKDb7qenKcERERHXZA1JINBssda2e9xaS9Bapg9N6LZrvvnmm/j9fgCKioooLS0lIyOjy/XW1NSwZs2a1ucbN25k2LBhXa4XnJlfe/bsOeu6o6Ojueuuu7j//vtpanJavwoLC/njH/9IVVUVMTExxMfHU1xcHLIzqzSLSkREXJOZGMXkjHhnFlX8ybOoDlfWMzk9noyEqE7VX1dX12ZA8b//+7+Tn5/PAw88QGRkJACPPfYYqampHa579erVbepetmwZP//5z/n6179OVFQUMTExne5G+ulPf8qvfvWr1uevv/469913HxUVFYSFhTF69GieeeaZM9bxgx/8gIkTJxIZGUlMTAw//vGPmTZtGtOnT2fSpEmMHDmSCy+8sFMx9nbmVFlzqMvOzrY5OTluhyEiErJ27NjBhAkTznheg7+ZZR8dYltBJR5jiAjz0hhoJmgtk9LjmT9zKJG+04/TkdDU3u+QMWaDtfaMc/jVgiMiIq6K9HlZOGc4hyvq+dehT1cynj404aS1cUTOlhIcETmlhoAz8DAyLNLlSEKXtZb6QD0+jw+f1+d2OK4xxpCZGE1mYrTbobSxcuVKHnzwwTZlI0aMaF1grysWL17MK6+80qbspptual0UULpGXVQicpKgDbLywEreL3gfi+XCjAuZN3weHqN5Cd2pIdDAy7teZnf5brweL9eNuo4Zg2e4HVa3OdsuKpFT6UoXlf61EpGT7Cjbwdr8tQyKGcTg6MGsy1vHzrKdbocVctblO+9rWkwaiRGJvLbnNY7UHXE7LJGQoARHRE5ytO4oPq8Pr/Hi9XgJ84RRWl/qdlghp7C2kLjwOIwxhHvDMcZQ0dh3FlIT6c2U4IjISdJi0wgEAzQ1N9HU3ESzbSY1puPTaOX0hscPp6qpiuZgM3X+OgyG5Khkt8MSCQlKcETkJGMSxvD5kZ+nqqmKqqYqrh15LaMTRrsdVsiZkz6H2WmzKakvodk285UJX2Fg5EC3wxIJCUpwROQkxhjmZMzhh7N/yA9n/5A5GXM0VbcH+Dw+rh99PT+a8yMenPkg4wZ2z87TfZa1UHEICjc5X7thEowxhttuu631eSAQICUlhWuvvRaA4uJirr32WqZNm8bEiRO55ppr2LJlC1lZWWRlZTFw4EBGjBhBVlYWn/3sZ9u9Rm5uLsYYfvjDH7aWHT16FJ/Px7e+9S3AWYl47ty5ZGVlMWHCBO655x5WrlzZep3Y2FjGjRtHVlYWCxYsaPc6a9asIT4+vvU1x+J59NFHWbJkSYffm6VLl7bGd6Kamhq+/vWvM2rUKCZNmsTFF1/M+vXrO3wNN2mauIickpKac0PvM1BfAR8/B6X7wHjABiFpFJx/N0R1fpuGmJgYtm7dSn19PVFRUaxatarNtgwPP/wwV1xxBQ888AAAmzdvZsqUKWzcuBGAhQsXcu211/KlL33ptNcZOXIkK1as4Cc/+QkAr7zyCpMmTWo9fv/997No0SKuv/56ALZs2cKUKVOYN28eAHPnzmXJkiVkZ59+ctBFF13EihUrOvgudNzdd9/NiBEj2LNnDx6Ph/3797Njx44ev253UguOiIi4y1onuak4BPFDID7T+Vp+ED7+7y635Fx99dX89a9/BZztFObPn996rLCwsM12C1OnTu3UNaKiopgwYQLHlh9Zvnw5N9988ymvM2XKlE5d50yeffZZzj//fKZNm8aNN95IXV0d4CRckydPZtq0aVx88cWt5xcUFHDVVVcxZswYvvOd7wCwb98+1q9fz09/+lM8HidNGDlyJJ/73OcA+MIXvsCMGTOYNGlSm+0iYmNjefDBB5kxYwaf/exn+eijj5g7dy4jR47kjTfe6JH7PR0lOCIi4q7KPKflJjYVjrVmGQNxaVC6Fyrzu1T9l7/8Zf70pz/R0NDA5s2bmTVrVuuxe++9l7vuuotLL72UxYsXU1BQ0OXr5Ofn4/V6SU9Pbz22aNEiLrvsMq6++moef/xxKio6N1vunXfeae2iWrx48UnHv/jFL/Lxxx+zadMmJkyYwH//938D8OMf/5iVK1eyadOmNsnGxo0bWb58OVu2bGH58uXk5eWxbds2srKy8Hrb3x7jd7/7HRs2bCAnJ4cnnniC0lJnhmVtbS1z585lw4YNxMXF8YMf/IBVq1bx2muv8fDDD3fqfrtCCY6IiLirvtzpljqxq84Yp7y+vEvVT506ldzcXJYtW8Y111zT5ti8efPYv38/X/va19i5cyfTp0+npKSkU9e56qqrWLVqFcuWLeOWW25pc+yOO+5gx44d3HTTTaxZs4bZs2fT2NjY4WtcdNFFbNy4kY0bN7a74vHWrVu56KKLmDJlCi+++CLbtm0D4MILL2ThwoU8++yzNDc3t55/+eWXEx8fT2RkJBMnTuTgwYNnjOGJJ55g2rRpzJ49m7y8vNZdzsPDw7nqqqsAp4XqkksuwefzMWXKFHJzczt8r12lBEdERNwVleiMuTmxK8papzwqscuXuO666/g//+f/tOmeOmbgwIHceuutvPDCC5x//vmsW7euU9cIDw9nxowZ/OIXv+DGG2886Xh6ejp33nknr7/+OmFhYWzdurVT1zmdhQsX8tRTT7FlyxYeeeQRGhqc7VaefvppfvrTn5KXl0dWVlZrq0tERETra71eL4FAgEmTJrFp0yaCweBJ9a9Zs4a33nqLDz74gE2bNjF9+vTWa/h8vtbxZB6Pp7Vuj8dDIBDo9ns9EyU4IiLirvghzoDi6sJPkxxrnefJY5wxOV1055138vDDD5809uXtt99uHadSXV3Nvn37GDp0aKev8+1vf5uf/exnJCUltSl/88038fv9ABQVFVFaWtpmsHN3qa6uJi0tDb/fz4svvthavm/fPmbNmsWPf/xjkpOTycvLO2Udo0aNIjs7m0ceeYRj2znt2bOH119/ncrKShITE4mOjmbnzp18+OGH3X4P3UWzqERExF3GOLOlTppFNRqy7zy566oTMjMzW2dKHW/Dhg1861vfIiwsjGAwyN13383555/f6etMmjSpzeypY/7xj3/wwAMPEBnpbFz72GOPkZra/Ytn/uQnP2HWrFkMGzaMKVOmUF1dDcB//Md/sGfPHqy1XH755UybNq11plh7nnvuOb797W8zevRooqOjSUpK4rHHHmPq1Kk8/fTTTJ06lXHjxjF79uxuv4fuos02RUSkR3R4s01rnQHH9RVOt1R8ZrckN9J3dWWzTbXgiIhI72AMJAx1HiJdpARHRETkLGzZsqXNqsjgDNLt7hV+V65cyYMPPtimbMSIEbz22mvdep1QpwRHRETkLBy/wnFPmjdvXusKx9J5mkUlIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiFt8eLFTJo0ialTp5KVlcX69etZsWIF06dPZ9q0aUycOJHf/va3LF68uHUjS6/X2/r9E088cdr6p02bdtIWEB9++CGzZs0iKyuLCRMm8Oijj/L73/++tc7w8HCmTJlCVlYWDz30EEuXLiUlJYWsrCzGjx/P448/3lrXo48+ypIlS04bQyAQIDk5me9+97ttyjt6n48++igZGRlkZWUxceJEli1b1lrXwoUL+fOf/wyA3+/noYceYsyYMUyePJmZM2fy97///ax+HueMtda1B/A74Aiw9biygcAqYE/L18SWcgM8AewFNgPnHfea21vO3wPcfjbXnjFjhhURkZ6zffv2Dr8mGAzapkCTDQaD3RLD+++/b2fPnm0bGhqstdaWlJTY3Nxcm5aWZvPy8qy11jY0NNidO3e2eV1MTMxZ1b99+3Y7efJkm56ebmtqalrLx44dazdu3GittTYQCNht27a1ed2wYcNsSUlJ6/Pf//739t5777XWWnv06FGblJRkDx06ZK219pFHHrGPPfbYaeP461//aufMmWNHjhzZ+t41NTV1+D6Pv9bu3bttXFycbWpqstZae/vtt9tXXnnFWmvtgw8+aBcsWND6vhYVFdnly5efNsbOaO93CMixZ/E573YLzlLgqhPKHgJWW2vHAKtbngNcDYxpedwD/BeAMWYg8AgwC5gJPGKM6frObCIick4drT/Kk/96kkc/eJQn//UkR+uPdrnOwsJCkpOTWzd+TE5OJi4ujkAg0LpfVEREBOPGjetU/S+99BK33XYbV155JW+88UZr+ZEjR0hLSwOcTSwnTpx41nUmJSUxevRoCgsLz/o1y5Yt44EHHmDo0KGt+0NVV1d36T7HjBlDdHQ05eVtd3Ovq6vj2Wef5cknn2x9XwcPHszNN98MwDe+8Q2ys7OZNGkSjzzySOvrhg8fzve+9z0uuOACsrOz+eSTT5g3bx6jRo3i6aefPuu4zparCY61dh1QdkLx9cDzLd8/D3zhuPI/tCRwHwIJxpg0YB6wylpbZq0tx2n1OTFpEhGRXsxay0s7XqKysZKM2AwqGyt5acdLrZs9dtaVV15JXl4eY8eO5Zvf/CZr165l4MCBXHfddQwbNoz58+fz4osvtrtz9tlYvnw5t9xyC/Pnz2/TnbNo0SLGjRvHDTfcwG9/+9vWHbfPxqFDh2hoaGDq1KlndX59fT2rV6/m2muvbRNHV+/zk08+YcyYMQwaNKhN+d69exk6dCgDBgxo93WLFy8mJyeHzZs3s3btWjZv3tx6bMiQIXzwwQdcdNFFrV1eH374IQ8//PBZx3W23G7Bac9ga20hQMvXY+9sBnD89qf5LWWnKj+JMeYeY0yOMSanpKSk2wMXEZHOCQQDFNcVkxTltDYkRSVRXFdMIBjoUr2xsbFs2LCBZ555hpSUFG655RaWLl3Kc889x+rVq5k5cyZLlizhzjvv7HDdH3/8MSkpKQwbNozLL7+cTz75pLW14+GHHyYnJ4crr7ySl156iauuOvPf3cuXL2fSpEmMHDmyzcacZ7JixQouvfRSoqOjufHGG3nttddobm4G6NR9Pv7444wbN45Zs2bx6KOPnlUMx3v55Zc577zzmD59Otu2bWP79u2tx6677jrAWTRx1qxZxMXFkZKSQmRkJBUVFR2+1un0xgTnVNrbcc2epvzkQmufsdZmW2uzU1JSujU4ERHpvDBPGIOjB1NaXwpAaX0pg6MHE+bp+oL7Xq+XuXPn8qMf/YinnnqKV199FXA+ZBctWsSqVatayzpi2bJl7Ny5k+HDhzNq1Ciqqqra1DNq1Ci+8Y1vsHr1ajZt2kRpaelp67vlllvYtm0b77zzDt/+9rcpKio66zjeeusthg8fzowZMygtLeWf//xn6/GO3ueiRYvYtWsXy5cvZ8GCBSe1Po0ePZpDhw617lR+vAMHDrBkyRJWr17N5s2b+dznPtfm9ce6tDweT+v3x54HAl1LZk/UGxOc4pauJ1q+HmkpzweGHHdeJlBwmnIREekjjDHcOuFW4iPiOVxzmPiIeG6dcCumi7uJ79q1iz179rQ+37hxI4MHD2bNmjVtyoYNG9aheoPBIK+88gqbN28mNzeX3NxcXn/99dbuob/+9a+t3Wt79uzB6/WSkJBwVnVfcMEF3Hbbbfz6178+47lVVVW8++67HDp0qDWO3/zmNyxbtoyampou3ecXv/hFsrOzef7559uUR0dHc9ddd3H//ffT1NQEOGOd/vjHP1JVVUVMTAzx8fEUFxe7OrOqN+5F9QbOrKj/bPn6+nHl3zLG/AlnQHGltbbQGLMS+L/HDSy+EvguIr1QXnUeZQ1lJEclkxHbbk+qSK9lrWV/5X5q/DVkxGaQHJXcrfUnRyVz3/T7CAQDhHnCupzcANTU1HDfffdRUVFBWFgYo0eP5te//jVf//rX+frXv05UVBQxMTEsXbq0Q/WuW7eOjIwMMjI+/f/44osvZvv27RQWFvLCCy+waNEioqOjCQsL48UXX8Tr9Z51/Q8++CDnnXce3/ve90573l/+8hcuu+yyNq0h119/Pd/5znf45S9/yc9//vMu3efDDz/Mrbfeyte+9rU25T/96U/5wQ9+wMSJE4mMjCQmJoYf//jHTJs2jenTp7d2tV144YUdul53Ml0dwNWlixuzDJgLJAPFOLOh/gd4GRgKHAJustaWGec3/SmcAcR1wB3W2pyWeu4Ejv0WLLbW/v5M187OzrY5OTnde0Mip/FhwYf8777/xRiDxXLD6BvITs12OyyRs2KtZcX+FXxQ8AEe48FrvCycvJAR8SNO+ZodO3YwYcKEcxilhJr2foeMMRustWf8x9PVFhxr7fxTHLq8nXMtcO8p6vkdzpo6Ir1SIBjgbwf+xqDoQfi8PhqbG/nr/r8yY/CMbvkrVaSnlTWUsb5wPemx6XiMh8rGSlbmruTfpv2b26GJtKs3dlGJhBxrLUEbxOtxmqjDTBgBG3DKzNk3W4u4JRAMYFr+A/B5fDQGGl2O6txYvHgxr7zySpuym266ie9///vnNI57772X9957r03ZAw88wB133HFO4+grlOCInAM+r4/s1GzWF6wn2hdNXaCOizIuak14RHq75KhkhsUPY3/FfqLCoqgL1PHFMV884+ustX2+lfL73//+OU9m2vOb3/zG7RDOqa4OoVGCI3KOXDvyWlJjUimoKWBI3BDOG3Se2yGJnDWvx8tXJ3yV9YXrKWsoY2ziWCYmnX513sjISEpLS0lKSurzSY6cW9ZaSktLz3otoPYowRE5R8I8YcxOm+12GCHLWsuG4g28d/g9wr3hzBsxj5HxI90OK6REhkVyyZBLzvr8zMxM8vPz0cKq0hmRkZFkZmZ2+vVKcEQkJGwv3c6ru19lYNRA6gP1LN26lPum30dKtBb1dIvP52PEiFPPshLpSb1xoT8RkQ7bW7GXKF8UMb4YBkQMIGiDHK457HZYIuISteCISEhIjEykIdCAtRaLpdk2E+uLdTssEXGJEhwRCQkzU2eyp3wPByoPADA7bTajEka5HJWIuEUJjoiEhMiwSBZOWsjR+qOEecIYGDlQM3dE+jElOCISMrweL4NjBrsdhoj0AhpkLCIiIiFHCY6IiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCIiIhIyNFmm9JnWWspriumLlBHanQq0b5ot0MSkV6moqGCssYyEiISGBg50O1w5BxSgiN9krWWtw6+xZr8NXiNl2hfNHdNvouU6BS3QxORXmJ32W5e3PkiQRvEYLh57M1MTpnsdlhyjqiLSvqko/VHWZu/ltToVFJjUmkKNPGP3H+4HZaI9BLWWl7d8ypxvjjSYtJIiEjgL3v/QnOw2e3Q5BxRgiN9UkOgAY/x4PV4AYj0RVLVVOVyVCLSWwRtkDp/HZFhkQC1maqhAAAgAElEQVREeCNoam7CH/S7HJmcK0pwpE9KiU4hPiKe4rpiqpuqKasvIysly+2wRKSX8Hq8TE2ZSkFNAdVN1RTUFjBu4DgivBFuhybniMbgSJ8UGRbJnZPvZPWh1VQ0VnDJkEuYmTrT7bBEpBe5fvT1xEfEc7DqIFNTpnLpkEsxxrgdlpwjxlrrdgyuyM7Otjk5OW6HISIiIh1gjNlgrc0+03nqohIREZGQowRHREREQo4SHBEREQk5SnBEREQk5GgWlYicleLaYioaK0iKSiI5KtntcPq0Y1OXB0cPJiEywe1wREKSEhwROaOPiz7m9b2vY4zBYPjKhK8wbuA4t8Pqk9bmreUfB//hLFRpvNwx+Q6GDRjmdlgiIUddVCJyWv5mPyv2ryA5Kpm0mDQGhA/gf/b+j9th9UnVTdW8degtBkcPJi0mjQhvBCv2rXA7LJGQpARHRE7LH/TTHGzG5/EBzpL3df46+usaWl3R2NyIxeI1LVuMeCOpC9S5HJVIaFKCIyKnFRUWxbiB4zhcc5iKxgoKago4P/V8rQjbCYkRiQyJHUJhbSEVjRUcqT9C9uAzrlcmIp2gMTgiclrGGG4edzPv5L9DYW0hIzJGMDt9ttth9Ulej5fbJt7Guvx1lNSXMCZxjLYYEekhSnBE5IwivBF8dthn3Q4jJET7orlqxFVuhyES8tRFJSIiIiFHCY6IiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUezqPo5f9DP1pKtVPurGTFgBEMGDHE7JBGRfs9ay+7y3RTVFjEoehDjB47X2lMdpASnH2sONrNsxzJ2lO0gzIQRJMiCiQu0x5CIiMvW5q9lZe5Kwjxh+Jv9fHbYZ7VUQwepi6ofK6kvYVf5LjJjM0mLTSPOF8c/8/7pdlgiIv1ac7CZtw+9TVpMGmkxaaTHprM2fy2BYMDt0PoUteBIGwY1gUrfFbRBKhor8BovA8IHqElfpB9TgtOPHevX3V66vXXzvxvG3OByVCKd09TcxJ92/ond5bsB+EzGZ5g3fJ6SHOlzvB4vlw+9nDdz3yTMhBGwAT479LOEefSR3RF6t/oxj/Hw5fFfZtvRbdQ01TAsfhhD4jTIWPqmjwo/YmfZTjJiMwjaIOvy1zE2cSwjE0a6HZpIh12ceTGpMakU1xUzOHowYxPHuh1Sn6MEp5/zeXxkDcpyOwyRLittKCUyLBJjDF7jxWM8VDVVuR2WSKcYYxg3cJwmfXSBBhmLSEgYGT+S+kA9DYEGappqMBhSY1LdDktEXKIER0RCwuTkyXx+5OfxB/2Ee8P56sSvKsER6cfURSUiIcEYw5yMOczJmON2KCLSC6gFR0REREKOEhwREREJOUpwREREJOQowREREZGQo0HGIr3A0fqjvH3ober8dUwfNJ2pKVO1Aq+4IhAM8H7B++wp38Pg6MFcNvQyon3Rbocl0mFKcERcVtNUw3NbnqMh0ECEN4Jdu3bh9XiZnDzZ7dCkH1p9cDX/zP8nCREJHKg8QEFNAXdPvRuPUYO/9C36jRVx2eGaw9Q21TIoehDxEfHE+mLZdGST22FJP7XhyAZSo1MZED6AtJg08mryqGysdDsskQ5TgiPissiwSII2SNAGAWhsbiQ2ItblqKS/ivXF0hBoAJzuKoMhwhvhclQiHacER8RlQ+OGMiN1BoW1hRTWFjIgfACXZFzidljST10/+nqagk0U1hZSUl/CNSOu0Rgc6ZOMtdbtGFyRnZ1tc3Jy3A5DBABrLfk1+fib/aTFphEVFuV2SNKPVTZWUlJXwoCIAQyKHuR2OCJtGGM2WGuzz3SeBhmL9ALGGIbEDXE7DBEA4iPiiY+IdzsMkS5RF5WIiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCIiIhIyFGCIyIiIiFHCY6IiIiEHCU4IiIiEnKU4EhIq/XXcrjmMDVNNW6HIiI9oLyhnIKaAhqbG90ORXqZMLcDEOkpuZW5vLD9BfxBP17j5dYJtzImcYzbYYlIN3nv8Hu8mfsmAAkRCdwx+Q4GRg50OSrpLdSCIyHJWsvLu14mwhtBakwqMb4Ylu9aTtAG3Q5NRLpBaX0pfz/wd5KjkkmLSaO6qZqVuSvdDkt6ESU4EpKCNkhVUxUxvhgAosKiaAg00NTc5HJkItId6vx1eIwHn8cHQIwvhrKGMpejkt5ECY6EJK/Hy/ik8RTUFFAfqKewtpAR8SOI8Ea4HZqIdIPk6GRifDGU1pdS56+jrKGMyUmT3Q5LehElOBKybhxzI9mp2XiNl6xBWXx5/Jcxxrgdloh0g6iwKO6cfCdDBwwl3BvOlcOu5DMZn3E7LOlFjLXW7RhckZ2dbXNyctwOQ0RERDrAGLPBWpt9pvPUgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCISEgJ2iD9dWyhiHxKKxmLSEgI2iD/yP0H7xW8h8/j45oR15CdesZxiCISotSCIyIh4ZPiT1iTt4ZBUYOIC4/jtb2vkV+d73ZYIuISJTgiEhIO1xwm2heN1+MlwhuBwXC0/qjbYYmIS3ptgmOMyTXGbDHGbDTG5LSUDTTGrDLG7Gn5mthSbowxTxhj9hpjNhtjznM3ehE511JjUqkP1BO0QfzNfoI2qI0XRfqxXpvgtLjUWpt13II+DwGrrbVjgNUtzwGuBsa0PO4B/uucRyoirpoxeAaz0mZRVFtEaUMp1468lqEDhrodloi4pK8NMr4emNvy/fPAGuDBlvI/WGfqxIfGmARjTJq1ttCVKEXknAvzhPGF0V/g6hFXt9mEUUT6p97cgmOBfxhjNhhj7mkpG3wsaWn5OqilPAPIO+61+S1lItLPRHgjlNyISK9uwbnQWltgjBkErDLG7DzNue3toHjSQhgtidI9AEOHqulaREQkVPXaFhxrbUHL1yPAa8BMoNgYkwbQ8vVIy+n5wJDjXp4JFLRT5zPW2mxrbXZKSkpPhi8iIiIu6pUJjjEmxhgTd+x74EpgK/AGcHvLabcDr7d8/wawoGU21WygUuNvuoe1lsrGSqqbqrU6rIhINwraIJWNldT569wOJST11i6qwcBrxhhwYnzJWvumMeZj4GVjzF3AIeCmlvP/BlwD7AXqgDvOfcihJxAM8Nqe19hUsgmA2emzuWbENXhMr8yLRUT6jIZAA8t2LmN/xX4wcMWwK7g482K3wwopvTLBsdbuB6a1U14KXN5OuQXuPQeh9SubSjaxoXgDmXGZWCzvHX6P0QmjGT9wvNuhiYj0ae8efpc95XvIiM2g2Taz8sBKRiWMIiNW82O6i/4Ul1MqrS8lIiwCj/HgNV68xktlY6XbYYmI9HlH6o4Q44vBGEOYJwxjDFWNVW6HFVJ6ZQuO9A7DBgzjn3n/pCHQ4OzQjCUtJs3tsKQrmv2Q+x7sXwNN1ZAyAcbOg4QhZ3ypuKh4O+xZCZX5EDsIRl8J6Vlg2ptAKn3BqIRRbC7ZTIwvhqbmJjzGQ0q0Jr90J7XgyCmNTRzL9aOvpynYhMVy09ibtDJsXxYMQs7vYNNLTqITEQ9FW2Dtz6B0n9vRyakceAfe+xVUFjg/s9oyWP9fsOtNtyOTLjg/9XyuGHYFdYE6fB4fCyYuIDkq2e2wQorprzNjsrOzbU5OjtthiJw7Jbvh3V9C/NC2f/nXlUFMElzyoFoEeht/Pfz9IYhKhLCIT8uDAagugnmLISrBvfhEXGCM2XDcFk6npBYckf6ieCt4fCcnMVGJUHEI1P/f+1QccpKZ45MbAE8YYKFsvythifQFSnBE+otjH4rtsqDp/72P8XDqnxn6mYmchv7vEOkvUqc4rQE22La8tgRSxkNEnDtxyaklDANfFDSdsBBcoBGMF5JGuxOXSB+gBEekv0gcDiPmQsVBqCuFxmpnVo7HA5O/1G2XaWxuZG/5XvZX7Mcf9Hdbvb1dnb+O3eW7ya3MJXhiEtlZYeEwfQHUl0J1ITTVOGNvaopg2nyIiO2e64iEIE0TF+kvjIGpN8PgCc7MnMZqGDILRlwE0QO75RJ1/jp+t/V3FNUWYbEMHzCc2yfdTrg3vFvq760qGip4dsuzVDZWYrFMSZ7CzeNu7p5Vv9OnwdzvOlP7K/MgaRSMuMT5KiKnpARHpD/xeCBtmvPoAf868i8Kagqc1a+tZX/lfnaU7WBaSs9cr7d45/A7VDdVkx6bjrWWzSWbmZk2k5HxI7vnAglD4LzbuqcukX5CXVQi0m0aAg2EeZy/m4wxeIyHpkCTy1H1vLpAXWsrVet9N4f+fYv0ZkpwRPqQ3r5u1fik8VgspfWllNSVEO4JZ0TCCLfD6nFZKVnU+esobyjnSO0RYsNjyYzNdDus0+rtv0siXaWF/kT6gKLaIpbvWk5JXQljEsdw45gbiQ3vnQNMD1Yd5IOCD/AYD5/J+Azpseluh3RO7CzdyYbiDUT7orko86JeuyptcW0xL+9+meLaYkYljOJLY79EXLhm0EnfcbYL/SnBEenl/M1+Hv/kcfzNfhIiEiiqLWJ80ni+MuErbocmfUwgGOBXG35FQ3MDiRGJFNcVMzphNAsmLXA7NJGzppWMRUJEtb+a6qZqEiMTMcaQHJ3MgcoDboclfVCtv5bKpkoGRg7EGENKVIp+lyRkKcER6eVifbFEeCOoaaoBoLyhnIzYDJejkr4o2hdNdFg01U3VAJQ1lPWbLkTpf5TgiPRy4d5wbpt4GwEboLC2kJSoFG4YfYPbYUkf5PP4+OqEr2KtpbC2kMTIRG4ce6PbYYn0CI3BEekjmoPNNDY3EhUWhdGu39IFx36XIsMiu2cxQpFz6GzH4Gihvx5grdUHkHQ7r8dLtCfa7TAkBOh3SXpSb/kMVILTjfrSVF4REZHu1NuWIFDbZDfxN/t5ftvz1DTVkBqTyt7yvby+73W3wxIREelxgWCAF7a/QGVjJWkxaRyoPMBf9vzF1ZiU4HSTan81Nf4aEiMT8RgPyVGayisiIv1De0sQ5FbmuhqTEpxuctJU3kZN5RURkf6hNy5BoASnm4R7w/nKhK+0TuVNjkrWVF4REekXeuMSBJom3s00lVdERPqrc7EEgaaJu0TTL0VEpL/qTZ+B6qISkdDir4dAo9tRiIjL1IIjIqGhbD9sfQ1K94EB0s+DSV+AmGS3IxMRF6gFR0T6vvKD8M4voboQ4jMhLh2KNsE7v4CGKrejExEXKMGRfq3OX8eusl3sq9hHIBhwOxzprF1/B08YRCeBMeDxOklOQyUcWu92dNJJ9YF6dpXtYm/5XvxBv9vhSB+jLirptyobK3l287NUNFZgsYxLHMetE24lzKP/Lfqc4m0QO/jk8og4KN4CY6849zFJl9Q01fDslmc5Wn8UgJHxI1kwcQE+r8/lyKSvUAuO9FsfFHxARVMF6bHppMeks7NsJ/sr97sdlnRGeDQ0t/MXfrMftB9cn5RTnMPRuqNkxGaQHpPOvop97Crf5XZY0ocowZF+qy5QR7gnHABjDB7jwd/eh6T0fiMugdoiOH5dLxuEphoYNse9uKTT6gP1hHmd1lRjDAajbirpECU40m9lpWTR2NxIaX0pxbXFxPhiGDJgiNthSWeMugySx0HlIagphqpC5/uRl8KgiW5HJ50wOXkyQRuktL6UI3VHiPJFMXzAcLfDkj5EKxlLv7a3fC8bjmwgwhvBZzI+Q3KUphT3Wc0BOLIdijaDxwcZMyBplDPoWPqk3MpcPir6CJ/Hx5z0OQyOaWeclfQ7Z7uSsRIcERER6TPONsFRF5WIiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiIhRwmOiPQMa6GhChqr3Y6kZ1kL9RXQVOt2JCJynDC3AxCREFS2Hza/DBWHnOfJY2HKTRCf4W5c3a14G2x5FWqKnOepU2HKlyBGW36IuE0tOCLSvSrz4Z1fQm0pDMh0HuUH4Z1fOGWhomQ3vP8k+Ota7jPD2Qvr3V9CY43b0Yn0e0pwRKR77f4HGC9ED3Q2ujQGYgdBoBFy17kdXffZ/jqEx0FkfMt9eiAuDerKIV/73Im4TQmOdEp1UzXvH36fdfnrOFp/1O1wpDcp2eEkNyeKSoDi7ec+np7QHICyfRCVePKx8FjnPRBpkVeVx5q8NeQU5eBv9rsdTr+hMTjSYbX+Wn676beUNZThMR7W5a/j36b9G8lRGncgOB/wgSbwhrctDzRB7GB3YupuHi/4oqC5CcIi2h5rboKIAe7EJb3OrrJd/GH7H/AYD4FggC1Ht7Bg4gK8Hq/boYU8teBIh+0p30NZQxmZcZmkx6bTFGjiX0f+5XZY0luMnAu1Jc7somNsEBorYcTFbkXVvYyBEXOdwcXH32cwAIEGGDrbtdCkd1mXt45YXyxpMWlkxmayr2IfRXVFbofVL6gFRzrFYtt871GuLMcMmwMlu6BgA3jCAet88I+8xJllFCrGXul0Ux3d7bRWBYNgAzDh8zBwpNvRSW9h2j61WMyJhdIjlOBIh41NHMug6EHkV+djjCHGF0PWoCy3w5LewuuD8++G0rlQvNUZfJs2FRJHOC0focIXBXPuh5KdcGQH+CIhLQviM0PrPqVLLh1yKc9ve55afy3NwWYmJk9kcHSIdNX2csYe37zaj2RnZ9ucHM106Kxafy3bS7fTbJsZnziehMgEt0MSEemVCmoKyK3MJSY8holJE/F5fG6H1KcZYzZYa7PPdJ5acKRTYnwxnJ96vtthiIj0eumx6aTHprsdRr+jgRMiIiIScpTgiIiISMhRgiMiIiIhRwmOiIiIhBwlOCIiIhJyNItKJJRZ6+zuXVMMvmhIHuOsUyN9X1MtHN0DwWZIHA4xSW5HJNKrKMERCVX+esj5PRRtcVZTtTg7X8/+N+cDUfquvI/hXy84K0RjAQOjLodJN4BHDfMioC4qkdC19S9OchM/BOKHQsJQwML7v4Gmui5VXVRbxL6KfVQ3VXdPrN0p0AihvGNzZT5s+D1EJn76s41Lh90r4dAHbkcn0muoBUckFDXWwKH3YUBG220DIhOg4pCzhcKQmZ2qek3eGlYdXIXXeAn3hnPn5Dt7xyJm5bmw7TUo2e20YmRkw8TrIXqg25F1r9z3wHidrSGO8XghJsVJcoZf6F5sIr2IWnBEQlFjNWCcD74TGQ/UlXaq2oqGCt46+BaDoweTGpMKwN8O/K0LgXaTijxYtwQq8p1Wjdg0OPwJvLOk5b0IIdVFEB59cnl4DNQdbbu7uUg/pgRHJBRFJTgtN+111dggxKV2qtqG5gaMMYR5nMbfqLCo3tFNtetv4AmDmGTnvj1eGJAOdeWQ95Hb0XWvxKHOAOMTNVY596yNPkUAJTgiockXBSMvharDziwbcP6yry1xumwGTexUtUlRSQyKHkRhTSFVjVUcrT/KeYPP68bAO6loK0Qnn1weOQAKN537eHrSsAsB07ZlqrnJaZUbe41rYYn0NhqDIxKqJnzeGXCb+27LLCoL8ZmQfReERXSqSp/Hx8JJC3n70NuUNZRxSeYlzEqf1b1xdyqwKKe16sQuueaA03UTSmIHwQX3woalUJlHa1fktPmQMd3t6ER6DWP7aX9tdna2zcnJcTsMkZ5XXw41R5x1cOIzQ7MLY8dfYccbkDDs0/uzQag4CHPug9Qp7sbXE5oDzv0Fm52fa3vjckRCkDFmg7U2+0znqQVHJNRFJTqPUDb6MijZ4Sx854t2kpvmBhhxMQya5HZ0PcMbBkmj3I5CpNdSgiMifZ8vCi58wBmLU7TZWa05IxuSRmvhO5F+SgmOiIQGr88Zg6JxKCKCZlGJ9BhrLWUNZRytP0rQBt0OR6RH+Jv9FNcWU9VU5XYoIm2oBUekBwRtkP/d9798XPQxAGMSxzB//HzCveEuRybSfSoaKli6bSmlDc7CkdeOvJZZab1gVp0IasER6RF7yvfwYeGHpMakkhaTxq6yXeQUa9aehJY3c9+kvLGctJg0kiOTWbF/BeUN5W6HJQIowRHpEbX+WrzGi8d4MMYQ4Y2grKHM7bBEulVpQymxvlgAfF4fBkONv8blqEQcSnBEekB6bDoGQ3VTNXX+OhqaGxgdP9rtsM49fwMUbHQWGyzZDUGNRQolEwZOoKy+jIZAA6X1pUSHRZMUmeR2WCKAxuCI9IjUmFRum3gbKw+uJBAMcOOYGxk3cJzbYZ1bZQfgw//n7Gx+TOJwmP1vEBnvWljSfS7OvJhAMMCWo1tIi03j8yM/T7RPCw5K76CVjEWk+/kbYNUPwXjbJjNVh2HwZCfJ6euCzVC2HxqqnP29EoeH5irRIr2MVjIWEfcc2e603CQMbVsel+YsxFdX5iQFXWCtJb+8ngNHawkEg6TFRzFmUCxh3nPQ815dDOufhpoiwDj7fCWNgpn3OBt8iojrlOCISPdrrAbaaR02HufRWN2lBKestokX1x8k92itU60xWGBARBhfnjmEcak9mGQEm+HD/3LuIb4lgbMWynPhkz/AnG/13LVF5KxpkLGIdL/Ywe131wQDztfozg9ErWkM8PTafRRWNJCREEVmYrTzNSEKr8fw7DsH2F/SgzN5SvdCbTHEJH9aZgzEpcORbU7rjoi4TgmOiHS/5DHODtfVhU7rBjjJTWU+jLoMImI7XfX6/aWU1TSREheBOSGJiokIIybcy+sbC+ix8YUNle2XG+O0Tp3quIicU0pwRKT7ebww+5uQPBaq8qAq3xmvMuYKmPD5TldrreWdPUdJij31itDxUT4OV9RTVNXQ6eucVtTAdnvfsEEnmetC65SIdB+NwRGRnhGV6IxHqT3qjFeJSYaIuC5V2dQcpKYhQHxi1CnPMcbgMVBVHyCtJ2ajDxzpDJ6uKoS4VKflxgadJC49G2KU4Ij0BmrBEZGeFZMMA0d0ObkB8Hk8eL2GQPPpFwy0FsLDeuifN4/HmeY+cLjTOlWZ35LcnAdZ83vmmiLSYWrBEZE+w+MxZA9LZMPBcgYPiGz3nAZ/M9HhXoacppWny6IS4TOLnDFGDZUQnQyxKT13PRHpMLXgiEif8pkxyQStpa4pcNKx5qDlSHUDV0wc3PPr4RgDA9Jh0AQlNyK9kBIcEelT0uKjWDhnONUNAQ5X1FPTEKCuKUBxVQOFlfVcNn4wc0Yln7kiEQlp6qISkT5nYno8D109nk8OlbMpr5LmoGXc8DhmjUgiMzHqpOnjItL/KMERkT4pITqcy8YP5rLxg90ORUR6IXVRiYiISMhRC46InHNNgSBNzUEiwzznZnPMs2Ctpd7fjMEQ6fOom0ukj1OCIyLnTF5ZHWt3l7A5rwKLs1bNhaOSuXB0MvHRPldi8jcH2ZBbzj93HaGstpEgMCQhmkvHpzA1M0GJjkgfpQRHpD01R+Dge1C6D2IHwfDPOCvY9kWBRjj8L8j/2HmemQ0Z50FYxDkNY0t+Bc9/cBCfxzBoQCRej6EpEOSfu47wcW4Z37h0FIPi2l/b5qw01Tn3WPAv8IbD0NmQOhW8p/5nrikQZOn7B9hRWE1STDjpCdFYa6mo9/P793K5eGwKN0zP6F1JTkMVHFoPxVsgPAaGXQiDJjoLEPY1waCzQenB96GpFtKmwZCZ3bIopIg504Z0xphs4PvAMJyEyADWWju158M7e8aYq4BfA17gOWvtf57u/OzsbJuTk3NOYusoay0Hqg5Q1VhFakwqqTGpbofUZXX+OvZX7sdgGJUwisiwLnyQ9bTSffDer53l98NjwV8PgQbIuhVGXuJ2dB3jb4APfgNHd0Nky74FjZWQNBYuuBd85+bnUFHXxH/+fScDonxE+bwnHS+tbSQxOpx/v2Js55KJxmp493GoKoCIeLDN0FgFGTMg+65TJjn/2FbEm1uL2p15FQxa8ivqWThnGNOGJHY8pp5QexTe+QU0VEDEAGj2Q1MNjJwL0+a3v4N7bxUMwqaX4MA6CI9zfkYNVRA9EC76tvO1l6psrORg1UF8Hh+jE0fj87jT+thd+tpnjjFmg7U2+0znnU0LzovAfwBbgNOvj+4SY4wX+A1wBZAPfGyMecNau93dyDpn9aHVvH3obTzG+Yts/vj5TEqe5HJUnVfdVM0zm5+hrL4MiyUtJo27p95NVFgPrjTbWcEgfPI8+KIgMsEpi4yH5ibY/IrzF2ZUgrsxdsShD53kJmHYpx9+kQlO2aH3nZ29z4ENB8sJBG27yQ3AwOhwDlc0kFtax4jkmI5fYM8qZ2+ohGGflkUNhMMbIPN8p8XqBI2BZtbtKWHQgJN3JQdn1eT4KB9v7yzpPV1V2193Epr4oZ+WRSfB/rXOfSaPcS+2jirdAwfeafndbGl9ikxwktTtb0D2QlfDO5WSuhKe2fwMdf46ggQZlziOr078KmGevtshEmqfOcecTZtmibX2DWvtAWvtwWOPHo+sY2YCe621+621TcCfgOtdjqlT6vx1rMlbQ1pMGumx6SREJPC3A39zO6wu2VSyidL6UjLiMsiMy6SgtoCdZTvdDqt91QXOX8mRJyQx3nCwASjZ5U5cnXXwXecD8PgPZ2Ocstz3zlkY2woqGRB56g8AYwwGOHC0pnMXOPgexJ4wXdwYp5Xj0P9v786D47zv+46/v3tgF4v7JIiDBE9IpCjREkQdVmRFlqMj8dC3ZbeJldiR04madjqdaZP8kbRpZtJMM07aSTNWfNR2GjuKY7uMLZuSbUWydVgkRdk8RJEUSYm4iPtYnHv8+sezlHiAB8AFnt0Hn5cGI+K3B7777GL3g9/zO16a9yb947PMprLEIvOHLoDKeITu0Smm5jKLqyuf0rNeYCu78HGGIByD7lf8qWuxuvdBJP5OuDmrfBV07/F6pwrQT7t/Siqb8t7Pyls5NnKMN8cL7SPx6k2mJi/6zPn+ye/7Xd72S68AACAASURBVFZeXE3k/CMz+wLwI2D2bKNz7ltLVtXCtQCnz/m+C7jtwiuZ2aPAowBr1qy58OKCkHbe8vNnk3QkFGEyNelnSdcsnU2//XgADCOduXiZ/YKQzeCdhb0EVwAfdAuRSYHN8wEeCi/rB0gmC6Er9ICYeVstLO4HpL3HdNGdhr3et3lknbviGR0veBnZK5zKXxYu14F+YSAAb/zNJR5nwcrMzf9YLOQ9VleQJwyYy84Rzv1OmRlmRjpboO9nV+Fs7Wffo8OhMNPpaT9Lypur6cH5TWA78ADw/tzXry1lUYsw39vURe9IzrnHnXOdzrnOhobC3DumIlrBlrotdCW7GJwe5MzUGe5qucvvsq7JlrotlIRL6Jvso2+yj7JoGRtrNvpd1vwqm73TU6kLfsFdFrDiG2jccgtMDV3cPjXkDTZeJusbyhifufyHQNY5WqoTi/sBLTfD5MDF7bNj3jGYR325N8g6nb30B+nkbJrK0ghlJQVw+iFaCnUbYHr4/HbnvDFiqwtqWOSVNd0E6Wmv/nNNDUF9x7IPgr9atzbdymxmloGpAXqTvdTGa2mraPO7rEWrLKlkS90WupPdDE4P0j/VX/SfOWddzW/tTc65bUteybXpAs59hbUCPT7Vck3MjI9u/ijtVe0MTA2wtnItNzXc5HdZ16Qx0cijNz7KK2deIWQhOps6qYkXyKDNC4WjsO0jsPfL3tibeJU3O2dyADbcAxWFPfjuIuvuhrdehLEubzYYeDPE4lWw7peWrYzb1tXxk6MDpDPZede9Sc6kqYhH2byqfHE/YPP90Ptzb3fvsgavJ27yjBdYLxFwymIRbm2v5eWTwzRXXzwezDnH0OQsH765lVCoAMbfAGz9kDfIOHnG28E8k4JkHzR0eDOpiknTDVC7AYbf8E67haMwNeg9d1s/4Hd1l7S+aj2f2fYZDgweoDRSyo7VO0hEFxnMC8DZz5y1lWsZnB4MxGfOWVczi+pvgc8V8oBdM4sAR4H3At3AHuCTzrlDl7pNIc+ikgJw5jC8/iSMnPLGq2x8H6y9Y/7TIIVuahiOPeVNLQZvGu7m+5d9lsrTh/t48kAfdWUllMW8v62cc4xMpZhJZfjse9azsfEapgdP9MHR3d5YlHDEm9q/8b7LTjkem07x188cZ3RqjoaKGJHcVOu5dJb+iRk2NJbz6bvWXXaczrIbfQte/z70HYSSBKx7D2z4Za+Hp9ikpuH4j+Hks14vVNM22PwAVBdvj4gsvaudRXU1Aec1YANwEm8MTqFOE38I+Eu8aeJfcs796eWur4Ajsrycc+x7c4Tdh/oYmZojZEbWwbq6Mn7tptWsrVvE7Kk8GJtO8YODvex7cyRXKETCId69sY73Xr+K+CVmfomIP/IZcNbO116AM6kWRAFHxB/ZrKN3fIbZVIaKeJSGisIYa5GcTTM4MYsZrKqMK9iIFKi8rYNT7EFGRApLKGS0zDPmxW/lsQjlsQIYTCwieVGEa3uLiIiIXJ7+XBGRopTJOo73JznSN04642irLeWGlioShTClW0R8p3cCESk6fWMzfPn5kwwmZ4mGQ4TMePHEEN96pZuPdbZx89oCXYZARJaNAo6IFJXRqTn+5l+O4xy01py//shsKsPXXnqTWCTE1pYqnyoUkUKgMTgiUlRefGOIqbkMNWUlF10Wi4apSUT57i96udIM0bxIz8L0SMHumySykqkHR0SKhnOO548PUld+cbg5qzwWoWdsmu7R6Yt6ePImPQtHvuft4p1Ne5tGdjzg7c5ejItBigSQAo6ILK1sxuvhiMS44u6WVzCXyTKTylJXfukQYWaEzJicXaKNUZ2DV74KXXuhssXbYiA9Awf+EVJTsGXn0vxcEVkQBRwRWRrpOW+LiDd+DKkZKKuH638NWm9ddNCJhkJEI0YqkyU6z55WZzkHpUu1UN94N3Tvg+q17zyOSByq2rzHu+Hey24PISLLQ2NwRCT/nIN9X4bX/hlild7eQtk07PkCnPrJou82FDJuX1/HYHLukteZnE1TVRqlpWaJFhMc7wHs4pAWioDD2xNLRHyngCMi+Tf6JvS86vVyRHJbMcQqoGI1HPqO17uzSHduqCccgomZiwf2pjJZhiZneeCGJsJLtQN4JO7tyHch5/A2soovzc8VkQVRwBGR/Bt9C3AX93JE4t4A3eTiezkaKmJ89u4NpLOO7pEpRibnGJtO0TM6zcDELDu3t3DLUq6DU78ZIgmYTZ7fPj3sBbiq1qX72SJy1TQGR0TyL3yJDTTP9nJc6vKr1F5fxh88dD0Hu8c40D1GOutor0twy9paaueZPp5X0Tjs+G342d/AzAiEopCZ83qoOn/rmgdSi0h+KOCISP41XueNSUnPnH/KZmrIG4xb3njNPyIeDdPZXktne+0139eCNV4H9/0X6NkPkwNQ2QrNN0FJ2fLXIiLzUsARWSKD04O82PMi6WyazlWdtFW2+V3S8olXwbt+HV75CljI67FJT0FJOdz8G8Ho5Sithg2/7HcVvnLOcXjoMIeHDlMdr+bO5jspiyrkSWFQwBFZAqMzo3z+559nLjNHyELs79/Pozc+SmvFChqfseY2qF4Dp38Gk0NQtw5aOiFe6Xdlkiev9L/CN49+k0QkwWxmlqMjR3l026NEw1G/SxNRwBFZCifHTzKVnqKlvAWAM5NnODB4YGUFHIDK1bD1A35XIUvk5d6XqYnVUF5SDkBPsof+6f63X/ciftIsKpElEA1Fz9sLKe3SxDV9WAImHokzl/Wm/GddFoCI6e9mKQwKOCJLYHPNZtor2+lOdtOT7KE2Xsstq27xuyyRvHrf2veRdVl6k730Jnu5telWGhPXPoBcJB9sWXbcLUCdnZ1u7969fpchAZbKpDgxdoKMy9Be2U4iukQbP4r4aGRmhJ5kD6XRUtZVrsOCMIBcCpqZ7XPOdV7peupLFFki0XCUjtoOv8sQWVI18Rpq4ku4sKLIIingiEhwTPTB8AlvDZ76zd5UbhFZkRRwRKT4ZTPwiyfg5LPvtFkEbvoYrLvbv7pExDcKOCJBl83A7ARES9/Z+DJo3nwB3ngGatZ6CwuCt33Cq3/v7Q1Vu97f+pbK3KT3/MYqgrF4okgeKeCIBJVz8OaLcGQXzIxDKAxtt3vr0lzDlgKpbIqDAwcZmxujvbKd9qr2/NW8WMeehrKGd8INQLjEW0H51E99DzjOOQ4PH2ZgaoCmsiY6ajqubTBucgAOfhP6DnjfVzbDto9Cg8Z8iZylgCMSVKd+Aq/8HZSv8vZ/yqa9D/uJPrjr33uBZ4GyLssTrz/BwcGDRENRMi7DJ677BDfU37AED2ABzu7kfaFoKST7l7+eCzx16imeOf0MJeES5rJzPND+APe03bO4O5sZh5/8BaSmobIFMJgZg5/+Jdz9H6FuQz5LFylaWgdHJIgyKTi8y/vQL8lNTw9FvKAzdAwGjy3qboemh3ht6DVay1tpKmuiqqSKH7/14zwWvkjVa70P+QvNJX3/wE9lUvyk5ye0lLfQVNZEc1kzz5x+5u2F8Rbs9MswOw4VTV6PlZk3mDqagCPfy2/xIkVMAUckiKaGvL/woxesnmwGFoaRU4u62wtPqzhcYax70vGgF3BS0++0zYx6AWDtXf7VBWBgGA5vzbFrXnvszCEoqbi4PVELA0e8U5MiooAjEkiRGODm/7BzmUWPwamL17GtfhtdE130JHsYnxvnvjX3XVut+dB0A9zyiDfodqwLxk57Y3De/e+gvMHX0qKhKPe03kPvZC89yR7OTJ3hvjX3EbJFvv3GKyEze3F7Zg6iZRpsLJKjMTgiQVRaA41bvFNRFU3vtKdnvFNVTYsbM2NmfHjzh9lSt4XxuXHWVKyhrbItT0Vfo7V3QMstMNHjPcaKZggVxt9w9665l9aKVganB2lMNLKxeuPi72ztnfDWS97sqbPjqJzzxlZt2ZmfgkUCQAFHJKhu+gQ8/5cw+pbXm5FNAeb1dJQufuXZSCjCtoZteSszryIlUNPudxUXMTM6ajvoIA+znOo3Q8cDcPQpL+BYyOu9adwCG+699vsXCQgFHJGgKquDX/5Dbyrx8BteqGm5Bcrq/a5MroUZbPkANN8MvT+H9Cys2upNEV/EzDiRoFLAEQmyaBzabvW+JDjMvEUNa9b6XYlIwSqME9QiIiIieaSAIyIiIoGjgCMiIiKBo4AjIiIigaOAIyIiIoGjWVSyKJlshu5kNxmXoaW8hZJwid8liYgUpMnUJH2TfSQiCZrKmgpje5MVQAFHFiyVTfH1177O6yOvYxiry1fzm1t/k0Q04XdpUkimR2H4hDeluW4jxObZPykIJgdh5E0IR6F+k7eDuUhO/1Q/XzzwRabT02Rdlrtb7+Z9a9+nkLMMFHBkwY6OHOXI8BFaylswM7onutl3Zh+/1PpLfpcmhcA5eP0HcOS7QBZvt8kQ3PhxWBeg10g2Awf/CU48A5j3uCMxuPkRaNnud3VSIHaf2k0qm6KprIlMNsNzXc/xrsZ30ZDwd4+0lUBjcGTBZtIzmNnbf4FEw1GSqaTPVUnB6H0VDn8byldB1RqoaoNEPbz6f2HoDb+ry59TP4FjP4SKFu8xVq+BWCXs+VtvXygRYGJugng4DkA4FMYwZjIzPle1MijgyIKtrVxLNBRlaHqIkZkRUtkU19de73dZUiiOPQ3xGu+UzVmRGETicOJffCsrr5yDo7u9EHfu9gjRUq+36q0X/atNCsrNjTczMjvC+Ow4fZN91MRraEw0+l3WiqBTVLJg9aX1fGbbZ3iu6znS2TS3r76d9qp2v8uSQpHs93oyLlRSDhO9y1/PUshmYGbU66G6ULQUxtWDI57bVt9GKBTi0OAhqmJV3Nt2L7FwzO+yVgQFHFmU1opWPnn9J/0uQwpRVSuMdUGi7vz22Qlo2OxPTfkWCkOiwXtMFw6eTk1CdZs/dUnBMTN2NO1gR9MOv0tZcXSKSkTya/P93gd/+pxxBnNTkE3B+nv8qiq/zOC6h2BqEDKpd9pnxsHCsOYO/2oTEUA9OCKSb43Xw82fggNPQGYQcN5pmx2f9QbiBkXbbTA95s0WcxmvLV4Fd/5bKKu7/G1FZMkp4IhI/rXfCS03w+hb3qDb6jUQCdhikGbQcT+su8s7JReKQE37+YOORcQ3CjgisjSi8eCMubmckjJo6PC7ChG5gMbgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgaKE/WdGGZ4Y5PnKcknAJ19VeRzwS97skuRbJfhg+6a0mXL8Z4vPsai5FY3RmlGMjxwiHwlxXex2JaMLvkqSIKODIitU/1c/jv3ic6fQ0zjlaKlr4zLbPEAvH/C5NFiqbhYP/CG/8C+C8tlAYbvoEtN/lZ2WySMMzw3z+559nYm4CgMZEI4/e+KhCjlw1naKSFevl3pdJZVK0lLfQWtFKT7KHk2Mn/S5LFuOtF+H4j6CyBarXel+JBtj/d16PjhSd/Wf2M5WaorWildaKVvqn+jk2eszvsqSIKODIipVxGczsnQYHWZf1ryBZvGNPQ6L+/I0uIzHv69RP/atLFi3jMmDntznn/ClGipICjqxYtzbdCkBvspfuZDf1iXrWVa3zuSpZlKlBb9PLC0VKYbJ/+euRa7a9cTsloZK3fz9r47VsrN7od1lSRDQGR1as5vJmfuem3+HI8BGioSjbG7dTGin1uyxZjOo1MDkIpTXnt88loWaHPzXJNWlMNPI7N/0Oh4YOEQlFuLHhRspLyv0uS4qIAo6saE1lTTSVNfldhlyrjgfhhf8F0VI4OxNuZgzMNMi4iDUkGrgncY/fZUiR0ikqESl+Tdvg5kdgdgLGumDstDce587fg/JGv6sTER+oB0dEgqH9Tmi9Bca7IRTxZlSdO+hYRFYUBRwRCY5IDGrX+12FiBQAnaISERGRwFEPTh4Nzwyz6/guzkydYXPNZh5c96CW/hcRkRVhdGaUXSd20ZvsZVPNJh5c96CvM1PVg5Mn6Wyarxz6CqfGT1ESLmFP3x6ePPmk32WJiIgsuUw2w9de+xpvjL5BSbiEfWf2sev4Ll9rUsDJk/G5cYZnhmlMNBILx1iVWMVrQ6/5XZaIiMiSS6aS9E/1syqxilg4RlOiiSPDR3ytSQEnTxKRBGELM52eBrzAU19a73NVIiIiS680Uko0FGUqNQV4n4F1pXW+1qSAkyfxSJyPdXyMibkJ+ib7iEVifHDTB/0uS0REZMmVhEv4eMfHmUxN0jfZRyQU4SObP+JrTbZSNy/r7Ox0e/fuzfv9TqWmSKaSVMeqKQmX5P3+RURECtVyfAaa2T7nXOeVrqdZVHmWiCZIRBN+lyEiIrLsCukzUAFHpAhoCQLJl0KbyiuyVDQGR6TApbNpvnroq1qCQK7Z2am8J0ZPFMxUXpGlooAjUuAm5iYYmhnSEgRyzc5O5T37WiqEqbwiS0UBR6TAlUZKiVhESxDINZtvKq9eSxJUCjgiBS4eifPRjo8WzRIEY7NjvNT7Ent695CcS/pdzrIZmBrgxe4X2de3j5n0jN/lzGu+qbwf3vxhv8sSWRKaJi5SJIphCYKRmRE+//PPMz43DkBdvI7P3vRZykvKfa5safUme3n8F48zl5kjS5a2ijY+s+0zBfs8FcNrSeRSrnaauHpwRIpEIpqgMdFY0B9Ivxj4BclUktaKVlorWhmaHeLoyFG/y1pyL/S8AEBLRQttFW10J7s5NX7K36IuoxheSyLXSgFHRPLG4S5sIOuy/hSzjOZ73Cu1d1ykUGgdHJGVZuIM9OyH2Qmo2wirtkIkP3/Jb6vfxvPdz9Od7MY5R3W8mo7ajrzcdyG7ffXtHBg8QE+yh6zL0lzeTHtVe/5+wNwk9LwK491Qvgqat0O8Kn/3LxJAGoMjspKc/An8/OuAQSgCmTmoaoE7/23ePjCHZ4Y5PHiYkIW4oeEGKksq83K/ha5vso+jI0eJhWPc2HBj/hbPGz0NL/xPmE1CuASycxCOwR2PQf3G/PwMkSKirRpE5HwTZ7xwU9YIkdg77WPdcOg7cMun8vJjauO13NV6V17uq5g0lTXRVNaU3zvNZmHPF8AB1WveaZ8dh5c/D7/yp3nrfRMJGo3BEVkpevYDdn64Aahogq49kJr2pSy5jNE3YXIAErXnt8cqvdNWQ8f8qUukCCjgiKwUsxPeaakLhcLgHBTo2i0rWnoGsEtfntJzJnIpCjgiK0XdRsjMXtw+l4TSaohp0GrBqViNNxUtc367c+Cy3vgpEZmXxuDIZZ0aO8WLPS8SCoW4q+UuWsr1hlq0Vm2FqlZvzE1Fk9dzMzfpnQK59bchpL93Ck5pNWy4F4497YWdSMwbGD7eA2tu955HKVqHhw6z78w+yiJl3N12t7bNyDMFHLmkrokuvnjwi5SESnA4Xht6jcfe9Zh+CYtVpMSbLXXw296YG/A+QG/9bWi94oQE8cvWD0JJORx7CiZnIRyFjgeh4yG/K5Nr8Prw6/zd4b+jLFpGKpvi6MhRHnvXY4Ff9Xs5KeDIJb0+/DqGUVdaB0B3spsToycUcIpZvAo6H4EbP+adropVqeem0IXC0PEAbHyvdzoxWqaZUwHw6sCrJKIJauI1APQke+hKdnFd7XU+VxYcCjhySaWRUjLOO/fvnCPrssQunIEjxakkAST8rkIWIhyF0hq/q5A8KYuUMZeZA955f9XWGfmlgCOXtL1xO/sH9tM90Q0GG6o3sKV2i99liYgUvbta7uLI8BF6JntwWcdNDTfRXtnud1mBUnArGZvZHwO/DQzkmv7AOfdk7rLfBz4NZIDfc87tzrU/APwVEAa+4Jz7syv9HK1kfHXmMnOcnjiNmdFW0UY0FPW7JBGRQJhKTdGd7KYkXEJbRRsh0+niq1HsKxl/zjn3P85tMLMtwMPAVqAZ+KGZbc5d/NfA+4AuYI+Z7XLOHV7OgoOqJFzChuoNfpchIhI4iWiCTTWb/C4jsAo14MxnJ/AN59wscNLMjgM7cpcdd86dADCzb+Suq4AjIiKyQhVqf9hjZvYLM/uSmZ0dVdcCnD7nOl25tku1i4iIyArlS8Axsx+a2cF5vnYCfwNsALYDvcBfnL3ZPHflLtM+38991Mz2mtnegYGB+a4iIiIiAeDLKSrn3H1Xcz0z+1vgu7lvu4C2cy5uBXpy/75U+4U/93HgcfAGGS+gZBEpcM45Xu57mRd6XqAkVML97fezsWaj32WJiE8K7hSVma0+59sPAgdz/94FPGxmMTNbB2wCXgb2AJvMbJ2ZleANRN61nDWLiP8ODx3mO8e/QyabYWJugq8e/ir9U/1+lyUiPinEQcZ/bmbb8U4znQI+C+CcO2RmT+ANHk4Dv+uctwqdmT0G7MabJv4l59whPwoXEf8cHz1OaaSURNRbwDCZStKT7KEx0ehzZSLih4ILOM65X7/MZX8K/Ok87U8CTy5lXSJS2GriNcykZ3DO4fBWhi2Pal8fkZWq4AKOiMhi3Lb6No6NHOPk2EkA7mi+Q2s4iaxgCjgiEgixcIxHtj7C0MwQkVCEmlgNZvNNshSRlUABR0QCIxwKa8yNiAAFOItKRERE5Fop4IiIiEjgKOCIiIhI4GgMjgRWJpthf/9+upPdNJU1ccuqW4iE9JIXCYqp1BQv973M2OwY19VeR0dth98lSQHRu70E1lNvPsWzXc+SiCR4qfcleid7+cDGD/hdlojkQSqb4iuHv0LXRBexcIyXel/i4Y6HuanxJr9LkwKhU1QSSFmX5YWeF2gpa6G+tJ6W8hb29u1lLjPnd2kikgdnJs/QPdFNS7n3O14dq+bF3hf9LksKiAKOBJJhRENR0i4NeKerQhYiZHrJiwTB2dPNWZcFIJ1NEwvH/CxJCoze7SWQzIyH1j3E4PQgPckezkyd4cH2BzUGRyQgViVWsb1xOz3JHnqSPaSyKe5bc5/fZUkB0bu9BFZnUydNZU0MTg9SG69lTeUav0sSkTwxMz606UPc2HAj0+npt09ViZylgCOB1lrRSmtFq99liMgSCFmIzTWb/S5DCpROUYmIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiBSImfQM43PjOOf8LkVWuEw2w9jsGKlMyu9SRBYt4ncBIgIv9bzEkyefJOuybKzeyMPXPUw8Eve7LFmBhmeG+eqhrzI0M0RJuIRPdnySDTUb/C5LZMHUgyPis77JPr574rvUxetYXbaao6NHea7rOb/LkhXq28e+zdjsGKvLVhMPx/n6ka8zm5n1uyyRBVPAEfHZ2OwYZkY0HMXMqIhWcGbqjN9lyQrVN9lHdawagLJoGbPZWSZTkz5XJbJwCjgiPmtINBAiRDKVJJVNMT43zrqqdX6XJSvUxuqNDEwPkMlmGJoeorKkkoqSCr/LElkwBRwRn9XGa/nXW/41IQsxPjvOe1rfwx2r7/C7LFmh3r/h/Wyt28rwzDD1pfV8auuniIaifpclsmC2UmdsdHZ2ur179/pdhoiIiCyAme1zznVe6XrqwREREZHAUcARERGRwFHAERERkcBRwBEREZHA0UrGIhIYJ8ZOsKdvDyWhEt7d8m4aE41+lyQiPlHAEZFAODV2ii8d+BKxcIyMy3B46DCPvesxqmJVfpcmIj7QKSoRCYQDgweIhqLUldbRmGhkKjXFm+Nv+l2WiPhEPTgrnHOOnskeplJTNJU1acVSKVrxSJx0Ng14r2uH0wJ1UtSGpocYnhmmJl5DfWm93+UUHQWcFcw5x9NvPs2zp58lFAoRD8f59LZP01TW5HdpIgt22+rbODBwgJ5kDw7H5prNbKzZ6HdZIotyaPAQ//D6P+DwFuP92OaPsa1hm89VFRcFnBVsaGaI57qeo6msiXAozND0ED849QMe2fqI36WJLFhlSSX/Zvu/4a3xt4iEIqytXEskpLc4KT7OOb517FtUxaoojZQyk57hW8e+xdb6rYRMI0uuln77V7DZzCxmRjgUBrwu/uRc0ueqRBavNFJKR22H32WIXJOMyzCbmaUmXgNALBxjODtMJpshFFbAuVo6UitYQ2kDdfE6+ib7GJsdY3hmmFsab/G7LBGRFS0SirC9cTs9yR7GZ8fpnuzmhvobiIY1pmwh1IOzgpWES/itbb/FM6efYXRmlPfWvZdbV93qd1kiIivezg07qYnVcHriNJ0VndzderffJRUdBZwVrrKkkp0bdvpdhoiInCMajvLete/1u4yiplNUIiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4mkUlIlfknOPI8BGGZ4ZpKmtifdV6zMzvsopSJpvhteHXGJsdo7WilbWVa/0uSSSQFHBE5Ip2n9rNs13PErYwGZdh58ad3L76dr/LKjrOOb5z/DvsObOHiEVwOD7e8XFubLjR79JEAkenqETksmbSMzzf/TzNZc00lzezKrGKp089jXPO79KKztjsGPv799Na3kpzeTPVsWp++NYP/S5LJJAUcETkslzuP+z8Nlm4s8fNcgfTMAVFkSWigCMil1UaKeWO5jvoSfbQN9nHmakz3Nt2r8bgLEJ1rJpt9dvoSnbRN9nH8Mww97bd63dZIoGkMTgickUPrnuQ9sp2BqYHWF22ms01m/0uqSiZGR/e/GE6ajsYnR1lTcUa1lev97sskUBSwBGRKwpZiK31W/0uIxDO7hQtIktLp6hEREQkcBRwREREJHAUcERERCRwFHBEREQkcDTIWIrWXGaO/f37Sc4l2VizUUvei8h5nHMcHjpMz2QPqxKruKH+BkKmv+tXCgUcKUrpbJqvHf4ax0ePEw1F+fHpKRRrbQAADE9JREFUH/MbW36DjtoOv0sTkQLxzOlneOrUU8TCMeayc9zdcjcPrn/Q77JkmSjKSlE6M3WGk2MnaS1vpamsiYpoBc+dfs7vskSkQGRdlme7nvW2FylbRXNZM8/3PM9cZs7v0mSZKOBIUTLsvO0CsmS1sq6IvM1y/53dCsPhMLO3t8mQ4NMpKilKTWVNXF97PYeHDmNmhCzEvWu15L2IeMyM+9fez64TuwhbmIzL8L617yMajvpdmiwTBRwpSiEL8fB1D/Pa0GtMpadYW7mWprImv8sSkQJye/PtrCpbRf9UP3WldWys3uh3SbKMFHCkaEVCEbY1bPO7DBEpUGbG+ur12u9rhdIYHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEJlEw2Q9Zl/S5DRHym3cRFJBAy2QxPnXqKF3pfIGIRfnX9r9LZ1Ol3WSLiE/XgiEgg7O/fz7Pdz9JY2khVrIpvH/82XRNdfpclIj5RwBGRQOhOdpOIJAiHwpSESzCMwelBv8sSEZ8o4IhIIKwuW81Ueoqsy5LKpMi6LHXxOr/LEhGfaAyOiATCLatuoXeylz19ewhZiPevfz9tlW1+lyUiPlHAEVlGb46/yfDMMPXxen345lk4FGbnxp08tO4hzIxISG9v+ZZ1WY6PHmcqNUVzeTONiUa/SxK5JL0DiCyT57uf53snvkfIQjjn2LlpJzuadvhdVuBEw1G/Swgk5xz//MY/87Pen2FmhC3MI1sfYX31er9LE5mXxuCILIN0Ns3uU7tZlVhFc3kzDYkGvn/i+1qvRYrG0MwQe/r20FzeTEt5C4lIgt2ndvtdlsglKeCILAPnHFmXJRwKAxC2MGmXxjnnc2UiV+dsGDcM8E4JprIpP0sSuSwFHJFlEA1H2dG0g+6JbganB+lOdvPu5ne/HXhECl1dvI71VevpTnYzMDXA8Mwwdzbf6XdZIpekMTgiy+RX1/8qq8tX05vspaW8hXetepffJYlctXAozL/a8q/Y07uHkdkRNlVvoqO2w++yRC7Jl4BjZh8F/hi4HtjhnNt7zmW/D3wayAC/55zbnWt/APgrIAx8wTn3Z7n2dcA3gFrgFeDXnXNzy/doRK5OOBTm1qZb/S5DZNFi4Rh3td7ldxkiV8WvU1QHgQ8Bz53baGZbgIeBrcADwP82s7CZhYG/Bh4EtgCfyF0X4L8Dn3PObQJG8MKRiIiIrGC+BBzn3GvOudfnuWgn8A3n3Kxz7iRwHNiR+zrunDuR6535BrDTzAy4F/hm7vZfAT6w9I9AREREClmhDTJuAU6f831Xru1S7XXAqHMufUH7vMzsUTPba2Z7BwYG8lq4iIiIFI4lG4NjZj8Emua56A+dc//vUjebp80xfxBzl7n+vJxzjwOPA3R2dmp+roiISEAtWcBxzt23iJt1AeeuX98K9OT+PV/7IFBtZpFcL8651xcREZEVqtBOUe0CHjazWG521CbgZWAPsMnM1plZCd5A5F3OWyXtGeAjudt/CrhU75CIiIisEL4EHDP7oJl1AXcA3zOz3QDOuUPAE8Bh4AfA7zrnMrnemceA3cBrwBO56wL8J+A/mNlxvDE5X1zeRyMiIiKFxlbqUvGdnZ1u7969V76iiIiIFAwz2+ec67zS9QrtFJWIiIjINVPAERERkcBRwBEREZHAUcARERGRwFHAERERkcBRwBEREZHAUcARERGRwFHAERERkcBRwBEREZHAUcARERGRwFHAERERkcBRwBEREZHAUcARERGRwFHAERERkcCJ+F2AiBSmE6MneLbrWQDe0/Ye1let97mi4HHOse/MPvb376e8pJz71txHQ6LB77JEAkE9OCJyke5kN18++GV6J3vpSfbw5YNfpifZ43dZgbO/fz//dOyfGJ4Z5tjwMb5w4Ask55J+lyUSCAo4InKRN0bfwOGojlVTE6/BOceJ0RN+lxU4BwcPUlFSQUVJBfWJeqbSU/RO9vpdlkggKOCIyEXKImVkXAbnHM45Mi5DIprwu6zAqYxVMpOeASDrsmSyGeKRuM9ViQSDxuCIyEW2NWzj54M/543RNzCMzTWb2Va/ze+yAuee1nt4Y/QNeid7cc5xZ/OdtJa3+l2WSCCYc87vGnzR2dnp9u7d63cZIgUrnU3Tm/ROl6wuX00kpL+HlsJMeoa+yT5i4RhNZU2Ymd8liRQ0M9vnnOu80vX0jiUi84qEIrRVtvldRuDFI3Haq9r9LkMkcDQGR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCx5xzftfgCzMbAN70u45lVA8M+l3ECqTj7g8dd3/ouPtjpR33tc65hitdacUGnJXGzPY65zr9rmOl0XH3h467P3Tc/aHjPj+dohIREZHAUcARERGRwFHAWTke97uAFUrH3R867v7QcfeHjvs8NAZHREREAkc9OCIiIhI4CjgiIiISOAo4AWFmHzWzQ2aWNbPOCy77fTM7bmavm9n957Q/kGs7bmb/+Zz2dWb2MzM7Zmb/YGYly/lYipWZ/bGZdZvZq7mvh865bEHPgSyOjufSMrNTZnYg9/rem2urNbOnc+8XT5tZTa7dzOx/5p6LX5jZzf5WXzzM7Etm1m9mB89pW/BxNrNP5a5/zMw+5cdj8ZMCTnAcBD4EPHduo5ltAR4GtgIPAP/bzMJmFgb+GngQ2AJ8InddgP8OfM45twkYAT69PA8hED7nnNue+3oSFv0cyALpeC6bX869vs/+IfWfgR/l3i9+lPsevOdhU+7rUeBvlr3S4vV/8N4rzrWg42xmtcAfAbcBO4A/OhuKVgoFnIBwzr3mnHt9not2At9wzs06504Cx/Fe7DuA4865E865OeAbwE4zM+Be4Ju5238F+MDSP4JAW9Bz4GOdxU7H0x878d4n4Pz3i53AV53nJaDazFb7UWCxcc49Bwxf0LzQ43w/8LRzbtg5NwI8zcWhKdAUcIKvBTh9zvddubZLtdcBo8659AXtcnUey3UTf+mcv5YW+hzI4uh4Lj0HPGVm+8zs0VzbKudcL0Du/425dj0f+bXQ47zij3/E7wLk6pnZD4GmeS76Q+fc/7vUzeZpc8wfbt1lri9c/jnA6xr+E7zj9SfAXwC/xcKfA1kcvXaX3rudcz1m1gg8bWZHLnNdPR/L41LHecUffwWcIuKcu28RN+sC2s75vhXoyf17vvZBvC7OSK4X59zrr3hX+xyY2d8C3819u9DnQBbncsdZ8sA515P7f7+ZfRvvtOAZM1vtnOvNnRrpz11dz0d+LfQ4dwH3XND+L8tQZ8HQKarg2wU8bGYxM1uHNxDtZWAPsCk3Y6oEbxDsLuet/PgM8JHc7T8FXKp3SM5xwfiCD+IN/IYFPgfLWXPA6HguITMrM7OKs/8GfgXvNb4L730Czn+/2AX8Rm6Wz+3A2NlTLLIoCz3Ou4FfMbOa3OnyX8m1rRjqwQkIM/sg8L+ABuB7Zvaqc+5+59whM3sCOAykgd91zmVyt3kM7wUfBr7knDuUu7v/BHzDzP4bsB/44jI/nGL152a2Ha8b+BTwWYBFPgeyQM65tI7nkloFfNubh0AE+Hvn3A/MbA/whJl9GngL+Gju+k8CD+ENqp8CfnP5Sy5OZvZ1vN6XejPrwpsN9Wcs4Dg754bN7E/wgj/Af3XOXThwOdC0VYOIiIgEjk5RiYiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IhIUTOzdjM7YmZfMLODZvZ/zew+M3vezI6Z2Q6/axSR5aeAIyJBsBH4K+BG4Drgk8BdwH8E/sDHukTEJwo4IhIEJ51zB5xzWeAQ8KPcvmoHgHZfKxMRXyjgiEgQzJ7z7+w532fRnnsiK5ICjoiIiASOAo6IiIgEjnYTFxERkcBRD46IiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEzv8HXx7EmX8ffqIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x576 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "subarray.peek()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$4.9235437 \\; \\mathrm{km^{2}}$"
+      ],
+      "text/plain": [
+       "<Quantity 4.92354368 km2>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.footprint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get info about the subarray in general"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[TelescopeDescription(type=LST, name=LST, optics=LST, camera=LSTCam),\n",
+       " TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam),\n",
+       " TelescopeDescription(type=SST, name=ASTRI, optics=ASTRI, camera=ASTRICam)]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.telescope_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[CameraGeometry(cam_id='LSTCam', pix_type='hexagonal', npix=1855, cam_rot=0.0 rad, pix_rot=100.89299992867878 deg),\n",
+       " CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg),\n",
+       " CameraGeometry(cam_id='ASTRICam', pix_type='rectangular', npix=2368, cam_rot=0.0 rad, pix_rot=0.0 deg)]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.camera_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[OpticsDescription(name=ASTRI, equivalent_focal_length=2.15 m, num_mirros=2, mirror_area=14.56 m2),\n",
+       " OpticsDescription(name=MST, equivalent_focal_length=16.00 m, num_mirros=1, mirror_area=103.83 m2),\n",
+       " OpticsDescription(name=LST, equivalent_focal_length=28.00 m, num_mirros=1, mirror_area=386.73 m2)]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.optics_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "[$95^\\circ38{}^\\prime18.0015{}^{\\prime\\prime}$\n",
+       " $117^\\circ35{}^\\prime31.273{}^{\\prime\\prime}$\n",
+       " $15^\\circ56{}^\\prime32.527{}^{\\prime\\prime}$\n",
+       " $166^\\circ24{}^\\prime15.7253{}^{\\prime\\prime}$\n",
+       " $90^\\circ00{}^\\prime00{}^{\\prime\\prime}$\n",
+       " $78^\\circ42{}^\\prime54.1682{}^{\\prime\\prime}$\n",
+       " $101^\\circ17{}^\\prime05.8318{}^{\\prime\\prime}$\n",
+       " $16^\\circ19{}^\\prime25.416{}^{\\prime\\prime}$\n",
+       " $38^\\circ42{}^\\prime43.3493{}^{\\prime\\prime}$\n",
+       " $138^\\circ18{}^\\prime26.2816{}^{\\prime\\prime}$\n",
+       " $160^\\circ45{}^\\prime08.6066{}^{\\prime\\prime}$\n",
+       " $45^\\circ50{}^\\prime11.5818{}^{\\prime\\prime}$\n",
+       " $68^\\circ26{}^\\prime09.4249{}^{\\prime\\prime}$\n",
+       " $11^\\circ27{}^\\prime33.9556{}^{\\prime\\prime}$\n",
+       " $111^\\circ33{}^\\prime50.5751{}^{\\prime\\prime}$\n",
+       " $134^\\circ09{}^\\prime48.4182{}^{\\prime\\prime}$\n",
+       " $168^\\circ32{}^\\prime26.0444{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime43.7281{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime16.2719{}^{\\prime\\prime}$\n",
+       " $16^\\circ02{}^\\prime24.2016{}^{\\prime\\prime}$\n",
+       " $38^\\circ36{}^\\prime32.8491{}^{\\prime\\prime}$\n",
+       " $141^\\circ23{}^\\prime27.1509{}^{\\prime\\prime}$\n",
+       " $163^\\circ57{}^\\prime35.7984{}^{\\prime\\prime}$\n",
+       " $45^\\circ48{}^\\prime42.2049{}^{\\prime\\prime}$\n",
+       " $68^\\circ25{}^\\prime33.0227{}^{\\prime\\prime}$\n",
+       " $11^\\circ21{}^\\prime07.5916{}^{\\prime\\prime}$\n",
+       " $111^\\circ34{}^\\prime26.9773{}^{\\prime\\prime}$\n",
+       " $134^\\circ11{}^\\prime17.7951{}^{\\prime\\prime}$\n",
+       " $168^\\circ38{}^\\prime52.4084{}^{\\prime\\prime}$\n",
+       " $49^\\circ01{}^\\prime53.8821{}^{\\prime\\prime}$\n",
+       " $130^\\circ58{}^\\prime06.1179{}^{\\prime\\prime}$\n",
+       " $153^\\circ34{}^\\prime33.8961{}^{\\prime\\prime}$\n",
+       " $57^\\circ29{}^\\prime13.3129{}^{\\prime\\prime}$\n",
+       " $80^\\circ06{}^\\prime19.0782{}^{\\prime\\prime}$\n",
+       " $99^\\circ53{}^\\prime40.9218{}^{\\prime\\prime}$\n",
+       " $122^\\circ30{}^\\prime46.6871{}^{\\prime\\prime}$\n",
+       " $1^\\circ21{}^\\prime19.7674{}^{\\prime\\prime}$\n",
+       " $23^\\circ51{}^\\prime29.0911{}^{\\prime\\prime}$\n",
+       " $156^\\circ08{}^\\prime30.9089{}^{\\prime\\prime}$\n",
+       " $178^\\circ38{}^\\prime40.2326{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime26.1515{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime33.8485{}^{\\prime\\prime}$\n",
+       " $34^\\circ34{}^\\prime02.3914{}^{\\prime\\prime}$\n",
+       " $57^\\circ11{}^\\prime07.3317{}^{\\prime\\prime}$\n",
+       " $122^\\circ48{}^\\prime52.6683{}^{\\prime\\prime}$\n",
+       " $145^\\circ25{}^\\prime57.6086{}^{\\prime\\prime}$\n",
+       " $15^\\circ57{}^\\prime57.3762{}^{\\prime\\prime}$\n",
+       " $38^\\circ34{}^\\prime56.9335{}^{\\prime\\prime}$\n",
+       " $141^\\circ25{}^\\prime03.0665{}^{\\prime\\prime}$\n",
+       " $164^\\circ02{}^\\prime02.6238{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime25.2281{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime34.7719{}^{\\prime\\prime}$\n",
+       " $11^\\circ18{}^\\prime54.9244{}^{\\prime\\prime}$\n",
+       " $168^\\circ41{}^\\prime05.0756{}^{\\prime\\prime}$\n",
+       " $45^\\circ48{}^\\prime11.2618{}^{\\prime\\prime}$\n",
+       " $68^\\circ25{}^\\prime20.4612{}^{\\prime\\prime}$\n",
+       " $111^\\circ34{}^\\prime39.5388{}^{\\prime\\prime}$\n",
+       " $134^\\circ11{}^\\prime48.7382{}^{\\prime\\prime}$\n",
+       " $63^\\circ12{}^\\prime03.8214{}^{\\prime\\prime}$\n",
+       " $85^\\circ49{}^\\prime13.7063{}^{\\prime\\prime}$\n",
+       " $29^\\circ21{}^\\prime33.4806{}^{\\prime\\prime}$\n",
+       " $51^\\circ58{}^\\prime41.6293{}^{\\prime\\prime}$\n",
+       " $3^\\circ09{}^\\prime32.0002{}^{\\prime\\prime}$\n",
+       " $25^\\circ45{}^\\prime53.6564{}^{\\prime\\prime}$\n",
+       " $94^\\circ10{}^\\prime46.2937{}^{\\prime\\prime}$\n",
+       " $116^\\circ47{}^\\prime56.1786{}^{\\prime\\prime}$\n",
+       " $128^\\circ01{}^\\prime18.3707{}^{\\prime\\prime}$\n",
+       " $150^\\circ38{}^\\prime26.5194{}^{\\prime\\prime}$\n",
+       " $154^\\circ14{}^\\prime06.3436{}^{\\prime\\prime}$\n",
+       " $176^\\circ50{}^\\prime27.9998{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime24.8214{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime35.1786{}^{\\prime\\prime}$\n",
+       " $15^\\circ57{}^\\prime47.4141{}^{\\prime\\prime}$\n",
+       " $38^\\circ34{}^\\prime53.4825{}^{\\prime\\prime}$\n",
+       " $141^\\circ25{}^\\prime06.5175{}^{\\prime\\prime}$\n",
+       " $164^\\circ02{}^\\prime12.5859{}^{\\prime\\prime}$\n",
+       " $11^\\circ18{}^\\prime46.4095{}^{\\prime\\prime}$\n",
+       " $168^\\circ41{}^\\prime13.5905{}^{\\prime\\prime}$\n",
+       " $52^\\circ49{}^\\prime06.0105{}^{\\prime\\prime}$\n",
+       " $75^\\circ26{}^\\prime16.4206{}^{\\prime\\prime}$\n",
+       " $38^\\circ57{}^\\prime04.2653{}^{\\prime\\prime}$\n",
+       " $61^\\circ34{}^\\prime14.3105{}^{\\prime\\prime}$\n",
+       " $104^\\circ33{}^\\prime43.5794{}^{\\prime\\prime}$\n",
+       " $127^\\circ10{}^\\prime53.9895{}^{\\prime\\prime}$\n",
+       " $118^\\circ25{}^\\prime45.6895{}^{\\prime\\prime}$\n",
+       " $141^\\circ02{}^\\prime55.7347{}^{\\prime\\prime}$\n",
+       " $66^\\circ31{}^\\prime35.8563{}^{\\prime\\prime}$\n",
+       " $89^\\circ08{}^\\prime46.5312{}^{\\prime\\prime}$\n",
+       " $26^\\circ24{}^\\prime12.8535{}^{\\prime\\prime}$\n",
+       " $49^\\circ01{}^\\prime22.348{}^{\\prime\\prime}$\n",
+       " $90^\\circ51{}^\\prime13.4688{}^{\\prime\\prime}$\n",
+       " $113^\\circ28{}^\\prime24.1437{}^{\\prime\\prime}$\n",
+       " $130^\\circ58{}^\\prime37.652{}^{\\prime\\prime}$\n",
+       " $153^\\circ35{}^\\prime47.1465{}^{\\prime\\prime}$\n",
+       " $5^\\circ52{}^\\prime51.9148{}^{\\prime\\prime}$\n",
+       " $28^\\circ29{}^\\prime50.4816{}^{\\prime\\prime}$\n",
+       " $151^\\circ30{}^\\prime09.5184{}^{\\prime\\prime}$\n",
+       " $174^\\circ07{}^\\prime08.0852{}^{\\prime\\prime}$]"
+      ],
+      "text/plain": [
+       "<Angle [ 95.63833374, 117.59202028,  15.94236861, 166.40436814,\n",
+       "         90.        ,  78.71504671, 101.28495329,  16.32372666,\n",
+       "         38.71204146, 138.30730046, 160.75239071,  45.8365505 ,\n",
+       "         68.43595137,  11.45943212, 111.56404863, 134.1634495 ,\n",
+       "        168.54056788,  78.69548002, 101.30451998,  16.04005599,\n",
+       "         38.60912476, 141.39087524, 163.95994401,  45.81172359,\n",
+       "         68.42583965,  11.35210877, 111.57416035, 134.18827641,\n",
+       "        168.64789123,  49.03163391, 130.96836609, 153.57608224,\n",
+       "         57.48703137,  80.10529951,  99.89470049, 122.51296863,\n",
+       "          1.35549094,  23.85808087, 156.14191913, 178.64450906,\n",
+       "         78.69059764, 101.30940236,  34.56733094,  57.18536991,\n",
+       "        122.81463009, 145.43266906,  15.96593785,  38.58248153,\n",
+       "        141.41751847, 164.03406215,  78.69034114, 101.30965886,\n",
+       "         11.31525677, 168.68474323,  45.80312828,  68.42235035,\n",
+       "        111.57764965, 134.19687172,  63.2010615 ,  85.82047396,\n",
+       "         29.35930018,  51.97823035,   3.15888895,  25.76490456,\n",
+       "         94.17952604, 116.7989385 , 128.02176965, 150.64069982,\n",
+       "        154.23509544, 176.84111105,  78.69022816, 101.30977184,\n",
+       "         15.96317058,  38.58152291, 141.41847709, 164.03682942,\n",
+       "         11.31289154, 168.68710846,  52.81833625,  75.4378946 ,\n",
+       "         38.95118481,  61.5706418 , 104.5621054 , 127.18166375,\n",
+       "        118.4293582 , 141.04881519,  66.52662676,  89.14625866,\n",
+       "         26.40357041,  49.02287445,  90.85374134, 113.47337324,\n",
+       "        130.97712555, 153.59642959,   5.88108744,  28.497356  ,\n",
+       "        151.502644  , 174.11891256] deg>"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from astropy.coordinates import SkyCoord\n",
+    "from ctapipe.coordinates import GroundFrame\n",
+    "center = SkyCoord(\"10.0 m\", \"2.0 m\", \"0.0 m\", frame='groundframe')\n",
+    "coords = subarray.tel_coords  # a flat list of coordinates by tel_index\n",
+    "coords.separation(center)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Telescope IDs vs Indices\n",
+    "\n",
+    "Note that `subarray.tel` is a dict mapped by `tel_id` (the indentifying number of a telescope).  It is  possible to have telescope IDs that do not start at 0, are not contiguouous (e.g. if a subarray is selected).  Some functions and properties like `tel_coords` are numpy arrays (not dicts) so they are not mapped to the telescope ID, but rather the *index* within this SubarrayDescription. To convert between the two concepts you can do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0,  4, 22])"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.tel_ids_to_indices([1,5,23])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or you can get the indexing array directly in numpy or dict form:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,\n",
+       "       16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,\n",
+       "       33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,\n",
+       "       50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66,\n",
+       "       67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,\n",
+       "       84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97])"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.tel_index_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0,  4, 22])"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.tel_index_array[[1,5,23]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.tel_indices[1]  # this is a dict of tel_id -> tel_index, so we can only do one at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 2, 3, 4]"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ids = subarray.get_tel_ids_for_type(subarray.telescope_types[0])\n",
+    "ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 1, 2, 3])"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "idx = subarray.tel_ids_to_indices(ids)\n",
+    "idx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<SkyCoord (GroundFrame): (x, y, z) in m\n",
+       "    [( -20.,  65., 16.), ( -20., -65., 16.), (  80.,   0., 16.),\n",
+       "     (-120.,   0., 16.)]>"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.tel_coords[idx]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "so, with that method you can quickly get many telescope positions at once (the alternative is to use the dict `positions` which maps `tel_id` to a position on the ground"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[-20,~65,~16] \\; \\mathrm{m}$"
+      ],
+      "text/plain": [
+       "<Quantity [-20.,  65.,  16.] m>"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subarray.positions[1]"
    ]
   },
   {
@@ -260,7 +962,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g.groups['LST:LSTCam']"
+    "g.groups['LST_LST_LSTCam']"
    ]
   },
   {
@@ -269,7 +971,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.loc[g.groups['LST:LSTCam']]"
+    "df.loc[g.groups['LST_LST_LSTCam']]"
    ]
   },
   {

--- a/docs/examples/InstrumentDescription.ipynb
+++ b/docs/examples/InstrumentDescription.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,9 +43,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : MonteCarloArray\n",
+      "Num Tels : 98\n",
+      "Footprint: 4.92 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "      LST_LST_LSTCam    4    1 ..   4\n",
+      "    MST_MST_FlashCam   25    5 ..  29\n",
+      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
+     ]
+    }
+   ],
    "source": [
     "subarray = event.inst.subarray\n",
     "\n",
@@ -54,9 +70,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<i>Table length=98</i>\n",
+       "<table id=\"table48025685576\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>tel_id</th><th>pos_x</th><th>pos_y</th><th>pos_z</th><th>name</th><th>type</th><th>num_mirrors</th><th>camera_type</th><th>tel_description</th></tr></thead>\n",
+       "<thead><tr><th></th><th>m</th><th>m</th><th>m</th><th></th><th></th><th></th><th></th><th></th></tr></thead>\n",
+       "<thead><tr><th>int16</th><th>float64</th><th>float64</th><th>float64</th><th>str5</th><th>str3</th><th>int64</th><th>str8</th><th>str18</th></tr></thead>\n",
+       "<tr><td>1</td><td>-20.0</td><td>65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>2</td><td>-20.0</td><td>-65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>3</td><td>80.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>4</td><td>-120.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
+       "<tr><td>5</td><td>0.0</td><td>0.0</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>6</td><td>0.0</td><td>151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>7</td><td>0.0</td><td>-151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>8</td><td>146.65599060058594</td><td>75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>9</td><td>146.65599060058594</td><td>-75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>89</td><td>956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>90</td><td>956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>91</td><td>-239.19699096679688</td><td>1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>92</td><td>-239.19699096679688</td><td>-1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>93</td><td>-956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>94</td><td>-956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>95</td><td>1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>96</td><td>1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>97</td><td>-1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "<tr><td>98</td><td>-1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=98>\n",
+       "tel_id        pos_x        ... camera_type  tel_description  \n",
+       "                m          ...                               \n",
+       "int16        float64       ...     str8          str18       \n",
+       "------ ------------------- ... ----------- ------------------\n",
+       "     1               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     2               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     3                80.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     4              -120.0 ...      LSTCam     LST_LST_LSTCam\n",
+       "     5                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
+       "     6                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
+       "     7                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
+       "     8  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
+       "     9  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
+       "   ...                 ... ...         ...                ...\n",
+       "    89   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    90   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    91 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    92 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    93  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    94  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    95  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    96  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    97 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
+       "    98 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.to_table()"
    ]
@@ -70,9 +149,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<i>Table length=3</i>\n",
+       "<table id=\"table48031953864\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>description</th><th>name</th><th>type</th><th>mirror_area</th><th>num_mirrors</th><th>num_mirror_tiles</th><th>equivalent_focal_length</th></tr></thead>\n",
+       "<thead><tr><th></th><th></th><th></th><th>m2</th><th></th><th></th><th>m</th></tr></thead>\n",
+       "<thead><tr><th>str18</th><th>str5</th><th>str3</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th></tr></thead>\n",
+       "<tr><td>MST_MST_FlashCam</td><td>MST</td><td>MST</td><td>103.83055877685547</td><td>1</td><td>84</td><td>16.0</td></tr>\n",
+       "<tr><td>SST_ASTRI_ASTRICam</td><td>ASTRI</td><td>SST</td><td>14.562566757202148</td><td>2</td><td>2</td><td>2.1500000953674316</td></tr>\n",
+       "<tr><td>LST_LST_LSTCam</td><td>LST</td><td>LST</td><td>386.7332458496094</td><td>1</td><td>198</td><td>28.0</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=3>\n",
+       "   description      name type ... num_mirror_tiles equivalent_focal_length\n",
+       "                              ...                             m           \n",
+       "      str18         str5 str3 ...      int64               float64        \n",
+       "------------------ ----- ---- ... ---------------- -----------------------\n",
+       "  MST_MST_FlashCam   MST  MST ...               84                    16.0\n",
+       "SST_ASTRI_ASTRICam ASTRI  SST ...                2      2.1500000953674316\n",
+       "    LST_LST_LSTCam   LST  LST ...              198                    28.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.to_table(kind='optics')"
    ]
@@ -86,9 +194,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : SCTels\n",
+      "Num Tels : 69\n",
+      "Footprint: 4.92 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
+     ]
+    }
+   ],
    "source": [
     "tab = subarray.to_table()\n",
     "sc_tels = tab[tab['num_mirrors'] == 2]['tel_id']  # select tel_id of entries where the mirror type is SC\n",
@@ -105,9 +227,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : SCTels\n",
+      "Num Tels : 29\n",
+      "Footprint: 1.06 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "      LST_LST_LSTCam    4    1 ..   4\n",
+      "    MST_MST_FlashCam   25    5 ..  29\n"
+     ]
+    }
+   ],
    "source": [
     "gtab = tab.group_by('num_mirrors')\n",
     "sc = gtab.groups[0]\n",
@@ -124,9 +261,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel = subarray.tel[5]\n",
     "tel"
@@ -134,54 +282,142 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$103.83056 \\; \\mathrm{m^{2}}$"
+      ],
+      "text/plain": [
+       "<Quantity 103.83055878 m2>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.optics.mirror_area"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "84"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.optics.num_mirror_tiles"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$16 \\; \\mathrm{m}$"
+      ],
+      "text/plain": [
+       "<Quantity 16. m>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.optics.equivalent_focal_length"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.camera"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[-0.028867999,~-0.072168998,~0.057735,~\\dots,~-0.54848301,~-0.50518101,~-0.54848301] \\; \\mathrm{m}$"
+      ],
+      "text/plain": [
+       "<Quantity [-0.028868  , -0.072169  ,  0.057735  , ..., -0.54848301,\n",
+       "           -0.50518101, -0.54848301] m>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tel.camera.pix_x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb2f419080>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsnXeYVdW5/z/r9N7P9N47M8PA0HvvXXoXERETTYwmGrFEY6JGjTFG0343vd7E1JvE1JubYjSKFUE6DAwM03vZvz9OYe+zN0KMCpj9fR54OOdz9tn7nBn2u961vut9hSRJ6NKlS5cuXRcjw6W+AF26dOnSdeVIDxq6dOnSpeuipQcNXbp06dJ10dKDhi5dunTpumjpQUOXLl26dF209KChS5cuXbouWnrQ0KVLJiFEjhBCEkKY/s33OSSEmPZOXZcuXZeL9KCh6z9W0Rt7txCiI/YHSHuPzu0RQjwshDgSPff+6OPQe3F+XbrervSgoes/XfMlSXLF/gAn3u0TCiEswDNAOTAL8ABjgCZg5Lt9fl26/h3pQUOXrreQEGKTEOI1IUS7EOKAEOIaGQsJIX4qhGgRQpwVQvxJCCH/P1UthNgjhGgVQnxHCGGLPr8eyAIWS5L0qiRJQ5IkNUqSdLckST+PvvctQog3o+d9VQixWHbejUKIPwshPhM99wEhxJjo80eFEI1CiA3vxfej6z9PetDQpeut1QjMI5INbAI+I4SojbKbgGNAGEgGPgrI6/KsIJJJ5AJVwMbo89OAX0qS1PEW530TGA94gTuBrwshUmW8HtgDBIFvAt8GRgAFwFrgMSGE61//uLp0vbX0oKHrP10/io7WW4QQP0qEkiT9TJKkN6WI/gD8isjNHKAfSAWyJUnqlyTpT5KymNujkiSdkCTpLPAToDr6fBBoeKuLkiTpe9FjhyRJ+g6wD+XU1UFJkr4iSdIg8B0gE7hLkqReSZJ+BfQRCSC6dL2j0oOGrv90LZIkyRf9sygRCiFmCyH+Gp1+agHmALHF6k8D+4FfRaeIbkk4/KTs311AbOTfRCTYnFdCiPVCiBdiAQ2okJ0X4JTs390AkiQlPqdnGrrecelBQ5eu80gIYQV+ADwAJEuS5AN+DggASZLaJUm6SZKkPGA+cKMQYupFvPVvgJlCCOd5zpsNPAXsBILR874cO68uXZdSetDQpev8sgBW4DQwIISYDcyIQSHEPCFEgRBCAG3AYPTPhfQ14CjwAyFEiRDCIIQICiE+KoSYAziJrI2cjp5nE5FMQ5euSy49aOjSdR5JktQO7AK+CzQDq4GnZS8pJJI1dAB/AR6XJOn3F/G+vUQWw18Hfk0k4PydyPTT3yRJehV4MPqep4BK4M/vyIfSpevflNCbMOnSpUuXrouVnmno0qVLl66Llh40dOnSpUvXRUsPGrp06dKl66KlBw1dunTp0nXR+rfKP1+OCoVCUk5OzqW+DF26dOm6ovTcc8+dkSQpfKHXve+CRk5ODv/4xz8u9WXo0qVL1xUlIcThi3mdPj2lS5cuXbouWnrQ0KVLly5dFy09aOjSpUuXrouWHjR06dKlS9dFSw8aunTp0qXroqUHDV26dOnSddHSg4YuXbp06bpo6UFDly5dunRdtPSgoeuy1pnjTTxy7ZP89afPafKmhmYeve6L/PlHf9fkzada+OzOL/KnH/xVk7ecbuVzu77M77+j3a6iramdxz/wFX77zT9p8vbmDp648av8+r/+gFabgY6WTp788H/xy6/8TpN3tnXx1Ee+zs+f+g1DQ0Mq3tXezZc++k1+8sSvNHl3Zw9fvf3b/OixXzA4qO7/1NPVy/+74zv88JGfMTig5r3dvXz97u/z/Yd+wkD/gIr39fTxzXt/yHc+9WP6+/rVvLefb9//I75133/T16vmut5/et/106irq5P0HeHvD/3yK7/jc7u+RE9nLwAjZlVz148/gskcKWTwm6//kUd3PEV3Rw8AtdMqufvpW7DYLAD87tt/5uFrvkBXezcA1ZPLuevpW7A7bQD86Qd/5cGtn6eztQuAyvGl3PPTW3G47QD834+f5YHNn6O9uROA8rHF3POTW3H5Il1a//az5/jUxs/R1tQOQEl9IZ/46a14gm4Anv2fF7h/3aO0nonworp87vnprfiTvAD887cvce/qR2hpbAWgoCaXe356K8FUPwB7/vgqn1j5Gc6ebAEgb1g2dz99C0mZkVbhr/zfXu5e8SBNJ5oByKnI5O6nbyElJwmA1/++j7uWPcjpY00AZJWmc/fTt5CWnwLAvucPcOfSBzh1+DQAmcVp3Pmjm8ksTgfgzRcPsXvJpzl5sBGAtIIU7vrRzWSXZQJw6JWj3LHofk68GWlNnpqXzO4ffpi8qux/+Wet69JLCPGcJEl1F3rd+66MiK4rX//41YuU1hfw/G9ejAcMgGd/+QJ9Pf28+PtXKB5RwPPP7IkHDIDnf/MS3R09vPy/r1NQm8sLv30pHjAAXvjdK3S2dvH63/aRV5XNC797OR4wAF7602u0NbWz77kDZJVlsOcPr8QDBsArf95LS2MrB/YcJqMoNf76mF7/2z6aGpo58toxUvKSeeXPr8cDBsAb/3iTM8eaOLH/JElZIV79vzfiAQNg/z8PcurwaRqPnCGY6uP1v+2LBwyAAy8e5uTBRppPtuANe9j77P54wAA49PJRTuw/SVtTOy6fk33PHYgHDIAjrx3n6N4TdLV3Y3Pa4ueL6ejeExx57Tj9vQOYLCYO7DkcDxgAJ/af5NDLR5EkEAIOvXwkHjAAGg6c4sCew3rQeJ9LDxq6Lhsd2HOYz93wZfb84VV8SV6Ss0Oq19w+/5Ps+eOreENuUqMjZrnuXvEQL/7+FdwBF5nFaSp+/7rP8sLvXsblc5JdnqHiD279PC/89mUcHjv5w9Q3v0ev+yL/fOYlHG47BbW5Kv7EjV/l+d+8hN1lo6guX8W/eOs3eP7Xe7A5rJTUF6r4f+3+Ds/9ag9Wu4XyMcUq/s17f8jzv96D2WqiYlypin/vgad57td7MFlMVE1Q8/9+9Of88zd7MJqMVE0qV/GfPvErnn/mJQwGwbDJ6rbkv/zyb3n+mZcQQlAzRW9b/p+oSzo9JYT4MjAPaJQkSfUbKIQQwCPAHKAL2ChJ0vNv9Z769NSVq3tWPsQfvvsXxXPekJvWM+0IIUjJDdNwoFHJwx5aT7cBkemRhgOnFNyX5I2P5tPykxUjYwB/spfmU+fngVQfZxsio/20ghRO7D+p4KE0P2eio31Nnh7gzPGz5+cZQc5Es4H0whSO71PypMwgjUebznt8UlaIxiNnzsuTs0OcOvwWPCfMqUOnz/v5U3KT4tmG1vebmpcU/5kUDs/jo9+4gYwidbDWdfnrYqenLvVC+FeBWW/BZwOF0T/bgM+/B9ek6zLSoutnY7GZqZ5STp7GyH/R9bOx2i1UTSijUGPkv3DnLKwOKxVjSygeUaDiC66bhc0ZGfWXjVaP7BdcOzOSNYzIp3JciYrP3T4Dh8dOQU0u1Roj97nXTMfpdZBblc3waVUqPufqqZGspyyDupnVKj5ry9RI1lSSzqh5w9V88xQ8ITfpBSmMXqD+/z594yR8SV5S85IZt6RezddPxJ/iIzk7zPhlo1R8yprxBNP8hDODTFo5VsUnrxxLKCNAKD3AlntX6wHjP0CXfCFcCJED/PQ8mcYXgN9LkvSt6OO9wCRJkhrO9356pnHl6qmbv8Z3H3g6/tjmsNLTdW5Nw2gyKhxAVoeF3q6++GOD0cDQ4DmHkdVuobf77XOL3UKfnBsEQ0Pn/r9YbGb6es45hoRBIMm42Wam/6241Uy/zHEUSawlYv8lzVYT/b0yR5MAAXFuspgY6Evg4tw5zBYT/X1KR5T8MxrNRgb7B8/PE77vyHMGBgeGVP+OafcPP8zYRSPRdeXpSsk0LqR04Kjs8bHoc7reh7r6U+v4wBPbcPocjF00kpFzaxV8cGCQnZ/dgsvvpH5urermNDQ4xM7HIrxuZjXjl4/S5O6Ai9ppVUxePU7Fr39sC56gm+pJ5czYMFHJhyR2PrYZb9hD5fhSZm+ZquDSkMTOx7bgS/JQNrqIedunq/lnN+NP9lIysoBF1yuTbEmS2PHIZgKpfgqH57HsxvnKL0iCaz+ziVB6gPzqHK66eaGKb39wA+HMILmVWaz66GKN73gtydlhssoyWPfxZSq+9f41pOQmkVmSxoa7rlLxTfesIq0ghbSCFDbds0rF25ra+ert3+ZLt36D7o5uFdd15etyzzR+BtwnSdL/Rh8/A9wsSdJzCa/bRmT6iqysrOGHD19ULxFdl5l+9NgvePJD/xUfHcvXK2KSj859SR5aGhP5udG5L+yhJeF4eXagdbzVZqG3p++855dnP1rvL+dax9tdtrjjS4s73Da62qM85KH1TAL32Olq645yt8KdBeD02OmMck/QrXB3ATh9Djpbus7LXT4nHS0Rx5g74KL9bIeCu/3OuKNM/u84lx0TSPVz148/QrGGIUDX5af3S6ZxDMiUPc4ATiS+SJKkJyVJqpMkqS4cvmC3Ql2XkYaGhvjj9/9C65k2Xv7f1xTTKa2n25i+fiJCQGZJGjVTKxXTOS2NbczYMBFhEKQXpjJ8RpViOqfldBszNkxCGARp+cmMnF2jmE5qaWxjxsZJGIwGknPC1M+rjQeM2PlnRnlSVojRC+oU02Utp9uYtWkyRpORUEaQsYtHKnjr6TZmbpqM0WwkkOpj/NJRCotwa/R4k8WEP9nLxBWj4wEDoPVMG7M2TcFsMeENe5i0cmw8YER4OzM3TsZiM+MJupm8alw8YEBk1D9z4yQsdgtuv5Opa8bHA0aMz9gwCZvTitPnYNq6CfGAAdB+tiPOHW4b09dNVASJ9uZOpq+biMNtw+6yMWPDJEWQOdvQzOFX5BMFut4Putwtt08DO4UQ3wbqgda3Ws/QdWXp1b++wWM7v8i+5w/i8jk1LbaHXonsC2g60YzVYdXmQxJnG5pxeuwqfvjVYxF+sgV3wKXJhwaHaDnVSmt0051cR14/ztDgEK2n2xR7KuLHv36cwYFBWk+30nyqRcWP7T3BYP8gbU0dnG1oVvGjb5xgoG+AtqZ2xZ6L+PH7TtDfN0BHc2fchSXX8Tcb6OvpZ6B/kDPHm1T8xIFT9HX3MdA3QOPRMyrecPAUPZ29CAGNh9X85MFGerv6EALFno44P9xId0dv/LW63v+61JbbbwGTgBBwCrgDMANIkvRE1HL7GBGHVRewSZKkt1zl1hfCrxzdtfwB/vSDvymei1lUjSYjqblJHNunHCOEMgKcOXYWg9FAWkEKx/YqE8+YRdUQzT6OJvKoRdVgEGQUpXHk9eMKHrOgCiHILEnjyGtKHrOgCiHIKk3n8KvHFFxuS80uy1Bxue01uzxTNRKX226zyzM4/Iry+IzCFI7tO//xmcVp8c+sdf4L8azS9PhnvhDPKsvgSCKXPVc5vpQPf+U6UvOS0XX564qYnpIkaZUkSamSJJklScqQJOlLkiQ9IUnSE1EuSZJ0nSRJ+ZIkVV4oYOi68jV17QRMZiNlo4tIL1Jv3pu2dgImi4mSkQVklqjtnVPWTMBsNVNYl09Oeaaarx6PxWYmvzqH3KosNV81DqvdQm5VFgU1agvvpKvGYnVYyS7PoHB4ngYfg81lI6s0nZKRaovvhGWjsbtsZBSlUjaqSMXHLx2Fw+MgLT+FSo3Ne+OWjsLlc5KSm8SwiWUqPmbRCNwBF0lZIWqmVqr5whF4gm7CGUFqp6stwPVzh+MNewim+Rk+c5iaz6nFn+wlkOKjfnaNio+YWU0g1Yc37GHxrjl6wHgf6pIvhL/T0jONK0dfue1bfPPeH8Yf2902umVz+gaDQVGkz+620y0rC5JoYZUvMl8UF0JRRFCLyy2wNpeNHhlPtMDanFZF2ZNEC6yKo7S4Wh1WeruU3Gg0MBjjCRZhUNpiNbnMVptoEQYwmY0MRHmiBRiUtl6VBRilrVjr+I996wNMukq9v0PX5acrItPQ9Z+tTfes4gNf2IbL72T80nrqZihHtkNDQ+x6fCvugIsxC0dQn2DBlYYkbvj81XiCLurnDmfs4pEqvuvzV+MJuqmbWc3EFaOVXIpwb9hN7bRKpiRYcCVJYtfjV+NL8lA9uZwZGyYpP4AE1z++FX+yN2LB3TpVzR/bSiDFR9mYYuZfO0P1Hex4ZBPBND8lIwtYsmuOil/7yCZCGYGIBfem+Wr+0AbCmaGIBfcjC1X8mgfWk5wdJrcyi9W3LVXxrfevJSU3ieyyDNbdobbgbrl3NWkFKWQWp7HxrpUqvuHOq8goTiO9MIVNn1DzWBXgR3c8pXKC6boypWcaui6Zvv3J/+Yrt30rvmHO5XfSIbdwJozUVRbPC3GUI3ktLt+gpjo/ypG4NjfFS4rL7apxLhupu3wOOmTuJVCO/uV2WE3udSgKLIIyu3B4HHS1JXDZBki5HTcmefbjcNsVBR4TeWImmPhcYqYWec9zFmKXz8ndT39Es2aWrksvPdPQdVlqoH+AX375t5w53sQbz72p2GHd0dzJ/GtnYDAaKKjJZfj0KsX0UntzJ/N3zMRgNJBXlc2IWdWa3GgykFOeyah5wxU7vNubO1lw3UyMZiOZJemMWThCsaO5o7mTBdfNwmQ2kl6Yyvgl9fGAEeMLd87CbDWRlp/MxOWjFT0oOlpi3ExyTphJK8cqdmx3tHSxcOcsLDYzSVkhpq4er5gu6oxyq8NCKD3A9PUTlby1iwXXzcTmsBJM9TNjwyTFdFRXWxcLdkTKnvhTfMzaPFmxY76zrZv510bKnnjDHmZvmaKYLutq72be9hk4vQ48QTdzrp6m4N3tPczdNh2X34nL72TutumKINLd0cOcqyNlT5xeB/O2z1BYiDtaOjn2hm5+vNJ1uVtudb2P9PwzL/HZ657i2BsN2JxWkrPVe2pe+N0rDA0OcfT14wz0qxdRX/ztyxG+97hmU6M9v3+FwYEhju1rwGBSj4le/P0rDPYP0vDmSSw2s4q/9MdXGegf5OTBU9hdNjX/w6v09w5w8tBpnF6Hir/8v6/T39tP45Ez8b4aibyvp5/TR89w9A3VliNe+b+99Hb10dd9liOvHVPx1/66j56uXnq6ejmswV//+366O3ro7ujh4EvqPRJ7n90f3evRzYGXjqj4G/94M57NvPnCIRXf/8+D8Wxr/wsHVfzNFw7F92rse+5NFdd15UvPNHS9Z3r6c7+IjzR7Ons5/OoxUvMiDYMsNjNZpRkcjVpge7v7OPTyUdIKIg4qs9VMdnlG3CLb3zvAwZeOkF6YCkSmkXIrsuIW0YG+AQ68eDheHt1oMpBbmRW3sA70D/LmC4fIKolUpTEYDeQNy+Zg9EY6ODDE/n8eJLssUj5dGAT5w3LiN9qhwSH2PS/jAvKrc+M3WmlIYt9zB8ipyIzzghoZlyI36NzKcw6uwtpc9j9/MM73PvumojdFYW0e+547EH+89+/7yR+Wc44Pz+ONf5y7Ue99dj/51Yk84XgVVx4vd5AVDs9j77P7FcfLy8MX1uay91n58W8qikiOmFWt6ejSdWVJDxq6Lqnq5w2P3rBzCGcG1HxObfyGn5SlzkxGzqnBaDaSU5FJSo6aj5hVjcliIqssg7R8deYyfOYwTBYTmSVppBekqvmMYZitZjKKUsks1uYWm5m0ghSyStVl0WqnVWG1W0jJS9a0ANdMrcTmsJKcE9ZsXjRscgV2l42krJDiBh9T1cQy7G47ofSApkW4cnwpTo+DQKqfIg2LcMW4Elw+J74kL8Uj1OU+yscU4w648IY8lGr0/yitL8ITdOMOuCjVqBJcPLIQb9iDy+dkwvIxJGWpN3DqurKkL4Tres/0tbu+x9fu/F58Wilx4TfRApu4cJxogVUtLCcsjKsWli/EUS6cay08yxfOtbh84VxeJ+ocP7dwrsXltlathWmL1Rzvxa21MC23wGotTMsX1rW4fGFdyyIsf+7t8Ju/upPp65WFIHVdHtIXwnVddlr38eXsenwrLr+TiSvGUD1JWaMyYoHdhjvgYtziempnVKn549vwBF2MXjCCkXOUFlwkuOHxiMV25Jxaxi4cqcm9ITd1M4cxQaN/xM7HtuANe6iZUqGy4ALs/OwW/MleqiaWMX2D+ua349FNBFJ8VIwtUVtwgR2PbCSQ6qdUowouwPaHNhJKD1A8Ip9Fu9StZq55cD3hzCCFtXks++A8Fd/2qXUkZ4fJG5bNisQquMCWT0aq2OZUZLLqVnUV3I2fWEVafgrZZRms0aiCu373CjKKUskoTmP97hUqvvb2ZWSVpJNekKJp0W1v7uDha77AfWsfUbSi1XXlSM80dL1n+urt3+Ybn/hB/HHiSDtxM96/zAXAuWxFzZWZitZIX55pqEb6CZlK4mZDUGYiWpmAgmuM9OWZimozIcrNelojebnFV4vLN+BpbSaUZyJamwXl3GKz0NeTwO1m+rr7Va+NSW4Btjms3Pnjj1Crr3NcFtIzDV2XhXq6evnhIz+j4cApDr2idOt0tXWz7Kb5GE0GyseWMDxhc19XWzfLPzQfk9lI6agiRs6pUR//oQWYzCaKR+QzesEIxfRWV1s3K25eiNlqpqAml3GLRyIfI3W1dbP8wwswW83kVWUzacUYhUW3q72bq25eiMVuIac8kykrxymCVnd7Nys+vBCr3UJmSRrT1k1QWHi723tYcfNCbE4r6YWpzNw4Wck7eljx4QXYXTbS8pOZvXWqwuLb09HDig8twOG2k5KTxNxt0xRNk3o6e1l203ycHjvhzBDzr52hsPj2dPay/Kb5uHxOQhkBFl43S7Fju7erl6UfnIc74CKQ6mPR9bMVN/ne7j6WfmAu3pAbX7KXxTfMVfC+nj4W75qDL8mLL+xhyQfmxgNGhPez6PrZ+FN8eIIult04X2EB7unq5WRC+1hdl7+Mu3fvvtTX8I7qySef3L1t27ZLfRm6gP97+lk+Nude/vC9v/DTL/ya/r5+VX+GM8fP0tHcScupFkCirUnJm4430362I8qhLaF/xNmGZtqa2qN9MSRVf4mzDc20nmmP971I7F/RcqqV1tNttJ5uQ5JQ9cdoaWyLvOZMG5IkqfpvtJxpo/lUK+1NHUhDkqoSbuuZds42tNB+tiNSTTeBt53toOlEM+3NnQwNDMX7lcfU3twR+Y5aOhnsH1TxztYuTh87S1dbFwN9A2re1sXpo010tXXT39uv4t0d3TQePkN3Rw+9PX20JPCezl5OHjpNT2cvvV29quvv7erl5MHGiA24U4N399Fw4BS93X10tXervr/R8+s0a3jpeu915513NuzevfvJC71OzzR0vWv6xZeeic9b9/f2c3zfybhF1e62kVuZReORSDnu/r4Bju1tILciYkG1Oa3kDcuOl+Me6B/k6Osn4g4jq8NCfnVOvBz34MAgR147HregWu0WCmtzaTgQ4UODQxx+9Rj5UYeR2WqiaHgeJ96MVIwdGpI49MpRCmojNzCTJZK9HI9W2ZUkOPTy0bgDyWQ2UjKygONvxLjEwZeOUBRtOGQ0GSipL1RU4T340pF4n3KD0UDpqMK4xRjgwJ7DlNRHuDAIykYXKarsHthzmNJRhTJerKhCe2DPYUpHR4ogChFxPsmr5B7Yc5iyMeccTuVjijn08rm9HAf3HFHyscVxC3Ls+svHvjUvG1McnQaE8jFFCn7o5aOUjSmK8/FL61XZo67LX3rQ0PWeqnRUIUII0vJT8ATV/S2KRxYgDILUvGS8Yc95eUpOEr5kdf+LohH5GIwGwlkh/Mk+9fHD86JNlcIEUv3q4+vyMJqMhDOCBNPUFuCC2jyMZiPBtAChdDUvrM3FZDERSPWTlBlU8fzqHMxWM4EUH8nZSSqeV5WDxWbGn+wjJUfNcyuzsdot+MIeUvM1eHkmVocVT9CtaTHOLsvA7rLhDrjie1zkyipNx+624/I7ydDgmcXpODx2nF5HfA+Mghel4fTasbvtZJVkqHhGYRouvwOb00bF2FJ8Gj1MdF3e0hfCdb1r+vYn/5uv3P7t+DqBJ+hSTj+JaCXbOFe3H5UvHF+Qh9yq6Sv5wrAWl1tctd5fbnHV5LLFXk0uWxjWap8qbw+ryWWL2VpcvpiuVRtLvhivxeVmAK3aWHKuZVGW2461LMjyY7SMBzc+tV3Va13XpZG+EK7rkmvlLYu59jMbcfkcTLxqDOVjSpQvkOC6RzfFq9wOm6TuD3HdI5tx+Z2MWTBCs//DdY9uxh1wUT+3lhGz1FMdOx7eiCfoom7GMMYsUP9/2P7QJjwhN7VTKxm3tF7Fr/nMBrxhD8MmlTNp5Rg1f3ADviQvFeNKmLp2vJo/sAF/io+y0cXM3DRZxbd+ai2BVD8lIwqYu01twd1y3xpC6ZEqt/N3zFTxTZ9YSTgzSF51tmaV3I13rSQpO0RuZRbLblRXyV13x3JScpPIKstguYZFd+3ty+JVblfdorborrp1CRlFqaQXprBGo4ruVR9eSFZpOql5yay/Y7mKt51t55PrHuW2+fdxTKOsiq7LT3qmoetd0+c/+FV++MjP4o8TLaDyLEGLy+2v7wo3CEXBRPmoH9QWX7ldFNSbERMtqokWX6vdTK/MXZTYj0NlUU2w+Mo37ml9Rq1+F/J+HJpc9jMwW0yKHu2gtADLszYtLu/tEeeyY+R24Zjk12QyG9n9ww9TP3c4ut576ZmGrkuijpZOvn739zn86lFOHDipYD2dvay9fRkmi4nhM6qonValyc1WM9VTKlSLpD2dvaz7+HIsNjOVE0oZnZA59HT2svbjy7HYLZSPLWZcQn+Nns5e1t2xHKvDQkl9IRNXKDOHnq4ItzmtFNXlMXW1MnPo7epj3R3Lsbts5NfkMCNhc19vdx/r7liGw20ntzKLWVumKCy+vd39rLtjOU6vg+yyDOZtm6HgfT39rP34Mlw+J5nFaSzcMUsRtPp7+ll7+zLcARdpBSks3jVHERT7ewdYc9tSPCE3KblJLP3gvHjAiPFVH12CL+whOTvM8g/NVwTt/r4BVt66GF+yl3BmkKtuXqiwAA/0DXDVRxYRTPMTTPOz8pZFCj44MMh6lW4KAAAgAElEQVSKmxcSyggQSPGx6tbFiiAz2D/I8pvmk5QVwpfkZfXHliiC2ED/II1H9Q1/l7v0TEPXO6bffut/efyGL9N6pj2ymJwZ4OTB04rXeMMeWk+3YTAaSM4Oxd1NMfmSPLQ0tmEwCJJzk2h4U+nj96f4aD7ZgsEgSMlLjvfbjimY6qepoTmy2F6QHO+3HVOsB3mEp8TdUYkcIKMoVVXKO5wZ5HT0xqbFYz3IATKK01Q9zJOzw3FHmLxfd0wpOWFOHjo/l/cg1+T5yfHvTIvLe5RrXf+FeHphavw7k/87Jvkx8n7n8eOLUuOOM/m5Ytr1+NXM365uVqXr3Zeeaeh6z/XMN/4Y3ycxODDIqUNn4kXwvCE3+cNy4vskhgaHaDjQGLeYugMuCmtz4z7+oSGJhjdPxS2mLp+Dorp8mk+2xPmJ/Scpi1pMnV4HJSMLaGpoBiIW2OP7TsYtona3jdJRRfGAEOENVIyLcpeNsjHnOMCxNxqonBBpGGR1WCgfWxIPGDFeFeN2C5XjS+MBA+DY3hMMm1QOEM+OYgED4KiMm60mhk0qjweMGK+eEuEms5Fhk8rjASORG00GqqdUKILs0b0nqJkaKdViMEa4/CZ97I0GqmW8RoPXTKlEGESET61UBInj+xqonlKBMAiEQVAztUIRZI7vO0n1lAoMRkOUV8YDBsCJ/SepnlyB0WRECMH09RNV2aGuy0960ND1rkmSpHjPDG/Yi81lVb0mZiv1hjzYNPpXJOckIQR4Qh7s7vNzd8CFw21X8+wwwiDwBNw4NI5Pyopwl9+J06Puj5GUGcJgELh8Tlwa/TNCmSEMRgNOrwOnT4OnBzCaDDg8Djx+dX+NUHoAo9mIw23HHVBbkIOpAUwWE3a3HU9IfXwwNYDZYsLusmv27/Cn+DFbzdhdNnwaFuZAsg+L3YLNYcUbVttf/cleLFZzxAasYY/1J3mx2ixYbRb8SWqLsy/sxWq3YLaY8KeouTfsweqI8NTcZBwe9c9Q1+UlfXpK1zumH3zmp3zp1m/EF1N9yV7VDmN57SN/sle1Q1m+MKrF5YvFsakqueSL0VpcvtityWWL5VpcbnHV5LJ6VFpcbjv1J/toPqXkctuq1ueXt5TV4vKWtrGpPgWX2Xa1uNw2HJtKVHCZbdkb8qj6fsuf07I4+8Ke+K57LYvyDZ/fxrxr1C4yXe++9OkpXe+5ln5wHpvuXYXDbWfiijGKBjwxXX3/GhweO+OXjopPPSn4J9fi8NgZvaCOivElGsevxel1UD+3lmGTy1V8831rcPkc1M0YRp2GRXfLJ9fg8jupmVpJvcZu5C33rcYdcFE1sUzTorv53lV4gm4qxpUwQcOiu+melXjDHkpHFTFphdqiu/GulfiSPBSPKGDqWnUV3Q13rsCf4qOgNpcZGhbddXcsI5jmJ29YNnM0quiuuW0ZoYwAORVZzNNYG1h162KSskJklaaz8Dp1Fd0VNy8kOSdMRlEqS25QW3iX3zSf1Lxk0gpSWHaT2sK7+IY5pBemkpKbxIoPqy28C66fRWZJGknZIVbeoubNja3csfhT3Djx4+x7/oCK67r00jMNXe+YPrPtCX7+xWfijxMtqnJ7JqgtqomWTovdQp+MJ1o2Ey2qF+QJllA1V1qA5VkRqC28iRbWC/FEC2/i51XxhO8rVn4j9n9Wm5+z+GpZXOXn0LLIym3IiZ8nwg0MDQ2dl8u/Q2EQIEkKh1gil3/exGs2GAS3fedGxi9Vl7DX9c5LzzR0vSc6e7KZp27+Gm889yZnTpxVsL7ufjbevRKLzcLo+XXUJFhse7v72HTPKqx2CyPn1DBi5rCE4/vYfO8arA4rw2cMY/R85e9zX08/m+9dhc1ppWZKBeMTFlEjfDU2l42qiWVMumqMim+5bw12t53ysSVMSbDY9vf2s+W+1Tg8dkpHFTJj46QEPsCW+1bj9Dooqstj9pYpKr75vtW4/E4KanKYf61y5D/QN8DmT6zCHXCRW5nF4utnK3n/IJs/sQpvyE12WQZLb5yn2Bcy0D/IxnsimUtmcRrLPzRfcYMe7B9k490r8Sf7SC9MYeUtixQ36cGBQTbsXkEwzU9qXhKrP7ZEsW9laHCI9XcsJ5wRJDk7zLrbl8UDRoyv/fgykrJChDODrNu9XBF0pSGJ1R9dSkpOEsH0AOvvukrFV966mLT8ZPwpPjbevVIR5IaGJM4mTO/puvTSMw1db1s//+IzfOGm/0dXezdCCELpAVVjndgcvhCCUEZA4T4C5Ry+3K4ak3wOPik7ROPhBO530d4c4XI7a0zyefPknDCnDiVYgEPuuONLi8vn/VNyk+IFEs9xb7yya0pOEicPKbl8XUPr+GCqj6aGt+BpfppONF8U17r+UEaQM9GfiRYPZwTjPzOt7y8pM0Tj0TNRHuJUwvcv/5lp/fzk7ym3K18s3/nZLZrTaLreeemZhq53XX/6wV/iTYokSaLpZDNVEyOlQGLd5WKLvpIkcfpoU3wdItadTl6rqPHIGWqmRRryBFJ9lI4qVNRaajx8Jl5KxJfkoWxMUTxgAJw6fDrek8Mb9lAxrkSx0Hrq0GnqotmMJ+iiakKZopT6qUOnGTGrGojUaRo2qVyxUHzyYGN8w6HT46BmSoWiFPjJQ+e4w2OndlqVYiH85MFG6udGug3aXTaGTx8WDxhxHu1GaHNaqZtZHQ8IMT5qbi1CRKb2RsyuUfBTh05TP7cWYRBYbGZGzq6JB4wYHzU30pPdbDVRP6dWEeRPHY4cbzRF+dzaeMCI8DPUzx2O0WzEZDExam6tIkg0HjlD/ZxaTBYTRrORUfOGK4LQ6aNNjJxdg9lqwmgyaPIRs2uw2MwYjAbmXzuTySvHouvykh40dL1zkiLrBBCZrxdGoXqJ1WYBInPXBqP6189sjR5vNmlyS5Qbz8PNVlOEmwwYtXjs/Kbzn18IgdFkxGhSc5PZFOFmw/mPN0SON2gdbzFF9j2YDBjNRjW3Rj6XwWjQPr/VjDAaIseb1MebLWYMhujxGu9vtBgxRPddaJ7fYkIIA0IYMJlNGp/fgEEIBGC0qLnRbIxygUnr/GZj9P3Fed7fiDAYEAIs0eCi6/KSPj2l623rx5/7JU/d/LX4YrZ8qgQAEbW4Ri2swXQ/TcebFe8ht7jKd2PHJK/SKp9KiUluYdXi8ukvremPC3F5ZVgtLp8+0+Ly6TEtLp8e0+Ly6TGtzye33cqnorR5gDPHlN9vIMUXXzfQ+v5jO+xB4+eb8JwWl79nINXH2QblGoX8muTXElNsekqSpLgRQNe7I316Ste7rnnbp7Pqo0uwOiyMXzqKnPJMBRcI1ty2DKvDythFI+INkuRae/sybE4r9fOGxxsYybXmtggfMauGEg2L7prblmF32aidVknFOLVFd9XHlmB32xk2uTy++1qu1bctxeGxUzG+RFULCyJVXJ1eB2Vjihg5W23RXXnrYlx+J8UjC1QL9QBX3bwwstt9eB5jNXY7r7h5IZ6Qm7xh2UxYPlrFl920EF+Sh9zKLCavUlt0l944D3+Kl6zSdKatU1fZXXLDXAKpfjKK05i5YZKKL7x+NqH0AGkFycxKWMgHmL9jJuGsEKl5SZr7J+ZeM53knCSSs8MsuFZdhXfWlimk5icTzgiwcOdsFZ+xYTIZRakE0wOaFt+zDc18ZMZdXDv8Zl78wysqruu9l55p6Hrbum/tI/z2m/8bf5xokU20tCZaUFU8ocpqouU10aJ6QZ7wfokW1QvxxPdLtKgmvj7RspvIDSYDQzKeaImVV6TVOp/BKBgalGSPlZbXRAurFkc6Z9mV22c1j0+oAixE5K/Ya2ID/9gtRMU1LLeJ51Cf89w1JVqMAW752i6mrlEHR13/vvRMQ9e7ooYDp3j4mi+w54+vqnbzDvQNcPX9a7E5bUxYNoqqhJF9f+8A2x5Yj91lY+zikQxP2HzX3xflbhuj5g+nfq5yZD/QN8D2hzbgcNsZMauGMYtGqPmD6yOL0NOrVCP3gf5Btj+0AafXQfXkciavHqfJXT4nleNLmbFeWcV2cGCQax/agDvgomxMMbMTNtcNDgxxzYMb8ARdlIwsZG7CyHwoyr0hN4XD81h0nXLkPTg4xDUPrMeX5CW/OoelH5irPH5Q4upPryOQ4iOnIku1eU4akrj6/rUE0/xkl2Ww6tbFKr75vlWEMgJkFKex5rYlan7vapKyQqQVpLA2of+FJMHGO68iJSeJlNwkNtx1lSIgSBKs372CtPxkkrPDbPrEKhLHpGtvW0pGUSrhzCBbP7lWtU9j1a2LySpJJ5Qe4Or715A4qE38ndP13kvPNHRdtH748M/44q3fiI/uE+eghUFgtpji2YPWHLY8u9Di8jUOrTlyBddYI5GX+QimBWg6cf41Eq05fPkahyb3OemMlvHQ4vI1kGB6gCYVd9ERdXxpXZ+89IbW55d3P9Ti8tIfWlxuEQ6k+jnb8FZc/fORW4i1yqT4U7w0n4wcr1XmRH5O+bm0uFYZkx0Pb2KxRrMpXf++9ExD1zuuv/38OcV0UNvZDuqiFtX0olSKhucpppuaT7Yyan6koU5qfjKlowoV/GxDS7xUR0pumPKxxYomSU0nmuPZRFJ2iMoJpUp+vDm+ThDKCDBsUnk8YESOP8u4JZFSH8E0PzVTKuIBA+DM8bOMj5YC8Sd7GT69SmEBPnP8LBOWjkKISM2kupnD4gEjkXuCbkbOrlG0U206fpYJy0YjDAK330n93Np4wIhd34RloyMFD30ORs+vU9RqajrRzMTlozEaDTi9dsYsHKFol9t0opkJy0ZjNBmwu22MXTRScZNtOtHMhOWjMZlN2JxWxi2uV9ykzzY0M2HZKMxWEzaHlfFLE3kLE5aNwmIzY7VbmLBslCJINJ9sYfzSUVjsFiw2c5SfO775VCvjltRHChJaTUxcPloRpFoaWxm7uB6b04bJouatp9sYu2gkdpcNk9nIig8tUG2w1PXeS+1506XrIiVJEl3Rm2xvVy9Wu0XFYzfRvu4+Vdc3gPboTbi3u1/VVQ5QHC8PWDHFbuJ9Pf0X5H0aPNYTu6+3n96ePjVv7USSIlNnfT0a79/WFeX9ipIoCj4k0d8/qFjviamrvYuhwSEG+gbolXUNjB/f3s3QkER/36Ciq2BM3R3dDA1KDPQP0tPVo+bt3QwODiIGoKdTi/cw0D+INCQpAu659++hv28Ag0EoAq6cx36uWsf3dPYy0DfA0JAU39Oj5D0M9PUzODCozbt66e8bYHBgkLamds2fsa73Vvr0lK6L1i++9AxP3PT/6GrrxmA0EEzzKyyiBqMBh9tOR0snBoMglBFU7RB2+Rx0tHQhhCApK6TagRyzsAohSM4Oq3ZYe4NuWqPz2lo7pL1hN62nIzw1L0mjydO5KRF5Q6OY5FMq8oZGcS6bkknLT+ZEApdPCWlx+ZSW1vvLLahax8ttuVo8KStI45Gm835++Q5src8v3zWuxeXfudb3fyEuvyatHeryc2rtMI9NTw30D2ju89D19qVPT+l6xzV17QQW7pyN2Wpm9II60vKTVa9ZvGsOZpuZ+rnDyShOU/ElH5yHxWamblY12eUZKr70A3Ox2C3UTqskd1iW+v1vmIPVbqF6cgUFGlV0F++ai9VhpXJCGcUjClR80a7Z2JxWyscUxxs4ybXw+tnY3TZK6gupHFeqPv66WTjcdorq8jQtvAt2zMTpdZBfnaOqtQUwb/sMXD4nuZVZjJyltvDOu2Y67oCLrLIMRs1T98qes3Ua3pCbjOI0xiwcoeKztkzFl+QhrSBFs9DfjI2T8Cd7SclNYsJyNZ++fhLBVD/J2SEmrVRX6Z26Zjyh9AChjICmi2nKqnEkZYUIpvmZvm6iik9YPoaU3CQCKT5maFiAxy8dRWp+Mr4kr6qWF0R2nd8w7ja2VtzIX36iDw4vhfRMQ9dFa/fST/Pn//57/HGiZVa+SA1qy6rVYVVMwSRaThOr4l6QJ1atTbD8JlpcE6vqJlpSEz+Pmlvok01hJVpSVVVxEyytie+faDdNtAAnVq1VVc1N4OqqtygssFpVb+Wf8YI8wVIcee7cz+BCPPH7SLxmraq5ci4ijuHoXxHd+NR2Zm9Rl4jX9a/risg0hBCzhBB7hRD7hRC3aPCNQojTQogXon+2Xorr/E/WwZePcO+ah/n7L/4Zby4UkyTBtk+vw+GxM3nVONXmusH+QXY8vBGHx87EFaOpmVKu5o9uxul1MHbxSEYkjLwH+wfZ+dnNkUXiBXXxRfU4Hxhk56ObcfmcjJxdoxpZDw0MsfOzm3H7nQyfMYyJK5QW3KHBIa5/bAvugIvqyRVMXTdBxXc+tgVPyE3VxDJmbpqk5EMS1392C96wh/IxxczdNi2BD3Hdo5vxJXkpHVXI/ITNb9KQxI5HNuFP8VFUl8+SDyottpIkce1nNhJM9VNQk8uymxao+DUPbSCUHiCvKouVtyRYbCW45tPrCWcGyS7PZM1tS0nU1k+uITknTGZJOusTLLYAm+9dTWpeMulFqWy4e6WKb7z7KtILU0jNT2bTJ1ar+Prdy8ksTiMlN4mtn1qr4mtuW0p2WQZJWSG2fXqdiq+8dTG5lVmEM4Js/8xGRcAA4tUAdL13umSZhhDCCLwBTAeOAc8CqyRJelX2mo1AnSRJOy/2ffVM453TN+75Af9153fjo79EC2SkLpCIjyQTeaSGkyE+UtSyUMpH11qd5OTZihaXj961LJwX4vLsR5ufy260uDy70uJyC7AWl5dB0fp8Drc9vkCs9f3JLcJaXN7pT6uTntwirNVJT14mRW731eLyf8ckf095ReI4l12T/FpikncCdPocdLZ0Kfi1D21kScJ+Fl1vT1dCpjES2C9J0gFJkvqAbwPqVl66Lple+N1LiumCno4exi+LjObzq3MorM1XTA91NHfE58FzK7MoHV2kmC5pPd3G5NWRqqXZZRlUTihVTMe0NLYxZU1kw11mSRrDJpcrprdaGtuYunY8QkB6YQq106oU0z0tja1MXzcBISILrnUzhqn5+okIgyA5J8zIOTWK6bIYNxgMhDODjJpXq5gOa2lsZcaGiRiMBkLpAcYsHKGYjotxo8lAINXH2MUjFY6iCJ+E0WzEn+xl/NJRipFyS2MbMzdOwmQ24g17mLhitMJR1Hq6jRkbJmG2mPAEXUy6aozCIhzjFqsZt9/J5FXj4gEDoO1MO9PXT8Rqt+D0OZiyerziJt3W1M60dROxOqw4PHamrZ2gCAJtTR1MWzsBu8uG3W1T8fazHUxdMx67247NaWX6+omKINTe3MGU1eNxeh1Y7ZYIlwWxjuZOJq8ci8vvxGK3MGPDJEU72c6WLiZdNRZ30IXFZmb9HSuYe40yu9P17utSBo104Kjs8bHoc4laKoTYI4T4vhAiU4MjhNgmhPiHEOIfp0+f1nqJrndA0pDE0dePA5E9Ct2d6umqI69FeNOJZk0L5dHXTwBw9mSL4oYX07Eobz7ZqhpVAhzbewJJiuwBSBy1AhyN8pbT7efnQxKtp9tUo26A4/saGBoaoq2pg7Yz6uOP7zvJ0OAQ7Wc7VFkDwPH9pxgcGKKjuVOTn3jzJIP9g7Q3d6r6g0f4KQb6B+ls6VRtrANoOHiK/r4BOlu744UE5Tp5qJG+3n662ntUGwcBTh1upLe7j662bs4cb1LxxiOn6e3qpbu9m9NHz6j50TN0d/TQ09GjKJse0+ljTfR0dNPT2atyPgGcOdZEV3s3vd19KuccRH5vOlu76OvuUznnAJoaztLZ0kVfTz8HXz6synx0vfu6lNNTy4GZkiRtjT5eB4yUJOl62WuCQIckSb1CiO3ACkmS1JYKmfTpqXdOv/n6H3nixq/SeqYds9VMINWnsEgazUbcPictp9swmY2EM4I0yC2WAvxJEQuryWwknBU6r4XVaDKSnBPmxP6TCh6rsmowGkjNS+b4vgYFj1lUDQZBWkEKx95Q8phF1WAQpBemcnTvCQWP2TqFEGQUp8WDYkwxi6oQgsyStHhQjCklJ8zJ6HeSVZqu4nKLaVZZBkdePabgcttsdlkGhxN5QUr8O9Hi6YUpHN938rzvn1GUGv9ONHlxGsei30lWaQZHXlPyzOK0+Hem9fkyS9Lj35n83zFllaRzJMZl7xXnsnNmFKVx7I3z8/SiVI4n/Hy3P7iBxTfMob+3H6vdiq63rytheuoYIM8cMgDFb4wkSU2SJMXy/6cAtQdR17umsYtGMGX1eIwmA7XTKglnBBXcYDAwbV1kOmbYlAqScsIKLhCR6RiTkcqJZaTlqS26semY8nHFZBSmqvj0jZMwWUyUjS4iq1SdiE5fPwmz1URJfSE5FWqL7rS1E7HYzBTV5ZOnUWV32roJWO0WCmpyKKxRW3inrBmH1WEhtypLswrv5DUTsDmt5FRkUlKvtvBOXjkOu8tGVmk65WOKVXziVWNweOxkFKVSOV5t8Z24fAxOr4O0/GRNi++EpaNx+Z2k5CRRO7VSxccurscdcJGUFaJuxjAVH7NwBN6wh1BGgBGzq1V89II6fEkeAqm+eIMouUbNHU4gxYc/2cvoBer7zcg5NQTTA3jDHsYsUlf5rZtRRTgziCfoZtwSNa+dVklydhi336lpIT5x4CQ76j7CxqJd/Obrf1TVqtL1zutSZhomIgvhU4HjRBbCV0uS9IrsNamSJDVE/70Y+IgkSW/ZZV7PNN45fWzevfz95/+MP060lMoXcUFt+ZQv4oLaUimvAwVqC+sFuWyRGdQWVhVPqJr6r3MUFlab06baZS2/hkQLcuJ3kGhBBqVNONFiDEoLqyaX2WYTLb4Xw+XGg0SLr5qbVTu05c8lWq5VPOH3BZS26URL9cVwvT3s29dln2lIkjQA7AT+B3gN+K4kSa8IIe4SQsS8hbuEEK8IIV4EdgEbL83V/ufo1b/s5fYFn+QP3/uLquyF0WjgmgfW4/Q6mLZuIqX1yv4WkgQ7HtmE0+dg8qpxlI9XWnCHBofY9bmtuPxOJiwfTc3UCiUfktj1+NW4/E7GLR4Zb70q5zd8/mrcARej59cxaqHy91saktj1+avxBF2MmF3D+GjdqXPXJ3H941vxhNwRC+5VYzS5N+yhZkoF0xI2r0kSXP+5rfiSvFRNUFtwAa5/bCv+ZC/lY4uZc7V6kfa6RzbHW9ku2KG+uV338CaC6X6K6/I1XUHbH9pAOCOoacEFuOaB9SRlh8irylZVuQXY9ql1pOQkkXMeC+6W+1aTmp9MVmk663dfpeKbP7GS9MJUMopS2Xi3mq/fvYLMknTSClLYcp/agrv248vILssgJTeJq+9XW3BX3bKI3MoskrPDXPPgehVf8eEFFFTnEM4Mcu1nNqi4VqkWXe+s9M19uuJ66iNf57uf/nH8caKF0mQxMdg/GB+JJ3KD0YA0JJ2XCxEZzceyBZVFM8ql83GUI/W3w+UjbS0uH/26/U7aEyygcouwJpeNpLUspPLR/QW5zC4bkzw70eLy7EZux71YLs/uEjNJUGZfiZlk4jGJmWIit7ls9CTUq5Jfk1amJudamdr2Bzew9IPz0PWv67LPNHRdfnrtb28oHg/0DcRLQVSMLaawNlcxZ9zT2cPMjZMRAkpGFVI6ulDBO5o7mbN1KkIIikbkUzWxTDG91H62gznbIrygNpeaqZWK6aX2sx3M3TYdYRDkVWVTN3OYYnqr/WwH866ZjsEoyCnPoH5OjYrP3z4do9FAZkkaoxfUKXY8t5/tYN61MzCajKQXpjB20QjFdEl7cyfzr52B0WwkLT+Z8UtHKSzC7c2dLNgxC7PFREpOmIkrRiumazqaO1mwYyZmq4mkrBCTV41VTAfFuMVmJpQeYOra8UreEuV2C8FUH9PXT1TcJDtaItdndVjxJ3uZsXGS4ibb2drF/O0zsLtseMMeZm2arOLzrpmOw2PHE3Qze8tUxU2+q62budum4fQ6cAdczLl6qmK6rqu9mzlbp+L2u3D6HMzdNl0RZLrbe5i1ZQrugAun18Hca5S8p6OHmZsm4w17sLvtzNs+QxHEejp7mbEhUvbE5rQx/1ol7+3qZfr6iQRS/dicVrZ9ej0Ld+pTU++2jLt3777U1/CO6sknn9y9bdu2S30ZV6T+56u/o/HwOZuk0Wig7WwHHS2ddEaLFMotjsIg6Gzrov1sB11t3ZHXJ9hYuzt6aGtqj3CTIV5MMKbezj5az7TR1daNyWxUbW7r6+6jpbGNrvaeKFfaWHt7+mk51UpXezdmi0nVv6G/Z4Czp1robu/BZDGp+j8M9A1wtqGZno4eTFazyuY62D9I04lmujt6MFvNqv4TA/0DEftxRy9mq1nVv2JwYIgzx87S3dGDxaLmQ4MSp4820dPVi8VqVvXnkKRIvaXerl7MVpOKI6Dx8Gl6u/rOy08dOh09Xv3+wiA4eTBiwzVZjCpuMBpoOHCKvu4+TGb1+xtMRk68eZL+nn6MJoOKmywmTuw/SX9vP0ajmputJo6/0cBA3wBCoPp+zDYTx/Y2MNCvzS1WM8feOMFA3yASEhVjS/AE3Oj613XnnXc27N69+8kLvU6fntIV1x+//xce/8BXaDrRjN1lw5fkVVQ5NVvN+MIeTh9rwuawEkjzKyyysU1vjUfOYLVbCGeGVBbK5OwQpw6fwWIzk5wdVlkwYxZVs9VMal6yygIaqwxrtphIK0zh8CvaFlWjyUBmSTqHXj6q4OmFqRzf14DBaCC7LIODLx1R8JgFVRgEuRVZHNhzWMFjtlIhIK8qmzdfVPKYLfV8PKc8g0PRa86vzuHNFw4peUVm/JoLanLZ/8+DCp5bmRW/Zi2eV5Udv+a3w+XXdCGudf3yY7R5Dvv/GXkub1g2BxK+H/nx8mvV4rlVWRzco/z5bfvUOhbfMIeezl5cPie6Ll769JSuf1nDJpUzYnYNwiAoHV2EL6wcsRkMgrsz3a0AACAASURBVPq5tRgMguL6AgIpXgUXQjBq3nAMBkFRXT6BNJ/qHGMWjsRgNFBYm0c4M6ji9fPqMJgM5A/LJjk7pOKj59dhNBvJqcwiJTdJxUfNG47JbCSnIou0/BT1+8+txWQxkV2WQbqGxbd+Ti1mq4msknQyS9RVekfOrsZiM5NelEZWqbpKb92sGix2C6n5KZoW4OEzhmF1WEnNSya/KkfFa6dXYXPZSM4OU6BhAa6dVonDbSecGaRweJ6KV0+uwOGxE0zzUzxCbREeNqkcp9eBP8VHSYKRAaByfCkuvxNf2KNZBbhiXAmeoBtP0K2qNQZQOroIb9iDO+DUtBCX1hfhT/bi8jk1LcTFI/IJpPpxeBxUT65Q8cLheQTTAzjcNmo0LMZHXjvOtqqbWF+wkx899gsGBwdVr9H170nPNHTFdfP0u/jnMy/FHydaMhMXbhMtk4kLs4kW28SF10SLrIoLoVgjSaw9lFjlVbWwm7Cw/i/zhM/g9NrpbFUu/Moru2otHJtMRgaitlBNbjYx0D9wXi63vWotLFus5nhzqUSLMCh/hhfiWgvPcluvFrc5rPHmUFoWYPkxiVWGI/ycbVnLAiz/zBfiWhbhax5Yz7Ib56PrwtIzDV0XpWf/5wVunPRx/uerv6O/L8GzbzZFLLY+BzM3TlaNfIXBwI6HN+HyOZm6dgIlo5T9K6QhieujFtvJK8dSNbFMxXc9HrHQTlg2itppypGjJEnc8ESEj12ktuBKUsxi62bUvOGMTqiCiwQ3PH41npCbEbOqGbe0XsV3RS22tdOqVBZcOGexrZ5cwTSN/hDXfXYL/mQfleNLmbVpsorveHQzgVQ/5WOKmbNNbcHd8fBGgml+SuoLWaCxv2D7gxsJZwQpqstnqYYFd9sD60nKCpFfncPyD6ktuFvuX0tyTjhaBXeRiseq2GaXZbBaw4K78a6VpBemkFmSzrqPq6vgrr1jGZnFaaQXprLxLnUV3DUfi1SxTctPYdO9q1R81a0Ri21KbhJbNCy4y29aQP6wHJKyw1z9KXUV3CU3zKVweCRrvfYhtQU3cR+Irn9fF8w0hBAGYBiQBnQDr0iSdOotD7qE0jONi9ejO57iJ0/8Kv44MVNI3LyVONJPzDQSR+qJm/ESR9IXk2nAuc12To+DzrbzZyKq90+w+KpG8gmZhtZIX55pXJBrWFDlG9DsbruqvLw8E9HKBOQb5LS43AKslQmYbWb63yKTkI/etSysCq6RKcif08wkZJmIVqYgvyb5tWpyjc2E8u8ksR8J6JnGv6J/O9MQQuQLIZ4E9gOfBFYBO4BfCyH+KoTYFA0ouq5QHXhJucgoSVLc4lo3c5gqsxjoG2DBjpkYDIKaaZWqOfGezl4WXT8bg0FQNbFMlVl0tXWz5ANzMZgMVIwrUW3u62ztYukH52I0GSgbXcSIWdWKoNDZ1sWym+ZjMhspGpFP/bxa1fsvu3E+JrOJgtpcxiwaqQhaXW3dLP/QfMxWE3nDshm/ZJQiaHW1dbPsQ/OxWM3kVGQy6aqxium1CF+IxW4hszSdKavHKXl7N8s/tACr3UJ6USrT109U7Fjubo+c3+a0kpafwsyNk+MBAyJOs2U3zcfuspGSm8TsrVMVO6q7O3pYftP8yJpGVoi526YpbpI9nb0su3E+Tq+DcEaQ+dtnKG7CPZ29LP3gPFx+J8E0Pwuum6W4ifd29bLkhrm4Ay78KT4W7Zyt5N19LNo1B2/Igy/Jw+JdcxRBore7j4U7Z+FP9uINuVnygbmKvuZ9Pf0s2DGTQKoPd8DF/2fvvcPkuM4z39/pnOP05JwDMDMYDAY55xwGIBKRQQAkwSAGiRQpBolKVCZX9l3ttdf23Wyvvbb3+q591155LVmmIjMJksg5Y4DJHWr/qO6aqjoFAqBAiSLme555gO63T3d1dXedc77v/d63+zPLDJNYcjDJ8n0LyCuJEYj4WfvociM+lGTpnnkkyuL4Qj7WPbrCMIkmh1Ms3j2XgsoE3qCHB7+/m9UPLWE0bm98mMnuC8DvA3sV03ZECJEPbAK2AH/88R3eaPwmI5VM85O/+hlKRuHNH71LtMBY6M6kMvz4v/2UTEbh7R8fIF4cNeBKRuHHf6Hi777yvmWh+0d//gqZVIYDPztIQaVc6P7RX/yUdCrD+784RGG1XOj+0Z+/QiqZ5tCrRxislQvd//yXPyWVTHH49WPSqhXgx//tZySHUhx587jB1S8XP/mrnzM8lOTY2ycQCAn/l7/6KcMDw5w8cAqHwy7j//3nDA0Mc+r9M7g9Lgl/5f/9JYN9Q5w+dBZPQBbY+9n/9ysGegcZ6B3kvZ99ION/+yr91wbovzbAuz+V8Z//3av09fTT19PPWz85IOG//J+v03u5j97Lfbz5o3ck/Ff/6w2t4fH1f3pbwl//x7c0ufLXfvimjP/vdzTa86v/8IaEv/njdzVa8y//5+sS/tZPDmi03J//7asS/s4r72se6T/9H7+S8AM/+0AT1fy7P/lHxs5oprLFUhx7ND5iXHenoCjKRkVR/rd5wshi5xRF+a6iKKMTxu9wbPjcao2BFIoHiRdHuZTtYxjsG+LS6SsUZy/Mwaifgqp8jSc/NDDMuWMXKK1XGUj+sI/ShmLOn1B/0MODSU59cEYTGfSFvFS0lGly2cmhJCcOnKaiWWUgeQMeqsaWaz/45HCK4++eonKM+oP3+N1Ut1VwJquim0qmOfbOSarGqgwlt89NbXuVphibTqU5+vYJqtsqADU1UtdRpVGEM+kMR946Tk17JaCmPurH12gqqpmMwuE3j2k+5A6Xg4bOGk0xNpNROPzGMY3B5HDaaeiq1aTfFUXh0OtHNZFDu8NOY1etphKrKAqHXjtKfZbhZLPbaJpUZ1CxPfjaURq6anV4vYFCfPDVI9puz2YTNE824odeO0rTJBUXQtA8pd5AMVbx+hF8cr2BwnrotaMGBlXzlAYDRfbQ68do0uOT6zn8uhFvnlyvpRmbJ9cbxh9+w4g3TTLiR948TvPkemy2HF5nwI++dZymSSN448RaA/7uK+/zL//9FwwPDlvK0I/GR4sbppeEEHYhxAohxINCiEdyf7+JgxuNjzdq2itpzF6UyptL8Yd9Btxmt2l4aWOxxHsXNqFddMoaiwnGAqZXUHEhoLSuiHCe3HSVu2gU1xQQyQ9LeNNEFS+qLiBaIFN4mybVI2yCwsoEsSIZb+yqw2YX5FckiBfHZHxCLXa7arqUVyrjDRNqsTvs5JXESJTLO6OGzhocTjux4hgF5QkJrx9fg9PlIFYUsaQI13dU43Q7iBaEKbJQAa4bV4Xb6yKSCFFisbOqaavA7XMRygtRXCtTiKvHVuDxewjFA5TWyxTiqjFleAMeglE/ZY2yinBFcxm+kJdA1E+FhcpwRVMpgYgPf1hdFJijrLGEQMSHN+ixpCCX1qvfG4/fQ3WrjJfUFRGKB3H73JYqxcU1BYQToaxSsUxRPvzGUXY1P8y2ugf4D1/5c41pNhofPW6mEP43wCDwBqDt5xVFef7jPbSPFqOF8JuPR2Y+wxv/NJKicHmcJIdSWh3BbO/pcNrJpDNancCM2+w2UJTr4rnH5OoAVri+cGxlP6ovvn8kXFdYtsL1xVar49MXcy1xnQqrlbaVvlhshesLx5a4rjBspV2lp7Ba4frCsZV9qr5Yb0VB1pMBfCEf/VeNuD/kpU/DZeKA/jmtCvuBiI/e7DFZUYz178mqsK/XA7Mq7O/6yibJS3001LidlNtSRVHWKIryrKIoz+f+bsMxjsZvIf7xv/wz947/LH/5/f8hNT65PC52fmUT/rCPhTtmU2VaGTqcDu55cQv+sI/5W2ZS22FsLhNCsO/b2zWV28ZJcvPY/S+pFN2Z6yZbNofd//JOAlE/U1d30TZHbv6673s7NZXb8QtbLfAdBGMBuhaPY+JS2f/hvu9u11Rup66aIOH3fmcb4USI9tljmLFWVuHf9+3tRPJDtM5oZvamaRK+95tbVZXbKQ3M3ypTdPd8cwuxoihNk+pYtGuuhO/6+t3Ei6PUd9awfN98Gf/qZk3ldtUDiyV851c2kF+eR1VrOd0PyRTdbV/aoKncWlF0tz67TlO5Xf85maK7+em1msqtlUruhidXU9ZYTHFtIVueWSvhdz2+koqWMgqr8i1Vctd8ZrmmcrvjBZmiu2r/Ymrbq0iUxdn1tc0SvvzehdR31hAvibHnRZnCqydGjMZHi5vZaXwd+HtFUf7uQx/4CYnRncb142tbX+Lv/90/abfNzWr6VTLIK0UzJfJGfhqSH4bOKwLklabkt3ED3KySaqb4mleiZoqvhJsovla4/vei3xWoOAa/DWmlK0CA1oxoRVE1+G3cALf0y7DbSH8YrlP5taKwGvEP99Ow8ssw4BZ+GfrX1L+WJW7lp6F7T+bvw83goyq414/budP4F+AvhBADQoirQohrQoirNxw1Gp+4MFup2ux2Vj+wGLvDxtTVXdRki8a5UBSF7s8sw+6wM3l5Jw0m57rkUIr1n12Jw2lnwpJxjJlmlI0Y7B1i45OrcTjtdCxoZdwcI8V2oHeQTZ9fg8PloH3OGDoXtkv45qe6cboctM5slii2gznc46RlaoPkDDfYN8TmL3Tj8jhpnFgn7RwG+4bY/HQ3bq+L+s4aZm+cZlLxHWLzF9bi8bupHVfFvLuN/hqD/er4XBF/4Y45hklpqF8d7wt6qWgpZcnueejXaEMDw2x+uht/2EtZYzHL711ouMjl8EDET0ldESvvX2TAhweTbHpqDcFYgKLqAlY/tESbMHL4xs+vIZQXpKAiwdpHlhku0smhJBueWE0kP0SiLM66R5eb8BTrP7eKaGGEvJIYd312pWGSSA2nuOvxlcSLo8QKI2x4YpURT6ZZ99hy8krjRArCbHxytWGSSifTdH9mGfnleYTzQmz6/Bojnkqz+qElFFblE4oH2Px0t2ESzKQzrNy/iOKaAoJRvyW+/N6FlDYU4w/7eOwP77P0KBmNW4ub2WkcAlYBb1gxqT5pMbrTuH48OOXzvPMv72u3PX4PDqed3it9qhhhQYjzxy5quMvjxO1zc+1Sb7aYG+XsUZ1HuMNOIOKj58I1HE47eaUxzhw+b3jNSH6YK+d6sDvs5JeZPMQZ8Qi32W0UViY09lMuYkVRLp2+jM0mKKwukD3Ei6NcPKXiRTWFsod4SYwLJy8hhKCkzsJDvDTO+RMXVby+SPPLzkXOQxysPa5zHuKgkgFy7KlcFFbla4wvvV/2zeJF1QWaaKSVB7feY9wS13mMW+F6j3Gr49d7jFu9f73HuP7/VriVx7f+OXNikgZcd8z692KJ686FFV7ZUsbjf3Q/9eNlTa7RuL07jfeBN38XJozR+PDY/qWNGsU1XhwlrySqdYAnh5L0XurTKK7RQpXtkyvEJodTXD57RaOwRvJDlDUW05OVQk8l05w7dpG6LEU1nBekurVckzJPp9KcPnyO+k61DhKMBahpr9SkyjPpDKcOnqWhS/1BByI+6jqqNSnyTEbh1AdnNIqpP+yjYUKNRgHOZBROvn+apskq7g16aOyq1Tj/iqJw4r3TtExR2V7egIemSfUaRVhRFE4cOEXLVNXH2+1z0TylQZswAI4fOMXYrBuh2+uiZWqjYRI9/u4pxs5Qd1suj5Mx0xq1CQHg2LsntYZHp9vB2BlNMj5LxR1OO60zmw0qw8ffPUnb7BYNb5vVYrhI6nG7w0777BbDRfb4uydpnz0GIUQWH6NNGLnjb5/dghACm91G+5wxhkn2+IFTtM8Zg7AJhE2ouG6SOHHgFG2zr4+ffO80bbNbsNltCKHi+kno5PunaZvVgt1hH8F1k9ypD87QNrMFh1Ptj2mf3WLED56ldWYzDpfaftY2y4gfees4P//b1xjoHeDMEePiZTRuPm5m0jgN/FAI8eQo5fZ3O/LL4hRUqrTQeHEMp8dpwIUQGi00XhTF7TU1p2WprwCxwihun9y8VpjFo4UR3H6PhOeUZ6MFYbxBa1wIdYfiC1ngtQUIgWrcE/LKeHUhwiYI54UkCjFAYWUBwiYIxQPWeFUBNpsgFA8StJDWLijPx2a3EYj6CUYt8IoEdocNf8RPKC5TjPPL4tiddvxhH+F4yALPw5HD82Q8URLH4bKr0vUJa9zpcuAJuC0pzPHiKE63A7fPZUlhjhfHtB2mFR4rjOD2uHB7XcQLo9a4z43b4yJeZIEXRPD43TjdDksKtGq45MbpcpBXIuPh/BAev0fFS+Xm0XAihDfgwe60WzaXvv+LQ2yvf5CdjQ/xbz737yTZl9G4cdxMeupZq/s/qQyq0fTU9eOhqU/x9k9G3PncPhfJoZSWJw8nQvScHylXOd1OMumMVoyM5IcMJknqinBEFC6XisqFEAKH065JXZhxMBZOrXB9MTZaEJZMlvSFTytcX0y2wvXFbEtcVwy3wvXF+khBmCtmXEdhtRqvJxNE88NcNr1/PUXV6vzoKahWuJ6CGk4EJRMsPa3X/PmDkVYcygtKJlv6+6wozOG8oLYbDcb8XLtkpADrX9PKPleP+yN++kz2tvr3bEURvhG+/YsbLFlgd2LctvSUnmY7Srn93YpMJsPf/Jv/ybb6B/jPL/6lBdPExZZn1uINeli0czalDcbmMKfLwbbn1+MNepm3ZaYkx2Cz29j5lU34Ql5mb5xGzbhK6Rh2f20zvpCXmesm09gl55L3fkOl8E5d3cWYbGpIH/d8Yyv+sI/Jy8dLWlagmu4EIn66Fo+jw8Jf4Z4X7yYQ9TN+fisTFo+T8F1f30wwFqB9zhgmL5d/L7u+uplQPEjrjGamre6S8B1f2Ug4L0TL1AZm3SWr5O748gYi+SEaJ9UxZ+N0Cd/+pQ1EC8LUd9Ywf/ssCd/2/HriRVFqx1WxeLdM0b37C+vIK4lR3VrB0r0yRXfT090kyuJUtJSx8n6ZorvhidUUVCQoayxh9YOyTtNdn11JUXU+JXVFrHtUFv5b+8gyimsLKaopYN3jMoV39UNLKW0oprAyn41PrpHwlfcvpLy5lPzyPEuV3WX75lM1tpxEaZytz8oqu4t3zaGmvZJ4cZStz98l4Qu3z6JufDXRwoilCu9o1v3W47o7jaxY4cuKokgCMkIIP7AeGFIU5d9/vId4azG60xiJ57q/wY//4qfabbMKq5lSaqbImv0RzBRYM6XT/HxmSqaZQmqmXJpxM2XTTAk2UzJvFTdTMs3vx4ybKcdmiq+ZwirjRgqrmeJrVmk14+bzaab4WlFc9TRjK4qr/hitKK76c6D3DsmF/j4riqv+Oc3nw3xMVuP170nYBCiKgYGmPydmfxUwnlPz+QS49zvbWWPRz3Inxu3Yafwe8AUhxDtCiD8VQvyeEOIPhRD/BPwzEAT+7DYd72h8DHHhxEXDbZfXybpHV+B0OZizaZok62Cz29jwxCqcbicz75qiFbVzkckobH66G5fbybQ1k2iebNwZJIdSbHvuLlweJ5NXdNI2y7gzGBoYZvuXNuDyuJi4tIPOBW0SvuNLG3F7XXQuaqdriXFnMDwwzM4vb8TtczFu3lipOW94YJgdL2zE43fTNquZGSb/DHX8JjwBD2OmNTLH1Jw3PJhk55c34g16aJ5cz/wtM4zvbzDJji9vxBfy0jChhkW75pjef5KdX9mIP+KjtqNK8s9IDqXY8eVNBKJ+qlvLWXH/IsMFLDmcYscLGwnGAlS2lLL6oSUGPDWcYvsLGwgnQpQ1lrD20RUGim8qmWb7F9cTyQ9TUlfE+s+uMuDpZJptz68nVhihqKaAjU+uMVzE06k0W59bR7wkRmFlPpue6jZcxNOpDHc/s5ZEWZz88jzufmadYRLJpDNsemoN+RUJ8kpibH3+LsMklMkobHxS1TuLFUXZ9vxdhkksk86w/rMrKa4tJFoQYfuXNhgmQSWjsPbRFZQ2FBNJhNjxwgbDJKooCqsfXkpFcymheJAdL2w0TMKKorBy/yKqxpYTjAV46j8+PDphfIS4mZpGAOgEilD9NN5RFEWWz/yExOhOYyT2T3yCAz87qN32BjwoGYXB/iHsDjuR/JDGPgJ1pS9sgsG+IWx2G7HCiMY+AnVV53I76b82gM0miJfENMVRUFeC3oCH/qvWOIx4dgghSJTFDewkGMmxCyHIL49z9qg1DlBQmdAEDnOhz7EXViY4Y8L1OXI93TUX+hy4Fa6vS+T8zA14lkJ8vfE5ijBAUVW+REGOF8e4eEo954XV+ZwxPX9eaYwLJy5d9/lzFOLr4fllcc4dvz6eKI9rtGur85tfkce57GeipxvnQn+fnq6cC/1nkiiLS9+PwqqERtu2xkeOOUenvj4e5cLJywZcf84Lq/L53J88wJipsjLBnRi3s6bRqyjKDxVF+Y+Kovy3T/KEMRrG2Pft7dpuoaSukLySmFb0TafSDPYNaT7SRdX5FFbla+mlTDpD7+U+TSW1oDJBWUOxlt7KZBQun+3RKKr55XlUt1ZoRd1MRuHCiUtaHSJeEqNufLVG8VUUhXPHLmg+0bHCCA1dtdqEoCgKZ49eoD3bEBjJD9M0qd6gxXT2yHnNkyNXV9AXas8cOU/HfFVqJBQPMnZao6HQe+bwOcYvUPFg1E/rzGZDIfnM4XN0LlR3Q/6wj7ZZLYZC9ulD5+hcpOK+kJf2OWO1CSM3fsJitWHRG1A9rfWT9OnD51RPdiHw+N2Mn9+mTRgAZw6do2tJB0II3D4XnQvatAkj9/xdS1RPd5dH3Z2d1+0uVbwDm92G0+NkwqJ2bcKQcLeDrsXjDH06Z4+cZ+KSDuwOGw6Xg4lLOrQJA+Ds0fN0LR6H3WnH7rQzcUmHYRI5d+wCXYvH4XA5sDtsTFzaYZjEzx+/yIRF7TjdDmz2LH7YAvc4EVl/ev0kd+HkJToXtGmLnYlLzPhlxi9ow+NzI4Sga8k4wyR95vA5Xv2HN7l2uZcjb42oA4/Gh8eoidKnODw+N26f6tngcrsQNtPHLRjBPS5VcNCEe/y58U7sFv4R3oBKi3W6HJZ4brzTbY3nxjuugxvHy19XT8CbHW//0PEOlx27U7aP8WRpwXaXQ+P/6yN3fhwuu8b/N4z3uhFCzb07XRavn8XtTjtOy/EuEGptwOmW8dwF0e6wSxRpALfHhc0msDkELrcF7nVhEwK73YbLwt/D5XFis9kQNpvl8zuzuM0mPhwXAtf1cLsNIaxf3+lWcXW8NW63q6/vMlPAAYfbic2h9n24vPLrO1wO7E6b4buuj3deeZ9tdQ+wt/0xvrvvB5pXyGhcP26Ynvpdi9H0lLpKF0JI6SmP3006mSY5nEIIQSQ/ZFg5uzwuFEUhOZRECEG0IKz5a4B6YbTZbVqxOFYU0Qx1QE1PudxOrZgdK45y6ZQxPaAvlutTNbnQF9ut0g96iqo+VXOzuJ52mVcal+o+esvbRGmM86bxeoqrPhWUC336zOr59bRUK1xPUbU6fn16zer86NNrVrg+vRYviXHRjOvSa1afjx7PdevrQ3+f/rG50D+nFQVZn56zohDrj9lMATe/Z/251HDdObXCtzyzjq3PySysOyFuZ0f4aPyORCqZ4k+/+VdsKNnDHz3znyQmitvnZt2jqh3p/K0zJX8Hl8fJ+s+uxO1zM2fTNErqjP4NdoedTZ9fg9vnZtb6qVp3eS5sNht3f2Etbp+b6d2TLP0Rtjy7Do/fw5SVEzQDI33c/cw6vAEPE5d20DixVsafXYc36GHCwnYtNWbAv7AOX8jLuLljaZshU3Tv/sJaLdVkRdHd/PQa/GEfY6Y1MmGRTNHd/NQaAlE/zZPrmbRsvIRvelLVgmqYUGOporvhyVWE8oLUdVQxo1tW0V3/xGrCiRDVbZXM3iir6N71+AqiBWEqx5Qx11SoB5UCGyuKUt5UwoJtsspu98NLySuJUVpfzGJTIR9g1QOLyS/Po7imkKV7ZArvyvsXUVCZoLAqnxX3LZTwZfvmU1RdQH55HqstVHiX7J5LSV0hidI43RY6UAt2zKKssYR4cdSS4jt/ywwqW8qIFkYsVXrnbJpGdWsFkfwQ65+QVXpnrptC7bgqwnkhNjw5KpH+UeJmCuH1wONABTp7WEVR5G/cJyDu5J3Gk4tf4Od/+5p220yhlW6bKLTm22YKrVnV1UzJNVNazRRWMyX11m8bKavSbRNl1UxRveXbJgqr+baZwnoj3ExZNVNc9Qq1Vo83U1LNt80qvrf6eJXSOkJJtcZHKK3SbRMFWL6tyvxe7/bNHqPx8YJM+vrjpXNqum1WXt7/8i5W3r+IOzFu507jT4FfAk+jTh65v9H4hIW5m9cb8LDhiVW4vS4W7ZhNeaNxZ+B0O9n89FrcPnXnUWVSubXZbGx9bj1un4s5G6dq1qO5yKQVdrywEbfPzQwLf4zkUIp7vn43Hr+bqau7GGda2SeHktzzoopPXt7JhEVtEr7nG1vwBjx0LRknNd8lh1Lc880teINexs9vY9oaI8U2NZxizze3qjuPOWOYvWGqJe4P+xg7o4m5m43Nd6lkmr3f3Eog4qdlagMLdxrXSelkmr3f3EIw6qdxYi1L7plngW8lFA9Q31nNctPKPJ1Ks+ebWwnnBalpr2S1aeWdTmXY840tRPLDVLVWsPYR48o7k85wz9fvJlYYoaK5jA2mlXUmnWH31zYRL45S1ljMRtPKWsko7PzKJhJlcUrqitjyhXUGiq+SUT/f/IoERdUFbH12naEHQskobH1+PYVV+RRUJtj+pQ2GC7qiqOme4ppCEmVxdnzZjCts+nw3pfVF5JXE2P31zdLueMMTqyhvKiVWFOWeF+82jAdY99gKqsaUEy0Is+cbW6Xxqx9eSk17JeFEiL3f3GKYMED156gfX00oHuTZP3/sjp0wbiVuZqfxC0VR5H34JzTu5J3GfZ2f5f1fHtZuewMekkNJUsk0QgjC+SGDzIXb5yKTJHaeygAAIABJREFUyozUOApCXD4zgjuzhdXcat9cw7A5bDgc9uvWOMC4O4kXRbl4+qPXOKxy8PqGxY9SAzHWOGRcX8Owwo01jBvhFjUOHUXYsoahr3FYvD99jSNeEuWiiWKqrwtYnV+99MlHqmEURrS6l1UNQ/+diBZEJK9u/XfCSkblRjUO/TmJJEJcOX/9GoeVDIr+nEcLwjzx7x6yTFveCXE7dxp/LYS4TwhRJISI5f5uwzGOxm2Oz/xgn5bnr26tIK80rqVLFEUhnUxrFNjKljKKqgq0dI6iKAz1DWsU1/KmUsoaiw3pod4r/RqFtaS+mJrWSkP6qef8VU2qo6imkIauWkM66+Lpy5onRmFVgubJ9Yb018VTl5m8XF2f5FfkMWZqoyFddvHkJSavVOsEeaUxWmc0GTrcL5y8xJRsHSFeHKV9dovBJOrCiUuaFEi0MMy4uWMNWkQXTlzSdiuR/BDj57cZ7FIvnLjE9DUTEUK9AHUuajdQgPV4MKZKmxjxi0zvnoSwCfwRHxOXdhguYhdOXGL62knY7LasdEqnoVB74eQlZqydhN1hxxf0MmXlBMPu8uLJy0zP4p6Ah6mrJhgushdPXWZ69yQcLgcev5tpq7sMi4gcnhM0nLZmomESuHT6MtPXTMTlceLyOJnePdFAlLh85grT1kzE5XXhdDuYvnaSYRFx+ewVpq7qwu1z4XA5mLF2kmERcflcD1NWTcATUCX7Z6ybbKAgXznXw5QVnXiDHuwOOzPWTjJMolfOX2Xy8k58IR82u03Cr164xsRl4wlE/CO4bpK+fLaHN//pHS6ducw7r4xYCIyGMWSOnxzbsv/qU1IKIFcxR+O3GoN9Q9pFWGUwGXeRiqJoF+GhwWEcJgqqgqI54Q0NDGGzm1RmMyN4cnCYtIniqCho4nzJoWFJkgLQairJoRSpZErC+7XnT5FKyXju+VNDKZJJ+fn7dc9vdp1T8dz4NKnhpIRrzz+cJmmF9w6iKFl80ALvG8GHh2R8sG8QJaNO4FbjB/uGyKQzpJIpyXVPff0h0qk0qWRKcvUDGOobIpNOk04Khgcsnr9/UPtcLMf3D5FKprFnFIYHhiR8sH84u3PFUM/Sxg8Mk06mUBT1WCR8cJh0Mk06nZH8vQGGB5KkhlNqH5HJP1wdnySdTJNJp63HDyZJJ1URzoE+eXxycJjkcFLFLZ7/zR+/y3/9zn+n/9oAszZMZc+LW0hYqOneyTFKuf0URCqZwuF0SOkpX8hLJpUZ6QBPhAwru1wPQ64DPFoYMaR/XB61N2Ogd1DtEC+KGtIrdocdt891/Q5wAf6Qmv65Xgd4IOKj90r/R+8AjwW4msULK/MlnwR9eseqA/rGHeIjtE7rDvCwltLTGyblQp/SsRpv6BC3wPXpE6vnN3SIW3SQJ8ryOH/8wnXfn75r2+r86ju8rTrsDR3gum7xXOg/E8sOcd0x3Qi36hDXnzOr9J/+nFml9/TjrdKnm5/qZvuXZKHDT2PctvSUEMIphHhQCPFn2b/9Qgi5i2Y0fuMx2D/EH33hP9Gd2Mn/9cgfSUU+t8/Nkj3zcLoczNowhXiJ0d/A5XGy/N6FOF0OpndPIr88z4DbHXZW7l+M0+1g6qouiquNFF2b3cbqB5fgdDuZtLyT0nqjSi4KdD+yDJfHSdfSDomiC7D2keW4PE7GL2ylqrVCxj+zDLfXRce8VmrHVUl492eW4fa5aJvVonW362PNw0vx+N2Mmd5E86R6GX9oCZ6Ah6bJ9ZrBkj5WP7gUb9BLQ1et1r2uj1X7F+MLe6nrqKJjnpwLX3n/QgIRPzVtlUxYKFN4l9+7kGA0QOWYMiYtk3+vS/fMJxQPUt5UwpSVMoV32Z75hBMhSuuLmL5GpvAu3j2HaEGY4poCZq6bLOGLds0hVqQabs21UOGdv20meSUx8svzmHu3TPGdt2UG+WV55JXGWbh9toTP3jiVgsoEsaIIC3fK+My7plBUU0C0MMLiXbKK7/S1kyipKyKSCLHUpOUFMHVlF2UNxYTzgizfK+OTlo2noqWMYCzA8nsXSPiExR1Ut1UQiPpZsX+0CH4zcTOF8P8bcAJ/nL1rC5BWFGX3x3xsHynupJ3GIzOf4Y1/eke7babU6ovAAJ6Ax7DlN6veun1uhvqvr3prptSan89MkTU/n5mSaqbs3kj19oa4pGrrNKRoJPwGqra3jN9A1VZSzTWr2propLKqrVHF1Xw+zRRY8/kyU2DN50MIEMJGJnN9VVv9e7BWtdWp3tpGnmsEH3lNK9Va/TELkU2w6lVt9aq3AkAYGF/SOTOd0xudc/Nn9tDv72GZheT8pzFuZyF8gqIo2xRF+Yfs3w5AXvKMxm88+q4aDWX8YT+bnlqDN+Bh+b0LKa0vNuAen5st2ea4xbvnUjHG6I/hdDnY8YKq8rpg+yzqOoxlK5sQqj9G0MPczdNpzupS5SKTzrDvWyrFddb6KZLKbSqZ5r7vbscX8jK9eyLjs0X1XKSTae5/aQf+sI8pKycwcWmHJR7IFpGnmJrn0qk097+0k0DET+fCdmaumyLh+1/eRTAaYNzcsczeaKTgZtIZ7n95F8F4gLZZLczfNkvC97+8k1BekDHTGiWV20xGYf9LOwknQjRPrmf5voXS+Pu+t4NIfpiGrlpWmfwrlIzCfd/bQawwQl1HtUSxVRSFfd/eTrw4SnVbJes/t0oav/db20iUxqkaW86mz68xjYd7XtxCfnke5U2l3P3sWgnf9fXNFFblU9pQzLYvrsccO17YSHFNAcW1hex4QU7bbH1+PaX1RRRV57Pra5skfMszaylrLKGgIsGeb2zBvGbd9Pk1VLaUkSiLs/db28xlOdZ/bpVK8iiJce93d0h+GGsfWUZdRzWxoij3v7RDouiufmgJDRNqiBaE2f/STglfft9CmifVE8kP8cJfP3HHTBi3Ejez0/glsE5RlIPZ29XAnymK0vGhA39LcSftNPZ1PM7BV49ot71Bj1oIzf4QzDIJHr+b4YHhEdzk1ObyOEkl09d18nM47SgK13Xys9lUb+kRJz9Z5kG/0rN26hvZrVg54elX95a4bjdk6eSn2/18FKe+Gzr56XZnVu9Pv/uzxn30X8059cnnzx/20tejjrdy2tO721nhegqxFQVV755n5cSnryEF4wGuXew14rox+nqUhuteMxAN0HvZiOu/s3pJl1zoabWBsI9ekxOf/j3rz6U2XnfOfUGPRpzIhf4zDUT8fO5PHrDs/P80xu3caTwO/C8hxA+FEP8I/APw6K97gABCiEVCiANCiA+EEE9Y4G4hxH/O4q8IISpvx+t+WuLJf/8QHfPVPHrLlAbySuKG9IgQQqPANk6so7CqwOifkExrP4j6zhrKGksM6YahgWGmZimqteOqqG6rNKQz+q70M32tmkevaq2goavWkC7pOX+NWRvU1X5FSxljpjYaUgNXzvUwK7vaL2sspnVmsyG9deVsD7M3qXhJXSHtc8YY0kFXzvYwd/N0hFALmh3zWw3ps8tne5iXxQsqE3Quajekyy6f7WHelhkIm1qk71rSYWDkXD7bw/wtM7DZbOSVxJi0fLyMb52RJQlEmLJygiGdd+WcOt7usBEtCDN1dZchXXjlXA/zt87E4VRl6mesnWS4yF05d5X522bicDkI5QWZuW6yNmGo5/cq87fOxOl2EowFmLV+isEOtef8VeZtnYnL4yQQ8TN7w1QDhfjqhWvM2zIDt8+FL+RlzqZpBrvVqxevMffu6Xj8brxBL3M3T9cmDIBrF3uZu3k63oAHj9/NvLtnGCaZa5d6mbNxGr6gF7fPxbwtMwyTVO/lXmZvmIo/7MOVlbbRL3J6r/Qxa/0UAlE/Lo+T+VtnGvowenv6mbluMqF4AKfbyYJtMw2TZP/VfqZ3TyKcCOFw2pm/baZhku6/Nsi0NROJFoSxO+0s2DbLsAjovdLHu6+8z9mj5/nF/z+itHCnxw0pt4qi/L0Qog5oAATwrqIoMtftFkMIYQe+D8wHTgA/E0L8laIob+setgu4rChKrRBiA/B1VMfA0UCVrj57RGWbnD9xUVKpTacznMkyRy6evCSplGYyGY1ZcuHkJXwhrwFX0hlOvn9aHX/qEqF40DheUTT80unLRAvDxvGKwsn3VPzK2SuWKrWn3j+j4ueu4rZQMT31gXp8Peev4Qv5JPzkB2dQFOi5cI1QLCjjB8+iKHD1Yq+0qgU4ffAsSkbh2qVerl26JuGnDp0jk8lw7XKftKoGVR49k87Qe6XfUiH1zJHzpFMZ+nr6uXpefv6zR86TSqbpvdwnNbZp+HCKvivW+LljF0gOJUmn0oaeiVycP3aB4UG1wdMSP36Rof5hhE1IjX2g9o4M9g0hBBLzCNT7BrPUVrN4I6i9OQNZmrEVfunMFfqvDaBkFIk5BWrvR//VATLpjDV+roe+nn7SqYzE7AJ1Yu670kcqmeasiVkH6sR67XIf6WSa04fPSvhrP3yLP/3WXzE8mGTC4nHc/70dlNQWSY+7k+LD7F7nKIryD0II2dgXUBTlz3+tFxZiMvCcoigLs7efzD7vV3WP+dvsY34ihHAAZ4CE8iE5tTshPTXQN4jX72HvuMc49NpR7f5AxI+iKPT19OP2ugjGAoYfui/oxWa30XulD5fHSTgRMlAY3T43Lo+Ta5d6cbqdxAojBn8Ep8uBL+Sl58I1HE47eSUxww/VZrcRigW4cv4qDqedRFlcopDmUi52h538ijxOHzT+UHNdxTa7jaKqfE5+cMaA5yisNpugqKZQm7RykaNV2myC4tpCTrxnxHPKtUIISuuLOH7glBHPUlSFEJQ2FHP83ZMGPL8iwbnsOSlrLJFwPW21rKmE4+8YcT2FtLyphGMmvKimQDsnVnhxTSGnDp657vOX1BZq58xqfEldkXbOrPDS+iLtnFm9v9KGYk5kz1lZQ7F0/vS4/v+5KGss5vi7p6TXGsFHXlN/rLkobyzhWBYvri3klOn7oX9P+nNpiVtQmPW4FUV5wxOr2fUVuVbzaYjbkZ7KSWQut/hb9msfIZQAeueTE9n7LB+jKEoK6AGkThshxB4hxM+FED8/f15ebXxa4trlXr7/4B/SnbeT7+791wahNVDZSLM2TMXmsDFpeSfhRMiAOz1O5myaht1hp2tJB7HCiAF3OO3M2zIDu8POhEXtxEuMjf82h435W2did9oZP7+N/IqEdIwLd87G4bTTPmcsRdUFEr5491wcLgetM5sprZNXbEt2zcHpcjB2ehNljeavAyzaORun20nzlAYqW8okfOGO2bg8Thon1lHdVinhC7bPxu11Ud9ZY0nhXbB9Fh6fm9pxldR3yhTe+Vtn4PG7qW6toGlinYTP2zIDb8BD5ZgyxkyRVXjnbp6OL+SlrLGEsdNkFd7ZG9V0TUldEe2zx0j4rA1quqaopoCOua0SPnPdFEKxgJqOM9npAkzvnkg4ESK/PI+uxTIFeOrqiUTyQ2o6ziKXP3XFBGJFEeLFUUsK8OQVncSLo0QKwlr3vT4mLhlPoixOJBFiuoXK74RF7eRX5BGKB5mxTsY75rdSVJ1PMBpg9vqpEt4+eywldUX4Iz5LleDWGc2UNRTjD/kkrTGAlqmNVLSU4Q16mHe3jI/GzRXCqxRFOXyj+275hYVYByzMUXeFEFuALkVRHtA95q3sY05kbx/MPkbe52bj07zTkOxbTZRYvY4SyJRYM26mxJopui6Pi+HB4eviZvqi+XjMlE6ziq6Zsmk+XjOFVRpvwj0BN4O9I+/HTKc0q/aqFNYRVddbxzFQWM0UYvMxmM83Qn2NDxuvP0dmii8YVVvNlGgwfgZmSjQYKa5WuJ7iav68wUhxNdNdzWPMFGDza1rh+vdsVqg141YUYP05EbYsPVd3ydPTtq3G6z8Tm03w8L/ea9lP8mmI21kI/68W9/3ZrR+SFCcA/VKxFDh1vcdk01NhQE6s3iFhln0IxYJsemoNvpCXVQ8spqjGuLL3Bb1sff4ufCEvy/ctoKzRSMF1e13s+PJG/GEfi3fNoca0Mnc47dzz4t34wz4WbJ9Fg3nlLQT3fmc7/rC6ajN7LasU1V0EIj5mrZ9K+5wWCX/w+7sJRP1M757IhIXGlXEmo/Dg791DMOpnysoJdC3rsMZjASYu7WDaaqPKrZJRePD3dhOKB5mwSKbgKorCA7+3m3BekI65Y6WVp4YnQrTNapH8KRQFHvhXu4kUhBkzrVFSuQXY//JOYoURmic3yM1lCtz/0k7ixVEaumpZbaLgAtz33e3kZa1yrfwj9n1nO4myODVtldz12ZUSvvebWyioyKNqbDmbn+6W8HuyFNuK5lK2PLtOwnd9dRPFNYWUNRSz7UtyOXH7F9dTWl9MSW0hO7+8UcK3PHcX5U0lFFUXcM+Ld0v45qe7qRxTRkFlgr3f2CLhG55YTXVrBfnleez7zjYJv+uxFdR1VJNXGuf+7+6Q8DUPLaWhq5Z4cZT9L++SKLwr7l9E86R6YoUR9r+8Uxq/dO98xkxtJFIQ5kt//eSndsK4lfiwmkYj0AK8iFF3KgQ8riiK3B57Ky+sTgLvAXOBk8DPgE2Koryle8z9wFhFUfZlC+FrFEX5UFutT/NOY2/7Yxx6faSGYW7O09MlQV4ZmymQbq+L4cGktpI24063g9RwegQ3USztDjtKJqOt9s3jhRAIwXVxMK7urHD9StmKAqpfCVuN169+Q/EAV03FbH0zl55OOoKPrIStxutXulavfyNcv9K1xHUrXT1dNhf6z9iKourxe7RCtXmnCcbdmxWup6Wad5rm+26Ee4NeTdsrF/rXNO8kze/J/H2+GVz/mzA3g4IqLHnt0ofhI5+J2+vi8T/ab9lZ/2mI27HTaECtXUQw1jM6gHt+3QPM1ij2A38LvAP8F0VR3hJCfFEIkVtS/QEQF0J8ADwCSLTcOyme+4vHNRXWiUs7pJqD060qjwKMmztGqikIm2DGXeoXvnVmM2WNJYbmqHQqzZxN00DAmGmNVLdWGPDh/mHmZd3imibX0TChxpAe6uvpZ9HO2QghaJhQy5hpjQb82qVeFu2agxAqhbd9doshHXDtUi9L7pmHsAlq2iromN9qSG9dvXhNwyvHlDFhUbuB4nvtUi9L987DZrdR3lTKxKUdhnTJ1Yu9LNs7H7vdRkl9EZNXTDB0/1691MuyffOxO+0U1xQwdXWXIV1z9WIvy/ctwOG0U1iVz/S1kwzpomuXelm2bwEOl4P88jxm3jVFwpfvW4DT7SCvNM7sDdMMF6kc7vK4iBdHmbt5uiFd1Xu5j2X75uP2uYkWRJi3ZYbhItl7pY9le+fj8buJ5IdYsG2WNmHkPp+le+bhDXoI5QVZuGO24SLd19PPkt1z8QW9BGMBFu2aY+hj6L86wOLdc/GHfQQifhbvnmuYJPqvDrBo5xwCUT++kJcl98wz4APXBli4YzaheABv0MPSPfMMk9RA7yDzt80inAjhCXhYtne+YRIc7Bti/paZRArCuH1ulu2T8bmbpxMriuLyulh+7wLDImpoYJjZG6eRVxLLSugs0CaMHD5r/RQSZXk43Q5W3LvAMIkPDQzzwa9+raz8pyKuS7lVFOUvgb8UQkxWFOUnH8eLK4ryN8DfmO57Rvf/QUDeM9+hUVRVwLN/9hhnjpyjsDKfveMeM+CpZIp3f/oBAIdfP4Y7K0iYi3QyzYFXVPzIm8fxR4wU1kw6w9s/eQ8UOPrWcUJ5xkJ6JqOoOHD8nVMSxRYF3vzRuyiKwvEDJ8krkdVB3/7nAygKnPrgDPkVeRL+1j8fQMkonHj/tGHC0cb/RMVPHzonUYzV53+PTDrD6UNncLnlr/fb//Ie6XSGc0cv4PV7JPydf3mfdDLNuWMXCET8Mv7K+6SSaS6cuChRkAEO/PQDUsMpLpy8xBkLCue7P/uA5FCKS6cvc/rQGQl/7xcHGR4c5tKZpMQcA/jgl4cZ6h9ieGBIozPr4/1fHdLUjo8fOCnhB187ysC1QQauDXLsnRMSfuiNY9ru9ehbxyX8yJvHtAv9kTePyfjbx7Xd0GHdrjgXx945qe3WDr4m48cPnNR6Lawu0MffO0XPuR4UBYM4Zy5OfnCGy2cuoyjw3s8PSvjpg2e4ePoySkbhwM8+kPFD57h46hKZdIZ3firjo/Hh6anPKoryohDiZaRMICiK8uDHfXAfJT7N6Slz/N0f/5AfPP4n9Fy4hj/swxf0Grjw/ogPp8vJlXM92upRT6H1Bjx4Ax4unbmCN+AhnAgZKIYuj4tgzM/FU5fx+NzEiiKc0lEYHU470YII509cxO11kVcalyiSOeVSl8dJfnmeRLEsqMjj7NELON1OCisTEoUzp0LqdDkoqimQKapZ2qTDaaekroijbxsvhDkKqt1hp6yxmCNvGi+EJXWFnHz/DDa7jYqmUg6bLoQ52qjNJqgcU25ID8IIhfR6eI7CKYSgqrXcQJEGqGgu5ejbJxBCUN1WYejwB9X35Ej24l3TXinhVWPKtWO2xMeWc/iND8FbK7SL+43w6rYK6fj199W0VUgTQU1bJQdfU5+zurVCOj/616xqLefw68dMeAUHXz0qvRer8ZVjyqTPV4/nzrX5+A69fhRFUSwpyNWtFRx+4xiKolA7ropH/s0+SV7n0xK3Iz2VU8L7OfALi7/R+C3HhEXtdC5oQwhom9Us7RycLicTFrUjhGDsjEaCsYABd7gcTFzSgRCClqkNhE07C7vDxqSl4xE2QdOUeqIFRoqusAkmr5iAzSZomFhHvMiooguqCqnNbqNhQg2JMnlnMXV1FzaHjbqOKgoqZQrv5BUTsDts1LRXWlJ4p6ycgMNpp2psOcW1hRbjO3E4HVS2lEpaXACTlnXicDkobyqhrEmm+E5aOh6X20lpQ7GlSu/EJeNxeZwU1xZS1Vou4V1LOnD7XBTVFFDTXinhnYva8fjdFFQmLC9GnQvb8AY9FFQkLCnAHfNb8QW9JEpjNJrseAHGzR2LP+wjXhKzVPltn91CIOonWhCmxYIi3D6rhVA8SCQ/TOv0JgkfO72JcCJEKB5k7EyZQtwytYFoQZhgLGBJIW6eVE+sKEIg4qNjjqwS3NhVT15pDH/YpxmA6aOhs4b8sjjeoIfOhe0SXjuumsLKfLwBj6aOoA/1e5WPx+eia4msjDR5eScvv/JVHv2D+/j+z772qZ0wbiVuyU9DCGEDAoqiyK2vn5C4k3Ya93c9YdiCmwuJ5sKo3nrVCjdTNs24mVLpj/jouzKSkzaropoLq0IYFUmtcBihuMo46FVNrXAhRmi4vrCPflNhV0+BtSr86gvzVoVd/Xu0xHW0UTNRAYyFe2vcoZlTWRWGHS47qeH0dXGX26mZP1kVhp0ep2b+5PG5GDRRfPWFe4kijPE7YkXx1ReTrQrL+te0ovjqj/mGuAUFWE/71p8rS9xhJ2UyCtN/pg6nncf/7f3M2XRn9GvcTj+N/yCECAkh/MDbwAEhxOM3GjcaH3+Yne8CET9bnl2HP+xjxf2LKKkzrrw9AQ/bv7QBf9jH0r3zKWsyrrxdbie7v343/oiPRTvnSCtjh8POvm9tIxDxMX/rTAv/CsH+rMrsnE3TGDPNSMFVFIUHshTbmeumSBTcHMU1GPMzbfVEOk0UXEWBB39/N8F4gMkrOulaNk7CH/i93YTiAboWj7NsLnvg+yrFtnNBG9MtWDAPfH8XkUSIcXNkCi7A/pd3ESkI0zqzmQUmFVyA+7+3k2hhhDFTG1l8j0zPvPd7O4gVRWmaVM+yfbK/w33f3Ua8JEbDhBpWPyRTcO/9lkqxre2oYu0jco/tPS/eTUFFguq2CkkFF2D311SKbeWYMjY+JVNwd35FVbEtbyphyzNrJVyl2BZRWl/MdgsV3C3P3kV5Y4mqgvtlWQV301PdVLSUUVRdwO6vb5bwDU+oKrYFlaoKrjnWPbac2nFVJMrz2PutrRK++sElNHTWkFca497vyBTcFfctpGliHfHiKPe9JONL7plHy9RGYoURvvTXT94xE8atxM00972qKEq7EGIzMB74HPALRVHkveInIEZ3Gr+5nYYZ/13Yaeh3EjfaafhDXvo+dKchq6h+3DsN/er6RjsNb8DNQO+H7DQsdiKGncJH2WnoxnwcOw39e/5oO40R2q/+XOdCv9Nwuhw89of33TETx+1s7nNmnfpWAX+pKEoSi8L4aPzm44W/foJFO2ZjswlmrZ8i1QQcLgfzt85ECJWiW9pg3FkIm2DxrjmqGu6iNqrGGHPy6VSapXtUimvH3LFSTn1oYIgV9y3CZhO0zmqhZYpxZ9HX08/qB5ZgswnGTG+ifXaLjD+0BJvdRtPkesYvaDVMKn09/XR/Zhl2h42Grlq6lnRI+JqHl+Jw2qnrqGLS8k4D46q/p5+1jy7D4XJQ01bBtDUTDRTfvp5+1j6i4lVjypixbrIRvzqgOQuWN5Uwe8NUw6TYf7Vfw0vri5h793RDR3P/tQHWProct89FcU0B87fONFCE+68N0P2ZZXh8boqq8lm0Y7bhIjbQO8jaR5bjDXjIr0iweNdcw0VyoHeQ7s8swxfyklcaZ+meeQZf8oHeIdY8vFStaRRHWb5vgcGXfLBviNUPLSEQ9RMrjLDivoWGi/xQ/xCrH1ySrWmEWLV/kWGSGB4YZuX+RWpNIy/IqgcXGyaZoYFhVty3UKtprHloqSEdlhxKsnzfAmJFUQIRP90PLzVMYsmhJEv3zCevRK1pdD+yzDBJJodTLN49l/zyPHxBL2sfXW5QJEgNp1m4Yw6FVfl4Ah7WPrLM0CeSSqZYsG0WRTUFuH1u1j26wpBuTA6npML4aID9ueee+9AHPP/88w7UDvBLwFeff/75CmDpc889928//sO79fjBD37w3J49e37bh/EbCW/Aw5SVE1hx30Lmb53F//iDv+fS6RElU7vTzpnD5xnsG+Jv4YzOAAAgAElEQVTymSsoKIaVtd1u4+zR8wz0Dqo+1wLDzsFms3H++AX6rw5w+VwPQmDgvQshuHjyEn09/Vw524OwITWnXT57hd4rfVw514MQQmqOu3Kuh2uXeuk5fxUhkPwdrpzv4erFXq6evwoCg3Q2qOq3PReucfXCNYRNSP4RPReu0XP+Klcv9iIEkj/F1YvXuHIuhwvJ3+La5V4un1GPUQgk/4xrl/u4fOaKRjM14309/Vw8dZneK/0gVNVWffRfU/G+nn4URbHAB7lw4mL2c1MkpdqB3gHOH7+oKsFmMtL4wf5hzh27wMC1QTJpWel2eGBY+w6kkmlpfHIwyZnD5xjsGyI5nJLxoSRnDp1jqH+Y5JCMp5JpTh08y/DAMEODw9L5SafSnPrgDMODSYb6hyQ8k1VaTg4lGewblPxTlIzCiQOnSA6n6O8dkD5fUDj+7klSwyn6rw4YpNUBECoNOJ1M09vTJ31/Wmc00z5HLuB/GuP5558//dxzz/3gRo+74U5DUZSXFEUpURRliaLGUUA2+x2N31rkWE8bn1xDoiyevS9IIOLXLoL91wbou9JPQVZkMBQPEikIaxeRgd5BrpzrobBK9QEPRv0kyuKaXPZg3xDnT1zSGEr+sI/imgKN4js0MMzpQ+c0n3BfyEt5U4lG8R0eTHLivdOalInH76aypUyj+CaHkhx/9xQVTSpDye1zUTW2XFMpza36ciKFbq+LmrZKTfE1lUxz9K0TVI1Vd0tOt4Pa9kqNApxOpTny5nGqsz7kDpeDuo5qjQKcSWc4/MYxqrN1HIfTTv34ak2RNZNROPT6MWqyIod2h436zhpNkTWTUTj02lHqOlQ8xxjLUTwVReHgq0eoG6+yb4RN0NhVy9G3jHhuNydsgsaJdYZeiA9+dUSrI9lsgqZJdQaK6cFfHTEwqJom1Rl6JT741REaJ6q4EIKmSfUGCuzBV4/QqBNhbJpcr9FlLfFJdQYK7sFXj9A0yYjrKbyHXjtK06Q6LQ3ZNNGEv37MML7RhB9+/RiNE+uw2dTxDV21BvzIG8dpnFiXTWNCfWe1EX/rOI1ddVp/jxk/9vYJGrpqsTvsAIyd0SS5O47GzRXCw0KIb+dUZIUQ3wLkrqfR+K1Hw4QaGiaoF4Wa9ip8QaM/ht1h136UVWPL8Zv8KewOO82T60FA5ZhyAiYKr80mVFqmgPLmUonCK4RgzLRGhBCUN5ZIFF6AsdObETZBWWMJkfywhLdMb0TYBKV1RURNKrwALdMaVdn0mgJiRTLePKUBm91GcU2h1DGv4vXYHXaKqvK1CdaAT6rD7rSTX5EgUS5TgJsn1WVl3/MorMyX8MaJ9TjdDhKlcQqrZIpw44RanB4neSUximpkinBDZw1ur4tYYYQSCwpxXUc1bq+LcH7YkkJcO64KT8BDJD9MWYNMIa5pq8Qb8BCMB6iwoBhXt1bgC3kJxQOWFOOqseUEsh3h5nQmqGZbwVgAf9hH1dgKCS9vUr833qDHkoJc1lBCJNsRXmuBl9YXE0qEcPvc2gRswOuKiBVFcXtd2m9BH+r3JorL46ShS1Yp7lo0jn/96jd45s8e49s//CIVzbKS8p0eN1MI/6/Am8AfZ+/aArQpimLps/HbjjupEG4Oc2H8ZrSn9DnsG2pPmXC7w0YmrVwXv93aUx8J1xWmb6RNZYXri60fRVvKgJu0wcBYTLbSlrqR9pQBv5H2lIkiDcZiuRWFWF94tir864v5VvapRu0powoyGMkIVoX5G+K692SlEmzQnrLA9efU43Pzuf/nAUn48k6J21kIr1EU5VlFUQ5l/54HRjtcPoGhZIyyzr6Qj63P3YU/7GPZvgWSf4Xb52bHlzepKre751LRYlxZOl1Odn8tq3K7bZbkP2Gz29n3bZWCO3fzdBosmsvuy1JwZ62fKqnggkphVVVuJ9E2S24Ou/+lnQRjqsrteAt/iP0v78qq3I5n4hK5eWv/SzsJxYN0LmxjyirZ/+G+7+1QVW7njdV0u8x4JD9E++wWy1TFvu9sJ1oQZuz0RubdPUPGv7VNVbmdUs/CnXMkfO83t2gqt8v3zpfwe76+hbzSGPXjq1lx/0IJ3/21zarKbXslax6WKbo7v7yBgooEVa3lrHtkuYRve349hdWqyu2GJ1ZL+Nbn7qK4tpCyxmI2PyXjm57uprShmJK6QkuV3A1PrKK8qZSimgK2PS9rja57bAWVY1WVWyuV3O7PLKWmTVW53fVVmaK7av9i6jqqSJTGuedFmYK7bN8CTeV27zdkfMnuuTRPVhsMn/uLx+/YCeNW4mZ2Gj9BVbX9Ufb2VOCbiqJ8IqUe7+SdxsPTn+atHx/Qbt/IT8NMwTXjt+qnYaaQ3qqfxo38Mm4V//X9NEBP8b2Rn4bVSlj/Hm/kl3FD3ILCavDTsPLb0H0GlrjBT8NhEHAEk5+GFX4jPw3dGP1zjeA6Pw0TZdt8zObvkxm39MO4oV/GCEXYZrfx2B/cx/ytRgn8OyVu507jXuD7QogjQoijwL8C9v66Bzgatz9e+Osn6X54KU63k0U7Zks5cYfTwYr7FmJz2JjWPVHaWYDaHGV32JiyopPaDuPOIp1Ms/bR5diddiYu7aBpslGWYmhgmPWfXYXDaWf8wjZaTbISA72DbPz8GhwuB+PmjmX8vFYZf3K16uw3q1mSdRjoHWTz09043U7GTGtk8opOCd/01BpcHidNk+uYvsa4ahzsG2Lz0924vC4aJtQwc/0UA4V3sG+ITU+twe1zUTuuijmbpkv45i+sVZ372iqYv3WWYVIa7Bti81PdeAMeKlrKWLRrjuEiNdQ/zOanu1WSQGMJS/fMk/BNn+/WnPuW37vAiA8Ms+mpNQSifoprCli5f7HBlGh4MMnGJ1cTzDr3rXloieEiOzyYZMMTqwjnBUmU5dH9mWUGinByKMX6z64kkh8mryTGuseWGy7yyaEUdz2+glhhhFhRlLseX2mYJFLDKdY+upx4cYxoQZgNT6wyTDKpZJruzywjURonnAhl8ZFJLJ3KsPqhJRRUJAjFg2z6/BrDJJdOpVm5fxGFVfkEYwE2PmXEM+kMK+5dqDr3hX1semqNYZLNpDNqU2tjMb6Ql81PdxsowqrQpSwyORrGuGkZESFECOCTLCECd/ZOIxc5D3HZ6c+Lw2Hj2uWcR3iY88cvaLjb58Llcek8wsOcPTqC6z3CnS4H8eIYZ46MCBwKmyCcF+LKuR7VQ7wszhmTR3isMMKlM1ewO+wUVOQZBBAB4kVRLp6+jM1uo7AqX/KAjpfEuJj1ALf0CC+NceHEh3iEl8U5f/zidT3C8yvyOHc05xFepLGnclFQkdAYYVYe2jf0AM8KMF4Xv5FHuM4Xu7ypVFKqvRUPcEtc7wFu8f70vuCWuO4+a4/wD8f1x2TpEW7AVbHJ6+F6P3VrvED6/m15Zh1bn/tQy55PbdxOGZG4EOIl4IfA/xJCfE8IIdNORuMTEznJ721f3EBZtqEvr0Rd/eWKgsODSfp6+ijPMmhiRVESZXlaITc5lOTK+atUjlHZI9GCMEU1hVqfRHI4xfmTF6luUxky4USIyuYyjeKbSqY5e/i8RkENxYNUt1ZoFN90SuXv5xgwgaif2nFVXDytUnwz6QynPjijUVADET9146u5eFI1bsxkFE6+f1qro/hCXhom1HDhxAh+4r3TNGbZYt6Ah8auWs4fVynCqnz7KZUthppaappUz7nsJKkoCsffPUXLFBV3+9w0T24wqAQff/ckLdk6jdvromVqg0El+Ng7JxkzXcVzu6PTh4z42KwIoMPlYOyMJm3CyOG53ZrDaad1RrNhEj32zgkNt9lttM5sNlxkj71zktZZLRreNrPZMImquDpe2ARts1oMF/Hj756kbVYLQghsNkH77BbDJHv8XfX4chTXtlkthknkxIFTtM1qwWYTCCFomy3jrTNVNl1uvH4SO/n+aVpnNmsUWBk/Q+uMJuwO9TLWOrPZgJ86eIaxM5pwuFSJ/LEzmkz4WcZMa8TpdgIwadn4OzY1dStxM+mp/wScB7qBtdn//+eP86BG4/ZEUXUBhVll2ERZHLfXZcBtNhsltWpxPFEaw+Mz4sJmoyRbPI+XxPCY/Dlyq3WAeHEUT8CIA5Rk8WhhGF/IK+G5SS1aYI2XNqjjI/kh/GGfhJc1FCMERBIh/Bb+F6W1RQibIJQXJGCiCIO6mhU2QSgelCjEoK7sbTYboZifcJ4FXlOAzW4jEPVbUoyLqwqwO2wEo34iCZliXFiVj91pxx/2EbWgIBdUJHC47PhCXtm/JIu7PE78YR8xC4pyfnkeLo8TX9BDrFimIOeX5eH2ufAFvcSLZZXiRGkcl8+F2+e2pDAnSuN4/B48fjeJUnktGS+O4vk/7L13mBzXeeb7VnXOOU5PzjnngEkAJiDMAJgEzACDMEMSBMEABjATBEmToAJFUZKtsJKu7bXXe++15fV12HXc+9iy1/KKtgLFgDwIk3PsUPtHdReq6tQQFAUSpFTv80Bgz29OdXU1VKfO973n+wwaqHVqySrHDp8NerMOap0a7gSS27026E1aqDUqyf4rNo8VBoueLa2fTFqgrW4LDBY9lCoFfBIW6NKthfjOz76M1/77szj7p6clKynLEuqjJML/jWGYUtHPfvRRljF3Q3J46pYeqHqSa8oEsE/TG6sbXPLY4jILdsCqtSqEgmEuji7mSpUCDAMuTi7mNE2BVtBcHFzMAWHy3Oo2Ezt4+YlRq9tC7NDmJz4lOc/CKsX5iVEpzk9mfxzOt5VK81u1j6Q432wgdX0MFh2W51kudX35ZgaL00TsoDda9ezudABmp4nYgc+3oEq11+XbiqUsxvyWuFIWY/4xpSzE/HMyWA1YFlmI+Z+Zfy2kuJSFmH9NTTYDnvz9B1HeRrrufhN1JxPhf0dRVD9FUXT0Ty+A/+9XP0VZn7TEDwQavQYHnu2BzqRF+7EWIlGu0qhw6Ewv9CYdth1qRGKOcPOXUqXEkZf7oTfp0DLYgNTCJAGnaBrHXj0AvVmHxr4ayf4PI68PQW/RoX5vFXKqyf4NI+dYi2/N7nLkN5D9G0ZfH4LRqkdVZwmKW8j+C6OvD8JoM6BsexHKt5MW3WPnBmGyG1HSWoCqnaUEP/rqAZgdRhQ25qJWwqJ77NUDMDtNyK/PxpZe0kB45JX9sLrMyKnOQFM/adE98nI/bB4LMivSJEMhh17sh91nRXppCtokLLoHz/TBEWdHalESdkhYdIee74Er4EBSXjx2399G8APP7oM70YWEnAD2SFTRHXiyG95kN+Iz/dgrUUW377Fd8Kd54U/zou/x3QTf+8hOBDJ88KW40f8kadHd81AnErLj4Ely4cAzZJXd3fe3ISkvHu54Bw5KWHh33LMVKYWJcMbZcegMWUW3/VgL0ktTYPdZMXyW5NsONSKzPA02jwVP/cHD8oTxMfRRVhqLYHeAx2wUCgCx6Z9hGIZck99FySuNW3qs9Qze/tufcq/FFlz+Uy9AVjUVb8YSVzUVW0zFlkzx8fj2TpYLLaZiS+XtuPh8xJbK23KRpZjkQouq2OIrrsIqtvgSXGTxFVuWCS66nixnEPu/LGFxpQAK4Lj4eostwlIWVpqmEYnu95GywPKvkZSFlT+Gf6xb/NZ7UjQFMLc+j/icKTpqd+Zxvm1XbImWuibiysr8a05RFB759n1oOyxXRQLu4EqDYRgTwzA0wzCq6B86+jPTZ23CkCXU2T89jaHneqA369B1oh0JWeKVgwK9j+6GUq1EY18tUgvFZR8o9J/uhkqjRP3eKqJ/RigYxoFn9kGlUaFmdzny6oQrg43VDRw80wu1VoXKHSUoEa0M1lc2MHy2D2qtCmVtRShvLyL5SwNQ69Qo2ZpPrAw2VjcwfLYfGr0ahU25xOa8jVV2vEavQX59Nhr7aoR8bQOHX+qHzqhFTnUG0T9jYy2Iwy8NQGfSIrMiDduGhTeX4HoQh1/qh96sQ3pJMtqPtUjwARiseqQUJmLHvVsFN7DgRgjDZ/thshmQlBePrgfahXw9hOEX+2B2GJGQFYc9D3UIbrChjRAOnemDxWVGIMOHnlO7BDwcDOPgmV7YPBb4Uz3ofbxLMKmFQ2EMPdcDu88GbxK7MuDf5MOhCAaf2wdnnB3uBCcOPLNXMElEwhHsf3ovXPEOuAIODD67TzDJRCIRDDzZDU+iCw6/DUMv9AgmKSbCoPex3fCleGDzWHHwTK9gkmMiDHpO7UJcug9WtwXDZ/sFFmCGYVcu8Zl+mJ0mHD7bT+wT2f1AO5KipU2Gz/YLJmmGYTDFa48s66Ppl+rc93mQvNIgFQqGoFQpcbLmKbzzz+9zP48ltteW16FQKmDzWDAVdScBbG8GpVqJlcVV0AoaDp9N0INcoVRAo1djZWEVNE3BEWfn3EkxxUpb0DQFZ8CBiStTAh6Li1MUBXeCU+BOAm7FwCmKgjvRifFLIs6LgfPtrjHxY9xSnJ9XiPUb5ytmEd6U+2yYiTq+pLjDb+OKPvLttDE54+zcNZca7wo4uGsuyaMW4s14rEc7y90C9xZwy2K82fXhc0+yG+Mi7k1yc7ZrT5KL+H68yS7cvDhJHCsmX7IbN6LHlOLeFDdn23bFOwUWcfFn5l8LjvOuOf9ax3ToTB8GnyWbTf0m6k7mNGR9zqVUsZbD0dcPchZYb7IbrngnF14Kh8JYXljhVhOeRCf8aV5uh3ckHMH81AJX8NAZsCMxJ8AlGiMRBtPXZ5Fby+YpHH4b0oqTuVpIkQiDiStTXJ7C5rUioyyVS6QyDIPxy5OcBdTqNiOrIo1LmjIMg/FLkyiM9uSwOE3IrsoQJHJvXpzgylibHUbk1mYKEsU3L06gpJVd7RhtBuTXZwsS0TcujHN9qA0WPQq25AhKid+4MI7SbSzXm3UobMrlJowYj3Ub1Bm1KGrO4yYMALhxfhzlbexqSmvQoLglX3ATu3HhFtfo1CjZWiCYpFnOxuDVWhXKthUKbpIxTtEUVFoVyrYXCibpGxcmUNHOcqVaifK2IsFN+ubFCZS3FYFW0FCoFAQf53MljYr2YsE+nfFLkyhvK4JCpWB5RzE3YQDAxOUplG0vglKlAEVTqGgv5iYMPldplCzvKBbs85m8OoXSbYUsp4CK9iLBJDl5dRqlWwug0aujPWKKBJP01LUZlLQWQGvQgKIotByoR9tRMm8k68Ol3AxQFPXnAI4zDHPp0zsdWZ+k9CYd9NHKtjqjlkiUAxTHtUYt54+/hSkYLAZuvEIl4gBni9XqNVB+HG5mj6/RaTh/vXA8y9U6NVSSnD2+WquGSq0iuN6sA0VRUGvVkse/xVWcf1/AjTr2pqyR5jrTLa7WqgmuNWhBK2go1UrCAg0AOqPuNlwDhVIBpVoJ9WacZm/qGh1pgdYYouNVSmj0JI+dH62gNuHR742S5hq9BgolDSbMSI/XR697MAytUUuO16mhUCrAhBloDdJcpVYhEmagNZIWbbVODaVKgeB6CDoTyQsbc/HY9+7H1Ng0siSq3Mq6vTYNT0VdUi+BrW57Ltqx7zMvOTy1ucThKY1ejUgoguBGCBRFweo2C5rgqDRKABSXzOWHagCAVtJQKhVcstjuswqaQAFCi2tst7eA85Ll/FBOTPx6UrHd4JtxqfAD33b5cTi/iqoU59tGpTjflirF+RZUKc63zUpzM+an2NWU1PXjh+ekrr/VY+EaG/FDbTHZPBbu34T4+wfYFWOs8ZIU5/+bkLIY889JkvM+k5TF+Lac92/G7rPhqd9/EIWNwg6Sslj9yuEphmH+CEAxADOAH1EU9ShFUY/E/tzBc5V1l6TWqtH7RBc0ejVahxq4BksxKVVK7H+qG1q9Bs3767gGSjHRNI3BZ3ugNWiwpbdGsn/CwRd6oTVoULenEmnFSQQffrEPOqMW1bvKJKvkHjzTC51Ji8qOEm53tpjrzTqUbitEfgNZJffgC73Qm/Uobs5DsUQHtoPP93ChqLK2IoIPPbsPRpsBeXVZqOosIfjgs/tgshuRXZWO2q4Kgu9/eg/MThMyylNRv7eK4ANPdcPiMiOtJFmyim7fE12weSxIKUhEyyDZq7rvcbYWVFJuPLYeIl1APY/uhCPOhoTsOLSPtBB874OdcMU7EJfuQ+doK8G7TnbAk+SCP9WDXcdJC+/u49vhTXHDm+TG7hMk33HPNvjTvXAnOCUtvG3HWhDI9MMZcKDnFFmFd/twExJzAnD4bZIW39ahLUjOT4DNa0X/EyRv6q9FalESrG4zHvnWvfKEcQf0oYlwiqLUAE4D2A92FzhnjYiWSP/MSV5pbK5nd72Kf/6zf+Nei6vCil+LLbXi1+Kqq+LXYsuqSqsS9KgWW0rFFlWxJVXMxfZK8e+LOfFaVHX1l+Viy6rY4iq2rIq52LIqPh6toBAJMzwuPJ54/G1fiyywYgux+LXYEhsrF8K9FnOp36eENmS+LZntt0Jx50RRrGd4s9+X/ozCa0ReM+E1ffh37kHHCDk5yroDKw2KotoAvA1AD6Ak2lPjTOzPHTxXWZ+Snv9/HsW9XzwUrUDazdWViolW0Bh8bh80ejVaDtQjvUTYNoVhgEMv9kGj16CxrwY5oif/4EYIR17ZD41eg/q9VVzdI46vBTHy2iC0Bo1kf4zgehAj5wahM2pR2VmCyh2lJH99CDqjFmXbi4gn++BGCKOvD0Fv0qGkJR9beoSb70IbIYy+fhB6sw4FjTlo3l9P8Hu+cBAGix55dVnYeqhRYvwQjFYDsqvT0SGy2IaDYYy+PgST3YjM8lTsuHcbwUe+MASzw4S0kmTiyTwcCmPk3BAsLjNSChOx9+GdIh7BsdcGYfNYkJQbj55HhTwSjuDYawdg97Eri/4nuoQ8EsGRVwbgjLMjkOHDftHmukiEweGXB+COd8Kf6sXQcz0CCy/DsG4jT5IL3iQXDp3pE/IIg6Hne+FL8cCd4MTw2QHBDR8ADjy9F3FpXjgDdhx+ZUAwiTEMg4HT3YjP9MPht+HYqweI8b2P7kJiTgA2jxUj5wYFEwQA7HtkJ1IKEmF1mTH6+iCxD4XoES7rl9aH5TT+fwD3Mgzzs0/3lH41ySuN24thGFAURfTfUGvVYBgGwfUgKIqCzWsR5CiUKiVoBcWtHsQxdIqmoNGquR4dUjF2/mrldjmM2+YgohVtN+N8u2pM/DIbUpyfo5Di/BzFx+H8HIUk58XlXQE7JkWfjx/3dwYcxD4DAZe4fjaPFbPj7Hcqdf35OQqH347p68Lx/LyHVI6Ef0ypHAn/nPjvJcl5+RSO875zqRwI/5pIlWE5/NIA9j/1mWw6etd1J3Ia9Z+3CUPWR1Ns5/EDbx3jqqQmZMchLt3LhX8YhsHK/CpnYQ1k+pGYGxCEm+anFrnVgj/Ni/SSFEFTp+nrsyhvZy2ivhQ3sirSBOGt6euzqIz2zHAnOpFTnSEIj01dm0FVdLXhincgry5LUEtoamyG2/Dn8NtRsCVHwCfHplGzmy0FYvdZUdSUJ2gyxedWtwXFLfmCWkiTY9Oo7a4ARbEl30u3FghqLU2OTaO2i+UmhxFl24sIXrenEhRNwWgzoLy9WFALanJsGnXdFaAVNAwWPSo7SwSJ3MmxGdTtqQStoKE361C1o0xwk5wam0ZddyVoJQ1tNC8k4NfY8QolDY1ejZrd5dyEEbv+dXsqoVQpoNapUdtVIbiJT1+fQV13BZQqJVQaFWq7KgSTwPSNWdR2V3BOs7o9lYJJaObGLGq7KlinmkqJ+j2Vgkls9uYcanaXQ6NnHU/1e0V8fB7Vu8o4R1b93krBQ8LcxDyqdpRCZ9KC5vg0jy+gqrMURqsBtILGznu3SZZekfXLaVPLraxff22sBbkyG8H1IFeiOiYGEHApi2nM+RRcDxIlJYQ8JM2jxw9thAQNhSR56EN4MESEIgBwkxg7nuQbq+sfOn59ZQMMwyAcCiEkNX49yoNhoitd7PyYCMvDEnwjet3CoTBCGyQPrgfBRKI8GJLgG2DCEURCYUE+RzCeYUNP4t3SMR6JMEA4IsgXcXwjBIaJAAy9yfhb1y24Jj0+EomAYSLYkDh+aIP9dxEOR4iugiwPg4lEEIkw0jwYRiQUAbPJ+Ny6LDz63eOYHZ9HUm48wWX98pJ3hP8GiwhP6dSgaQpry+ugaQp2n03w5KdUK6FSK7G6tMZyv03w5EfRFHRGLVYWVkFRFJwBcod4LDxEURRc8eQOcX54SGqHMD/8I7UDmV9lVZLfwR3kUpwfcpHi/JCNFOeHd6Q4P3xzW57kwk3R5+eHb/gNpWLi76r2JDoFTbgA4Q5z/n/HxD+mK8GBySvC75//nUqF5/jfmVR4js+lwm/8a+JL8eD0751EThXpupNFSt4RLuuXlkqtRNeJdqg0KtTvqyL6EygUNPY82MHWmuqq4HptxERRFPY9shNqrQrVO8uQkE22k+15bBfUWjXKO4qRnE8++fU8ugsanRpl2wuRVpRM8lM7odFrUNySJ1lFd9+pndAaNChozOEaLAn4IzugNWqRV5eFvGgDJb72PrwDOpMW2VUZkvbMPQ92QG/WIaMslailBbDtcg0WPdJKkrnd3XztPtEOo82A5IJEVHWSVXZ33d8Gk8OIxNx4ySq7O+7dBovThPgsP1FrK8atbjPiMnzY0kdaeDtHt8LutcKf6iFqbQFA+9EWOPx2eJJcaBkiq/BuG26EK94Bd4IT2yQK/bUMNcCd6IIzYEf7EdLi23KgHt4UN+w+GzokLL6NfbXwp3lh81gIIwEANOyrRnymHxaXGTuPbyd4bVcFEnMDMDtMGDk3KE8Yn4DklcZvsF7q/xL+4Y9+yL0WV7UVV5kVV8kVW2q1eo0gpyG2qIotuWJL6+24uGqt2MIqPh+iKu5tuNjSK7Z33paLLL9EVVwxF41XqpSCEJS46q34ehBVbwkOYVVb0fUSn6Nk1SyuMSwAACAASURBVFveOUpVvRVUtZWoeksraUS4qrfC6yE+J7G9VvyZpKri8v+Nia8XAJz8+gh2Skw+skjJKw1Zt9VT//khnPr2ffCnejB8tp/oj0HTNI68PACdUYvWoQZklQs33zEMMHJuCDqTFk0DtVxr05jCwTDu/dIw9CYdGvZVEf0vQsEwjr9xGHqzDrVdFcTmulAwjONfOQyDRY+qHaWo3in89xwOhnH/m0dgsOhR3lZEbJ4Lh1hutBpQurUAjaL+FuFQGMffPAKjzYCiply0DgmfvCPhCO5/8whMDiPyG7Kx/UgTyb9yBGanCTk1megUJVkjEQb3v3kEFpcZWZXp2CWy2EbCERx/4zBsHgsySlOw56FO0fVlcM+XDsHusyKtOAk9j+0i+RcPwRFnQ3J+AvpEFluGAUbPDcEVcCAxJx4HniZdQ8deG4Qn0YX4TD8GJfpXHHl5AN5kN+LSfRg+00fwQy/2wZ/qhS/FgyOvDBD84PM9CGT44Uly4ehrBwh+4Om9SMgOwBXvxOjrQwTvO92NpLwEOOPsuOcLByF+xu05tROphUlw+G2478uHiNI4fOODrDsjeaUhi9OppufxH//wc+61SqNEJMxwT59ii6NCSYOiKO5JUMwpin165jr18UpW3HqPW0/vUhZL/upAkvNWH1KcX6ZEyuLJtwDz7ai3uBZry2ubcv7qTOr9+RZgqfF8C7DUeH4ZEynOzwFJWVBNNiMWZ5einLSgmuwGLM6w46XKcPDLnEhxvoWYn0/iOG+MNDdhfjLayc9uxJKoEyD/M0l1+hNwXlfCmI69Oii5k1wWKXmlIeuX1iPfupezsKYWJSEpN14QrlhZXEVNNM6eUpCItJIUQThkcWYRddE4e1JuPLKrMgThmLnxeTREu93FZ8Uhry5LEO6ZHZ/nel7EZfhQ0JgrCCfNjs+jaT+7WvClelDcnCcIV82Oz6N5oBYUxSZkS7cWCJpAzd6cQ8v+elAUm/AtbysSWIBnx6OcpuCMs6Oyo4SbMGK89UADaJqG3WdF1c5SQThvdnweLQcaQCtoWN0WVO8uF1iAZ8fn0DpYD4WShsVpQm13heBJeHZ8Hq2DDVCoFDA7jKjfV8VNGHyuVCtgtBnQ0FMtuInOTcyj5UA9VGolDFY9GvtquAmD5QtoOVDP9gw369DYX8tNGAAwP7mA5v310OjU0Bm1aB6oE7R7jXGtQQOtUYvm/XUCC/HC9BKaBmqhM2qh0bEbRPmTzML0Ehr7a6E3sT3BWwbruQkDAJZmlrCltwZ6ix5qjQqtgw2CSXBpdhkNPdUw2gxQqZVoHRLxuRXU762C1W2BSqNC/+lu7Douh6butGTLrSxOU9dmOGfK7Pg8jFa98BciDI/PweIS9uBiGHB8bnIBtIJ8Jon1Y1iYWoBaS1p4Y6W2F6YWoZeoUjoeLbW9OL0Es91Ijr88CYYBFmeXJEMTNy9PgGHYG4z4qRQAxq9OgYkwWJ5f4cq6C/kkIpEIludXBTfcmCavTiESjmBlcZV4agaAiavTCIciWF1aI/pvA8Dk2BTCwTBWl9axILF7efLaNEIbYaxhnXjqB9i9E6xNliFWFTG+sRZEKBgmVn0AMHOT5RRNYUa0KgLYvRexiVhcnBBg/92sr7I2ZPHGPwCYG5/D6vIamGgpfbHmJxewvryOSDiCKdHGwhhfXVxFOBQhnFMAkF2ZjlPfuQ+LM0vwJrkJLutX110JT1EUZQdbyyoJwCUAvQzDEP+CKIoKA/hJ9OUVhmF2iX9HLDk89fH1SONz+Mn/fId7rdaqoNGpsTi7DKVKAYffLrBoKpQKGCx6LEwvsjzOTlhcrS4z5iYXoFAq4Ip3kBbVaMiFVtDwJrlw/bx0EySapuBN8eD6BzeFPGphpSgK/jQPrr0v5LFdzRRFIS7di7H3bgg43/YZyPCRnNf4Jz7Tj6vvXhdwvu1UivMtovFZflz9hZDzmxhJcX6TofisOFz9xTUh5zUZkuL+NA+ufzC+6fnFpXu5axbI9GPsw3iGH2PvCTn/mkldP/7P4tJ9uPa+kMdn+nD13RvRc/US3y//mvhTvbh+fnOenJ+Ax79/QtJ1J+v2+qyHp04D+BuGYdIB/E30tZRWGYYpiv657YQh685KoVRg26FGKJQKlLcXwZXgFHCKptB2pBlKlQLFWwvgSyaf7NqPtUCpUqCoOQ8BkUWX5a1QqpUo2JKDQKZfcrxKo0Refbbk5iyWq5BdnYEUiSq77UeboNapkFWZhrRi8may/XATNHoNMspSJC2824cboTVokFachKxKsv/C1kON0Bq1SM5PQE5NJsmHtkBv0iExNyBZhbdlqB4Giw6BTD+KmsgqvE3762C0GuBP86I02iCKr+aBOpjsRvhS3FwDKL4ae2phdprgSXKhooOs0tuwrxpWlxmueAdhNACAuj1VsHktcPhtqO0mLcC13ZWw+22w+6yo3UNagGt2lcMVcMDqtqB+H8krO0vhTnDC4jSjsbeG4GXbi+BNdsPsMEpWAS5pLYQ/zQujzYC+J7rkCeNT0N1aabwLoJFhmBsURfkA/D3DMMT/4yiKWmIYhoxBfIjklcbH1xePfh1/+d2/417zk7gAaVnVm3RcZz+AtNiKq+aKLZtiC6/YsnlbLqq6ezsutnTejvOT6ABp6RRbksUWWDEXv4fYYgyKPUaMi6+3+DNKcYWC5nbWi6sKA8LvQGwhBoQWV3EVYjEXf9/in4ktwIDQdixlAeafs5QFWK1RcTvLpSy+D7x1DLsk9m/Iur0+6ysND8MwNwAg+vdmwUctRVE/oijqnymK6trkd2TdIZ36znE8919PIbUoCfd9eZiockvTNEajVWBbhxq41q8xMRGGs8g2DdRxda1iCocieOCtozBa2SRuaavwyTkSjuDk147BaDOgrrsCFe1FJP/6MZjsRlTtLOXqRknx8rYi1O8TWnCZCIOTXzsGs8OE0q0FxJMrE2Fw8hsjsDhNKGrKw9aDDULOMHjga0dhdZtR0JCD9qMtBD/x1aOweSzIrcnEjnvIJOz9bx6B3WtFVmU62X+CAU68eRQOvw0ZZamS/Sfue2MYroADacXJ6H2MdAWNfvEg3AlOpBQmYv/pboKPnBuCN8mFxNx4DD67l+BHXz0AX6oHCVlxOPQCabE9/PIA4tJ9iEv34fDZfoIfPNOL+Ew//KkeHH2VtNgOPrcPiTkBeJPdGD1HWmwHntyD5PwEuBNduPeLBwne+8RupBYlwRXvwH1fHiY4f5KX9cnoE1tpUBT11wC8EuhpAN9nGMbK+91ZhmFsEsfwMwxznaKoFAB/C6CFYZjzEr83CmAUABISEkovX758pz7Gb7Qe3/oifvw3P+FeK1UKRMIRboOW2EJJK2iAYXjcRCR7+U+HUpz/dCnF+U+vkpz3pCvF+U/P0vzW07cU5z/dS1lI+RZgKc5fffBLosTE3yApyXmrL76dNia+BVjKospf/RmtBiLZz19d8u2+t7geKwvsz/h24Zj4PzOYdVjmrVTFxxSvZMXnLF6pirl4JQoA93zhIPY9QjZzknV73fWVBsMwrQzD5En8+QGA8WhYCtG/JzY5xvXo3xcA/D3YToJSv/dNhmHKGIYpc7lcn8jn+U3U498/geb9dQAF5FRnIK0kRbCjd2VxDVsPbgEoIKsiDdlV6QK+OLOEtiPNoCgK6SXJKNiSIwgnLEwvov1YCyiKQmpREoqb8wThCI7TFJLzE1C6rVAQ7liYXkTHSAtoBY2EnAAq2osF4RKWt4JW0Ahk+lG1o1QQblmYXkTnPa1QKBXwp3lRvbtcEK5ZmF5E5+hWKFQK+FLcqNtTKQgHLUwvYcc9W6FUK+FOdKJhX7XAArwwvYTO0a1QqZVwxTuwpa9GEK5anGHHq7UqOOLsaN5fJ9hRz3GdGjavFS0HGgQ3ycXZJXSOtkKj18DqtmDrwS0CC/DS7DI6R1qhNWhgcZqw7VCj4Ca8NLeMjmMt0Bm1MNkN2H64SXATX55bQfvRZujNOhitBrQdaeYmDIDdONd2pBkGiw56sw7tR1sEk8jywiq2DzfBaDNAZ9Ki/ViLYBJaWVjFtkONMDuM0Bq06BxpFUxyq0traB1qgMVlhkavQeeokK8traFlsB6ugAN6kw5Hf+uAZPdAWXdWd8ty+6cADgF4Nfr3D8S/QFGUDcAKwzDrFEU5AdQCOPepnuVvuC7+5Ap+8b8+ABjg6i+uweK2CDjDMPjFv7wPMMDYezdg94kXiwx+/sN3wTAMxt6/AXcCOaG/88P3wDAMrn9wExGJRPo7//IemAiD6+dvElV4Wf4+IuEIxi9OQK0mLby/+F9RfmkCOoNGgn+AcCiMiStTMFoMBH/vRx8gHAxj8uo0zHYTwd/90XmENkKYvjaDcc8kwT/48QUEN0KYvj7L2Y35ev/HF7GxFsTMjVnOJSUY//ZFbKxuILgexI0LNwl+/t8vY31lHRur64QzCQAu/OQy1pbXsba8jrH3rxP84k+vYnVpDRRFEc4rALj88zFuIrkixd8Zw/L8avR3rxL86rvXuBv95Z+RfOy961icWQbDMLjwkysEv/7BTSxMLYBhgAv/QUYQ0otT8NBv34PVxVXYPFaCy7rzuluJcAeAPwKQAOAKgB6GYWYoiioD2/jpGEVRNQB+B2yLWRrAGwzDfOd2x5YT4XdOj7W8gLf/7lZLFZVaCbPThOnrs9Do1HD47QILJE3TcPhtmBybhlqrgiveQVhgYxZVlUYFT6KTsGjGqqSq1Ep4U9ykRTVaxVSpUsCf5sOVd8YEPGZRVSgVCGT4cPnnQh6zddIKGglZcbgkupHFLKY0TSExJx4Xfyq8kcUspDRNITE3HhdFN7qYBZSi2NWR+EYXs8VuxhNzAtw5pxYm4vy/b85TChNxQcST8uJx6adXNx3P55Lj8xNwKfqZpHhyfgL3mVMKEnDhP4SfP7kgERejn4n/uzGlFCRyn1mS896Tf65SPKcmE6e+fR8SsuIg61fXXQ9PfZgYhplmGKaFYZj06N8z0Z//iGGYY9H//ieGYfIZhimM/n3bCUPWJytaQaN2dwVomkJOTSbsftGTHQXURpsKZVWmwxlwEMeo31sFWkEjsyIVnkRy5VG3l20alFaaQlTZBcA1DUopSoI/zUPw2mjToOT8BAQySItvze5yKNVKJOXGIyGbvNnU7C6HWqNCQnYAiblkld6qneVQa1WIy/AjuYC0+FbtKINGp4Y/zYuUQpJXdpZAa9DAl+JBemkKwcvbi6EzauFNciNTVOsLAMraiqA36eBOcCJbwgJctq0IBosOzoAdOdWkBbi0tQBGqwF2vw15ddkEL2nOh9lhhM1jQUE9aREubMqDxWmC1WVGYSNpES5oyIbVbYbZYUJxM1kFOK8uC3avFUabASWtpIU4tzoTjjg7DBY9SreRVYKzqzLgindAb9Zh+3CT5Hcs65OVXHtK1qb62oP/CX/y1b/gXosTo+KqrOLEqNgSKU58ii2ut+Pi47MOWIqzwBLjRRZYqcQr/z0ILrLAii3GgNDCejsuriIMCBP7Uolfvi1VivMtrGIL8Ufh/MS+uEoxy9XYWGPzMIRFWPQzKQswP/EvxfnnJGURFnAJi/CJrx7F7vvlPMad0Gd6pSHr86H7v3IEr/7VM8ivz8bD37wXGaXCzW8UTeH4G4dhtBrQcqAe2aL+FUyEwQNRC21jXy3Rn4KJMHjwGyMw2Qyo31tFbF5jIgwe/O0RmOxG1Owu51rHcpwBTn79GMwOIyo7SQsuwzA4+fURmJ0mlLcVoUFkwQXY0tkWlxklrQVoGqgTQoblVrcFRU15aBVZcAHg/jdZi21+fTbajjRL8COw+6xRCy7ZavT4G4fh8NuQVZGG3Q+0E/y+Lw/DGXAgozQFex/uJPjoFw7CleBEalESeh8j97+OvD4ET5ILyfkJ6Jew4B75rf3wpbiRmBPAfokquMMv9SMuzYv4LD8OvtBL8KEzvQhk+tkquC+RFtzBZ/YhITvAWnB/i7TgDpzuRnJ+ArxJboy8Nkjw3sd2IbUwEe5EJ+75AmnRleomKOuTlbzSkPWR9VTHy/jXv3ybey3enCVeiRArBTEXbZYjOcBfSUhxirrVo0HKAspf7Xwczl8pSHLeNZDi/JWE1EqHbxGWWqnwn66lxvOf3nUmHVYXP4RLrFT4KwV+RV9uPM9CLN7syI65tRKQ5LzVi9RKhW+bFfdLEZ8zf2NfTPd/5Qi6JCZbWb+85JWGrDuu0793Ep2jW0HRFAqbcomY+trSOnYd3w6KppDfkI0CUdmM5bkVdD3QzuZEqjNQ3JIn6H+wPLeC7pMd0ZxHGkq3FxF8z4MdUCgVSC9NQUVHicDiuzy/gu6HOqBUKZBalISa3eWC8Njy/Ar2PNzJ5jTy4lG/p5LkD7E8ISeALb3Vgh3sy/Mr2PvwDqi1KgQy/WgaqBVMmizvhFqrgj/Ni5bBeoFFeGVhFXsf3gGNns1pbD20RfCkvLLIcq1BA3eiC21HmgXhmJWFVex9qBM6oxbOgAMdx1oE4Z7VxVWus6DDb0PnaKuQL61xnQVtXit23rtNcBNfW15D1wPtMNmNsLot2Hl8u+Amvr6yjt33t8HsMMLiNGH3iTZBuGt9hf3+LS4zTHYjuh5oF4S71lc3sOPebbC5LTBaDeg+2SGwEG+sbqBztBUOvw0Gix57HuoUTHIb60G0H2uBP80Li9PENliSq9h+6lK88MILd/sc7qi++c1vvjA6Onq3T+PXUv/23/8Df/zmn2N5fgXzkwugaEqw+YwChdnxeSzNLWNhchEURRGb42Yn5rE0u4z5qQVQNM31645pYWoBC9NLWJhaBE3TmJ8SVmqdn17AwtQiFqcXQSkootLr0swS5iYXWE5TRKXXxZllzE3MY3FmOcqFlV6X5lYwNz6PxZkl0DRN9K9YmlvG7M05LM0ugaYpgq8srmHmxiyW55ZBURTRv2N1cQXT12exPLcCiiIrxa4tr2FqbIZbUYj5+soGJq9OY2VhFQyAmRsivraBiStTWF1cA8MwBA+ub2D88hTWltYQiURIvhHCzYsTWFteRyQUId4/HArjxoUJrK9sIBwMEzwUCuPG+XFsrG4gFAwRPBKO4Pr5m9hYCyK4HiSuDxNhcO39GwiuB7G+ukFc320HG/HofzqOXfdtR15dNmhafu69Uzpz5syNF1544Zu3+z35isv6yPrB1/6Cqwi7tryOm5cm4U9lHUx6sw5xGT6uCu7ayjrG3rvOuVt0Ri0Sc+K4iq8ba0Fc/cU1xEeLFGoNGiTlxXNVboPrQVx5Z4zrM67RqZGcn8BVbA1uhHD5Z2NIjBYxVGtVSC1M4iy8oWAYl356Fcl5CQDYME9qURJXpTUcCuPiT64gOT/K1UqklyRzexUi4Qgu/MdlpEQdUkoVu7rheITB+X+/jNSiJADsTvaMslRuL0IkwuD825e4Iom0gkZmWSou/Yy1yzIMgw9+fIkr1ULTFDIr0jgLKssvcg4rmqaQVZEmsOh+8L8vckUWKYpCVmWawCL7wf++iMxyIT//tjQHgKzKdJx/+9It/uOLyKxI4/E0fPDji5vzijSc/zF//CVBkcesCuH4829fQlZlGhemzCwX8gv/flnAy9uKULWzFCq1CgaJPTWyPh3Jk4asjy2KolDQkAOKAhJz42FxkpvfWE4hIScAq2hzIAAUNuWCoinEZ/ph95Kbswq35ICiKQQyfHD4iUozKGjIBq2g4E/zwhmwEzyvIQsKBQ1fihvueNICnF+fDYVKAU+SC24JC3BeXRaUKgU8iS74JPoz5NZmcju+YxMoXzk1mVBplHAF7IiTqPKbXZUOtVYNh9+GQAZZ5Te7Mp3bER4vsR8hszwVWoMGVreZm2D5Si9Nhc6ohcVpQlJuAslLUqA36WB2mJCcR1YRTitKgsGih8luREpBEsFTCxJhtBlgsBq4CZSv5LwEmBwmGMw6pJWQFuPEnHiYnSbojFpklJE8ITseFpcJOqMGZduL4I53Er8j69OVnAiX9ZH13Wf+AH/wW3/M5RnEtZFoBQ0mwtziNgMWeWUfKIoCRYHLQ4h57BixPAO/FSl7AHYD4aYcwtpV0vxWYluqthM/MS11fnwuVduJn3iWGs/nUrWf+Mng23OyvSk/MS2VmOdzqcS6zqDB6odxnm1YKnHP/5mUxZh/TKnaUXqLHivRc5ayCMsW209OciJc1h3X4ZcG8OYPX0bVjlI89Z8fEoQ2AHZSOP4V1oLbNFBH9JdgGAYn3joKo82ALb3VyN9Cbh478dZRmGwG1HVXorhFtPmLAR742lGY7EZU7ypDeTvZH+L+rx6B2WFERXsxqneR/R9OfPUozE4TyrYVom5PBcGPf+UwLC4zipvz0NhP9m84/pVhWN0WFGzJQetgPcHv+dIwbF4L8mozsW24ieD3fvEQ7D4bsqsy0DHSQvDRLwzBEWdHRlkqdt5PlvgefX0QrngH0kqS0X2yg+BHXtkPd6ITKQWJ2HeKLNx35OUBeJPdSMqLR98TZJXcgy/2wZ/qQUJOAP1PkhbdwWd7EMjwIZDhw+Cz+wi+/+k9iM+Kgz/Ni0MSFt2+x3cjMTcAX4obh8+SVXR7T+1Ecn4CPEkuHH1lP8HFpdBlffqSVxqyPrae7z6Hf/rBv3KvxRZcsQVUvNlP/CRK05TADSW2iBJcNF5s8RWPF1t8SQ7wLb5iCypFsf8Tew+pJ2H+Z5TaLMfnUhZVISf7cfBXUlIWVv53ILWZjm8Bvh2X2kzH/xl/4+AtfquKsFQ/Dv57SvXTuB1/6LdH0TlK7neR9atLXmnI+sR1+vdOoufRnVAoFSjbXoS82iwBX11cRd8TXVCoFChuyUdxc56Ir6H/yS4oVQoUNuaibLuwbMTq0hoGntoDlVqJvLosVHaWEuMHnuyGSqNCTnUGakWb+1aX1rD/qT1Qa1XIrEhDw74qgYV3dWkN+5/eA7VOjfSSFDT21wn42vIa9j+9Fxq9BimFiWgZbBBMSmvL6xh4ag+0Ri2S8uKxbbhRMCmuraxj/1N7oDNqkZAdh7ajzQK+vrKOgae6oTfrEMjwofOerSK+gYEnu2Gw6OFP9WDX8e2CKsDrqxvoP90Fo80Ab7IbXQ+0C26yG2tB9D3RBbPDBHeCE3se7BRYgDfWguh9fDcsTjOccXbsfXiHgAfXg+h9bBesbgvsPit6Tu0UTCLBjRD2ndoJu88Km8eC3sd2CSaJ4HoIex/eAYffBovLjL4nugSTVDgYxp4HO+CKd8DsNKH/NMl3n2hHUl48XPEOPPn7D8oTxmdAsuVW1sfWP/7xv+APX/sBVhdXMXl1CgwDIsZ/4/xNrCysYmpsGpEIQ/Dr529ieX4VU2MzYCIRIsdw88I4luaWMXVtBpGwBL80gaXZZUxfn0E4zBAW3/HLk1iYXsLsjVmEQ2GCT1yZxMLUImZvziEUChMW4MmxacxPLmBuYgGhjRDmRXxqbBpzE/OYm1hAcCNEWICnr89gdnwe81OLCK4HCT5zfRYzN+ewML2EjdUNgs+Oz2H6+iwWZ5extrJO8ol5TF+bwdLcMlaX1gg+P7WAyavTWJ5fwcriKsEXphYxcXUKK4urWFlYIfnMEiYuT2J1aQ1Lc8vE51+aW8bNi5NYW17H4uwSwZcXVnDzwgTWV9axML1IXN+VxVVcPz+O9RX2s4u/n61DW/DIt+/Frvu2I72YTJTLunOSLbeyPnH91ff+jtvnENwIYfzyJFekj3XjJHA+/VCQ9e+nlbAWVKPNgJTCRG6fQDgUxrUPbnIWVKPVgLTiZExdmwHAxrKvvX+Ds5jqzTqkl6ZgaizKIwzG3rvOFfnTGbXILE/FxJUpjl999zqyKlmuNWiQVZGG8cssZxgGV9+5xpVC0eg1yK7KwM1oOXOGYXDlnWvIqYlynRo51bc4AFz5+Rhyo3kclUaF3JpMzkIMsGXG8+rY1ZgyunralKsUyKvPFlQJvvyzMeQ3sEUGFUoF8huycY1XJfjyz29xWkEjvyEbY+9eF/BYN0VaQaNgSw6uEjwbFEWBpikUbskRlEu/8s415Ec5RVEo2JKDK+8IeUFDDmia5YWNubjCqzJ89RfXWLdbtMR9wZYcQRXiq+9eR35DDtvMC0BjXw1quyugUCig0ZFl7WXdHcmThqw7qljlWGecDXqzjuCJUVtobNcvMT6HHW/zsruGpY5PUYDda4XJtgmnKdg8Fpgk+l8kZAVA0RQsLrYSq1jxmX7QNA2L0yRpIQ6k+0EraJgdRkkLcVyGDwpllEv0d/CneaFQKWC2GyX7P/jTvFCqFDBYDXD4SO5L9kClUcFg0cHhJy3GvmQP1FoVDGYdnHGkxdiT6IJap4bepIVLogqxJ9ENtU4NrVELl4S91RPvgkavhtaggUeiP4orwQmtQQO1Tg13AjneGXBCZ9JBo1fDI2FhdsbZYTDroNaqkJSXALPdSPyOrLsrOREu62PrD1/9Y3zvuf/CxdktLrMgvEFR7BNxLE4u5oDQAivF+YlXq8uMOYLfSrZa3WZiBzjfoirFNVo11tc+hPOS0VKcn+yWOn++rVTq/PnJeKnxfIuqxWkiwj/8lqqSnGe7lWpfy6/nJdWelm8rlrIo838m1X6W/55SFmU+N1gNWBZZjB946xh2HSddZLLuvOREuKxPXP2nu/E7b7+OpoFavPiDJwgLLkBh5PWDMFj02NJbjexKsj/EvV8ehsGqR92eSuTXZxH8ni8chNFqQPWuMhQ2k/0b7v3iIRhtBlR0lKB0ayHJXx+CyW5E6bZCVHaQFt3RLw7B7DCiuDkfNbtJC+7ouSFYnCYUbslB/d5qgh87Nwiry4y82iw0D5AW3aO/dQA2jwXZVRloGSSr5B55ZT9sXisyy1Mlq+QOn+2Hw29DWkkKOiWq5B56sR/OgB0pBYmSN9eh53vgTnAiKS8eXSfJwn4H+fxJPQAAIABJREFUntkHT5ILCVlx2PPwDoIPnO6GL9WDQIZPsopuz6O7EJfugz/Vg/7TXQTf+3An4rP88Ca7Javodp3sQGJuPNyJTgw9R1p4f90ean8dJK80ZN0xvTzwZfz9f/kn7jXfvgmQFlO+ffTjcLGFV2xRJbjIonpbLrL48ntLAKTFV2xhFVt8b8fFFlexxVfKwso/BykLLP8zir8PMZeyuPJXguLvQ8zF11N8zNtxiqYA5lb/EwB4/Hsn2D70sj5xySsNWZ+6Hv/+CQw+uw8qjRJVO0uJ/hnrK+s4eKYXKo0K5e3FKN1WQPBDL/ZCrVWhZGsBKjqKCT78Yh/UOjWKmvNQ21Uh4hs49GIfNHo18htyiP4Z66sbGD7bD61Bg5yaTDSJNu/FuM6oRVZlOlqHhDerjbUNDL/UB71Ji/TSFGw/3CTiQQy/2AeDWY/UoiR0jLYKnpQ31oIYPtsHg1WP5PwE7Dy+XcCD60EMn+mDyW5EQnYcuk52CCal4HoIh870wewwIZDhx95Hdgj5RghDL/TC4jLDn+ZFz2O7BDfpUDCMwef2weaxwJvsRv/pLgEPB8MYfHYfHD4bPIlODDzZLajyGw6Fsf/pPXDG2eGKd+DAM3sFPBKOYODJbrjiHXD4bRh8rkcwCUXCEfQ93gVvkhs2rxVDzws5E2Gw79FdyKpIQ3ymHy/92ZPyhPEZlLzSkHXH9D/+r3/A1x/6LpbmlkHTFJwBB+deiikWA6dpCq54J1fgMKZYXJ2iKHgSXbh5aULAY3F7iqLgSXIJ3EsAYHGZMD/Jxshj/cL5snosmItWTpXidq+Vc3z5Uz0CdxPAJvCnr8+yPM3DFVCU5KleQQ91gE30xhxhsX7lfLkCDq4opBSP9Vjf7Pz43JfqwQ0R9yS5uKKRUp/fm+TCzQ/j0R7t4v+OyZfixo0LH43zzyWmk18fwY7ofhWFUgFZn57klYasT11//0f/yNVKikQYTFyZQm4ta0G1+6xIK0nmkqaRCIPxy5PIr2ctojaPBRllqVwilmEY3Lw0wfXksLjMyKpM5xK9DMPg5sUJzkJqdhiRU53BTRgAcOPCOIqa2DyI0WZAbm0WN2FwPJonMVj1yKvPEpTyvn5+HCWtbJ9rvVmHgoYcbkIAgOsfjHN9rnUmLQobc4X8/E2UbmPzLFqDBkVNedyEwY6/xTV6NUpa8rkJI8bLtheCoiiodWqUtOYLJuHr58dR3lbEcq0KpdsKBPzG+XGUtRWBoiko1UqUbisU3KRvXGDH0woaCpUCZdsLuQkjxsu2F3K8vK1IMAncvDiBsu2FUChpKJQ0yrcXcRMCx7cVQqFSgFbQKG8T8vFLkyjdVgilWgmKptBxrAUN+6pAUZQ8YXyGpbzbJyDr11sxW6vOqIVKTf5zi3GNQQOVhuQmB2u51Bo0UGlUBI/ZYrV6DdQS3BS1bGp0aqi1JOfeX6uGRqsmuNFmBEWx+Qy1XoobWK5RQSPFrXpQNBXl5F4Do1UPWkFDpVZBYyC5wWIATVNQqZXQGUkLs96sg0JBQ6lSQmvQkuPNeigUCijVCuiNJNeZdKAVNJQqxSbH10OhpEHRFHQmkutMOihUCoCBpMVaZ9JBqVIgEo5Ic6MWyuh4s9Ms+R3J+mxJDk/JumP6k7f+At96/He5ZC8/1BMTP9ls99kwc2P2l+J8Cys/FBSTzqDF6vLmnG9hdfjtmL4+I+S8Kq1S4/kWVkecHdPXhOP5lWelxvMtqlLvb7YbscBxcrzZaeJ2VUtxvu1W6vrxbb12n5VowsS3Bdu8VqJJks1j4RojSXMrZsfZn1ndFqLJFX+MlIX55NdHsPNeuRvf3ZAcnpL1qavrRDu+8/M30Dm6Fef++jlkEBZccInm2q4KZJZtwk1aVO0o5XZfC/iLfdCbdahoL0Z+PVkl99BZNhFdsrWAC03xdfAMm4guaspF2XbSonvwTC+MNgPy67NR2UladA++0AOjzYjcmkyi1hUADD7XA7PDhKyKdNTvrSL4gWf2wuI0Ib0sBY39NQQfeHoPrG4L0oqS0HKArKI7cLobdq8VyfkJ2HaokeB9T3TB4bchMSeA9qOkhbfn1E64Ag7EZ/kl6zjtfWQHPIkuxKV7ses+8ua9+4F2eJNd8KV40HWCLFG+6/g2+NO88CS5sPfhToLvuGcrAhk+uOKd6DlFWnhlffYlrzRkfWI6d/gt/I/v/wP3WmwJFVtMxVxsUeX3smDHCy2oYkupmIstpeLjiceLudhyKv59saX0dpxvV2U5hUiY4XHh+4ktvgoFjTDveGILr/j9WEsrj9M0IhH+eAgsvmLLcfTwnCVWfD7iMeLjid+TPV+hxfaZP3wYW3rJyVTWJy95pSHrruvR7xzH0VcPQKPXoLarAsXRpHJMwfUgRl4bhNagQdXOUpS3Cy22G2tBjJwbgs6oRXl7Map3lYnGhzBybhA6oxalWwuIJ/vgeggjrw9Cb9KhqCmPsNiGNkIYfX0QerMO+fXZxOY7lg/BYNUjtyaTsNiGgmGMvj4Eo82ArIo0dI62EnzkHLu5MKM0hdh8Fw5FMPLaIMxOE1ILk9D9YKeIhzHy2iCsbjOS8xPQI+qPEQ5HcPTVA7B5rEjIjkPfE7sFFt5IOIIjr+xnuwJm+jHwZLeQRyIYfmkAzjg7/GleHHh2n+AGH4kwGD7bD3eCE75kNw4+3yu4wTMRBgdf6IUnyQVPohPDZ/sEkwzDsCsrf6oHrngHDr88IJikGIbB/mf2obAxF+klyfjy/3xRnjA+B5JXGrI+Mf35t/4a33jke1zPCUecDdPXRDkGXg7BGbBzBQhj4vfM4NtRY+LnGFzxDkxeFXFemQxXvBOTV4UWYH5pC6nx/ByEK8GJSZGFmF8Gg2935TgvByHF+TkEqffnx/3d8Q5MiDg/RyB1ffh5JUnOy3tIXX9+3oRvF77Fb+VlpHI8/DFSOZiHf+cedIyw+1liKyVZd0fySkPWXdcP/+xHgiZF09dmUd7GribciS5kV6YL2oVOjc1wG/pc8Q7k1GQImixNjk2jcgfbU8MRZ0deXbagnenk1WlURbndZ0XBlhxuwmD5FLdasXksKGrOE9RCmrw6zXGLy4ySlnxBraXJK1Oo2V0OiqJgdrClSfi1nCauTKGmi+VGmwFl2wsFpcAnrkyhtrsCFE3BYNGjor1YUItq8uo0arsrQCto6M06VHaWCBLFEzGupKEzalG1o0yQiJ4cu8W1Bg2qd5YJjAgxrlAqoNapUbOrXJAonxqbQW1XBZQqBdRaFWp2lwtu8lPXZlCzuxxKtRIqjQq1XRWCRP50lKu1KijVStR1Vwgmmenrs6jeVQa1Tg2lSoGeUzuxpY9dWcgTxudHsuVW1qeqUJDNEURCYUGo4hZnY/jhUJiIlwNAKJoDiYTCYCTHs8cPByOSrUFjOY5wMCzJY+8fCUU2Ob8QGIZhuaikRuy4HJc6/kYITITl/HwG//2ZSGTT8eFgGEyYPTdxSQ+ORxhEwhGEw5ufH7PZ+FCYDTFRzCY8wl53ikI4GJIeH46AYRiiZEmMM5EIIhEGwfWQ5Hcs67MtOTwl6xPTX3737/CNh7+LlYVVUBQFZ8BOho944SV3ggMTV4Scb2F1JzoxcXnz8JIn0UXsMDfZDVic2Zzzw0dSO5T5FlYpzreVSnGb24LZKOfvtuY4L7wkNZ5vi5Xi/JCP1Ofjh4fciS5MiDkvJCUVPuOHzKQ4/2dS4TUBlwiPxcJTsu6+5PCUrLuutsNN+N67b6Ln1E688Y8vIaOU7LzW93gXNHo1KjpKkFqUtAnXoHRbITJKSYtu72O72d3WzXmSVXR7H90NnVGLgoYc5EV3p/PVc2ondCYtcmsyud3lfO17ZCf0Zh2yKtNR0pJP8L0Pd8Jg0SOjNAXlona1ALDn4U4YbWxDKXG7WgDoPtkBk92I5PwE1EpU2e16oAMWpwmJuQFJC++u+9tgdVsQyPRzoR6+dt63DXavFXHpPrTsJy28naNb4fDb4EvxSNZ5aj/aDGfAAU+iC9uGGwm+dbgR7gQnXPEOSYtv69AWeJPdcMTZ0THSQnBZnz/JKw1Zn5revP/b+G/f+Cvu9e0stQQXWVjFXGypVWlVCH4YF1l+xRZXwrIrssiKLcKE5Vb0eUhLrpILp0lz4eclLLeiz0NRlMAdJWXZ5VeRJSy5Ysvt7bjIsiv+mdiyCwC0kkYkdIs///8+hppd5H4XWZ++5JWGrM+cTn7tGO778mHoTDrU7alE6Tbhk3loI4T73hiG3qxD9a4y4sk8FAzj+FeG2SRyRzFqu4VP5uFgGPe9wfbnKNtWiC091QQ//pXDMNoMKG7OIzbPhUMsN9kNKNiSQ2yeC4ciOP6VwzA7TMirzUK76Mk5Ema5xWlCdlUGdoo2x0XCERx/4zCsbjMyy1OJ/haRcAT3fmkYNo8F6SXJ2PeI0GLLRBjc86VDsPtsSClIRN/ju4WcYTD6xYNwxNmRlBePgae6ifEj54bgincgISsOg6L+FQwDHH3lADxJLsRl+HDoTB/BD58dgC/FDX+qF8Mv9UOsgy/2wp/mhTfZjSOv7Cf4oRf6UNlZgoItOfjaj16TJ4zPoeSVhqxPTX/y1l/gm4/9Lvd0zy9JERN/9SBVpoLPpcqU8Dvp3ZZLlNHglymRen9+pz0pzi9TIsX5ORwpzs/R2LwWzN4UXh+j1cAVhZS6fnyL8O24VBkPfg5HqpOgxWnG/NTC5pz3M36+KKZT3zmONtF+F1mfDckrDVmfOb39tz8RhINmx+expZddDQQy/MhvyBaEm2ZvzqGxrwYUxZYBL2zMFfCZm3No6q8FRQHeJDeKW/K5CYHjA7WgaAruBCdKtxYI+Y05NO+vA0VTcAUcKG8r4iaM2Ps3768DTVNw+G2o7CjhJgyOH6gHraBh81hQtbOUmzD4XKGkYXWZUbO7XGARnr05h5YD9VCoFLA4TajbUymwAM/enEfLgXoo1UqYbEbU763iJozY9Ws5UA+VWgmj1YCGnmqBRXh2fB7N++ug0qigN+uxpbdGwOcmFtC8vw5qrQo6kxaNfbWCdrHzkwtoGqhje4IbtWjqr+UmDI7310Jr0ECj16B5f51gElmYWkRjXy10Ji00OjWGX+yX7G4o6/Ml2XIr664q5qxZmF6ATqIK68SVKTAMsDCzBGO0Yq2AX2X54uwSrIsWgk9enQYTYbA0tyzYE8LxsVt8eYHkU9dmEIkwWJ5fwfLCCsnHphEJR7CysCrYExLT9LUZhEMRrCyuEv2xAXbvQjgYxsriKhZnFgk+c2MWoY0QVrEmzW/OIbjB2oDFT/UAO3EE14OIhMNYmFqQ5BtrQdDBMOYn5wk+PzHP9linKKK/OQDMTc6zBSYZhljVAMD81AK7V4dhcPPiOFaX1qCWqCYs6/MjOTwl61PTP/zXH+KtE9/G3OQCaAUNd4KTaNITa5JE0xQ8yW6iiVCsiipFUfCleIgmR7EdzhRFwZ/mxbX3bwi534aZqEU1Lt1HcGfAgamoLTSQ4cPYe0LOt41Kcb7FNJDpx9i71wXck+jE+OUP4TxbrRT3Jrtw8+LmnN84Ser8+I2bJDmv8VNchg/XPoxLXL+4dC+uvX+T+O+YTn37Psle6LLuvuTwlKzPnLb0VON7772JQ2f68I1/O4f0kmTid3aMboVKo0RBYy4ScwIkv6cVaq0KefVZSC5IIHjHKMtzqjOQVkwev3OkFRq9BlmV6cgoIy3A7UebodVrkFGagqxKsspu29Fm6IxapBYlIbc2i+DbhhuhN2mRnJ+AgoZsCd4Eg0WPxJyAZBXerUNbYLTqEZ/pR+nWAoK3Dm2ByW6EP82L8jbS4ts0UAezwwRfipvbHc9XY18trG4zPIkuVEskoRt6qmHzWOAMOFDXXUnyfVVw+G1w+G2o30vyuu5KOOPssHutaBAZEWT9ekheaci6a/rW47+LP/rCn3KvtQYt1pZv5QzElk+tQSMoS3JbLrJ88pPgAGlh1eg1WBdxflVYfq8PqfFqnZoN5cS4yKJKjBdVeRVbiMWfUWwhBhW1uMa4yCIMCG230vyWjVhsEQaEtl+xBfgjcd4xVWolXvzT0yjbRpakl3X39ZleaVAU1UNR1M8oiopQFLXpSVIU1UZR1LsURX1AUdTpT/McZX3yGjk3hAe/MQKj1YC6PZUobxPeTCLhCB742jEYbQbU7C5H1c4ySW6yG1HZUYK6PcIn30iEwcmvH4PJYWQtuKLNb0yEwQNfOwaz04Tilny0DNaT/K2jsLjMKGzMxfYjTRLjj8LqNiOvLouocsswwIk3j8LmsSCnOgM7RVVuGYbBia8ehd1nQ2Z5GvY8RPafuO/Lw3DE2ZFekoKeR0X9Jxjg3i8dgivegdTCJAyc7ibGj7w+BHeCE0l5CTjw9F6SvzYIb7IbCdkBDL3QQ/DDL++HP9WDQKYfw2dJi+3w2X4EMnzwp3lx5OUBgh99ZT+29FajamcpvvXTL8kTxq+B7spKg6KobAARAL8D4FGGYYilAUVRCgDvAdgKYAzAvwIYYBjm5x92bHml8fnR//2l/4Zvn/597klYyqLJf3r9OJz/dM23k0pxqfH8p39JrlNhYzXKeRVvY+KvXswOI9cDPSb+6sfkMGJRxPkWX75d9qNyfhVhvp2X4zyLsBTnW4QNVgOW5z6M6wkzwOPfP4GtQ+ROc1mfPX2mVxoMw7zDMMy7t/m1CgAfMAxzgWGYDQB/CGD3bcbI+hzp5z98V7BjeWFqEduPNIGiKCTlxaOkNV8Q7liYWkTb0WZQNIWE7ABKtxcSvP1oM2gFjUCGHxXtxYJwzPzUItqPtYBW0PCneVG1o1TAF6YW0THSAoVSAW+yGzW7ywXhIpa3QqFSwJPoQl13BTdhAMDCNMuVaiVcAQfq91UJwl0L00voGGnF/2nv3sOjqs8Ejn/fcklIiCQhkAC5wYMgN2+g622FQr3AtvXS6pZtBYRKqbZ9cB/axbpVa0XKFmupFZRaCq3XB3m2RdcuihW3cjUgIYQkJORCQiCEO4GQBHj3j3MSZjJJOIFkZgLv53nmmTPznjnzzi/z5HfO+f3mPV26dqZn3zjGPHiL3+my4/XxiC7EJ8UyduJtflN8jx+qYsIj4+jarSuxvXsw7tv/HBAf/91xRER1pUdCDF95aLTfjLGqwycYP20ckdERxMR3545Jo/2mCFcdPsHdU50xm+5x0dw1ZYzfFOETR05w98NfJuqKbkT3iOKuh7/cKH6SOyePITo2iqiYbjy2YCpjJ97W7N/fdEzhPOW2H1Dq87gMCBx5A0RkOjAdIDU1cHDUdBw7MwpRVSqKK/lSp8B9mvyMQvSsUlGyny6RgV/f/C1FnD1zlsrSA01O4S3YUsjZM2c5UHaQ7rFRTcSLOHP6DAfLD9EjISYgvuuLIs7UOfG4xMApvoWZxZyuPc2hfYc50Kh4H0DhthLqak9zuOIoFY2K/wEUZZVQV1PHkcpjAcUNnXgptdW11NXUsbfRzDOAkuxSak7WUltdy95GM8sASnLKOHWihpqTNQEzzwBKc/c0dERl+U3E88obOpqyneUB8T0FexuONrLX5XL7AzcRnxQXsJ7puNrtSENEVovI9iZuXo8Wmiqw3+S5NFVdrKqjVHVUr169LjxpE1R3PTyW3qkJgDNImjyoL0XbSgCorjpFYWYJvdOcv2fnLp1IuaofuzKLAag5WcuuL4pJdOOdOncidUg/Cr4ocuLVteRvKaTPgN6AM6CcNjSZ/C1OvPZUHTszCukzINGJf0lIH5bMzs2FgFNCPe/zXfQdmHQuPjyFvIxdgFPSJHdTAf2u7AM4g9r9R6SSu6kAcEqO5GzMJ3lQo/jGfMAZj8nZsJOUwX0b2qP/1ankbDgX37E+j9QhyT7xNHI27ASc8ZQd6/JIHdKvIT7g6lR2rHfjCtnr8kgbluK3/R3r8s7F1+aR7hsfkUr2unMnALLX5pI+PLWFeB7pwxu9fu25+Jp31pGxKhNzaWm3Iw1Vvdh6x2VAis/jZCBw18Z0WP804XqW5PyG/1m8mhsnXM/Sn70VsPe6aPM8Pn79H4y88xrefH4Fpbl7/OIL1s/hH8s3cO3Y4az49XvszvGPv/DJz1m3MoOrbx/CyoWrKNlR5hef9+HPyFi1lSE3D2LVHz+hONs//tx7s8lcs4NBowaw5u21FG8v9Ys/vWIWOet3MuCaNNb99XOKsnb7xX/61kwKthSRNjSZzR9uC4j/eOlj7M7ZQ7+BSWz/LJc/bHvTLz7z1ensK9xP77QE8jcX8uqsP/nFf/DSNA7tPUJcUiy7c8p4+UdL/OLfmz+JqsMniInvTkXxfn4zY7FffOrz/0btqToioyM4sv8o86cu9ItPevoBEKFzl05UH69m7nd+6xef+MT9REZHoGed62/84sFfYy5t4Xx66nPgShHpD+wBvgUEVkAzHVpEtwjud6+NnTY0BVjfEEsZ3JeomG7c96MJAKQPTfGr5Np3YBLde0Rx7w+dwn+pjeJJ/XsTHRvNPY/d7cSHJPtNw01M60X3uGi+9n1nVlPOkHy/eK+UnlzRM4avfu8OAHZtLfabApvQL54eCTEN14MozS33m+Ia3yeO2F49GD/NKWy4r7jSb+A+LrEHcYmxDHF/D3K44qhf5dzYXlcQnxTLiNuc33ucOHrSrzLvFT1jiO8Tx3VjnZLtp2tP+w3cx8RFk9A3rqFk+5bV2/ym/XaPjaZXcs+G37NkfprtN2056opu9E5NYPANTsn57Wtz/Qbeu3WPJDGtF8NucUrO527K9xtYj4yOIDHdjvwvOaoa9BtwH86RRA1QAaxyn+8LfOCz3gScGVS7gCe9bHvkyJFqOq6sz3L038c8pctfWKl1tXUB8ez1eTpr7NP69ry/aG1NbUA8d1O+zhr3jL4xZ4XWnAqM79y8S39yx8/1z88u15rqmoB4wdYi/Y+7fqHLnn5Hq0+cCogXZpXoE+Of0yVPvqknq6oD4sXZu/Wn/zJHX5v9up48fjIgvju3TP/za3P11VnLtOroiYB4WX65PnXvPF30+B+16khVQLx81z595hu/0t/98A967NDxgPjeogp99sEXdMGjv9ejB44FxCt2V+pzE1/UF6e/oof3HwmIV5Yd0LnfWaDzpy3UQxWB8QPlh3Te5Jd03pSX9ED5oYD4oX2Hdf7Ul3XuQwu0cs/BgLgJX0CGevgfaz/uM8YYE95Tbo0xxnRM1mkYY4zxzDoNY4wxnlmnYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPLNOwxhjjGeX3C/CRaQSKAnBWycAgbWuw5/lHXwdNXfLO7iCnXeaqp63WNgl12mEiohkePkJfrixvIOvo+ZueQdXuOZtp6eMMcZ4Zp2GMcYYz6zTaDuLz79KWLK8g6+j5m55B1dY5m1jGsYYYzyzIw1jjDGeWadhjDHGM+s0LoCIPCAi2SJyVkSanRInIsUikiUiW0UkLC4n2Irc7xaRPBEpEJHZwcyxmXziReQjEcl37+OaWe+M295bRWRlsPP0yaPF9hORCBF5x41vFJH04GfZNA+5TxGRSp92/m4o8myU0xIR2S8i25uJi4j81v1M20Tk+mDn2BwPuY8RkaM+7f1UsHP04+WasHYLuMb5EGAwsAYY1cJ6xUBCqPNtbe5AJ5zrsg8AugKZwNAQ5/1fwGx3eTYwr5n1qsKgjc/bfsCjwCvu8reAd0KddytynwL8LtS5NsrpduB6YHsz8QnA3wABbgI2hjrnVuQ+Bng/1HnW3+xI4wKoao6q5oU6jwvhMfcbgQJVLVTVWuBt4J72z65F9wDL3OVlwL0hzOV8vLSf7+d5FxgnIhLEHJsTjn/781LV/wMOtbDKPcCf1LEBiBWRPsHJrmUecg8r1mm0LwU+FJHNIjI91Mm0Qj+g1OdxmftcKCWq6l4A9753M+tFikiGiGwQkVB1LF7ar2EdVT0NHAV6BiW7lnn923/DPc3zroikBCe1ixKO3+nWuFlEMkXkbyIyLJSJdA7lm4czEVkNJDURelJV/+pxM7eqarmI9AY+EpFcd6+iXbVB7k3t8bb73OyW8m7FZlLdNh8A/F1EslR1V9tk6JmX9gtJG3vgJa/3gLdUtUZEZuAcMY1t98wuTri2txdbcOpCVYnIBOAvwJWhSsY6jWao6lfaYBvl7v1+EflvnEP/du802iD3MsB37zEZKL/IbZ5XS3mLSIWI9FHVve5phf3NbKO+zQtFZA1wHc45+mDy0n7165SJSGegB+FxiuK8uavqQZ+HvwfmBSGvixWS73RbUNVjPssfiMhCEUlQ1ZAUYbTTU+1ERKJFJKZ+GbgTaHJ2RBj6HLhSRPqLSFecgdqQzURyrQQmu8uTgYAjJhGJE5EIdzkBuBXYEbQMz/HSfr6f55vA39Ud9Qyx8+beaCzg60BOEPO7UCuBSe4sqpuAo/WnO8OdiCTVj3eJyI04/7cPtvyqdhTqkfiOeAPuw9lzqQEqgFXu832BD9zlATgzTzKBbJxTQx0id/fxBGAnzl56yHPHOd//MZDv3se7z48CXnOXbwGy3DbPAqaFMN+A9gOeBb7uLkcCy4ECYBMwINRt3Irc57rf6UzgE+CqMMj5LWAvUOd+v6cBM4AZblyAl93PlEULsx7DMPcf+LT3BuCWUOZrZUSMMcZ4ZqenjDHGeGadhjHGGM+s0zDGGOOZdRrGGGM8s07DGGOMZ9ZpmEueiKSISJGIxLuP49zHae30fjNEZJK7PEVE+vrEXhORoW30Pve2tuKpiKxurkKwMV7YlFtzWRCRnwADVXW6iLwKFKvq3CC87xpglqq2eWl8EVmH89sJz78MFpHJQLKqzmnrfMzlwY40zOXiReAmEZkJ3Aa80HgFEUkXkVwRWeZTjC/KjY0TkS/EuT7KEp9fnv9SRHa46893n3tGRGaJyDdxfnw321hTAAACiklEQVT4hnsdhG4iskbc65iIyER3e9tFZJ5PHlUiMsctULdBRBKbyHUQUFPfYYjIUhFZJCKfiEihiIx288wRkaU+L10JTGyTFjWXJes0zGVBVeuAH+N0HjPVKfvdlMHAYlW9GjgGPCoikcBS4F9VdQROzbbvu6e77gOGues/1+g93wUygG+r6rWqWl0fc09ZzcMp9HctcINPVd5oYIOqXoNTq+yRJvK8FaeQna84d3uP4xQVfBEYBowQkWvdnA4DESISDhV1TQdknYa5nIzHKdcwvIV1SlV1rbv8Os5RyWCgSFV3us8vw7lwzjHgFPCaiNwPnGxFLjcAa1S1Up3S6G+42wSoBd53lzcD6U28vg9Q2ei599Q535wFVKhqlqqexSlB4buN/ThlY4xpNes0zGXB3dO+A+eqbY+3cAGexoN8StNltXH/2d8IrMC5KNT/tialFmJ1em6w8QxNV6Ouxqlf5avGvT/rs1z/2Hcbke7rjWk16zTMJc+tELoI57TUbuBXwPxmVk8VkZvd5YnAZ0AukC4iA93nHwI+FZHuQA9V/QCYiXOaqbHjQEwTz28ERotIgoh0ct/r01Z8rBxg4HnXasRtiyScSxEb02rWaZjLwSPAblX9yH28ELhKREY3sW4OMFlEtgHxwCJVPQU8DCwXkSycPfdXcDqD9911P8UZS2hsKfBK/UB4/ZPqlOV+AqdKbCawRb1f3AucsY7r6ktmt8JInPGS0618nTGATbk1poGIpAPvq2pLYx5hQ0QW4IxjrG7la1aq6sftl5m5lNmRhjEd1/NAVCtfs906DHMx7EjDGGOMZ3akYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPPt/4+W6FhppJ+AAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%matplotlib inline\n",
     "from ctapipe.visualization import CameraDisplay\n",
@@ -190,9 +426,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb2eed7630>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGAVJREFUeJzt3XuYJXV95/H3BxBQEeQmojCMl9EsKOBug/FRYVeYDVk3QIwoeGF0jUSMy6pPzLIPxhhidr3Fja6IsK5hNCo6GGVQvAwDqNmIoVEER0QuGpkFYfCKclGc7/5xasKx7cuvZ/pcZvr9ep7z9KmqX1d9Ts88/emqOqcqVYUkSS22G3UASdLWw9KQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDS1qSS5P8qMkO/XN2y/Jx5PcmeQnSa5N8pIkz0zys+7x8yTVN/2zJEu69d3bTd+Z5O+T7Nu37jcm+bu+6SQ5Lck3unWuT7IqyZOH/bOQWlgaWrSSLAWeCRRwbN+iDwK3AAcAewInA7dX1Zeqapeq2gU4qBv78E3zqup73bxXdWMeD+wCvH2WGO8E/gtwGrAH8ATgk8Czt/wVSgvP0tBidjJwBXAesKJv/mHAeVX186q6v6q+VlWfme/Kq+rH9Arg0OmWJ1kG/DFwUlVdWlX3VdXdVfWhqnpzN+bZSb6W5KdJbknyxr7vX9rt7by0W/ajJK9IcliSa5L8OMm755tbms0Oow4gjdDJwDuArwBXJNmnqm6nVyRnJflfwD/27UHMS5I9gecAN84w5ChgfVX90yyr+XmXcx3wJGBNkqur6pN9Y54KLAOOAFYDnwWOBh4EfC3Jqqr6wua8Bmkq9zS0KCV5Br3DTx+rqquAm4AXdItPAL4E/BnwnSRXJzlsHqt/V5KfAHcCewH/eYZxewK3zbaiqrq8qq6tqo1VdQ3wEeDIKcP+sqrurarP0yuZj1TVHVX1/7rX8ZR5ZJdmZWlosVoBfL6q7uymP9zNo6p+VFWnV9VBwD7A1cAnk6Rx3adV1W7AwcDuwH4zjPsBsO8MywBI8tQklyXZ0BXRK+gVUb/b+57fM830Lo25pTlZGlp0kjwYeB5wZJLvJ/k+8BrgkCSH9I/tSuXtwKPonahuVlXXAm+id6hrusJZC+yXZGKW1XyY3iGn/bsiei/QWl7SgrM0tBgdD/wKOJDeSepDgX9F71DOyUnekuRJSXZI8jDgVODGqvrBZmxrJfAIfv3dWQBU1Q3Ae4CPJPm3SXZMsnOSE5Oc3g17GPDDqro3yeE8cAhNGglLQ4vRCuBvq+p7VfX9TQ/g3cALgV2BTwA/Bm6md+7jN37pt6iqXwDvond+ZDqndds9q9veTcDvAxd1y18JnJnkLuANwMc2J4e0UOJNmCRJrdzTkCQ1szQkSc0sDUlSM0tDktRsm7uMyF577VVLly4ddQxJ2qpcddVVd1bV3nON2+ZKY+nSpUxOTo46hiRtVZL8c8s4D09JkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSp2UhLI8kxSa5PcmPf/QP6l782yTeTXJNkbZIDRpFTktQzsg/3Jdme3j0ElgPrgSuTrK6qb/YN+xowUVV3JzkVeCvw/OGn1bhbvt0JQ9vWmo2rhrq9UVizcdWoI2hMjXJP43B6d0O7ubtRzfnAcf0Dquqyqrq7m7yCme+1LEkaglGWxqOBW/qm13fzZvIy4DMDTSRJmtUorz2VaeZNexvBJC8CJoAjZ1h+CnAKwJIlSxYqnyRpilHuaawH9u+b3g+4deqgJEcDZwDHVtV9062oqs6tqomqmth77zkv0ihJ2kyjLI0rgWVJHpNkR+BEYHX/gCRPAc6hVxh3jCCjJKnPyEqjqu4HXgV8DrgO+FhVrUtyZpJju2FvA3YBViW5OsnqGVYnSRqCkd5Po6ouBi6eMu8Nfc+PHnooSdKM/ES4JKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmO4w6gLQQ1mxctU1vTxoXloYW3PLtThjq9tZsXDXUbQ57e6Mwip+ptg4enpIkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzUZaGkmOSXJ9khuTnD7N8iOSfDXJ/UmeO4qMkqQHjKw0kmwPnAX8LnAgcFKSA6cM+x7wEuDDw00nSZrODiPc9uHAjVV1M0CS84HjgG9uGlBV3+2WbRxFQEnSrxvl4alHA7f0Ta/v5s1bklOSTCaZ3LBhw4KEkyT9plGWRqaZV5uzoqo6t6omqmpi77333sJYkqSZjLI01gP7903vB9w6oiySpAajLI0rgWVJHpNkR+BEYPUI80iS5jCy0qiq+4FXAZ8DrgM+VlXrkpyZ5FiAJIclWQ+cAJyTZN2o8kqSIFWbdRphbE1MTNTk5OSoY0jSViXJVVU1Mde4Ub7lVkOyfLsTRh1hoNZsXDXU1zjs7Y3CYviZrtm4aqjb21Z4GRFJUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc3m/HBfku2AQ4BHAfcA66rq9kEHkySNnxlLI8njgP8KHA3cAGwAdgaekORu4BxgZVV5gyRJWiRm29N4E3A28Ec15QJVSR4BvAB4MbBycPEkSeNkxtKoqpNmWXYH8DcDSSRJGlst5zS2B54NLO0fX1XvGFwsSdI4arnK7UXAvcC1gOcvJGkRaymN/arq4IEnkSSNvZbPaXwmyb8feBJJ0thr2dO4AvhE93mNXwIBqqp2HWgySdLYaSmNvwaeBlw79a23kqTFpeXw1A3ANywMSVLLnsZtwOVJPgPct2mmb7mVpMWnpTS+0z127B6SpEVqztKoqr8YRhBJ0vib8ZxGknOTPHmGZQ9N8p+SvHBw0SRJ42a2PY33AH/WFcc3eOAqt8uAXYH3Ax8aeEJJ0tiY7YKFVwPPS7ILMAHsS+9+GtdV1fVDyidJGiMt5zR+Blw++CiSpHHn7V4lSc0sDUlSM0tDktSs5SZMTwBeBxzAr9+E6VkDzCVJGkMtnwhfBbwX+N/ArwYbR5I0zlpK4/6qOnvgSSRJY6/lnMZFSV6ZZN8ke2x6DDyZJGnstOxprOi+vq5vXgGPXfg4kqRx1vLhvscMI4gkafy1vHvqQcCpwBHdrMuBc6rqlwPMJUkaQy2Hp84GHkTvAoYAL+7m/eGgQkmSxlNLaRxWVYf0TV+a5OuDCiRJGl8t7576VZLHbZpI8lgW6PMaSY5Jcn2SG5OcPs3ynZJ8tFv+lSRLF2K7kqTN07Kn8TrgsiQ3A6H3yfCXbumGk2wPnAUsB9YDVyZZXVXf7Bv2MuBHVfX4JCcCbwGev6XbliRtnpZ3T61Nsgx4Ir3S+FZV3bcA2z4cuLGqbgZIcj5wHNBfGscBb+yeXwC8O0mqqhZg+5KkeZqxNJI8q6ouTfKcKYsel4Sq+vst3PajgVv6ptcDT51pTFXdn+QnwJ7AnVOyngKcArBkyZItjCVJmslsexpHApcCvzfNsgK2tDQyw3rnO4aqOhc4F2BiYsK9EEkakNlu9/rn3dMzq+o7/cuSLMQH/tYD+/dN7wfcOsOY9Ul2AHYDfrgA25YkbYaWd099fJp5FyzAtq8EliV5TJIdgROB1VPGrOaBy5g8F7jU8xmSNDqzndP4LeAgYLcp5zV2BXbe0g135yheBXwO2B54f1WtS3ImMFlVq4H/A3wwyY309jBO3NLtSpI232znNJ4I/Efg4fz6eY27gJcvxMar6mLg4inz3tD3/F7ghIXYliRpy812TuNC4MIkT6uqLw8xkyRpTM12eOpPq+qtwAuSnDR1eVWdNtBkkqSxM9vhqeu6r5PDCCJJGn+zHZ66qPu6ctO8JNsBu1TVT4eQTZI0ZuZ8y22SDyfZNclD6V3i4/okr5vr+yRJ256Wz2kc2O1ZHE/vnU5L6N1TQ5K0yLSUxoO6u/cdD1zY3bHPD9hJ0iLUUhrnAN8FHgp8MckBgOc0JGkRyuZclSPJDlV1/wDybLGJiYmanPQNX5I0H0muqqqJucbNeT+NJLsBfw4c0c36AnAm8JMtSqihWb7dtv2h+jUbVw31NQ57e6OwGH6mazauGur2thUth6feT+/SIc/rHj8F/naQoSRJ46nldq+Pq6o/6Jv+iyRXDyqQJGl8texp3JPkGZsmkjwduGdwkSRJ46plT+NUYGV3biP0LlG+YvZvkSRti+Ysjaq6Gjgkya7dtG+3laRFquUyInsmeRdwOXBZkncm2XPgySRJY6flnMb5wAbgD+jdcnUD8NFBhpIkjaeWcxp7VNVf9k2/KcnxgwokSRpfLXsalyU5Mcl23eN5wKcHHUySNH5aSuOPgA8D93WP84HXJrkriSfFJWkRaXn31MOGEUSSNP5a9jQkSQIsDUnSPMxYGkkuTrJ0eFEkSeNutj2N84DPJzmju3OfJGmRm/FEeFV9LMmngTcAk0k+CGzsW/6OIeSTJI2Rud499Uvg58BOwMPoKw1J0uIzY2kkOQZ4B7Aa+NdVdffQUkmSxtJsexpnACdU1bphhZEkjbfZzmk8c5hBJEnjz89pSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmqapRZ1hQExMTNTk5OeoYkrRVSXJVVU3MNa7lHuHSvCzf7oShbm/NxlVD3eawtzcKo/iZauvg4SlJUrORlEaSPZKsSXJD93X3GcZ9NsmPk3xq2BklSb9pVHsapwNrq2oZsLabns7bgBcPLZUkaVajKo3jgJXd85XA8dMNqqq1wF3DCiVJmt2oSmOfqroNoPv6iC1ZWZJTkkwmmdywYcOCBJQk/aaBvXsqySXAI6dZdMZCb6uqzgXOhd5bbhd6/ZKknoGVRlUdPdOyJLcn2beqbkuyL3DHoHJIkhbOqA5PrQZWdM9XABeOKIckaR5GVRpvBpYnuQFY3k2TZCLJ+zYNSvIlYBVwVJL1SX5nJGklScCIPhFeVT8Ajppm/iTwh33T3j1QksaInwiXJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1G8md+7RtW7Nx1agjaAH476jpuKchSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJajaS0kiyR5I1SW7ovu4+zZhDk3w5ybok1yR5/iiySpIeMKo9jdOBtVW1DFjbTU91N3ByVR0EHAP8TZKHDzGjJGmKUZXGccDK7vlK4PipA6rq21V1Q/f8VuAOYO+hJZQk/YZRlcY+VXUbQPf1EbMNTnI4sCNw0xCySZJmsMOgVpzkEuCR0yw6Y57r2Rf4ILCiqjbOMOYU4BSAJUuWzDOpJKnVwEqjqo6eaVmS25PsW1W3daVwxwzjdgU+Dby+qq6YZVvnAucCTExM1JYllyTNZGClMYfVwArgzd3XC6cOSLIj8AngA1W1arjxtLVZs3G4/0WGvT1pXIzqnMabgeVJbgCWd9MkmUjyvm7M84AjgJckubp7HDqauJIkgFRtW0dzJiYmanJyctQxJGmrkuSqqpqYa5yfCJckNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVKzbe5zGkk2AP88oNXvBdw5oHUPw9aeH7b+12D+0dra88PgXsMBVTXnlcS3udIYpCSTLR9+GVdbe37Y+l+D+Udra88Po38NHp6SJDWzNCRJzSyN+Tl31AG20NaeH7b+12D+0dra88OIX4PnNCRJzdzTkCQ1szQkSc0sjVkk2SPJmiQ3dF93n2bMAUmu6m4StS7JK0aRdTqN+Q9N8uUu+zVJnj+KrDNpeQ3duM8m+XGSTw0743SSHJPk+iQ3Jjl9muU7Jflot/wrSZYOP+XMGvIfkeSrSe5P8txRZJxNQ/7XJvlm939+bZIDRpFzJg35X5Hk2u73zj8kOXBo4arKxwwP4K3A6d3z04G3TDNmR2Cn7vkuwHeBR406+zzyPwFY1j1/FHAb8PBRZ5/Pa+iWHQX8HvCpMci8PXAT8Nju/8fXgQOnjHkl8N7u+YnAR0ede575lwIHAx8AnjvqzJuR/98BD+men7oV/vx37Xt+LPDZYeVzT2N2xwEru+crgeOnDqiqX1TVfd3kTozX3ltL/m9X1Q3d81uBO4A5PxU6RHO+BoCqWgvcNaxQczgcuLGqbq6qXwDn03sd/fpf1wXAUUkyxIyzmTN/VX23qq4BNo4i4Bxa8l9WVXd3k1cA+w0542xa8v+0b/KhwNDe0TROv+DG0T5VdRtA9/UR0w1Ksn+Sa4Bb6P0lfOsQM86mKf8mSQ6n95fNTUPI1mper2FMPJre/4VN1nfzph1TVfcDPwH2HEq6ubXkH2fzzf8y4DMDTTQ/TfmT/HGSm+jtjZ82pGzsMKwNjasklwCPnGbRGa3rqKpbgIOTPAr4ZJILqur2hco4m4XI361nX+CDwIqqGupfjwv1GsbIdHsMU/8SbBkzKuOcrUVz/iQvAiaAIweaaH6a8lfVWcBZSV4AvB5YMehgYGlQVUfPtCzJ7Un2rarbul+qd8yxrluTrAOeSe+Qw8AtRP4kuwKfBl5fVVcMKOqMFvLfYEysB/bvm94PmLr3uWnM+iQ7ALsBPxxOvDm15B9nTfmTHE3vD5Mj+w4xj4P5/vzPB84eaKI+Hp6a3WoeaO8VwIVTByTZL8mDu+e7A08Hrh9awtm15N8R+ATwgapaNcRsreZ8DWPoSmBZksd0P98T6b2Ofv2v67nApdWd1RwDLfnH2Zz5kzwFOAc4tqrG7Q+RlvzL+iafDdwwtHSjfqfAOD/oHWNe2/2DrAX26OZPAO/rni8HrqH3DodrgFNGnXue+V8E/BK4uu9x6Kizz+c1dNNfAjYA99D7S+13Rpz7PwDfpnd+6Ixu3pn0fkkB7AysAm4E/gl47Kh/1vPMf1j3c/458ANg3agzzzP/JcDtff/nV4868zzzvxNY12W/DDhoWNm8jIgkqZmHpyRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDW3zusu8fCfJHt307t30QK5s2l2B9OTu+Uu6KwVsWva+hboiaZLjk7xhnt9zyUxXCpZa+JZbLQpJ/hR4fFWdkuQc4LtV9T+GsN3LgT+pqskBrPsf6b1v/855fM8KYL+q+quFzqPFwT0NLRb/E/jtJK8GngH89dQBSZYm+VaSld19Fi5I8pBu2VFJvtbdw+D9SXbq5r+5774Mb+/mvTHJn3T3mZgAPtTd9+DBSS5PMtGNO6lb3zeSvKUvx8+S/FWSrye5Isk+02R9AnDfpsJIcl6Ss5NcluTmJEd2Oa9Lcl7ft64GTlqQn6gWJUtDi0JV/RJ4Hb3yeHX1Ljk9nScC51bVwcBPgVcm2Rk4D3h+VT2Z3jXbTu0Od/0+vU/jHgy8aco2LwAmgRdW1aFVdc+mZd0hq7cAzwIOBQ5Lsumy7w8FrqiqQ4AvAi+fJufTga9Ombd7t77XABd1r/Ug4MlJDu0y/QjYKcm4XFFXWxlLQ4vJ79K7ydSTZhlzS1X93+7539HbK3ki8J2q+nY3fyVwBL1SuRd4X5LnAHdPXdksDgMur6oN1bs0+oe6dQL8Ath0B8Kr6N3waKp96V02pd9F1TvefC1we1VdW70rFq+bso476N1wS5o3S0OLQveX9nLgt4HXdFfMnc7Uk3zF9JeqpvtlfzjwcXo3h/rsfCLNsuyX9cDJxl8x/dWo76F3/ap+m67UurHv+abp/nXs3H2/NG+WhrZ53R3xzqZ3WOp7wNuAt88wfEmSp3XPTwL+AfgWsDTJ47v5Lwa+kGQXYLequhh4Nb3DTFPdBTxsmvlfAY5MsleS7bttfWEeL+s64PFzjpqi+1k8kt5tiaV5szS0GLwc+F5Vremm3wP8VpLpbrxzHbCiuxPjHsDZVXUv8FJgVZJr6f3l/l56ZfCpbuwX6J1LmOo84L2bToRvmlm9uxD+N3pXKP068NWqms9l378IPKUrgfn4N/TOl9w/z++TAN9yK/2LJEuBT1XVbOc8xkaSd9I7j3HJPL9ndfXuqS7Nm3sa0tbrvwMPmef3fMPC0JZwT0OS1Mw9DUlSM0tDktTM0pAkNbM0JEnNLA1JUrP/D36ums6OBsFpAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CameraDisplay(subarray.tel[98].camera)"
    ]
@@ -210,18 +469,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAI4CAYAAABndZP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3Xl8nGW9///XNZN9b5YuSdp0pbTpkkLoQi0WUArCD44iIHqAAgJfROm3ehSPsqn0nO+RqkfEcxAQRSi1LHLgVAVrtSxSlha6L3Rv02xN2uyZZJbr98c9DV3SJcmk92TyfvK4H8l93zPX/bnTYeYz12qstYiIiIjEEo/bAYiIiIhEmhIcERERiTlKcERERCTmKMERERGRmKMER0RERGKOEhwRERGJOUpwRKRfMcasMMZ81e04RKR3KcERkQ7GmN3GmHZjTO4xx9cYY6wxZngPy+9ycmGMmWqM+ZMxps4Yc9AY874x5uaexNHF66caY5qMMX86U9cUkZ5TgiMix9oFXH94xxgzEUh2IxBjzAzgb8AbwGggB7gTuKwbZRljTHfe874ItAGXGGOGnKT8uNM5JiJnhhIcETnWM8CNR+zfBPzu8I4xJtMY8ztjzAFjzB5jzL2HEwdjzFxjzNvGmIXGmEPGmF3GmMvC5xYAs4BHwzUij4aPn22MWRaundlqjLn2iGs/DDxtrf0Pa22Nday21l4bfu4AY8zScCyHwr8XHhHrCmPMAmPMP4AWYOSRN2qM8YTj32OMqQ7fV+Yxf4+bgMeAdcBXjnn+bmPMPcaYdUCzMSbuBMe+a4zZYYxpNMZsMsZ8Pvz8xPB9TzyizIHGmFZjTN5p/nuJSCeU4IjIsd4FMowx44wxXuA64Nkjzv8CyMRJFj6Nkwwd2WQ0DdgK5AI/Bn5tjDHW2u8DbwFft9amWWu/boxJBZYBzwEDcWqO/ssYU2yMSQFmAC+eJFYP8BugCBgGtAKPHvOYG4DbgXRgzzHn5oa3C8P3k3bk840xw4DZwKLwdiPHux64HMiy1gZOcGwHTnKXCfwAeNYYM8Ra2wb8HvjnY8r7q7X2wEnuW0ROQQmOiHTmcC3OZ4EtwP7w8cMJz79aaxuttbuBn+AkEYftsdY+Ya0NAk8DQ4BBJ7jOFcBua+1vrLUBa+2HwEs4zUIDcN6jKk4UpLW21lr7krW2xVrbCCzASbqO9Ftr7cZw+f5jzn0F+Km1dqe1tgn4V+BLRzQt3Qiss9ZuAhYDxcaYKceU8Yi1dp+1tvVEx6y1L1hry621IWvtEmAbMDX82KeBLx/RfHYDzt9fRHpA7cMi0plngDeBERzRPIVTK5PA0TUhe4CCI/YrD/9irW0xxoBTM9KZImCaMabuiGNx4esfAkI4CdKWzp4cruX5GXApTkIEkG6M8YYTLIB9J7g2QH4n9xKHk5Dtx0lwngjfS7kx5g2cJquPjnhOZ+UfdcwYcyPwTWB4+FAazt8Sa+17xphm4NPGmAqcvkavniRmETkNqsERkeNYa/fgdDb+HPCHI07VAH6cxOSwYXxSw3PKoo/Z3we8Ya3NOmJLs9beaa1tAVYCV5+kvG8BY4Fp1toM4ILwcXOSax6pnOPvJQBUGWPOB8YA/2qMqTTGVOI0v11/TOfhzsrvOGaMKcJJkr4O5Fhrs4ANx8T4NE4z1Q3Ai9Za30liFpHToARHRE7kVuAia23zEceCwPPAAmNMevjD+5sc3UfnZKo4uqPvUuAsY8wNxpj48HaeMWZc+Px3gLnGmG8bY3IAjDGTjTG/D59Px+l3U2eMyQYe6OI9LgbmG2NGGGPSgH8DloT7zdyE0z9oPFAS3iYAKXRtFFcqTsJzIBz/zeFyjvQM8HmcJOd3iEiPKcERkU5Za3dYa1d1cuobQDOwE3gbp4PwU6dZ7M+BL4ZHPD0S7jdzCfAlnNqUSuA/gMRwDO8AF4W3ncaYg8DjwOE5af4TZwh7DU7n6Ne6eJtP8Ulz3C7AB3zDGJMEXAv8wlpbecS2K/z4m073AuH+Oz/BqY2qAiYC/zjmMWXAhziJ0FtdvAcR6YSx9mS1tyIiciYYY54Cyq2197odi0gsUCdjERGXhWeI/gJw7AgtEekmNVGJiLjIGPMjnE7HD4ebwEQkAtREJSIiIjFHNTgiIiISc/ptH5zc3Fw7fPhwt8MQERGRLli9enWNtfaUa7X12wRn+PDhrFrV2QhYERERiVbGmGPXlOuUmqhEREQk5ijBERERkZijBEdERERiTr/tgyMiIr3L7/dTVlaGz6e1Q6XrkpKSKCwsJD4+vlvPV4IjIiK9oqysjPT0dIYPH44x5tRPEAmz1lJbW0tZWRkjRozoVhlqohIRkV7h8/nIyclRciNdZowhJyenR7V/SnBERKTXKLmR7urpa0cJjoiIiMQcJTgiIiISc5TgiIhIVLDWUnaohQ376yk71EIkFoM2xnDDDTd07AcCAfLy8rjiiisAqKqq4oorrmDy5MmMHz+ez33uc6xfv56SkhJKSkrIzs5mxIgRlJSU8JnPfKbTa+zevRtjDPfdd1/HsZqaGuLj4/n6178OwNatW5k9ezYlJSWMGzeO22+/nddff73jOmlpaYwdO5aSkhJuvPHGTq+zYsUKMjMzO55zOJ4HH3yQhQsXdvlv89vf/rYjvmM1NTVxxx13MGrUKIqLi7ngggt47733unwNN2kUlYiIuK6+1c8z7+5hd00TBoPFMjw3jRumF5GZ3L1hwgCpqals2LCB1tZWkpOTWbZsGQUFBR3n77//fj772c8yb948ANatW8fEiRNZs2YNAHPnzuWKK67gi1/84kmvM3LkSJYuXcqPfvQjAF544QWKi4s7zt99993Mnz+fq666CoD169czceJE5syZA8Ds2bNZuHAhpaWlJ73OrFmzWLp0aRf/Cl331a9+lREjRrBt2zY8Hg87d+5k8+bNvX7dSFINjoiIuMpayzPv7qHsYAv5mcnkZyWTn5nMvoMtPPvunh7X5Fx22WX88Y9/BGDx4sVcf/31HecqKiooLCzs2J80aVK3rpGcnMy4ceM61jhcsmQJ11577QmvM3HixG5d51SeeOIJzjvvPCZPnszVV19NS0sL4CRcEyZMYPLkyVxwwQUdjy8vL+fSSy9lzJgxfOc73wFgx44dvPfeezz00EN4PE6aMHLkSC6//HIA/umf/olzzz2X4uJiHn/88Y6y0tLSuOeeezj33HP5zGc+w/vvv8/s2bMZOXIkr776aq/c78kowREREVftr2tld00TA9MTO0bOGGMYlJ7Irpomyut7NlHgl770JX7/+9/j8/lYt24d06ZN6zh31113ceutt3LhhReyYMECysvLe3ydsrIyvF4v+fn5Hefmz5/PRRddxGWXXcbPfvYz6urqunWNt956q6OJasGCBced/8IXvsAHH3zA2rVrGTduHL/+9a8B+OEPf8jrr7/O2rVrj0o21qxZw5IlS1i/fj1Llixh3759bNy4kZKSErxeb6cxPPXUU6xevZpVq1bxyCOPUFtbC0BzczOzZ89m9erVpKenc++997Js2TJefvll7r///m7db08owREREVfVtfgxmOOGBRtjMBjqWtp7VP6kSZPYvXs3ixcv5nOf+9xR5+bMmcPOnTu57bbb2LJlC1OmTOHAgQPdus6ll17KsmXLWLx4Mdddd91R526++WY2b97MNddcw4oVK5g+fTptbW1dvsasWbNYs2YNa9as4fvf//5x5zds2MCsWbOYOHEiixYtYuPGjQDMnDmTuXPn8sQTTxAMBjsef/HFF5OZmUlSUhLjx49nz55TL9T9yCOPMHnyZKZPn86+ffvYtm0bAAkJCVx66aWAU0P16U9/mvj4eCZOnMju3bu7fK89pQRHRERclZUSj8Ue1xRlrcViyUpJ6PE1rrzySv7lX/7lqOapw7Kzs/nyl7/MM888w3nnncebb77ZrWskJCRw7rnn8pOf/ISrr776uPP5+fnccsstvPLKK8TFxbFhw4ZuXedk5s6dy6OPPsr69et54IEHOibKe+yxx3jooYfYt28fJSUlHbUuiYmJHc/1er0EAgGKi4tZu3YtoVDouPJXrFjBX//6V1auXMnatWuZMmVKxzXi4+M7klSPx9NRtsfjIRAIRPxeT0UJjoiIuKogK5nhuWlUNbZ1JDnWWqoa2xiZm0Z+ZlKPr3HLLbdw//33H9f35W9/+1tHP5XGxkZ27NjBsGHDun2db33rW/zHf/wHOTk5Rx1/7bXX8Pv9AFRWVlJbW3tUZ+dIaWxsZMiQIfj9fhYtWtRxfMeOHUybNo0f/vCH5Obmsm/fvhOWMWrUKEpLS3nggQc6/j22bdvGK6+8Qn19PQMGDCAlJYUtW7bw7rvvRvweIkWjqERExFXGGG6YXnTcKKoRuWl8ZXpRRGZDLiws7BgpdaTVq1fz9a9/nbi4OEKhEF/96lc577zzun2d4uLio0ZPHfaXv/yFefPmkZTkJGsPP/wwgwcP7vZ1TuRHP/oR06ZNo6ioiIkTJ9LY2AjAt7/9bbZt24a1losvvpjJkyd3jBTrzJNPPsm3vvUtRo8eTUpKCjk5OTz88MNMmjSJxx57jEmTJjF27FimT58e8XuIFBOJeQb6otLSUnu4t7uIiETe5s2bGTdu3Gk/3lrL/rpW6lv9ZKUkkJ+ZpKUe+rnOXkPGmNXW2pOPp0c1OCIiEiWMMRQOSKFwgNuRSCxQgiMiJ+ZvdX7GJ7sbRyyzFtqbwZsAcT3vTCu9Z/369UfNigxOJ91Iz/D7+uuvc8899xx1bMSIEbz88ssRvU6sU4IjIscLhWDjS7Dj787+qIuh+PPg0biEiPK3wgdPQfVG8Hhh8vVQdL7bUckJHDnDcW+aM2dOxwzH0n16txKR41WuhY//Aun5zrbtNahc53ZUsefj152/a0YhJOfAR89CQ4XbUYnEBCU4InK8xiqnycTjdTYTD03dm/xMTqK+DJIywRiISwQMtB50OyqRmKAER0SOlzUMQn4ItDmbDUBW4amfJ12TMwZ8dRAKQluTk+ikDXI7KpGYoARHRI43cBxM+hL46p1t0vWQd7bbUcWe0RfByAuhqRJsEKbfCam5bkclEhPUyVhEjmeM8+E76sJP9iXyvPFQcj1M/pL+xr1owYIFPPfcc3i9XjweD7/61a84cOAA9913H6FQCL/fz7x586ipqeGFF14AnBFTh2c9vuWWW7j77rtPWP7kyZMZP348ixcv7jj27rvvMm/ePNra2mhra+O6666jqKiIn//85wBs2rSJsWPH4vV6ufTSSzn77LP59re/TUFBAT6fjzvuuIP58+cD8OCDD5KWlsa//Mu/nDCGQCDA4MGDue222/j3f//3juNLly7t0n0ePHiQJ554gry8PNrb27nvvvs6lreYO3cuV1xxBV/84hfx+/3cd999vPTSSyQmJpKSksIPfvADLrvssi7/+/Qaa22/3M4991wrIiK9Z9OmTV1/Uihkrb/N+RkB77zzjp0+fbr1+XzWWmsPHDhgd+/ebYcMGWL37dtnrbXW5/PZLVu2HPW81NTU0yp/06ZNdsKECTY/P982NTV1HD/rrLPsmjVrrLXWBgIBu3HjxqOeV1RUZA8cONCx/5vf/Mbedddd1lpra2pqbE5Ojt27d6+11toHHnjAPvzwwyeN449//KM9//zz7ciRI20o/Ldrb2/v8n0eea2PP/7Ypqen2/b2dmuttTfddJN94YUXrLXW3nPPPfbGG2/s+LtWVlbaJUuWnDTG7ujsNQSssqfxOa8mKhERiQ6NVfC3H8H/znN+Nlb1uMiKigpyc3M7Fn7Mzc0lPT2dQCDQsV5UYmIiY8eO7Vb5zz33HDfccAOXXHIJr776asfx6upqhgwZAjiLWI4fP/60y8zJyWH06NFUVJz+iLrFixczb948hg0b1rE+VGNjY4/uc8yYMaSkpHDo0KGjjre0tPDEE0/wi1/8ouPvOmjQIK699loA7rzzTkpLSykuLuaBBx7oeN7w4cP53ve+x4wZMygtLeXDDz9kzpw5jBo1iscee+y04zpdSnBERMR91sL7v4KWQ04n95ZDzn4PlxO65JJL2LdvH2eddRZf+9rXeOONN8jOzubKK6+kqKiI66+/nkWLFnW6cvbpWLJkCddddx3XX3/9UU1U8+fPZ+zYsXz+85/nV7/6VceK26dj7969+Hw+Jk2adFqPb21tZfny5VxxxRVHxdHT+/zwww8ZM2YMAwcOPOr49u3bGTZsGBkZGZ0+b8GCBaxatYp169bxxhtvsG7dJ1NMDB06lJUrVzJr1izmzp3Liy++yLvvvsv9999/2nGdLiU4IiLivqDfmQMoLfxhmjbQ2Q/6e1RsWloaq1ev5vHHHycvL4/rrruO3/72tzz55JMsX76cqVOnsnDhQm655ZYul/3BBx+Ql5dHUVERF198MR9++GFHbcf999/PqlWruOSSS3juuee49NJLT1nekiVLKC4uZuTIkUctzHkqS5cu5cILLyQlJYWrr76al19+mWAwCNCt+/zZz37G2LFjmTZtGg8++OBpxXCk559/nnPOOYcpU6awceNGNm3a1HHuyiuvBJxJE6dNm0Z6ejp5eXkkJSVRV1fX5WudjBIcERFxnzceMoZAU7Wz31Tt7Hvje16018vs2bP5wQ9+wKOPPspLL70EOB+y8+fPZ9myZR3HumLx4sVs2bKF4cOHM2rUKBoaGo4qZ9SoUdx5550sX76ctWvXUltbe9LyrrvuOjZu3Mhbb73Ft771LSorK087jr/+9a8MHz6cc889l9raWv7+9793nO/qfc6fP5+tW7eyZMkSbrzxxuNqn0aPHs3evXs7Vio/0q5du1i4cCHLly9n3bp1XH755Uc9/3CTlsfj6fj98H4gEDit+z1dSnBERMR9xsDUOyBlANTtdX5OvaPHo8u2bt3Ktm3bOvbXrFnDoEGDWLFixVHHioqKulRuKBTihRdeYN26dezevZvdu3fzyiuvdDQP/fGPf8SGm9e2bduG1+slKyvrtMqeMWMGN9xwQ8eIq5NpaGjg7bffZu/evR1x/PKXv2Tx4sU0NTX16D6/8IUvUFpaytNPP33U8ZSUFG699Vbuvvtu2tvbAaev07PPPktDQwOpqalkZmZSVVXFn//859O+XqRpmLiIiESH9EFw0X1Os5Q3PiJD55uamvjGN75BXV0dcXFxjB49mp///Ofccccd3HHHHSQnJ5Oamspvf/vbLpX75ptvUlBQQEFBQcexCy64gE2bNlFRUcEzzzzD/PnzSUlJIS4ujkWLFuH1ek+7/HvuuYdzzjmH733veyd93B/+8Acuuuiio2pDrrrqKr7zne/w05/+lB//+Mc9us/777+fL3/5y9x2221HHX/ooYe49957GT9+PElJSaSmpvLDH/6QyZMnM2XKlI6mtpkzZ3bpepFkbA87cPVVpaWldtWqVW6HISISszZv3sy4cePcDkP6sM5eQ8aY1dba0lM9V01UIiIiEnPURCUiInISCxYs6Jj597BrrrmG73//+2c0jrvuuot//OMfRx2bN28eN9988xmNo69QE5WIiPQKNVFJT6mJSkREROQISnBEREQk5ijBERERkZijTsYiIuI6ay3lzeWsP7CeurY6shKzmJg3kfzUfEwE5sOR/kc1OCIi4ipfwMeizYv4rzX/xcryleyo28HK8pX815r/YtHmRfgCp79Q5bHS0tKOO7Z161Zmz55NSUkJ48aN4/bbb+f111+npKSEkpIS0tLSGDt2LCUlJdx4442dlrtixQquuOKK444vXbqUKVOmMHnyZMaPH8+vfvUrFixY0FG21+vt+P2RRx7ptOwHH3yQhQsXHnd8wYIFFBcXM2nSJEpKSnjvvff4/Oc/T0lJCaNHjyYzM7Oj7HfeeQe/3893v/tdxowZw4QJE5g6daqrMwufaa7W4BhjngKuAKqttRPCx7KBJcBwYDdwrbX2kHFS+J8DnwNagLnW2g/Dz7kJuDdc7EPW2qPnlRYRkahkreXFj19k88HNx9XWWGvZfHAzL378Il8Z95WI1eTcfffdzJ8/n6uuugqA9evXM3HiRObMmQPA7NmzWbhwIaWlpxyocxS/38/tt9/O+++/T2FhIW1tbezevZuxY8d2DClPS0tjzZo1XY555cqVLF26lA8//JDExERqampob2/n5ZdfBpyEa+HChSxdurTjOd/97nepqKhgw4YNJCYmUlVVxRtvvNHla/dVbtfg/BY4donV7wLLrbVjgOXhfYDLgDHh7Xbgv6EjIXoAmAZMBR4wxgzo9chFRKTHypvLO01uAIwx5Kfms+XgFiqaKyJ2zYqKCgoLCzv2J06cGJFyGxsbCQQC5OTkAM7CkmPHjo1I2RUVFeTm5nYsyZCbm0t+fv4JH9/S0sITTzzBL37xi47nDBo0iGuvvRaAO++8k9LSUoqLi3nggQc6njd8+HC+973vMWPGDEpLS/nwww+ZM2cOo0aN4rHHHovIvZwpriY41to3gYPHHL4KOFwD8zTwT0cc/511vAtkGWOGAHOAZdbag9baQ8Ayjk+aREQkCq0/sJ44E3fC2hljDF7jZd2BdRG75vz587nooou47LLL+NnPfkZdXV1Eys3OzubKK6+kqKiI66+/nkWLFhEKhSJS9iWXXMK+ffs466yz+NrXvnbKmpjt27czbNgwMjIyOj2/YMECVq1axbp163jjjTdYt+6Tv+/QoUNZuXIls2bNYu7cubz44ou8++673H///RG5lzPF7Rqczgyy1lYAhH8ODB8vAPYd8biy8LETHT+OMeZ2Y8wqY8yqAwcORDxwERHpmrq2OhK8CSd9TII3gbq2yCQhADfffDObN2/mmmuuYcWKFUyfPp22traIlP3kk0+yfPlypk6dysKFC7nlllsiUm5aWhqrV6/m8ccfJy8vj+uuu67LC2ce6fnnn+ecc85hypQpbNy4kU2bNnWcu/LKKwGnZmvatGmkp6eTl5dHUlJSxJLBMyEaE5wT6Sy9tyc5fvxBax+31pZaa0vz8vIiGpyIiHRdVmIW7cH2kz6mPdhOVmJWRK+bn5/PLbfcwiuvvEJcXBwbNmyIWNkTJ05k/vz5LFu2jJdeeili5Xq9XmbPns0PfvADHn300ZOWPXr0aPbu3UtjY+Nx53bt2sXChQtZvnw569at4/LLL8fn+6Qj9+EmLY/Hc9Qq5R6Ph0AgELH76W3RmOBUhZueCP+sDh8vA4Ye8bhCoPwkx0VEJMpNzJtIwAY40bJB1lqCNsikvEkRu+Zrr72G3+8HoLKyktraWgoKOq3475KmpiZWrFjRsb9mzRqKiop6XC44I7+2bdt22mWnpKRw6623cvfdd9Pe7iSQFRUVPPvsszQ0NJCamkpmZiZVVVUxO7IqGufBeRW4Cfh/4Z+vHHH868aY3+N0KK631lYYY14H/u2IjsWXAP96hmMWOT0Hd0JzLaQNhAGReeMTOWOshQNboa0RsoZB+qAeF5mfms+47HEnHEVV3lzOuOxxDEkd0q3yW1pajupQ/M1vfpOysjLmzZtHUlISAA8//DCDBw/uctnLly8/quzFixfz4x//mDvuuIPk5GRSU1O73Yz00EMP8Z//+Z8d+6+88grf+MY3qKurIy4ujtGjR/P444+fsox7772X8ePHk5SURGpqKj/84Q+ZPHkyU6ZMobi4mJEjRzJz5sxuxRjtXF1s0xizGJgN5AJVOKOh/gd4HhgG7AWusdYeDA8TfxSnA3ELcLO1dlW4nFuA74WLXWCt/c2prq3FNuWM2/F3WLcEjHE+KM65CYpmuB2VyOmxFtYugV1/B+MB44Xz74a8s074lNNdbNMX8PHixy+y5eAWvMZLgjeB9mA7QRvk7Oyz+eJZXyQpLimSdyN9RE8W23S1Bsdae/0JTl3cyWMtcNcJynkKeCqCoYlEVjAAG16C9CHgTYCAD9b9HoZNdxIekWjXXAO73oDMYU6C03oINr4Ms+/pcdFJcUl8ZdxXqGiuYN2BdR0zGU/Km8SQ1CGayVi6JRqbqERijw06myf8v5wnHoJ+sCHnm7BItAv5w8l4ONnwxjuJeoQYY8hPyyc/7cRzu7jh9ddf5557jk7iRowY0THBXk8sWLCAF1544ahj11xzTcekgNIzSnBEzoS4RCiaCTvfhIRUaG+Gsy4Bj5Ib6SPSBkHOaKcPTnyK8xo+p/NlDI5kre3TNTBz5szpmOE40r7//e8rmTmJnnahUYIjcqZM+hJkDoX6fZA1XP1vpG/xeGH6nbDzDWipgYHFkF9y0qckJSVRW1tLTk5On05y5Myz1lJbW9vREbw7lOCInCneOBj5abejiF3Wwp53YPtfnRqz4s9DXmSmyZew+GQYe/oTxRcWFlJWVoYmVpXuSEpKOmqUWlcpwRGR2FC+Fj58GlLyoL0F3vkFXHQvpHd9+K9ERnx8PCNGjHA7DOmnonGiPxGRrqve6PQNSUyD5CwIBaFur9tRiYhLVIMjIrEhNRcCrU5TFdYZoZaY7nZUIuISJTgiEhtGXADVm6Bmm5PkjJwNeWe7HZWIuEQJjojEhvhkZ2bdpipnnqHUXE2iKNKPKcERkdjh8UJGdE0UJyLuUCdjERERiTlKcERERCTmKMERERGRmKMER0RERGKOEhwRERGJOUpwREREJOYowREREZGYowRHREREYo4SHBEREYk5SnBEREQk5ijBERERkZijBEdERERijhbblL7LWmgoh/ZmZ4HFxDS3IxKRaNNyEJprICXbWWFe+g0lONI3WQubX4WtfwbjdZKbT82H9MFuRyYi0aJqI7z3GISCYDxw7s1QeK7bUckZoiYq6ZsaK2Hra5BRCJmFEGiDjf/jdlQiEi2shdVPQ2IGZA6F5Gz46Bkn2ZF+QQmO9E2BVucbmcfr7Mcng6/e3ZhEJHrYELQ3QXyKsx+XBIF2CLa7G5ecMUpwpG9KH+K0qTeUO4lNcw0UTnU7KhGJFh6v855Qt9d5j6jfC4MnOImO9AvqgyN9U3wyzPy/sPl/ofUgjL0Mhs9yOyoRiSYl10PKAKjZBoWlcPblYIzbUckZogRH+q7UHCid63YUIhKt4hJh/FVuRyEuUROViIjgYfDNAAAgAElEQVSIxBwlOCIiIhJzlOCIiIhIzFGCIyIiIjFHnYxF5PTU73dGrKUNgrSBbkfTtx0eupxR4Ex3ICIRpwRHRE5t99vw0SJnckVjYNodMHii21H1TVv/DJtecZYY8Xhh5jzIGeV2VCIxR01UInJygTZYu8SpuckshKRM+OhZt6Pqm3z1sHmpU3OTWQhxyc7fVkQiTgmOiJxc0A82AN4EZz8uyVnB3Vp34+qLAm2AdWpvwPlb+ptcDUkkVinBEZGTS0iFQROhbg+0HIT6fc6s0ZoRtutScmDACOdv2HIQmiqg6FNuRyUSk9QHR0ROzhgovQW2LXM+mHPHwMgL3Y6qb/J4YcbX4OPXobEKBo3XEiMivUQJjoicWnwSjP//3I4iNiSkwoQvuB2FSMxTE5WIiIjEHCU4IiIiEnOU4IiIiEjMUYIjIiIiMUcJjoiIiMQcjaLq74J+KFvlzLCadxZkj3Q7IhERsRaqNjhrwGUMgcGTNPdUFynB6c9CQXjvcahcC5442BSCGXdpjSEREbdtfQ02vQyeeAj54ewrYPyVbkfVp6iJqj9rrHC+IWQNh8yhkJjpLAQoIiLuCYVg6x8ho9BZsyxzKHz8mlPjLqdNNTgiEjtCIWg96MwYnJSlKn3pw4597eq13FVKcPqz9HynOap8jfOBYIBzbnA7KpHuCbTB+09C9QbAwOjPQPHnleRI3+PxwNmXw4Y/ON0HQgFnJnFvvNuR9SlKcPozjwem3gblHzmdjHNGQ/YIt6MS6Z5dbzn9ybKGgw056z0NKoa8sW5HJtJ1Z81xmqcayiF9sPpGdoMSnP7OGw9Dp7odhUjPNVVBfIpTY2O8YDxO4i7SFxkDgyc4m3SLOhmLSGzIOxv8LeBvhbYGJ8HJLHQ7KhFxiRIcEYkNBefApC85Q2rjEmH6/4GMfLejEhGXqIlKRGKDMTD6ImcTkX5PNTgiIiISc5TgiIiISMxRgiMiIiIxRwmOiIiIxBx1MhaJBo1VztozbU0wbAYUlmoGXnFHMAA7lkP1Jme287Mvh8Q0t6MS6TIlOCJu8zXAWz+BgA/ikuCDJ5yJ6grPcTsy6Y82v+osupucDTUfQ91emPUtZ+ZzkT5Er1gRt9XthfZmSB8CyQMgMQPK3nc7Kumv9q6EjAJIzoKMoXBoF7QecjsqkS5TgiPitvhkZzE9G3L2Az5IynA3Jum/EjOc2aDBmTQR40ycKNLHKMERcVv2SBj+Kajf52xJmXDWpW5HJf1VyZch6IOGMmishInXqA+O9EnqgyPiNmNgyj87SU6wHTKHQkKK21FJf5UzCj7zoJPcJGVBxhC3IxLpFiU4ItHAGMge4XYUIo7kAc4m0oepiUpERERijhIcERERiTlKcERERCTmKMERERGRmKMER0RERGKOEhwRERGJOUpwREREJOYowREREZGYowRHREREYo4SHBEREYk5SnBEREQk5ijBERERkZijBEdERERijhIcERERiTlKcCS2tTXCoT3ga3A7EhHpDc21ULcX/D63I5EoE+d2ACK9pmY7vPtLCPrB44Wpd8Cg8W5HJSKRsn05bHgJMJCSDTPnQWqu21FJlFANjsQma+GDJyEuCTIKICENVv0aQiG3IxORSGg64CQ3aYMhsxB89bDxZbejkiiiBEdikw05b3gJ6c5+fCq0t0Cw3d24RCQy2hsBA954Zz8hHZoPuBqSRBclOBKbPF4YMhnq9zqJTcM+yBsLcYluRyYikZA2GJLSoakK2pud5CZ/ittRSRRRgiOx65wbYfgs8MbB0Blw3q1gjNtRiUgkJKTAzP8LuWMgLgGK/wnGXOJ2VBJF1MlYYldCCkz5ittRiEhvSR8MM+5yOwqJUqrBERERkZijBEdERERijhIcERERiTlKcEQktoRCzjxIItKvqZOxiMSGUMiZ6G3n38ATDxOvheHnux2ViLhENTgiEhv2roSPXwvPj5IJH/0ODu12OyoRcYkSHBGJDYd2Q0IqeOKcJTow0FTtdlQi4pKoTXCMMbuNMeuNMWuMMavCx7KNMcuMMdvCPweEjxtjzCPGmO3GmHXGmHPcjV5EzrjMoc6s1TYUXpIjBCk5bkclIi6J2gQn7EJrbYm1tjS8/11gubV2DLA8vA9wGTAmvN0O/PcZj1RE3FV0Poy8AOrLnJqbiddBzii3oxIRl/S1TsZXAbPDvz8NrADuCR//nbXWAu8aY7KMMUOstRWuRCkiZ543Dqb8M0z4orMW2eFFGEWkX4rmGhwL/MUYs9oYc3v42KDDSUv458Dw8QJg3xHPLQsfE5H+Jj5JyY2IRHUNzkxrbbkxZiCwzBiz5SSP7WwFxeMmwggnSrcDDBs2LDJRioiISNSJ2hoca215+Gc18DIwFagyxgwBCP88PESiDBh6xNMLgfJOynzcWltqrS3Ny8vrzfBFRETERVGZ4BhjUo0x6Yd/By4BNgCvAjeFH3YT8Er491eBG8OjqaYD9ep/EyHWQush8NVrdlgRkUgKhaDlILQ1uh1JTIrWJqpBwMvGGHBifM5a+5ox5gPgeWPMrcBe4Jrw4/8EfA7YDrQAN5/5kGNQMAAfPQNl7zsNfqNmw4RrwBOVebGISN/hb4X3n4DqzWAMjLsKxs5xO6qYEpUJjrV2JzC5k+O1wMWdHLfAXWcgtP5l3/uw5x0YMNypvdm+HPLGwZBJbkcmItK3bV8OVRshqwhCAdj0PzBwrPN+KxGhr+JyYs3VzoywxuMMuzUe8NW5HZWISN/XWAGJ6U7tjTfeeX9t1ftrJEVlDY5EiZxRsPVPTlWqDTnHMgvdjUl6xB8M8d7OWt7eXktTm5+xg9K5aNwgCrKS3Q5NTmJrZSPLN1dRXt9KXloiF549kIkFmYSb8aUvyhsLZR9AQhoE2pxEJyPf7ahiimpw5MQGTYCSr0CwzUlwSm+B7JFuRyXdFApZFr27h5c+3E8gGCIjKZ5NFQ38/K8fs6um2e3w5ARW7qjhsTd2UNngIzMpnkMtfn7zj938dXOV26FJTxR9CsZdCf5miEuA6V+DtIGnfp6cNtXgyIkZAyM/7WzS5+2saWLd/nqGDkju+OY/MD2JQy3tvPLRfuZ9ZoxqBKKMzx/k1bXlDMpIJDHOC0BmsofUBC+vb6xi6ogcMpM1qWGf5PHAuCucTXqFanBE+oktlY3EezzHJTFZyfGUHWqlsS3gUmRyImWHWgmEbEdyc1ic14MB9tSq5k3kRJTgiPQTXmOwx0/w7TDgUe1N1PEYOpmT/cjz+jcTORElOCL9RHF+JsGQJRQ6+hOzpqmdMQPTSEtUi3W0KRyQQlK8h5b2o2vX2gJBvB7DyLxUlyITiX5KcET6iaHZycwcnUtZXQsHm9tpagtQUdeK1wNXlkRw9Ibf50xedmArBP2RKzfatTU585rUbHdmqI2AhDgP15UOo67FT1WDj+a2ANWNPg40tvGFKQWkJCgpFTkRY/vp9PulpaV21apVbochckaFQpZNFQ28u7OWRl+AsYPTmTEyhwGpCZG5QHszvP0zqN8PWMgZA+d/HeISI1N+tGo5CG/9xFnWxIagoNQZdRihWb/317Xyj+01lB1qZVB6IjNH5zI8V7U30j8ZY1Zba0tP9Til/yL9iMdjmFCQyYSCzN65wN53oW7fJ7Nf12yFinUw9LzeuV602PYXaK2HzKHOfZd9ACNmOXOdREBBVjLXlg499QNFpIOaqEQkcvwt4Al/bzLGmZ014HM3pjOhLTyXCTj37fE6k7eJiGuU4Ij0JdHepDw4vE5ZUzU0VjpNU7lnuRvTmTBsqtM811ILjeXOFPzRvqZQtL+WRHpITVQifUF9Gax6ykkaBo6Hc26EpAy3ozregCKY9U3Y8XenFmP0xZA+yO2oet/giTDjLmdx2oRUOGtOdP77ADSUO6+lhnKnCe3cuZDUS02WIi5SgiMS7QLtsPJRCAYgowCqN8HaxTDtDrcj61zOKGfrb4ZMcrZoFgzAyl86I90yCqFmG3z4jNMRXCTGqIlKJNq1NYCvEVJynD4taYOg5mO3o5K+qL3RWbE6NdfpK5Q2yElyRGKQEhyRaJeYDnFJ4Gtw9ltqIavI3Zikb0pIg4QU8NU7+y01kKXRWRKblOCIRLu4RJjxNbABqN/n9GmZ8s9uRyV9kTcept8JWOe1lJLj9MERiUGa6E+krwgFwd/qdGLVGkTSE4dfS/EpEZuMUORM0UR/brJWH0ASeR4vJKa5HYXEAr2WpDdFyWegEpxIqtsHq37tzAEycDyce5PTf0JERCTWNVQ4n4EN5ZA71vkMTM5yLRzVTUZKoB3e/aWz4F5GoTOUd81it6MSERHpfYenIGg55HwG1m6Dj551NSQlOJHS1uCMcknJOWL4pYbyiohIP9De6Cw22zEFwWDXPwOV4ERKYjrEJTuJDoSH8g5zNyYREZEzISHNGQDhq3P2Ww64/hmoBCdS4hJh+v+BkIbyiohIP9MxBQFRMwWBholHmobyiohIf3UGpiDQMHG3aPiliIj0V1H0GagmKhGJKT5/kLZA0O0wRMRlqsERkZiwp7aZpWsr2FXbhMEwsTCTyycOISct0e3QRMQFqsERkT5v38EWfvn37VQ2+MjPTGZQRhIbyxv45YrtNPr8bocnIi5QgiP9W1sTVK6H6i3ORFXSJ/11cxVxHg/ZqQkYY/B6DIMzkmhoDbBq9yG3w5Puam+Byg1QvRmCSlSla9REJf1Xy0F46yfOTywMngRTbwev/rfoa7ZWNpLbSVNUemIcmysauPDsgS5EJT3ia4C3fgpNVYCFvLEw/S6IS3A7MukjVIMj/dfOFc7Mm1nDIHMYVK6Fmq1uRyXdkJzgxR8MHXfcHwyRmuh1ISLpsT3/gKbKT/7/rN4CVevdjkr6ECU40n+1N4M3/G3QGDAeCLS5G5N0y/mjcjjQ1MaR83qFQpbm9iBTR+S4GJl0m78VPPHO78Y4m5qppAuU4Ej/NXQqBHzQfMBZ/TYhHbJHuh2VdMOsMXmMHphGWV0rBxrbqGzwsb++lU+NzmHsoHS3w5PuyJ8CNghN1c4q1fEpkDPG7aikD9FMxtK/VW+G3e9AfBKM+Sykqa9GXxUIhtha1cjG/Q0kxHmYVJjJiNxUjGYU77tqd8CuN5yanNEXQ0a+2xFJFNBMxiKnY+A4Z5M+L87roTg/k+L8TLdDkUjJGeVsIt2gJioRERGJOUpwREREJOYowREREZGYowRHREREYo4SHBEREYk5SnBEREQk5ijBERERkZijBEdERERijhIcEekV1loafX6a2gJuh9KrrLXUt/ppaY/t+xTpazSTsYhE3O6aZl5Zs599B1vBWEYPTOeqknyGZCa7HVpEbalo4H/XllPd2IYFivMzuHJyPjlpiW6HJtLvqQZHRCKqvK6V/35jB7XN7eRnJZGfmcy+gy388m/bOdjc7nZ4EbO9uokn3tpJS3uQIZlJDMlIYmtlI/+9YgfNMV5rJdIXKMERkYj6+5ZqPMCAlASMMRhjyE1LpC0QYuWOGrfDi5jXNlSQmhhHRnI8xhg8HsOgjCTqWv18tPeQ2+GJ9HtKcKR7fPWwfTlsWwZN1W5HI1Hk46pGslISjjuemRzPlspGFyKKvEAwxK6aZrKS4487l5Lg5eOq2LhPiZCDO2Hrn2HX2xCInVrMaKc+ONJ1vgZ448fQXAvGOP/jfvoeSB/kdmQSBVIT42gLhEiIO/r7U3swxMCk2Oib4vUYkuO9+IOWhDhz1Ln2QIiMpOMTH+mnKjfAykfBeCHkh/2r4fyvg8frdmQxTzU40nXVm6G5BgYUQdYwCLTBvvfcjkqixMzRORxsbsNa23EsFLI0+gKcPyrXxcgixxjD+aNzqW70HXWfgVCI9mCIc4dnuxidRJWPX4fEDMgshKzhcGAL1Je5HVW/oBoc6TpjgCO/tdrwMRGYOiKH7dXNrCurI87jwWIJhiwzR+cwfkiG2+FFzEVnD2R3bTPbq5tI8HoIWQiGQlxaPJjhOSluhyfRwhg4IgnGoPfLM0QJjnTdwPFOc9ShXWA8kJgOw2a4HZVEiXivhxumF7GzJpfNFQ14PYbi/AyGZadgYuiNPSney+2zRrKtuomPqxpJivcyoSCT/MykmLpP6aGzL4d//BzqmsAGYchkyChwO6p+wRxZvdqflJaW2lWrVrkdRt/V1ggVayEUgsETIEVV8iIinarbCzXbnS+D+SXgVR+tnjDGrLbWlp7qcarBke5JTIfhn3I7ChGR6Jc1zNnkjFInYxEREYk5SnBEREQk5ijBERERkZijBEdERERijhIcERERiTkaRSUSw6y1lNf7qG7wkZIQx8i8VOK9+l4TC1raA+w80EwgZBmWnUJ26vHrf4n0Z0pwRGKUzx9k0Xt72FTegDEGC2QkxXHLzBEMzdZMu33ZR3sP8fyqffgDlsMziX/6rDwunzgEj0eTDIqAmqhEYtb/ri1nU0UDBVnJFGQlU5iVDBaeeGsnre3BnhVeXwbVW5xV5aNMWyCIPxhyO4xeU17XyqL39pKRFE/BgGQKBqQwOCOJv22u5oM9B90OTyRqqAZHJAY1twX4YPdBhmQkH7VsQEZyPPsPtbC5ooFzigZ0r/Ctf4ZNrzirIXuT4FPzomISs30HW1i6voIdVU14PFAyNIvLJgxhQIw13by/qxavx1kq4jCvx5CTlsDfNlczbUSOi9GJRA/V4IjEoKa2ABbng+9YxhgOtrR1r+CWg7D5f521dDIKnWPrX+h+oBGyv66VR/++nf0HW8jPSmJgehJr99Xzy79vp6kt4HZ4EVXZ0EZK/PHfTVMSvNQ2t9Nfl98ROZYSHJEYlJkcj9cYAp001YSsZVB6cvcK9rcCBjzhD9j4FPA1dD/QCFm2qRKvMeSkJWKMwesxDM5Moq61ndUx1mwzdEAyze3HJ22NbQGGaKFPkQ5KcERiUFK8l5mjc6mo9xEMOd/orbXUNreRnZrAWYPTuldw2kDIGOL0wWmtg+YqGHZ+BCPvni0VjZ2OIkpPjGfjfvcTsEiaOiIHYwxNvk+SnPZAiEPN7Xxm3CAXIxOJLuqDIxKjLp0wmPZgiHd31IIBG4KCAUl8ZXoRiXHeUxfQGW88nP8N2LwUmmvgrEth5KcjG3g3JMV78QdDeD1H35c/GCI1sZv3GqXy0hP56qdG8Nz7eymvawUDXmP4wjmFTCrMdDs8kahh+mt7bWlpqV21apXbYYj0uvoWPweafCQnxJEfo00Yf9lYyWsbKynM+qRTdShkKatr5bZZIxmfn+FyhJEXCIYoO9RKIGQpyEomOSG2EjmREzHGrLbWlp7qcarBEYlxmSnxZKbEux1Gr7rgrDw+rmpk54FmkhO8BEOW9mCI80flcPbgdLfD6xVxXg/Dc1PdDkMkainBEZE+Lyneyx2fHsWWigY2lDeQ4PUweWgWI3NTNfGdSD+lBEdEYkK818PEwiwmFma5HYqIRAGNohLpLdY6HXEbqyAUuzPrSj8XaIeGcmdUnUgUUQ2OSG8IhWDdYtj1NhhgYDFMvQ3iEt2OTCRyWg7CO49A0wFnf9K1UTGqTgRUgyPSO6o3wc43ILMQMoZC5XrY847bUYlE1oY/QHOt8zpPGwjrlji1liJRQAmOSG9oawTjCW8G4pL0xi+xp7kaEsND8L0JgIG22JpYUfouNVGJ9IasoU5y46t3FqX0t8LAs92O6ozz+YNsr26iqS1AblqiRjXFmsGTPll4tb0JElIhTbMpS3RQgiPSGzILYcZdsPFlCPrh3LkwaILbUZ1Re2tb+PXbO2luD2CtASzDslO4+VMjyEiK7Xl5+o2zLgUbhLJVzmt+0nVOkiMSBTSTsYhEnM8f5N/+tBmvMWQkf5LMVNa3cvaQDG6eOcLF6CIjGLLsrm2m0RcgOyWBodnJMTlLtEi00UzGIuKaj6saaW4LUjjg6FXLB2YksbG8gbqWdrJSjl8csyustZQ3l7Onfg8BG2BQyiBGZY0iztP7b2vVjT5++4/dVDf6AIO1lhF5adw0o4h01U6JRAUlOCIScc5K18fXDnuMwWOg0RfoUYJzyHeI57c+z97GvZjwfxZLWkIaV4+5mjEDxvQg+pMLhixPvb2bpjY/BVkpgJNs7attZskH+/jqrJG9dm0ROX0aRSUiEZeXnogzAdDRAsEQYMhO7X5y0+xv5qkNT1HZUkl+aj75afkMSRtCflo+XuPl6Y1Ps7t+d7fLP5VdNU3UNLWRk/rJnEbGGAZlJLGlsjFcqyMiblOCIyIRNzIvjYIBSVQ1+Djczy8QClFR72PWmFxSE7tfebyqchWHfIfIS847rs9LanwqqfGp/GnXn+it/oX1rYHOKqcw4dqphtZAr1xXRLpGCY6IRJzXY7h15khGDUyjvM5HRX0rBxrbmH32QC6dMLjb5Vpreaf8HbKTsk/4mIyEDMqbyqlqqer2dU4mOzUB20mGE7KWkKVHtVMiEjnqgyMivSIzJZ7bZo2ktqmN5rYg2WkJpPWg5gbAH/LT7G8mMzHzhI8xxmCMobG9kcGp3U+mTqQoO4XCASlUNfgYmJ6IMYaQtVTU+Zg8NEsJjkiUUA2OiPSqnLREhuWk9Di5AYjzxOH1eAmETtEMZCHB2zuJhsdjuGXmCIZlp1Be79ROVdT5mFSYyRfPLeyVa4pI16kGR0T6DI/xUJJXwtoDaxmYMrDTx/gCPlLiUyhIK+i1ODJT4rlz9iiqGtpo8PnJTk0gN00LqYpEE9XgiEifMiN/BiEbojXQety5YCjIgdYDXDj0wl6fD8cYw+DMJM4alK7kRiQKKcERkT5lcOpgvjLuKzS2N1LRXEGTv4kWfwvVLdVUNldyQeEFTB0y1e0wRcRlaqISkT5nbPZY5p87n7UH1rK+Zj3BUJApA6ZQOriU/NR8LZkgIkpwRKRvykzM5ILCC7ig8AK3QxGRKKQmKhEREYk5SnBE5IzzB535bE453PsMstbS4m+hNdDaa7Mgi8iZoyYqETlj9jft5+39b7OhZgNYiPfGM33IdKYNmXbSyft6kz/kZ03VGt7a/xaH2g4RsiEK0gq4oOACinOL1Z9HpI8y/fWbSmlpqV21apXbYUiUOtDYxvu7atld20xuaiLTR+VQlJPqdljd0hYIsr6sng/31gEwZWgWk4ZmkhjnPaNxbKzZyOIti4n3xJOdnI3XeGkPtlPbWktqQipfnfhVcpNzu11+a3uQD/ceZH1ZA/FxhtKiARTnZxLnPXFFtT/oZ9HmRWw9tJXspGxS41Ox1tLY3kh9ez3n55/PFSOviKokp9HnZ9XuQ2yuaCA10cvUETmMHZSOxxM9MZ6uUMiypbKRD3bX0twWpLggg3OLsiMyKaTELmPMamtt6Skfd6oExxhTCnwfKMKp8TGAtdZOikSgkWKMuRT4OeAFnrTW/r+TPT6qExxroWYb+OogIx8yY2B21LYmqNkKGBg4DuKT3Y7ohHbVNPP4mzsIhiypiXH42oO0BUNcfU4hM0d3/wPYDT5/kF+/vYvt1U1kJDkfGo2+AKMGpnHrp0aQFH9mkpz6tnp+uvqnZCZkkhSXdNz5g60HyUrK4q6Su7qVTDS1BfjvFduprPeRnhRPKGRpbAswuTCTf55edMIkZ/me5Szfu5yCtILjrhuyIcqbyvny2V9mQt6ELsfUGw42t/Po37fR0BogPTEOfzBEc3uQmaNzuPqcwqhKxE4lFLK89GEZ7+yoITUhjnivh8Y2P1kpCdw1ezQDonnJi5aDcHAneONh4HjnZ1/Wxz5zTjfBOZ00eRHwbWA9EOppYL3BGOMFfgl8FigDPjDGvGqt3eRuZN20eSlsWQrGONt5d0BBidtRdZ+vHt5cCM0HnP+RsobCp74JCSluR3acUMjy+/f3khTnJSPZedPKSIqnPRDifz7az4SCTDKT+86b2ardB9lR3cTQAckdH36ZyfFsr27ig90HmTUm74zEsaZ6DSEb6jS5ARiQNIDy5nL2Nu6lKKOoy+Wv2FpNZb2PwgGfvKayUuJZW1bPlPJ6Jg8dcNxz2oPtrCxfycCUgZ0mBh7jISMhgzf3vxk1TVV/XFdOc1uQgqxPviAMCFne2V7LlGEDGJWX5mJ0XbOzpomVO2opHJCCJ/y3zUiOp7Lex583VPDlaV1/HZwRjZXO+1l7k/N+NmgCTL8TvH241inWPnPCTqeT8QFr7avW2l3W2j2Ht16PrGumAtuttTutte3A74GrXI6pe9oa4eM/Oxl0VhEkZ8OG592Oqmf2feAkN1lFMGA41O2FynVuR9WpygYftc3tHcnNYQlxHkIWtlc3uRRZ97y36yADUhKO+nA2xpCdmsB7O2vPWBybD24mPT79hOeNMRgMexq699by3s6D5KUfPZuwMYb0xDhW7TnU6XOqW6ppC7WddM2q9IR0ypvKO501+UxrD4RYV1ZP3jGzJns8hvg4D+vK6lyKrHvW7qsnIc7TkdwclpeeyJp9dfiDUfl9GrYtg2C7836WVQTVG6F2u9tRdV+nnzkvuB1VRJxOyvmAMeZJYDnQdvigtfYPvRZV1xUA+47YLwOmHfsgY8ztwO0Aw4YNOzORdVUoAFgw4aYDTxy0N7saUo+F/ByVSxsPBP2uhXMywZDlxF/ULcFQ3+qz5g+G8HTyNcZrDP9/e3ceJVd5n3n8+6utq/dN3epdu0ACgQSN2AwGLNtgx8Z27NjYExPHsZ0zJslx4pl4OWcyZzI5J87GZOIlB8dkHE8SjJ3EJjEDNhgDBmQkzCqBQGhttaRe1PtSXcs7f9ySaKm7hbpV3bfq1vM5p6DrVnXpV7eqbj393ndJppfuuaRd+k1bQEIWIuMW9qWWymQI28zDWShkJFOzP0/nHMbZazq5MvlC68qljHM4YLauNmGb+3nmq6l0hvAsTyZkkHHe881L6ak3js8nWzwy+Xk8OycnRzIG6Tsn61xacD4BbAZuBt6TvfzKYha1AFduk9oAACAASURBVLMdpWZ8OpxzdznnOp1znQ0NS9M0P2/xGmjeDIMHYPQ4jByFtW/3u6rz07wZIlEYPuJdYhXeees8tLwqTkkkxGQyfdr2TDbYrKzPv9NqZ3NpWw0DYzMPvgPjU2xur1myOlZVrWJkauSs98m4DM3lzQt6/Etaa+gfm5qxfWQyyaVzPM/60nrAW79qLuPJcapiVZRF/X/d49Ewq5aVMzB++uvpnCORSrOxpcqnyhbmopYqJqbSM4bknxibYm1jxZJ3gj9nK6+D1KR3qmroMJQ1QN1qv6tauHgNNF8arO+crHNpwbnUObdp0Ss5P11A+7TrbUC3T7WcHzO4/BNQv9b7AC1bB21X+F3V+alqhuv/Kxx8EkJhWHEtlNf7XdWsYpEQt17awj89fYiqeJSqeJSJZJq+0QTXrVtGY9XsfUjy1TVrl7Hj4Am6BydOncLpHUlQWRrhmjVL12H68uWX80T3E6QyqVkXwRxNjlIeLWdNzZoFPf7bNjSyq3uI48OT1JfHSDtH32iCpur4nEGuLFrGlsYt/LLnl7MGK+ccJyZP8N417yVk+TFl2HsuaeGrj7xG70iCuvIYyXSGntEE6xoruKBp7lOA+WhDcxWrG8rZ1zdGQ0UJ0XCIE2NTpJ3j3ZsWFnSXRMN6uP7z0LUDomWw6nqIFeYISyCY3zlZ5zKK6pvAnfncYdfMIsCrwNuAI8AO4KPOuV1z/U5ej6IS3+05NsJDu49z8MQ4deUxbryggc6VdbM2qee7gbEpHtnTc6ovyuUrarnpgsYlH6XyyOFH+PGBH1Mfrz/VIuKcYzAxyGR6kk9c9AlW1yz8L+Ge4UkefrmHF44MEgmFuGp1HW+9oPGsQ46Hp4b55gvfZCgxRENpA+GQ12qQTCfpGe9hVc0qPr7x42ftp7PUugbGeejl47xydITSWJhr1tRz3bqGJRsRl0uTyTSPvdrLk6/3M5lMs6G5im0bl5/WiVrkTLkcJv4ysAbYj9cHJ1+Hib8L+F94w8Tvds79ydnur4AjsrScczzX8xwPH3qYwcTgqT43HVUd3LLyFtqr2t/8QRbB8NQwDx18iOd6nju1LRwKc1XTVdzQcQMl4ZKz/LaILLVcBpxZx+rl4UiqeVHAEfFHxmU4PnacRDpBRazivCb3y6Wx5Bj9E/0YRmN5o4KNSJ7K2Tw4hR5kRCS/hCxEc0X+9bEoj5ZTHi3gvhQicpr86DknIiIikkMFPPWiiBSzdCbNvqF9vDbwGqlMitbKVjbUbciLId0i4j8FHBEpOMfHjvOPL/8j/ZP9RENRQhbi6WNP8++hf+d9a9/H5sbCn2ZeRM6PAo6IFJShxBDfeulbOOdorWg97bZEOsF393yXeCTOhXUX+lShiOQD9cERkYLy9LGnmUhOUBufuYBmSbiE2pJaHtj/wIwZchdDIpVmaDyZv+smiRQxteCISMFwzrG9e/upZRZmUx4t5+jYUY6OHaWlomVR6kik0vx413GefL2PVMZREgmxbcNyrlvXUJCTQYoEkQKOiCyqdMaRTGcoiYTedMHNN5PMJEmkE9SH5w44ZkbIQowlF2fBQOcc3336MM91DdJUFScaDpFIpvnhs0cYn0rxrk2LE6pEZH4UcERkUUylMvxsTw+PvdbLZDJDfXmMd17UxJaOmgUHnUgoQjQUJZlJEg1F57yfc454ZHHWDTs2PMnzXYO01ZSeeh4l0TAtNaX8bE8v168/+/IQIrI01AdHRHLOOcc//eIgD7x0jIqSCK01paQyju9sP8BT+/oX/LghC3FF0xX0T8z9GOPJcapKqmgpX5yWlO7BScyYEdIiYe9wenx4clH+XRGZHwUcEcm5roEJXjwyRFttKSURbxHIipIIyyvj3P/iUaZSC++Uu7V5KxGLMDo1OuO2ZCZJ/2Q/2zq2nVo4M9fi0RDM0n/ZOUfGUZCLXooEkQKOiORc18A4MLOVoyQaJpHM0DOy8FaOZaXL+I2Lf4NkJsmR0SMMTA4wnBjm6NhR+sb7ePeqdy/qPDhrGiqIx8KMJVKnbR8YT9JUVUJL9eKcGhOR+dGJYhHJuVgkBMzsZ+Ocw526feE6qjr4g84/4OUTL7O7bzcpl6KjqoPNDZtnHT6eS/FomNuvXsndTxxgcCJJNGwk0xkqSiJ87KoV592RWkRyQwFHRHJu3fJKIiFIJNOUTDtlc2JsiraaUhoqzn+l7ngkzpbGLWxp3HLejzVf65ZX8oVbLuSFrkH6R6doqYlzcWs1ZTEdUkXyhT6NIotl5DjsewTSSVh5LdSt9ruiJVMVj/JrV3Rwz9OHMIOSSJiJZJryWJgPb20PRCtHdWmU69Y1+F2Gv5yD7ufg6PNQWgtrb4KSSr+rEgEUcEQWx/gJeOzPIZUAC8HhX8D1n4falX5XtmQuX1FLW20pzxw8Qf/YFCvry9ncXkNlfO7h3VJgDm2HZ/4eYhWQHIeeXXDd5yES87syEQUckUXR9ypMjULNCu/6cDcc+WVRBRyA5VVxTXwXZPsfg9J6iFd514cOw0h30b3PJT9pFJXIYghHveb7kzIpiJb6V4/IYojGIT3l/ewygIOwWm8kPyjgiCyG5RdD/VoYOAiDB6F8GXRc7XdVIrm18VZwKa/lZvAQrHwLVDb7XZUIoFNUIosjUgLX/p53qiqTgmXrIFbud1UiuVW7Em76b16Ij1V47/MAdCCXYFDAEVkskRg0Xex3FSKLq7zeu4jkGQUcEQmMnuFJDvSPEw4ZaxsrqC7ViC2RYqWAIyIFL51x/ODZLp58/eQinEY4BO/b0so1a5b5WpuI+EMBRyTg0hnHaCJFPBo6tfBl0Ow8cILHX+ujvbaMUMjrAzKVyvAvz3TRWlPKivpg9n8an0qRzjgqSiKBmDxRJJcUcEQCyjnHjv0neGDXMUYmU4RCsHVlPbdsajq/JQXSSTjyDEwMQP06WLY2d0Uv0CN7ellWUXIq3IC33lU0HGL7vn7/A45zcPQ5GDkGVa3QtOm8OuP2jSa477ludh8dBgfNNXFuvbSFtcs1i7DISQo4IgH11L5+vrfjMMsqS2ipKSWVzvDUvn6ODU/y229dQzi0gC/YTAZ23O0FnHDUGyG29TPQdlnun8A8nBibYnnlzPWtSmNh+kYTPlR0ht0/gFfu9+aISU/BRR+AC29Z0EONTCb5+iN7mUimaa6OY8DwZIq/fWwfd9y4lpXLgtlaJTJfmgdHJICS6QwPvHSMxqr4qdaaSDhES3Wcfb2j7O8bXdgDj/XAsee84cHVbVBWB3t+lLvCF6i9tpThyeSM7WOJFCv9br1JTcFrP4GaDm+fVbfDnvu9sLgAzxwcYHgyRWNlnJAZZkZ1aZTSaJgf7zqW4+JFCpcCjkgADYxNMZFME4+e3ufGzAiZcbB/fIGPbDBtgmacy4t5T7ZtbGR4MslkMn1q2/BEknDIuHK1z0OYZ+wfN+vdztWeYyNUlMxsfK8pi/JqzyjOnd/jiwSFAo5IAJVEwuCY9csu4xzlC+2DU9EIbZ0weMCbvXZyEDa85/yKzYENzdV8dGsHY1MpuocmODI4QSwS4tPXr2FZxcxTV0sqHIUL3vXGbL/DR7x9FlrY4bcyHmEqNbP1J5nKUB4Lq7OxSJb64IgEUHVZlPVNlezrGaOx6o0v+EQyTSQUYkNz1cIe2Awuux2aN3vhpm4V1K3OUdXn54pV9VzaXsvx4UnCIaOpKn5ap2NfXfhuqF0Boz3eUgaNGxb8UFtX1bHjwADpjDvVj8o5R89Igls2NeWqYpGCp4AjElC/elkbf/vo63QNTBCLGOm0A4PbtnZQXXYeE+CFI9B2ee4KzaFYJER7XZnfZcxk5o2cyoE1DRVs29DIT1/pIRzyTjkm0xnWN1Vy3bqGnPwbIkGggCMSUHXlMX7/7evZ3T3Mgf4xasqiXNpWQ73fp2zkvJgZ79rUzCVtNbx0ZIipdIYLmipZ11i5sJFxIgGlgCMSYPFomMtW1HLZilq/S5EcMjPa68rys7VKJE+ok7GIiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEjgKOiIiIBI5GUcnCZNIwcABcxltjJ6KhxyIis0qMwNARiJV765FptukloYAj85dOwi/uguMveR/U6ja49ve8D69I1tBEkoP9YxjGqobyWddPCoL+0QSHByaIho01DRUz1v+SIjd8FH5+J0yNeX8Qrn8nbLxVIWcJBPOII4vr2Itw7AWoWeF9SAcPwsGnYN02vyuTPOCc46GXj/Pj3cdxGcAgHDLet7mFq9cs87u8nElnHP/+Qjc/f7UXy65BGouEue2Kdja11fhdnuSL3T+E9JT3h2AmDa8+CO1XQlWz35UFnvrgyPylJr1gc/IvkFAUEsP+1iR546UjQ9z/4jEaK0porS2ltaaUurIY33umi/19Y36XlzNP7evjZ6/00FRdSktNGa01ZVTEIvzDUwfpGZ70uzzJF5NDEC31fg6FwUKQmvC3piKhgCPzV78WwiXewoHj/ZBJQvOlflcleeJne3qpLo0SCb9xeIlFQsQjYZ7Y2+djZbnjnOOnr/TQUFly2vIIpbEwITN2HDjhY3WSVzqu8o6TE4Mw3A1ldVDZ4ndVRUGnqGT+Khrhus95Ta3pJKy5CerX+F2V5Ine0cSs/W3KYmGOB6RlI51xDE+kaK0pnXFbPBoKzPOUHFh1vddqc+SXUFYLF/4KRON+V1UUFHBkYWpXwpWf8bsKyUMtNaV0D0xQWx47bfvYVIp1yyt8qiq3wiFjWUWM0URqRpibSKZpq9UaUZJlBquu8y6ypHSKSkRy6qYLGxlJJEmk0qe2jU+lSKYd164NRidjM2PbhuX0jyVIpjOnto9MJgmHjM6VdT5WJyKgFhwRybH1yyu57YoOfvBcN8n0FOCdtvmNq1cGqmXj8hW1DE0k+cnu46QzDoDK0gi/dd1q6s5ovRKRpaeAIyI5t3V1PZe019A1MEHIoK22jFgkWA3GZsbbNizn6jX1dA9OEAmFaKstPa1ztYj4RwFHRBZFPBpmbWMw+tycTVkswtrGSr/LEJEz6E8NERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcTfQnxW2sD3p2Q7gEmi+B6MzVoaVw9I4kOHRijJAZaxsrqIxH/S5Jzsf4CTi+C0IR7/MZK/e7IikgCjhSvIaPwmN/DslxcA7qVsK1n4No3O/KZJ4yGccPn+/midf6cHjrQkVCxvsva+Oq1fU+VycLMtYHj34FJkcAB1WtcP0fKOTIOVPAkeK1/zFIJ6FmhXd94CD0ver9pSgFZcfBEzy6p4e22jLCIQNgKpXhezsP01JdSkd9cBb5LBqHnoKpMajNfj4HD8Dx3dB+ha9lSeFQHxwpXi4NZtM2GLiMb+XIwv3slV7qK0pOhRuAWCRELBJi+/5+HyuTBXMOmPb5dKf+I3JOFHCkeK18C+Bg6DAMHoSK5bBsvd9VyQL0j01RFg3P2B6PhukbSfhQkZy39q0Qjr7x+SxfBg0X+l2VFBCdopLiVdMBb/0CHH0eIiXeATWmUxmFqL22lL7RBDVlsdO2jyVSXNZR61NVcl4qm+CGL0L3LyEUhbZOiFf5XZUUEAUcKW7Vrd5FCtrbNjTyzcf3UxoNU5JtyRmeTBIyUyfjQla5HC64xe8qpEDpFJWIFLyNLdXcdkU7o1Mpugcn6B6cIBwyPnX9ahoqS/wuT0R8oBYcEQmEravrubSjhmNDk4RDRnN16WmdjkWkuCjgiEhglETCrKjXPCkiolNUIiIiEkBqwcmlsT54/p9huBuWXwwX/6pmxRURkeIwfgKev8cb2t+wATZ90NeRqWrByZV0Cp78G+jbC+EYHHgcXrzX76pEREQWXyYD278OPa9434GHnvT+4PeRWnByZXLQa8GpbvOuVzbD0Rf8rUlERGQpJIa9sxfV7d71qlbfvwPVgpMrsXIIhb2FGwEmBqGi0d+aRERElkK0DMIl3vphAJNDvn8HKuDkSrQUOj/pvahDXV7fmy2/7ndVIiIiiy8Sgys+CVOjMHzE+4P/8tt9LcmcK87Fyzo7O93OnTtz/8CJUUiMQFmdN/2/iIhIsZgag8lhKK1dtEE2ZvaMc67zze6nPji5VlLhXURERIpNrNy75AEFHJFCMGMKgg94p0VF5mv8hPdeGurKi6G8IotFfXBE8l06BU99Ffpe84Zf7n8MXvie31VJIcqkvaG8vXvyZiivyGJRC45IvpschNHeN6YgqGqBY5qCQBYgMQzDR6e9l/wfyiuyWNSCI5LvzpyCIA+GX0qBipZ5LTd5NJRXZLEo4IjkuzOnIIiUwJb/5HdVcxs/Aa8/Cvsf90ZTFIuRY/D6I3DwSUhO+F3N7CIl0PmbMDWSN0N5RRaLhomLFIpCmIJgrB8e/Yp3KsQ5r3Xg+v8C8Sq/K1tcg4fh8b+AVAJcBupWw1s+l7+v08mhvPn8XhKZw7kOE1cLjkihKKmAqub8/kLq2uGFsJoVULsSxnrg+C6/q1p8rz8CjuzzXgUDB6F/r99VzS1Wnv/vJZHzpIAjIjnkZl51GV8qWVqzPMcibR0XyRcaRSVSZHpGJnmxa4jRRIrVyyq4oKmSWCRHf+u0dsLeh2HwoHe9rA6aLs7NY+ez1TfAkWdg8BC4NNR0QP3anD38+FSKF7uGODY8ybKKGJvaaqiKR3P2+CJBpD44IkVk+75+vv9MFwaEQ0YynaGlppRPXb86d1+YY33Q/SxYCFovh9Ka3Dxuvhs6Asde8jqFt12es9lcjwxOcNejrzM2lSIaCpHMOGLhEL913SpWN2jWdCk+WqpBRE7TMzLJ95/poqGi5LQWm6ODE/zo+aPcdmVHbv6h8mWw7u25eaxCUt3qXXIok3F856kDOKC15o3Zhkcmk3z7qQN8+V0bc9f6JhIw+mSIFIkXu4YwmPGF2FgV59nDg0wm0/4UJnM6MjhB3+gUtWWx07ZXxqOMJdLs6xv1qTKR/KeAI1IkRhMpwiGbsT0cMpxzJJLF0Bm4sEwm08x8xabfrtdMZC4KOCJFYtWycpLpmV+IY4kU1aVRKuM6Y51vllfHcUA6c3pfSecczjlaquP+FCZSABRw5Oz69sLTd8GOb3kjRKRgXdhURXNNKceGJk59YY4lUvSPTfHuS5oJzdK6I/6qike5fn0DRwYnSKS8U4jJdIauwQku76ilsUoBp6AdfQG2fwN++Q8w2uN3NYGjP9lkbgMH4Od/BZG4N5fJsRfghi9B5XK/K5MFiEVCfPr61fzH8908d3gQ56C6NMrHr17B5vYiGelUgN69qZmyWJif7emhf3SKaDjEtg2NbNvQ5Hdpcj6OvQhPfQ1KKiE95Y3Au+nLEK/2u7LAUMCRuR17EQhBeYN3ffAg9L2qgFPAquJRPnrlCt6/pY2pVIbKeEQtN3kuHDK2bVjOW9c3MJZIURoLUxIJ+12WnK9DT3tTCZTVe9eHDnszYDdf4m9dAaKAI3OLloFLej87512ipf7WJDlRGgtTGtOXZCGJhkPUnDGaSgpYSYW3dhl4x9ZMWktn5JgCjsyt4yo4vD3b98ZB44XQpL8uRETO27q3e6f9hw57XQDat0L9Or+rCpS8Czhm9t+BTwG92U1fcs7dn73ti8AngTTwu865B7Pbbwb+GggDf+ec+9OlrjuQYuVw3efhxD5vVtq61RDW9PAiIuetrA5u/JJ3Wioc846vIY37yaW8CzhZdzrn/mL6BjPbCHwEuAhoAR4ys/XZm78GvB3oAnaY2X3Oud1LWXBgRUqgcYPfVYiIBE+sHJZv9LuKwMrXgDObW4F7nHMJYL+Z7QW2Zm/b65zbB2Bm92Tvq4AjIiJSpPK1PewOM3vBzO42s9rstlbg8LT7dGW3zbVdREREipQvAcfMHjKzl2a53Ap8A1gDbAaOAn958tdmeSh3lu2z/bufNrOdZrazt7d3truIiIhIAPhyiso5t+1c7mdm3wT+I3u1C2ifdnMb0J39ea7tZ/67dwF3AXR2ds4agkSkQDkHB56AvQ9BJAYXfcAb+SciRSnvTlGZWfO0q+8HXsr+fB/wETMrMbNVwDrgaWAHsM7MVplZDK8j8n1LWbOI5IHu57wp7zNJmBiCp74Kw0f9rkpEfJKPnYz/zMw2451mOgB8BsA5t8vM7sXrPJwCPuucSwOY2R3Ag3jDxO92zu3yo3AR8VHPboiVQazCu54Y9uYYqWo++++JSCDlXcBxzv36WW77E+BPZtl+P3D/YtYlInmufBkkJ7xTVThv8rSSSr+rEhGf5F3AERFZkFVvhZ6XvfXSnIPVN0KD+uCIFCsFHBEJhmgcrvkdGO3xZtwuqwfTQqIixUoBR0SCIxRWnxsRAfJwFJWIiIjI+VLAERERkcBRwBEREZHAUR8cCa5MGg5th4EDUN0OK66BsN7yIoExNQb7HoOJE9B8CTRt8rsiySM62ktw7foBvPYgRMtg36MwfBg2f8zvqkQkF9JJePKrMLAfInHY/yhc8Slov8LvyiRP6BSVBFMmDft+CtUdULEcalfA/p9DKuF3ZSKSC8NHYPAg1KzwPuOldfD6T/2uSvKIAo4Ek4UgFPHWJQLIpLwhxBb2ty4RyY1Q1JvQ0WW865kUREr8rUnyigKOBJMZbPowjB6HwUMwchQu+lX1wREJiqoW6LjS+3wPHYL0FGx8r99VSR7R0V6Ca+U1UN3izWxbVg/1a/yuSERyxQy2fBzaroCpce80dEWj31VJHlHAkWCrXeldRCR4QiFYfpHfVUie0ikqERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRyRfJGcgIlBcM7vSqTYZdIwMQCpKb8rEVmwiN8FiAjw+iPw0r+Ay0DDBtj6WxAt9bsqKUZjffDU12C0ByIlsPXT0Hih31WJzJtacET8NtQFL9wL5Q1Q1QY9u+C1H/tdlRSrZ78DEyegug0ipfD0XZCc9LsqkXlTwBHx28QAWAjCMTCDWCUMHfG7KilWQ0egtM77uaQCUgmYGvW3JpEFUMAR8VtFkxdsEiOQTkJiCBou8LsqKVaNG2DkKGRSMNYLpTUQr/a7KpF5U8AR8VtFA1z1n71WnIkTsP5mWH2D31VJsbrkw9BymdcXp6IRrr4DwlG/qxKZN3NFOmKjs7PT7dy50+8yREREZB7M7BnnXOeb3U8tOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4mslYRIKj91XY/zhEYrDu7VDZ5HdFIuITBRwRCYa+vfDEnd7su5kUHH0ebvwSlNX5XZmI+ECnqEQkGI7shFDMW/KistmbfffEPr+rEhGfqAWn2DkHQ4dhagyqWiFe5XdFIgsTLYNM0vvZOe+iCeqkkI32erNJly/zJl2UeVHAKWbOwe4fwqsPerPoRkvhLZ+D6la/KxOZv1XXQ9dOGDrkrcq+/GJo3Oh3VSIL0/087Pgm4MABnZ+Atjed206mUcApZqM9XripaoVQ2Lu+61/hmt/xuzKR+SutgRu+4J2WCkWgfi2EdYiTAuQc/PLbUFrrtUwmJ71V3lu2eMdqOSf69Bez1KTXcnPyAxMt9RZ8FClUsTJoutjvKkTOTyYNqQkoq/euR0pgbMrrPK+Ac87UybiYVTZ553WHj8DEIIz3QfvVflclIlLcwhFouxIGD3rH5sGD0Hq5F3TknKkFp5hFSuDa34VX7ofxftjwK7DyLX5XJSIimz8K5fXQvw9WXgPrb/a7ooKjgFPsSmthy8f8rkJERKaLxGDDe/yuoqDpFJWIiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEjgKOiIiIBI5GUYnIm3MOjr3orYtT3QbL1oOZ31UVpkzaW+l8YgBqV0L9Gr8rEgkkBRwReXO7/g32/D9vCQSX9uboWH2D31UVHufg2f8LB58ACwMOrvgUtF3ud2UigaNTVCJydskJ2PsQ1KyAmg6obPEWaXXO78oKz8QAHN7+xr4srYeXf+h3VSKBpIAjImfnsqsZn7lN5u/Uvsye3jPTvhRZJAo4InJ2sTJY81YYOgRDXTDSDRe+R31wFqKsDto6YeCAty/HeuHCd/tdlUggqQ+OiLy5iz8EdWth9Lh3amX5RX5XVJjM4LLbYfnFMHEC6lZDwwV+VyUSSAo4IvLmQiF1hM2VcAQ6rvS7CpHA0ykqERERCRwFHBEREQkcBRwREREJHAUcERERCRx1MpbClUrAoV9AYggaN2rKexE5nXNw9DkYPAxVrdCyxeswL0VBAUcKUzoF278BPbshFINXfgRXfxaaNvldmYjkiz33w64fQCQO6QSsewds+qDfVckSUZSVwjR8BHr3QM1KqG6Fkmp49UG/qxKRfJHJwJ4HoLodqlqgugNef9hr+ZWioIAjhenMWXRdBkxvZxHJMsseJ04uheHwlsjQDNzFQqeopDBVtULTJdD9LITCXrjRlPcicpIZbHwfvHCPt3J7Jg0b3wuRmN+VyRJRwJHCFArD1k/B0echMQr1q6Gm3e+qRCSfrLnRO4U9fBQqGrzBCFI0FHCkcIUjWj5AROZm5q31pfW+ipI6LYiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IhIsGTS4JzfVYiIz7SauIgEQyYNu34Arz8M4Shs+jVYea3fVYmIT9SCIyLBcGg7vPYgVLZAvAae/Q4MHPC7KhHxiQKOiATDwAGIlkEoDJG4t220x9eSRMQ/CjgiEgzV7TA1Bi4D6SlvW1m9vzWJiG/UB0dEgmHFNTB8aJSLzQAACeJJREFUGA78HCwMmz4M9Wv8rkpEfKKAI7KU+l+HsV6oaIS61X5XEyzhCGz+GFz8QS/ghHV4y7lMBnpfhsQo1HRAVbPfFYnMSUcAkaWy96fw4r2AAQ62/LpG+SyGSInfFQSTc/DCP8O+xyAU8kLkNb8DDRf4XZnIrNQHR2QppJOw61+hstn7y7eiCV641/uLWKQQjPV6p/9qOqC6A6Ll8NK/+l2VyJwUcESWgsuAS0Mo22gaCoNLAZqQTgpEJo3X+mje9VAEMkk/KxI5KwUckaUQKYGV18HgQRg9DoOHYc3bvKAjUggqGmHZeu89PHIMxnthzTa/qxKZk/rgiCyVSz7sNe0PHYbaFdB+ld8ViZy7UBiu/G3Y/zhM9EPjRmja5HdVInPypQXHzD5kZrvMLGNmnWfc9kUz22tme8zsndO235zdttfMvjBt+yoz+4WZvWZm3zWz2FI+F5FzFgrDqrfA5tu8Ic0hNaBKgYnGYf3b4dKPQPMlYOZ3RSJz8usI+xLwAeCx6RvNbCPwEeAi4Gbg62YWNrMw8DXgFmAjcFv2vgBfAe50zq0DBoBPLs1TEBERkXzlS8Bxzr3snNszy023Avc45xLOuf3AXmBr9rLXObfPOTcF3APcamYG3AR8P/v73wbet/jPQERERPJZvrWRtwKHp13vym6ba3s9MOicS52xfVZm9mkz22lmO3t7e3NauIiIiOSPRetkbGYPAU2z3PRl59wP5/q1WbY5Zg9i7iz3n5Vz7i7gLoDOzk6NzxUREQmoRQs4zrmFjB/sAtqnXW8DurM/z7a9D6gxs0i2FWf6/UVERKRI5dspqvuAj5hZiZmtAtYBTwM7gHXZEVMxvI7I9znnHPAI8MHs798OzNU6JCIiIkXCr2Hi7zezLuBq4Edm9iCAc24XcC+wG3gA+KxzLp1tnbkDeBB4Gbg3e1+APwR+38z24vXJ+dbSPhsRERHJN+Y1ghSfzs5Ot3PnTr/LEBERkXkws2ecc51vdr98O0UlIiIict4UcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwIn4XICJ5qncPvPoAYLD+ZmhY73dFweMcHNoOB5+AeDVseA9UNvldlUggqAVHRGYaOAhP/DUMHobBQ9mfD/ldVfAcfhqe+XsY64Xju+Dxv4LJYb+rEgkEBRwRmal3DzigrN674LxtkltHdkJJNcRroGI5TI3BUJffVYkEgk5RichMJRXgUt4pFIBMCmIV/tYURPEaSE14P7uMd4mW+luTSEAo4IjITK2Xe6dPTrbaNF7kbZPcuuAW6H0Fhg57YXL1DVC70ueiRIJBAUdEZoqUwNV3wFC23011B4R1uMi5sjq48UswdMTb59VtYOZ3VSKBoCOWiMwuHIG61X5XEXzRUli21u8qRAJHnYxFREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHDMOed3Db4ws17goN91LKFlQJ/fRRQh7Xd/aL/7Q/vdH8W231c45xre7E5FG3CKjZntdM51+l1HsdF+94f2uz+03/2h/T47naISERGRwFHAERERkcBRwCked/ldQJHSfveH9rs/tN/9of0+C/XBERERkcBRC46IiIgEjgKOiIiIBI4CTkCY2YfMbJeZZcys84zbvmhme81sj5m9c9r2m7Pb9prZF6ZtX2VmvzCz18zsu2YWW8rnUqjM7L+b2REzey57ede02+b1GsjCaH8uLjM7YGYvZt/fO7Pb6szsJ9njxU/MrDa73czsf2dfixfM7DJ/qy8cZna3mfWY2UvTts17P5vZ7dn7v2Zmt/vxXPykgBMcLwEfAB6bvtHMNgIfAS4Cbga+bmZhMwsDXwNuATYCt2XvC/AV4E7n3DpgAPjk0jyFQLjTObc5e7kfFvwayDxpfy6ZG7Pv75N/SH0BeDh7vHg4ex2812Fd9vJp4BtLXmnh+j94x4rp5rWfzawO+CPgSmAr8EcnQ1GxUMAJCOfcy865PbPcdCtwj3Mu4ZzbD+zFe7NvBfY65/Y556aAe4BbzcyAm4DvZ3//28D7Fv8ZBNq8XgMf6yx02p/+uBXvOAGnHy9uBf7BebYDNWbW7EeBhcY59xhw4ozN893P7wR+4pw74ZwbAH7CzNAUaAo4wdcKHJ52vSu7ba7t9cCgcy51xnY5N3dkm4nvnvbX0nxfA1kY7c/F54Afm9kzZvbp7LblzrmjANn/N2a36/XIrfnu56Lf/xG/C5BzZ2YPAU2z3PRl59wP5/q1WbY5Zg+37iz3F87+GuA1Df8x3v76Y+Avgd9k/q+BLIzeu4vvWudct5k1Aj8xs1fOcl+9Hktjrv1c9PtfAaeAOOe2LeDXuoD2adfbgO7sz7Nt78Nr4oxkW3Gm37/onetrYGbfBP4je3W+r4EszNn2s+SAc647+/8eM/s3vNOCx82s2Tl3NHtqpCd7d70euTXf/dwF3HDG9p8tQZ15Q6eogu8+4CNmVmJmq/A6oj0N7ADWZUdMxfA6wd7nvJkfHwE+mP3924G5WodkmjP6F7wfr+M3zPM1WMqaA0b7cxGZWbmZVZ78GXgH3nv8PrzjBJx+vLgP+Hh2lM9VwNDJUyyyIPPdzw8C7zCz2uzp8ndktxUNteAEhJm9H/gboAH4kZk955x7p3Nul5ndC+wGUsBnnXPp7O/cgfeGDwN3O+d2ZR/uD4F7zOx/As8C31rip1Oo/szMNuM1Ax8APgOwwNdA5sk5l9L+XFTLgX/zxiEQAf7JOfeAme0A7jWzTwKHgA9l738/8C68TvXjwCeWvuTCZGb/jNf6sszMuvBGQ/0p89jPzrkTZvbHeMEf4H84587suBxoWqpBREREAkenqERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEpKCZ2Uoze8XM/s7MXjKzfzSzbWb2hJm9ZmZb/a5RRJaeAo6IBMFa4K+BS4ALgY8CbwE+D3zJx7pExCcKOCISBPudcy865zLALuDh7LpqLwIrfa1MRHyhgCMiQZCY9nNm2vUMWnNPpCgp4IiIiEjgKOCIiIhI4Gg1cREREQkcteCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4Px/uGHzFHgrkhUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x576 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "subarray.peek()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$4.9235437 \\; \\mathrm{km^{2}}$"
+      ],
+      "text/plain": [
+       "<Quantity 4.92354368 km2>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.footprint"
    ]
@@ -235,36 +521,210 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam),\n",
+       " TelescopeDescription(type=SST, name=ASTRI, optics=ASTRI, camera=ASTRICam),\n",
+       " TelescopeDescription(type=LST, name=LST, optics=LST, camera=LSTCam)]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.telescope_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[CameraGeometry(cam_id='ASTRICam', pix_type='rectangular', npix=2368, cam_rot=0.0 rad, pix_rot=0.0 deg),\n",
+       " CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg),\n",
+       " CameraGeometry(cam_id='LSTCam', pix_type='hexagonal', npix=1855, cam_rot=0.0 rad, pix_rot=100.89299992867878 deg)]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.camera_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[OpticsDescription(name=LST, equivalent_focal_length=28.00 m, num_mirros=1, mirror_area=386.73 m2),\n",
+       " OpticsDescription(name=ASTRI, equivalent_focal_length=2.15 m, num_mirros=2, mirror_area=14.56 m2),\n",
+       " OpticsDescription(name=MST, equivalent_focal_length=16.00 m, num_mirros=1, mirror_area=103.83 m2)]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.optics_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "[$95^\\circ38{}^\\prime18.0015{}^{\\prime\\prime}$\n",
+       " $117^\\circ35{}^\\prime31.273{}^{\\prime\\prime}$\n",
+       " $15^\\circ56{}^\\prime32.527{}^{\\prime\\prime}$\n",
+       " $166^\\circ24{}^\\prime15.7253{}^{\\prime\\prime}$\n",
+       " $90^\\circ00{}^\\prime00{}^{\\prime\\prime}$\n",
+       " $78^\\circ42{}^\\prime54.1682{}^{\\prime\\prime}$\n",
+       " $101^\\circ17{}^\\prime05.8318{}^{\\prime\\prime}$\n",
+       " $16^\\circ19{}^\\prime25.416{}^{\\prime\\prime}$\n",
+       " $38^\\circ42{}^\\prime43.3493{}^{\\prime\\prime}$\n",
+       " $138^\\circ18{}^\\prime26.2816{}^{\\prime\\prime}$\n",
+       " $160^\\circ45{}^\\prime08.6066{}^{\\prime\\prime}$\n",
+       " $45^\\circ50{}^\\prime11.5818{}^{\\prime\\prime}$\n",
+       " $68^\\circ26{}^\\prime09.4249{}^{\\prime\\prime}$\n",
+       " $11^\\circ27{}^\\prime33.9556{}^{\\prime\\prime}$\n",
+       " $111^\\circ33{}^\\prime50.5751{}^{\\prime\\prime}$\n",
+       " $134^\\circ09{}^\\prime48.4182{}^{\\prime\\prime}$\n",
+       " $168^\\circ32{}^\\prime26.0444{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime43.7281{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime16.2719{}^{\\prime\\prime}$\n",
+       " $16^\\circ02{}^\\prime24.2016{}^{\\prime\\prime}$\n",
+       " $38^\\circ36{}^\\prime32.8491{}^{\\prime\\prime}$\n",
+       " $141^\\circ23{}^\\prime27.1509{}^{\\prime\\prime}$\n",
+       " $163^\\circ57{}^\\prime35.7984{}^{\\prime\\prime}$\n",
+       " $45^\\circ48{}^\\prime42.2049{}^{\\prime\\prime}$\n",
+       " $68^\\circ25{}^\\prime33.0227{}^{\\prime\\prime}$\n",
+       " $11^\\circ21{}^\\prime07.5916{}^{\\prime\\prime}$\n",
+       " $111^\\circ34{}^\\prime26.9773{}^{\\prime\\prime}$\n",
+       " $134^\\circ11{}^\\prime17.7951{}^{\\prime\\prime}$\n",
+       " $168^\\circ38{}^\\prime52.4084{}^{\\prime\\prime}$\n",
+       " $49^\\circ01{}^\\prime53.8821{}^{\\prime\\prime}$\n",
+       " $130^\\circ58{}^\\prime06.1179{}^{\\prime\\prime}$\n",
+       " $153^\\circ34{}^\\prime33.8961{}^{\\prime\\prime}$\n",
+       " $57^\\circ29{}^\\prime13.3129{}^{\\prime\\prime}$\n",
+       " $80^\\circ06{}^\\prime19.0782{}^{\\prime\\prime}$\n",
+       " $99^\\circ53{}^\\prime40.9218{}^{\\prime\\prime}$\n",
+       " $122^\\circ30{}^\\prime46.6871{}^{\\prime\\prime}$\n",
+       " $1^\\circ21{}^\\prime19.7674{}^{\\prime\\prime}$\n",
+       " $23^\\circ51{}^\\prime29.0911{}^{\\prime\\prime}$\n",
+       " $156^\\circ08{}^\\prime30.9089{}^{\\prime\\prime}$\n",
+       " $178^\\circ38{}^\\prime40.2326{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime26.1515{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime33.8485{}^{\\prime\\prime}$\n",
+       " $34^\\circ34{}^\\prime02.3914{}^{\\prime\\prime}$\n",
+       " $57^\\circ11{}^\\prime07.3317{}^{\\prime\\prime}$\n",
+       " $122^\\circ48{}^\\prime52.6683{}^{\\prime\\prime}$\n",
+       " $145^\\circ25{}^\\prime57.6086{}^{\\prime\\prime}$\n",
+       " $15^\\circ57{}^\\prime57.3762{}^{\\prime\\prime}$\n",
+       " $38^\\circ34{}^\\prime56.9335{}^{\\prime\\prime}$\n",
+       " $141^\\circ25{}^\\prime03.0665{}^{\\prime\\prime}$\n",
+       " $164^\\circ02{}^\\prime02.6238{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime25.2281{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime34.7719{}^{\\prime\\prime}$\n",
+       " $11^\\circ18{}^\\prime54.9244{}^{\\prime\\prime}$\n",
+       " $168^\\circ41{}^\\prime05.0756{}^{\\prime\\prime}$\n",
+       " $45^\\circ48{}^\\prime11.2618{}^{\\prime\\prime}$\n",
+       " $68^\\circ25{}^\\prime20.4612{}^{\\prime\\prime}$\n",
+       " $111^\\circ34{}^\\prime39.5388{}^{\\prime\\prime}$\n",
+       " $134^\\circ11{}^\\prime48.7382{}^{\\prime\\prime}$\n",
+       " $63^\\circ12{}^\\prime03.8214{}^{\\prime\\prime}$\n",
+       " $85^\\circ49{}^\\prime13.7063{}^{\\prime\\prime}$\n",
+       " $29^\\circ21{}^\\prime33.4806{}^{\\prime\\prime}$\n",
+       " $51^\\circ58{}^\\prime41.6293{}^{\\prime\\prime}$\n",
+       " $3^\\circ09{}^\\prime32.0002{}^{\\prime\\prime}$\n",
+       " $25^\\circ45{}^\\prime53.6564{}^{\\prime\\prime}$\n",
+       " $94^\\circ10{}^\\prime46.2937{}^{\\prime\\prime}$\n",
+       " $116^\\circ47{}^\\prime56.1786{}^{\\prime\\prime}$\n",
+       " $128^\\circ01{}^\\prime18.3707{}^{\\prime\\prime}$\n",
+       " $150^\\circ38{}^\\prime26.5194{}^{\\prime\\prime}$\n",
+       " $154^\\circ14{}^\\prime06.3436{}^{\\prime\\prime}$\n",
+       " $176^\\circ50{}^\\prime27.9998{}^{\\prime\\prime}$\n",
+       " $78^\\circ41{}^\\prime24.8214{}^{\\prime\\prime}$\n",
+       " $101^\\circ18{}^\\prime35.1786{}^{\\prime\\prime}$\n",
+       " $15^\\circ57{}^\\prime47.4141{}^{\\prime\\prime}$\n",
+       " $38^\\circ34{}^\\prime53.4825{}^{\\prime\\prime}$\n",
+       " $141^\\circ25{}^\\prime06.5175{}^{\\prime\\prime}$\n",
+       " $164^\\circ02{}^\\prime12.5859{}^{\\prime\\prime}$\n",
+       " $11^\\circ18{}^\\prime46.4095{}^{\\prime\\prime}$\n",
+       " $168^\\circ41{}^\\prime13.5905{}^{\\prime\\prime}$\n",
+       " $52^\\circ49{}^\\prime06.0105{}^{\\prime\\prime}$\n",
+       " $75^\\circ26{}^\\prime16.4206{}^{\\prime\\prime}$\n",
+       " $38^\\circ57{}^\\prime04.2653{}^{\\prime\\prime}$\n",
+       " $61^\\circ34{}^\\prime14.3105{}^{\\prime\\prime}$\n",
+       " $104^\\circ33{}^\\prime43.5794{}^{\\prime\\prime}$\n",
+       " $127^\\circ10{}^\\prime53.9895{}^{\\prime\\prime}$\n",
+       " $118^\\circ25{}^\\prime45.6895{}^{\\prime\\prime}$\n",
+       " $141^\\circ02{}^\\prime55.7347{}^{\\prime\\prime}$\n",
+       " $66^\\circ31{}^\\prime35.8563{}^{\\prime\\prime}$\n",
+       " $89^\\circ08{}^\\prime46.5312{}^{\\prime\\prime}$\n",
+       " $26^\\circ24{}^\\prime12.8535{}^{\\prime\\prime}$\n",
+       " $49^\\circ01{}^\\prime22.348{}^{\\prime\\prime}$\n",
+       " $90^\\circ51{}^\\prime13.4688{}^{\\prime\\prime}$\n",
+       " $113^\\circ28{}^\\prime24.1437{}^{\\prime\\prime}$\n",
+       " $130^\\circ58{}^\\prime37.652{}^{\\prime\\prime}$\n",
+       " $153^\\circ35{}^\\prime47.1465{}^{\\prime\\prime}$\n",
+       " $5^\\circ52{}^\\prime51.9148{}^{\\prime\\prime}$\n",
+       " $28^\\circ29{}^\\prime50.4816{}^{\\prime\\prime}$\n",
+       " $151^\\circ30{}^\\prime09.5184{}^{\\prime\\prime}$\n",
+       " $174^\\circ07{}^\\prime08.0852{}^{\\prime\\prime}$]"
+      ],
+      "text/plain": [
+       "<Angle [ 95.63833374, 117.59202028,  15.94236861, 166.40436814,\n",
+       "         90.        ,  78.71504671, 101.28495329,  16.32372666,\n",
+       "         38.71204146, 138.30730046, 160.75239071,  45.8365505 ,\n",
+       "         68.43595137,  11.45943212, 111.56404863, 134.1634495 ,\n",
+       "        168.54056788,  78.69548002, 101.30451998,  16.04005599,\n",
+       "         38.60912476, 141.39087524, 163.95994401,  45.81172359,\n",
+       "         68.42583965,  11.35210877, 111.57416035, 134.18827641,\n",
+       "        168.64789123,  49.03163391, 130.96836609, 153.57608224,\n",
+       "         57.48703137,  80.10529951,  99.89470049, 122.51296863,\n",
+       "          1.35549094,  23.85808087, 156.14191913, 178.64450906,\n",
+       "         78.69059764, 101.30940236,  34.56733094,  57.18536991,\n",
+       "        122.81463009, 145.43266906,  15.96593785,  38.58248153,\n",
+       "        141.41751847, 164.03406215,  78.69034114, 101.30965886,\n",
+       "         11.31525677, 168.68474323,  45.80312828,  68.42235035,\n",
+       "        111.57764965, 134.19687172,  63.2010615 ,  85.82047396,\n",
+       "         29.35930018,  51.97823035,   3.15888895,  25.76490456,\n",
+       "         94.17952604, 116.7989385 , 128.02176965, 150.64069982,\n",
+       "        154.23509544, 176.84111105,  78.69022816, 101.30977184,\n",
+       "         15.96317058,  38.58152291, 141.41847709, 164.03682942,\n",
+       "         11.31289154, 168.68710846,  52.81833625,  75.4378946 ,\n",
+       "         38.95118481,  61.5706418 , 104.5621054 , 127.18166375,\n",
+       "        118.4293582 , 141.04881519,  66.52662676,  89.14625866,\n",
+       "         26.40357041,  49.02287445,  90.85374134, 113.47337324,\n",
+       "        130.97712555, 153.59642959,   5.88108744,  28.497356  ,\n",
+       "        151.502644  , 174.11891256] deg>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from astropy.coordinates import SkyCoord\n",
     "from ctapipe.coordinates import GroundFrame\n",
@@ -284,9 +744,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0,  4, 22])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.tel_ids_to_indices([1,5,23])"
    ]
@@ -300,36 +771,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,\n",
+       "       16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,\n",
+       "       33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,\n",
+       "       50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66,\n",
+       "       67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,\n",
+       "       84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.tel_index_array"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0,  4, 22])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.tel_index_array[[1,5,23]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.tel_indices[1]  # this is a dict of tel_id -> tel_index, so we can only do one at once"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[5,\n",
+       " 6,\n",
+       " 7,\n",
+       " 8,\n",
+       " 9,\n",
+       " 10,\n",
+       " 11,\n",
+       " 12,\n",
+       " 13,\n",
+       " 14,\n",
+       " 15,\n",
+       " 16,\n",
+       " 17,\n",
+       " 18,\n",
+       " 19,\n",
+       " 20,\n",
+       " 21,\n",
+       " 22,\n",
+       " 23,\n",
+       " 24,\n",
+       " 25,\n",
+       " 26,\n",
+       " 27,\n",
+       " 28,\n",
+       " 29]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ids = subarray.get_tel_ids_for_type(subarray.telescope_types[0])\n",
     "ids"
@@ -337,9 +881,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,\n",
+       "       21, 22, 23, 24, 25, 26, 27, 28])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "idx = subarray.tel_ids_to_indices(ids)\n",
     "idx"
@@ -347,9 +903,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<SkyCoord (GroundFrame): (x, y, z) in m\n",
+       "    [(   0.        ,    0.        , 10.),\n",
+       "     (   0.        ,  151.19999695, 10.),\n",
+       "     (   0.        , -151.19999695, 10.),\n",
+       "     ( 146.6559906 ,   75.59999847, 10.),\n",
+       "     ( 146.6559906 ,  -75.59999847, 10.),\n",
+       "     (-146.6559906 ,   85.59999847, 10.),\n",
+       "     (-146.6559906 ,  -85.59999847, 10.),\n",
+       "     ( 154.20500183,  238.47399902, 10.),\n",
+       "     ( 154.20500183, -238.47399902, 10.),\n",
+       "     ( 308.41000366,    0.        , 10.),\n",
+       "     (-154.20500183,  238.47399902, 10.),\n",
+       "     (-154.20500183, -238.47399902, 10.),\n",
+       "     (-308.41000366,    0.        , 10.),\n",
+       "     (   0.        ,  325.24200439, 10.),\n",
+       "     (   0.        , -325.24200439, 10.),\n",
+       "     ( 315.46801758,  162.6210022 , 10.),\n",
+       "     ( 315.46801758, -162.6210022 , 10.),\n",
+       "     (-315.46801758,  162.6210022 , 10.),\n",
+       "     (-315.46801758, -162.6210022 , 10.),\n",
+       "     ( 291.08499146,  450.15499878, 10.),\n",
+       "     ( 291.08499146, -450.15499878, 10.),\n",
+       "     ( 582.16998291,    0.        , 10.),\n",
+       "     (-291.08499146,  450.15499878, 10.),\n",
+       "     (-291.08499146, -450.15499878, 10.),\n",
+       "     (-582.16998291,    0.        , 10.)]>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.tel_coords[idx]"
    ]
@@ -363,9 +955,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$[-20,~65,~16] \\; \\mathrm{m}$"
+      ],
+      "text/plain": [
+       "<Quantity [-20.,  65.,  16.] m>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "subarray.positions[1]"
    ]
@@ -380,19 +986,896 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pos_x</th>\n",
+       "      <th>pos_y</th>\n",
+       "      <th>pos_z</th>\n",
+       "      <th>name</th>\n",
+       "      <th>type</th>\n",
+       "      <th>num_mirrors</th>\n",
+       "      <th>camera_type</th>\n",
+       "      <th>tel_description</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tel_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>-20.000000</td>\n",
+       "      <td>65.000000</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>-20.000000</td>\n",
+       "      <td>-65.000000</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>80.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>-120.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>151.199997</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>-151.199997</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>146.655991</td>\n",
+       "      <td>75.599998</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>146.655991</td>\n",
+       "      <td>-75.599998</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>-146.655991</td>\n",
+       "      <td>85.599998</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>-146.655991</td>\n",
+       "      <td>-85.599998</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>154.205002</td>\n",
+       "      <td>238.473999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>154.205002</td>\n",
+       "      <td>-238.473999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>308.410004</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>-154.205002</td>\n",
+       "      <td>238.473999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>-154.205002</td>\n",
+       "      <td>-238.473999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>-308.410004</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>325.242004</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>-325.242004</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>315.468018</td>\n",
+       "      <td>162.621002</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>315.468018</td>\n",
+       "      <td>-162.621002</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>-315.468018</td>\n",
+       "      <td>162.621002</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>-315.468018</td>\n",
+       "      <td>-162.621002</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>291.084991</td>\n",
+       "      <td>450.154999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>291.084991</td>\n",
+       "      <td>-450.154999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>582.169983</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>-291.084991</td>\n",
+       "      <td>450.154999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
+       "      <td>-291.084991</td>\n",
+       "      <td>-450.154999</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>-582.169983</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>MST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>FlashCam</td>\n",
+       "      <td>MST_MST_FlashCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
+       "      <td>205.500000</td>\n",
+       "      <td>-158.899994</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>69</th>\n",
+       "      <td>-883.377014</td>\n",
+       "      <td>227.686996</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>70</th>\n",
+       "      <td>-883.377014</td>\n",
+       "      <td>-227.686996</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>71</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>944.301025</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>72</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>-944.301025</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>73</th>\n",
+       "      <td>915.922974</td>\n",
+       "      <td>472.151001</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>74</th>\n",
+       "      <td>915.922974</td>\n",
+       "      <td>-472.151001</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75</th>\n",
+       "      <td>-915.922974</td>\n",
+       "      <td>472.151001</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>76</th>\n",
+       "      <td>-915.922974</td>\n",
+       "      <td>-472.151001</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>77</th>\n",
+       "      <td>1100.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>78</th>\n",
+       "      <td>-1100.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>79</th>\n",
+       "      <td>471.011993</td>\n",
+       "      <td>971.210022</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80</th>\n",
+       "      <td>471.011993</td>\n",
+       "      <td>-971.210022</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>706.517944</td>\n",
+       "      <td>849.808960</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>82</th>\n",
+       "      <td>706.517944</td>\n",
+       "      <td>-849.808960</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>-471.011993</td>\n",
+       "      <td>971.210022</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>84</th>\n",
+       "      <td>-471.011993</td>\n",
+       "      <td>-971.210022</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>85</th>\n",
+       "      <td>-706.517944</td>\n",
+       "      <td>849.808960</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>86</th>\n",
+       "      <td>-706.517944</td>\n",
+       "      <td>-849.808960</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>87</th>\n",
+       "      <td>239.196991</td>\n",
+       "      <td>1109.734985</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>88</th>\n",
+       "      <td>239.196991</td>\n",
+       "      <td>-1109.734985</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>89</th>\n",
+       "      <td>956.787048</td>\n",
+       "      <td>739.822998</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>90</th>\n",
+       "      <td>956.787048</td>\n",
+       "      <td>-739.822998</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>91</th>\n",
+       "      <td>-239.196991</td>\n",
+       "      <td>1109.734985</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>92</th>\n",
+       "      <td>-239.196991</td>\n",
+       "      <td>-1109.734985</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>93</th>\n",
+       "      <td>-956.787048</td>\n",
+       "      <td>739.822998</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>94</th>\n",
+       "      <td>-956.787048</td>\n",
+       "      <td>-739.822998</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>1195.984009</td>\n",
+       "      <td>369.911987</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>1195.984009</td>\n",
+       "      <td>-369.911987</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>-1195.984009</td>\n",
+       "      <td>369.911987</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>-1195.984009</td>\n",
+       "      <td>-369.911987</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>ASTRI</td>\n",
+       "      <td>SST</td>\n",
+       "      <td>2</td>\n",
+       "      <td>ASTRICam</td>\n",
+       "      <td>SST_ASTRI_ASTRICam</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>98 rows × 8 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              pos_x        pos_y  pos_z   name type  num_mirrors camera_type  \\\n",
+       "tel_id                                                                         \n",
+       "1        -20.000000    65.000000   16.0    LST  LST            1      LSTCam   \n",
+       "2        -20.000000   -65.000000   16.0    LST  LST            1      LSTCam   \n",
+       "3         80.000000     0.000000   16.0    LST  LST            1      LSTCam   \n",
+       "4       -120.000000     0.000000   16.0    LST  LST            1      LSTCam   \n",
+       "5          0.000000     0.000000   10.0    MST  MST            1    FlashCam   \n",
+       "6          0.000000   151.199997   10.0    MST  MST            1    FlashCam   \n",
+       "7          0.000000  -151.199997   10.0    MST  MST            1    FlashCam   \n",
+       "8        146.655991    75.599998   10.0    MST  MST            1    FlashCam   \n",
+       "9        146.655991   -75.599998   10.0    MST  MST            1    FlashCam   \n",
+       "10      -146.655991    85.599998   10.0    MST  MST            1    FlashCam   \n",
+       "11      -146.655991   -85.599998   10.0    MST  MST            1    FlashCam   \n",
+       "12       154.205002   238.473999   10.0    MST  MST            1    FlashCam   \n",
+       "13       154.205002  -238.473999   10.0    MST  MST            1    FlashCam   \n",
+       "14       308.410004     0.000000   10.0    MST  MST            1    FlashCam   \n",
+       "15      -154.205002   238.473999   10.0    MST  MST            1    FlashCam   \n",
+       "16      -154.205002  -238.473999   10.0    MST  MST            1    FlashCam   \n",
+       "17      -308.410004     0.000000   10.0    MST  MST            1    FlashCam   \n",
+       "18         0.000000   325.242004   10.0    MST  MST            1    FlashCam   \n",
+       "19         0.000000  -325.242004   10.0    MST  MST            1    FlashCam   \n",
+       "20       315.468018   162.621002   10.0    MST  MST            1    FlashCam   \n",
+       "21       315.468018  -162.621002   10.0    MST  MST            1    FlashCam   \n",
+       "22      -315.468018   162.621002   10.0    MST  MST            1    FlashCam   \n",
+       "23      -315.468018  -162.621002   10.0    MST  MST            1    FlashCam   \n",
+       "24       291.084991   450.154999   10.0    MST  MST            1    FlashCam   \n",
+       "25       291.084991  -450.154999   10.0    MST  MST            1    FlashCam   \n",
+       "26       582.169983     0.000000   10.0    MST  MST            1    FlashCam   \n",
+       "27      -291.084991   450.154999   10.0    MST  MST            1    FlashCam   \n",
+       "28      -291.084991  -450.154999   10.0    MST  MST            1    FlashCam   \n",
+       "29      -582.169983     0.000000   10.0    MST  MST            1    FlashCam   \n",
+       "30       205.500000  -158.899994    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "...             ...          ...    ...    ...  ...          ...         ...   \n",
+       "69      -883.377014   227.686996    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "70      -883.377014  -227.686996    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "71         0.000000   944.301025    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "72         0.000000  -944.301025    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "73       915.922974   472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "74       915.922974  -472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "75      -915.922974   472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "76      -915.922974  -472.151001    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "77      1100.000000     0.000000    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "78     -1100.000000     0.000000    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "79       471.011993   971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "80       471.011993  -971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "81       706.517944   849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "82       706.517944  -849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "83      -471.011993   971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "84      -471.011993  -971.210022    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "85      -706.517944   849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "86      -706.517944  -849.808960    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "87       239.196991  1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "88       239.196991 -1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "89       956.787048   739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "90       956.787048  -739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "91      -239.196991  1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "92      -239.196991 -1109.734985    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "93      -956.787048   739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "94      -956.787048  -739.822998    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "95      1195.984009   369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "96      1195.984009  -369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "97     -1195.984009   369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "98     -1195.984009  -369.911987    5.0  ASTRI  SST            2    ASTRICam   \n",
+       "\n",
+       "           tel_description  \n",
+       "tel_id                      \n",
+       "1           LST_LST_LSTCam  \n",
+       "2           LST_LST_LSTCam  \n",
+       "3           LST_LST_LSTCam  \n",
+       "4           LST_LST_LSTCam  \n",
+       "5         MST_MST_FlashCam  \n",
+       "6         MST_MST_FlashCam  \n",
+       "7         MST_MST_FlashCam  \n",
+       "8         MST_MST_FlashCam  \n",
+       "9         MST_MST_FlashCam  \n",
+       "10        MST_MST_FlashCam  \n",
+       "11        MST_MST_FlashCam  \n",
+       "12        MST_MST_FlashCam  \n",
+       "13        MST_MST_FlashCam  \n",
+       "14        MST_MST_FlashCam  \n",
+       "15        MST_MST_FlashCam  \n",
+       "16        MST_MST_FlashCam  \n",
+       "17        MST_MST_FlashCam  \n",
+       "18        MST_MST_FlashCam  \n",
+       "19        MST_MST_FlashCam  \n",
+       "20        MST_MST_FlashCam  \n",
+       "21        MST_MST_FlashCam  \n",
+       "22        MST_MST_FlashCam  \n",
+       "23        MST_MST_FlashCam  \n",
+       "24        MST_MST_FlashCam  \n",
+       "25        MST_MST_FlashCam  \n",
+       "26        MST_MST_FlashCam  \n",
+       "27        MST_MST_FlashCam  \n",
+       "28        MST_MST_FlashCam  \n",
+       "29        MST_MST_FlashCam  \n",
+       "30      SST_ASTRI_ASTRICam  \n",
+       "...                    ...  \n",
+       "69      SST_ASTRI_ASTRICam  \n",
+       "70      SST_ASTRI_ASTRICam  \n",
+       "71      SST_ASTRI_ASTRICam  \n",
+       "72      SST_ASTRI_ASTRICam  \n",
+       "73      SST_ASTRI_ASTRICam  \n",
+       "74      SST_ASTRI_ASTRICam  \n",
+       "75      SST_ASTRI_ASTRICam  \n",
+       "76      SST_ASTRI_ASTRICam  \n",
+       "77      SST_ASTRI_ASTRICam  \n",
+       "78      SST_ASTRI_ASTRICam  \n",
+       "79      SST_ASTRI_ASTRICam  \n",
+       "80      SST_ASTRI_ASTRICam  \n",
+       "81      SST_ASTRI_ASTRICam  \n",
+       "82      SST_ASTRI_ASTRICam  \n",
+       "83      SST_ASTRI_ASTRICam  \n",
+       "84      SST_ASTRI_ASTRICam  \n",
+       "85      SST_ASTRI_ASTRICam  \n",
+       "86      SST_ASTRI_ASTRICam  \n",
+       "87      SST_ASTRI_ASTRICam  \n",
+       "88      SST_ASTRI_ASTRICam  \n",
+       "89      SST_ASTRI_ASTRICam  \n",
+       "90      SST_ASTRI_ASTRICam  \n",
+       "91      SST_ASTRI_ASTRICam  \n",
+       "92      SST_ASTRI_ASTRICam  \n",
+       "93      SST_ASTRI_ASTRICam  \n",
+       "94      SST_ASTRI_ASTRICam  \n",
+       "95      SST_ASTRI_ASTRICam  \n",
+       "96      SST_ASTRI_ASTRICam  \n",
+       "97      SST_ASTRI_ASTRICam  \n",
+       "98      SST_ASTRI_ASTRICam  \n",
+       "\n",
+       "[98 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "tel_string = \"LST_LST_LSTCam\" # an LST with LST structure and LSTCam camera\n",
     "df = subarray.to_table().to_pandas()\n",
     "df.set_index('tel_id')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'LST_LST_LSTCam': Int64Index([0, 1, 2, 3], dtype='int64'),\n",
+       " 'MST_MST_FlashCam': Int64Index([ 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,\n",
+       "             21, 22, 23, 24, 25, 26, 27, 28],\n",
+       "            dtype='int64'),\n",
+       " 'SST_ASTRI_ASTRICam': Int64Index([29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,\n",
+       "             46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,\n",
+       "             63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,\n",
+       "             80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,\n",
+       "             97],\n",
+       "            dtype='int64')}"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "g = df.groupby('tel_description')\n",
     "g.groups"
@@ -400,33 +1883,201 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64Index([0, 1, 2, 3], dtype='int64')"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "g.groups['LST_LST_LSTCam']"
+    "g.groups[tel_string]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tel_id</th>\n",
+       "      <th>pos_x</th>\n",
+       "      <th>pos_y</th>\n",
+       "      <th>pos_z</th>\n",
+       "      <th>name</th>\n",
+       "      <th>type</th>\n",
+       "      <th>num_mirrors</th>\n",
+       "      <th>camera_type</th>\n",
+       "      <th>tel_description</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>-20.0</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>-20.0</td>\n",
+       "      <td>-65.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>-120.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>LST</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LSTCam</td>\n",
+       "      <td>LST_LST_LSTCam</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   tel_id  pos_x  pos_y  pos_z name type  num_mirrors camera_type  \\\n",
+       "0       1  -20.0   65.0   16.0  LST  LST            1      LSTCam   \n",
+       "1       2  -20.0  -65.0   16.0  LST  LST            1      LSTCam   \n",
+       "2       3   80.0    0.0   16.0  LST  LST            1      LSTCam   \n",
+       "3       4 -120.0    0.0   16.0  LST  LST            1      LSTCam   \n",
+       "\n",
+       "  tel_description  \n",
+       "0  LST_LST_LSTCam  \n",
+       "1  LST_LST_LSTCam  \n",
+       "2  LST_LST_LSTCam  \n",
+       "3  LST_LST_LSTCam  "
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "df.loc[g.groups['LST_LST_LSTCam']]"
+    "df.loc[g.groups[tel_string]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subarray : LSTs\n",
+      "Num Tels : 4\n",
+      "Footprint: 0.05 km2\n",
+      "\n",
+      "                TYPE  Num IDmin  IDmax\n",
+      "=====================================\n",
+      "      LST_LST_LSTCam    4    1 ..   4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$0.045238934 \\; \\mathrm{km^{2}}$"
+      ],
+      "text/plain": [
+       "<Quantity 0.04523893 km2>"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAI4CAYAAABndZP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3X+U3XV97/vXOzPJJCH8CCT8DBAQREE0eFLUWnupWqnVBe2911ZPT0vVe2mtVWtv7xGlv1dZ99Ryjh7be9ui9dReqa21Wlz0VKvc4jq2Ag0/yg8RQUEIBAg0/JL8muRz/5hNOsgkBMhkz/7k8VhrVvb+7u/+7vc338nMM9+990y11gIA0JN5wx4AAGBPEzgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BA8wJVXVHVb12huUfqKrbq+qxqlpbVX85WH7TYNljVbWtqjZNu/6Bvb8HwFwyPuwBAHamqs5J8tNJXtta+1ZVHZ7krCRprZ0ybb3Lk3yytfaxoQwKzDnO4ABz2fcl+WJr7VtJ0lq7t7V20e7csapeUFVfraqHq2p9Vf3ZrE4KzCnO4ABz2RVJPlJVdyf5hyTXtta27eZ9/68kf5PkVUkWJnnp7IwIzEXO4ABzVmvtk0neleTMJF9Jcn9Vnbebd9+aZGWSw1trG1tr/zg7UwJzkcAB5rTW2sWttdcmOSjJzyf57ao6czfu+t4ki5NcW1XXV9V/mM05gblF4AAjobW2tbX2V0muT/Ki3Vj/7tba25IckeTdST5eVcfM8pjAHCFwgLlkflUtnPbxv1XVG6pq/6qaV1WvT3JKkiufbkNV9ZNVdWRrrSV5aLB4cjaHB+YOLzIG5pL//j3Xb06yIcknk4wl+U6Sd7TWvrob23pFkg9X1f5J1iU5t7V2z54cFpi7auo/NwAA/fAUFQDQHYEDAHRH4AAA3RE4AEB3ungX1bJly9rKlSuHPQYAMMuuvvrqB1pry59uvS4CZ+XKlVmzZs2wxwAAZllVfWd31vMUFQDQHYEDAHRH4AAA3eniNTgA7Fu2bt2atWvXZtOmTcMehVmycOHCrFixIvPnz39W9xc4AIyctWvXZv/998/KlStTVcMehz2stZYHH3wwa9euzXHHHfestuEpKgBGzqZNm3LIIYeIm05VVQ455JDndIZO4AAwksRN357r8RU4AEB3vAYHgK611rJ2w8Zcd9dD2fD4lixdvCCrjj4oK5YuchaoY87gANCtTVu35U//6Y58+MvfzFdvW5/b7nssX71tfT785W/mT//pjmzauu1Zb3vJkiVPWXbLLbfkjDPOyKpVq/LCF74w5557br74xS9m1apVWbVqVZYsWZKTTjopq1atys/8zM/MuN3LL788b3zjG5+y/NJLL81pp52Wl7zkJTn55JPzx3/8x7ngggt2bHtsbGzH5Y985CMzbvs3f/M3c+GFFz5l+QUXXJBTTjklL37xi7Nq1apceeWV+fEf//GsWrUqJ5xwQg488MAd2/6nf/qnbN26Needd15OPPHEvOhFL8rpp5+ev/u7v3uGf4OzyxkcALrUWsunrrozN97zcI466Mlna1prufGeh/Opq+7Mz37/nnsn1rvf/e68973vzdlnn50kueGGG3LqqafmzDPPTJKcccYZufDCC7N69epntN2tW7fm3HPPzVVXXZUVK1Zk8+bNueOOO3LSSSfl/PPPTzIVXNddd90znvlrX/taLr300lxzzTWZmJjIAw88kC1btuRzn/tckqnguvDCC3PppZfuuM95552XdevW5cYbb8zExETuu+++fOUrX3nGjz2bnMEBoEtrN2zMjXc/nKMOfOpTUVWVow5clJvueTh3P7Rxjz3munXrsmLFih3XTz311D2y3UcffTSTk5M55JBDkiQTExM56aST9si2161bl2XLlmViYiJJsmzZshx55JE7Xf/xxx/PRz/60fz+7//+jvscdthh+Ymf+IkkyTve8Y6sXr06p5xySn7jN35jx/1WrlyZD3zgA3nFK16R1atX55prrsmZZ56Z5z3vefmjP/qjPbIv0wkcALp03V0PZXysdnp2pqoyryrX3vnQHnvM9773vXn1q1+d17/+9fnQhz6Uhx7aM9s++OCDc9ZZZ+XYY4/NW97yllx88cXZvn37Htn26173utx11115/vOfn1/4hV942jMxt912W4455pgccMABM95+wQUXZM2aNbn++uvzla98Jddff/2O244++uh87Wtfy6te9ar87M/+bD7zmc/kiiuuyK//+q/vkX2ZTuAA0KUNj2/JxNjYLteZGB/Lhse37LHHfOtb35qbb745b3rTm3L55Zfn5S9/eTZv3rxHtv2xj30sl112WU4//fRceOGFedvb3rZHtrtkyZJcffXVueiii7J8+fL85E/+ZP70T//0WW/v05/+dF760pfmtNNOy0033ZSvf/3rO24766yzkkyd2XrZy16W/fffP8uXL8/ChQv3WAw+QeAA0KWlixdk87Zdv4h48+S2LF28YI8+7pFHHpm3ve1tueSSSzI+Pp4bb7xxj2371FNPzXvf+9586Utfyl//9V/vse2OjY3ljDPOyG/91m/lD/7gD3a57RNOOCF33nlnHn300afcdvvtt+fCCy/MZZddluuvvz5veMMbnvTD+p54SmvevHk7Lj9xfXJyco/tTyJwAOjUqqMPyuS2ltbajLe31rK9tZx2zEF77DG/8IUvZOvWrUmSe++9Nw8++GCOOuqo57zdxx57LJdffvmO69ddd12OPfbY57zdZOqdX7feeutub3vx4sV5+9vfnne/+93ZsmXq7Ne6devyyU9+Mo888kj222+/HHjggbnvvvuG+s4q76ICRkZrLfc+silr7tiQ+x/ZlP0mxnPaMUtzwqFLMjbPzzPhyVYsXZQXHXXg1LuoDnzqu6jufnhjXnTkgTnqoEXPavuPP/74k15Q/Mu//MtZu3Zt3vOe92ThwoVJkt/7vd/L4Ycf/oy3fdlllz1p25/61KfywQ9+MD/3cz+XRYsWZb/99nvWTyP9zu/8Tj784Q/vuH7JJZfkXe96Vx566KGMj4/nhBNOyEUXXfS02/jVX/3VnHzyyVm4cGH222+//PZv/3Ze8pKX5LTTTsspp5yS448/Pq985Suf1Yx7Qu2sbEfJ6tWr25o1a4Y9BjCLJrdtz2evvTtXfvvBjM2bl0Xz52XrtpYtk9tzxEEL87ZXHpel++3ZpxqYu26++ea88IUvfNr1Nm3dlk9ddWduuufhzKvKxPhYNk9uy/bWcsqRB+Ytpx+ThfN3/Todhmem41xVV7fWnvZ99s7gACPhb29Yl69968GsOGhR5n3P2Zr7H92cj/6Pb+c9rz0xE+O+WfFvFs4fy89+/8rc/dDGXHvnv/0k49OOOegpPxuHvggcYM57eOPW/I9bH8hRM8RNkhy6/0TWbng8N9/zSFYds3QIEzKXVVVWLF2cFUsXD3uUJ/niF7+Y973vfU9adtxxx+34AXvPxQUXXJC/+qu/etKyN73pTTt+KOC+QOAAc94t9z6S1touX2ezZGI8V9z+rwJnH9JaG+kzMGeeeeaOn3C8p51//vkjHzPP9SU03kUFzHmPbZrMvKf5RrZgfF4e2bh1L03EsC1cuDAPPvjgc/4myNzUWsuDDz6448Xaz4YzOMCcd8Ci+dn+NN/INm/dnuX7T+xyHfqxYsWKrF27NuvXrx/2KMyShQsXPumdZM+UwAHmvJMO3z/zqjK5bXvGx2Y+8fzdLZP5/uct28uTMSzz58/PcccdN+wxmMM8RQXMefsvnJ/XvPCw3PPQxmzb/uQzOa213Pvwphx98OKcdPj+Q5oQmGucwQFGwg+ffFgmt2/P5besT2XqNTeT27dnclvL8cuX5KdfcWzm7+TsDrDvETjASBibV3nji4/MK44/JP+y9qGsf3RLFi8Yy4tXHJhjDl480u+mAfY8gQOMlEOWTOTVLzhs2GMAc5zzuQBAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3Rlq4FTVQVX1mar6RlXdXFWvqKqDq+pLVXXr4M+lw5wRABg9wz6D81+TfKG19oIkL0lyc5LzklzWWjsxyWWD6wAAu21ogVNVByT5wSR/kiSttS2ttYeSnJ3kE4PVPpHkx4YzIQAwqoZ5Buf4JOuT/LequraqPlZV+yU5rLW2LkkGfx46052r6tyqWlNVa9avX7/3pgYA5rxhBs54kpcm+cPW2mlJvptn8HRUa+2i1trq1trq5cuXz9aMAMAIGmbgrE2ytrV25eD6ZzIVPPdV1RFJMvjz/iHNBwCMqKEFTmvt3iR3VdVJg0WvSfL1JJ9Pcs5g2TlJLhnCeADACBsf8uO/K8nFVbUgybeTvDVT0fXpqnp7kjuTvGmI8wEAI2iogdNauy7J6hlues3engUA6Mewfw4OAMAeJ3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4MPXCqaqyqrq2qSwfXj6uqK6vq1qr6y6paMOwZAYDRMvTASfKeJDdPu/67ST7UWjsxyYYkbx/KVADAyBpq4FTViiRvSPKxwfVK8uoknxms8okkPzac6QCAUTXsMzgfTvIfk2wfXD8kyUOttcnB9bVJjprpjlV1blWtqao169evn/1JAYCRMbTAqao3Jrm/tXb19MUzrNpmun9r7aLW2urW2urly5fPyowAwGgaH+JjvzLJWVX1o0kWJjkgU2d0Dqqq8cFZnBVJ7hnijADACBraGZzW2vtbaytaayuTvDnJ/9da+6kk/5Dkfx2sdk6SS4Y0IgAwoob9GpyZvC/JL1fVbZl6Tc6fDHkeAGDEDPMpqh1aa5cnuXxw+dtJTh/mPADAaJuLZ3AAAJ4TgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdGdogVNVR1fVP1TVzVV1U1W9Z7D84Kr6UlXdOvhz6bBmBABG0zDP4Ewm+T9aay9M8vIk76yqk5Ocl+Sy1tqJSS4bXAcA2G1DC5zW2rrW2jWDy48muTnJUUnOTvKJwWqfSPJjw5kQABhVc+I1OFW1MslpSa5MclhrbV0yFUFJDt3Jfc6tqjVVtWb9+vV7a1QAYAQMPXCqakmSv07yS621R3b3fq21i1prq1trq5cvXz57AwIAI2eogVNV8zMVNxe31j47WHxfVR0xuP2IJPcPaz4AYDQN811UleRPktzcWvsv0276fJJzBpfPSXLJ3p4NABht40N87Fcm+ekkN1TVdYNlH0jyn5J8uqrenuTOJG8a0nwAwIgaWuC01r6apHZy82v25iwAQF+G/iJjAIA9TeAAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3xoc9wFy2eXJbtm5rWTR/LGPzatjjAMCc1lrLxq3bUqksnD8vVcP73ilwZnDng4/n8m/enxvWPpwkmZg/Lz9wwrK84nnLcuCi+UOeDgDmlslt23PNnRvyD99Yn/WPbU6SHHHgwvzQSYdm1dEHZd4QThIInO9x7Z0bcvEV38mC8bEcfsDCzJtX2Ty5LZfdfF/W3LEh7zjjeTlkycSwxwSAOWHrtu25+Irv5F/uejhL95ufIw9cmCR5dNNk/t8r7sg37zskP7H66L0eOU/7GpyqWl1Vn6uqa6rq+qq6oaqun+3BqupHquqWqrqtqs6b7cdLkgce25xPXXVnDlkykeX7T+w4GBPjYznyoMV5fMtkLr7yzrTW9sY4ADDn/eNtD+T6tQ/n6IMXZf+F81NVqaocsGh+VixdnCu+/WCu/s6GvT7X7pzBuTjJ/5nkhiTbZ3ecKVU1luT/TvLDSdYm+eeq+nxr7euz+bhr7vjXJMnC+WMz3r5syUS+8+B3s3bDxhx98OLZHAUA5rzJbdtz+S33Z/n+EzO+3mZeVQ7ZbyKXfeO+/Ltjl+7Vszi78y6q9a21z7fWbm+tfeeJj1me6/Qkt7XWvt1a25LkL5KcPcuPmRvvfiQHLNz5a2yeOHh3/evjsz0KAMx5Dzy2Jd/dsm2nJwaSZMnC8Tzw2JY8smnrXpxs987g/EZVfSzJZUk2P7GwtfbZWZsqOSrJXdOur03ysukrVNW5Sc5NkmOOOWaPPOi2tj3zduMV35PbPUUFANtby+6ck6kke/tb5+4EzluTvCDJ/PzbU1QtyWwGzkx/X0/6q2mtXZTkoiRZvXr1HvlrO37Zklz9nQ1ZtGDnJZpMvTIcAPZ1B++3IGPzKlu3bc/8sZmfFNq0dVsWLRjLAQv37vuadufRXtJaO3XWJ3mytUmOnnZ9RZJ7ZvtBX378Ibni2w9mcvv2jM976oF6ZOPWLN1vQY5fvmS2RwGAOW/h/LF8//OW5SvfvD9HHTTza1Pvf2xz3njqERnfSQDNlt15tCuq6uRZn+TJ/jnJiVV1XFUtSPLmJJ+f7QddsXRRXvOCw3L3ho15fMvkjuWttTz42OZ8d8tkfuplx/qhfwAw8EMvODSHHbAw9zy0MZPb/u29SFu3bc/dGzZm5cGL88oTlu31uXbnDM4PJDmnqm7P1GtwKklrrb14toZqrU1W1S8m+WKSsSQfb63dNFuP94SqyutPPTyHLFmQv//6vbnnoY2pSrZvb3neoUvyxhcf6d1TADDNkonxvOOME/KFG9flqts35IlXlMyryquevyyvO/nwXb4IebbU0/1Ml6o6dqble+GdVLtt9erVbc2aNXt0m9u2t6x7eGO2TG7PAYvmZ5kf7gcAu/TdzZNZ/+jU+5EOO2Dh076m9dmoqqtba6ufbr2nPYMzl0JmbxqbV1mx1NkaANhd+02MZ7+JufFLEvw2cQCgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDsCBwDojsABALojcACA7ggcAKA7AgcA6I7AAQC6I3AAgO4IHACgO0MJnKr6var6RlVdX1Wfq6qDpt32/qq6rapuqaozhzEfADDahnUG50tJXtRae3GSbyZ5f5JU1clJ3pzklCQ/kuT/qaqxIc0IAIyooQROa+3vW2uTg6tXJFkxuHx2kr9orW1urd2e5LYkpw9jRgBgdM2F1+C8LcnfDS4fleSuabetHSx7iqo6t6rWVNWa9evXz/KIAMAoGZ+tDVfVl5McPsNN57fWLhmsc36SySQXP3G3GdZvM22/tXZRkouSZPXq1TOuAwDsm2YtcFprr93V7VV1TpI3JnlNa+2JQFmb5Ohpq61Ics/sTAgA9GpY76L6kSTvS3JWa+3xaTd9Psmbq2qiqo5LcmKSq4YxIwAwumbtDM7T+IMkE0m+VFVJckVr7edbazdV1aeTfD1TT129s7W2bUgzAgAjaiiB01o7YRe3XZDkgr04DgDQmbnwLioAgD1K4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3Rlq4FTVr1RVq6plg+tVVR+pqtuq6vqqeukw5wMARtPQAqeqjk7yw0nunLb49UlOHHycm+QPhzAaADDihnkG50NJ/mOSNm3Z2Un+rE25IslBVXXEUKYDAEbWUAKnqs5Kcndr7V++56ajktw17frawbKZtnFuVa2pqjXr16+fpUkBgFE0PlsbrqovJzl8hpvOT/KBJK+b6W4zLGszLEtr7aIkFyXJ6tWrZ1wHANg3zVrgtNZeO9Pyqjo1yXFJ/qWqkmRFkmuq6vRMnbE5etrqK5LcM1szAgB92utPUbXWbmitHdpaW9laW5mpqHlpa+3eJJ9P8jODd1O9PMnDrbV1e3tGAGC0zdoZnGfpvyf50SS3JXk8yVuHOw4AMIqGHjiDszhPXG5J3jm8aQCAHvhJxgBAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANCdoQVOVb2rqm6pqpuq6oPTlr+/qm4b3HbmsOYDAEbX+DAetKp+KMnZSV7cWttcVYcOlp+c5M1JTklyZJIvV9XzW2vbhjEnADCahnUG5x1J/lNrbXOStNbuHyw/O8lftNY2t9ZuT3JbktOHNCMAMKKGFTjPT/Kqqrqyqr5SVd83WH5Ukrumrbd2sOwpqurcqlpTVWvWr18/y+MCAKNk1p6iqqovJzl8hpvOHzzu0iQvT/J9ST5dVccnqRnWbzNtv7V2UZKLkmT16tUzrgMA7JtmLXBaa6/d2W1V9Y4kn22ttSRXVdX2JMsydcbm6Gmrrkhyz2zNCAD0aVhPUf1NklcnSVU9P8mCJA8k+XySN1fVRFUdl+TEJFcNaUYAYEQN5V1UST6e5ONVdWOSLUnOGZzNuamqPp3k60kmk7zTO6gAgGdqKIHTWtuS5D/s5LYLklywdycCAHriJxkDAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHeG9XNwAJ6Vrdu259vrv5tHNm3NxPi8HL98SZZM+FIGPJmvCsDIuPbODfmba+/OY5snp35xXSXzqvIDJy7P6190eOaPOSkNTBE4wEi4+jsb8skr7siyJRNZsXjxjuWT27bn8m/cn0ce35p//7JjMm/eTL+zF9jX+O8OMOdtntyWz16zNofuvzCLFzz5/2XjY/OyYumiXHPXhtz+4HeHNCEw1wgcYM775r2PZdPWbVk4f2zG26sqC8fH8rVvPbiXJwPmKoEDzHnrH92UebXrp572mxjLuoc37qWJgLlO4ABz3sT4WLa3tst1Jre3LBif+QwPsO8ROMCcd+JhS5IkbReR8+imyaw+9qC9NRIwxwkcYM479ICFOeXIA3LvI5tmjJxHNm7NogVjecnRS4cwHTAXCRxgJPzk9x2TFUsXZ+2GjXl449Zs3bY9j2+ZzN0PbczWbdvzv//A8X7gH7CDrwbASNhvYjw//z89Lzfd83C+eusDWf/Y5iyaP5Y3nHpEXnrM0hy4eP6wRwTmEIEDjIwF4/Ny2jFLc9oxnooCds1TVABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDAHRH4AAA3RE4AEB3BA4A0B2BAwB0R+AAAN0ROABAdwQOANAdgQMAdEfgAADdETgAQHeqtTbsGZ6zqlqf5DvP4C7LkjwwS+PMJfvCfu4L+5jYz97Yz77sC/s5l/bx2Nba8qdbqYvAeaaqak1rbfVg0UVlAAAGlklEQVSw55ht+8J+7gv7mNjP3tjPvuwL+zmK++gpKgCgOwIHAOjOvho4Fw17gL1kX9jPfWEfE/vZG/vZl31hP0duH/fJ1+AAAH3bV8/gAAAdEzgAQHe6DpyqelNV3VRV26tq9bTlP1xVV1fVDYM/Xz3ttsur6paqum7wcehwpt99O9vPwW3vr6rbBvt05rTlPzJYdltVnbf3p35uquovpx2jO6rqusHylVW1cdptfzTsWZ+LqvrNqrp72v786LTbZjy2o6iqfq+qvlFV11fV56rqoMHy3o7nSP+725mqOrqq/qGqbh58LXrPYPlOP39H1eDrzQ2D/VkzWHZwVX2pqm4d/Ll02HM+F1V10rRjdl1VPVJVvzRyx7O11u1HkhcmOSnJ5UlWT1t+WpIjB5dflOTuabc9ad1R+NjFfp6c5F+STCQ5Lsm3kowNPr6V5PgkCwbrnDzs/XgO+/+fk/z64PLKJDcOe6Y9uG+/meRXZlg+47Ed9rzPYT9fl2R8cPl3k/xub8ezt39337NvRyR56eDy/km+OfgcnfHzd5Q/ktyRZNn3LPtgkvMGl8974vO3h4/B5+29SY4dtePZ9Rmc1trNrbVbZlh+bWvtnsHVm5IsrKqJvTvdnrOz/UxydpK/aK1tbq3dnuS2JKcPPm5rrX27tbYlyV8M1h05VVVJfiLJp4Y9y162s2M7klprf99amxxcvSLJimHOM0u6+Xf3vVpr61pr1wwuP5rk5iRHDXeqversJJ8YXP5Ekh8b4ix72muSfKu19kx+W8Cc0HXg7Kb/Jcm1rbXN05b9t8Hpt18bfAMdVUcluWva9bWDZTtbPopeleS+1tqt05YdV1XXVtVXqupVwxpsD/rFwVM3H5926runY/i93pbk76Zd7+V49nzMdqiqlZk6S37lYNFMn7+jrCX5+8HLG84dLDustbYumYq9JHP+pQ3PwJvz5P9AjszxHPnAqaovV9WNM3w87f+MquqUTJ0O/7lpi3+qtXZqpr5xvirJT8/O5M/Ms9zPmeKs7WL5nLKb+/yWPPkf37okx7TWTkvyy0n+vKoO2JtzP1NPs59/mOR5SVZlat/+8xN3m2FTc+4YTrc7x7Oqzk8ymeTiwaKRO567MHLH7JmqqiVJ/jrJL7XWHsnOP39H2Stbay9N8vok76yqHxz2QLOlqhYkOSvJXw0WjdTxHB/2AM9Va+21z+Z+VbUiyeeS/Exr7VvTtnf34M9Hq+rPM3Va+c/2xKzPxbPcz7VJjp52fUWSJ56a29nyOePp9rmqxpP8z0n+3bT7bE6yeXD56qr6VpLnJ1kzi6M+J7t7bKvqo0kuHVzd1bGdk3bjeJ6T5I1JXtMGT/6P4vHchZE7Zs9EVc3PVNxc3Fr7bJK01u6bdvv0z9+R9cTLG1pr91fV5zL1PeK+qjqitbauqo5Icv9Qh9xzXp/kmieO46gdz5E/g/NsDN6h8bdJ3t9a+8dpy8eratng8vxMfbG9cThT7hGfT/LmqpqoquOSnJjkqiT/nOTEqjpuUOhvHqw7al6b5ButtbVPLKiq5VU1Nrh8fKb2+dtDmu85G3yxfMKP598+H3d2bEdSVf1IkvclOau19vi05T0dz17+3T3F4Kn8P0lyc2vtv0xbvrPP35FUVftV1f5PXM7Ui+NvzNRxPGew2jlJLhnOhHvck86Qj9rxHPkzOLtSVT+e5PeTLE/yt1V1XWvtzCS/mOSEJL9WVb82WP11Sb6b5IuDuBlL8uUkH937kz8zO9vP1tpNVfXpJF/P1Gn/d7bWtg3u84tJvpip/fx4a+2mIY3/XHzvc8NJ8oNJfruqJpNsS/LzrbV/3euT7TkfrKpVmXoq444Mnk7d1bEdUX+QqXeEfWnwsrcrWms/n46OZ2ttspN/dzN5Zaaezr+hBj+yIckHkrxlps/fEXZYks8NPkfHk/x5a+0LVfXPST5dVW9PcmeSNw1xxj2iqhYn+eE8+ZjN+PVorvKrGgCA7uyTT1EBAH0TOABAdwQOANAdgQMAdEfgAADdETgAQHcEDgDQHYEDjISqWllV36iqjw1+h9XFVfXaqvrHqrq1qkb2t6kDe57AAUbJCUn+a5IXJ3lBkn+f5AeS/EqmfnIuQBKBA4yW21trN7TWtie5Kcllg1/MeUOSlUOdDJhTBA4wSjZPu7x92vXt6fx36wHPjMABALojcACA7vht4gBAd5zBAQC6I3AAgO4IHACgOwIHAOiOwAEAuiNwAIDuCBwAoDv/P+dlKcIa9+JfAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 576x576 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "lsts = subarray.select_subarray(\"LSTs\", df.loc[g.groups['LST:LSTCam']]['tel_id'])\n",
+    "lsts = subarray.select_subarray(\"LSTs\", df.loc[g.groups[tel_string]]['tel_id'])\n",
     "lsts.info()\n",
     "lsts.peek()\n",
     "lsts.footprint"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/InstrumentDescription.ipynb
+++ b/docs/examples/InstrumentDescription.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,25 +43,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : MonteCarloArray\n",
-      "Num Tels : 98\n",
-      "Footprint: 4.92 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "      LST_LST_LSTCam    4    1 ..   4\n",
-      "    MST_MST_FlashCam   25    5 ..  29\n",
-      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray = event.inst.subarray\n",
     "\n",
@@ -70,72 +54,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=98</i>\n",
-       "<table id=\"table48074305264\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>tel_id</th><th>pos_x</th><th>pos_y</th><th>pos_z</th><th>name</th><th>type</th><th>num_mirrors</th><th>camera_type</th><th>tel_description</th></tr></thead>\n",
-       "<thead><tr><th></th><th>m</th><th>m</th><th>m</th><th></th><th></th><th></th><th></th><th></th></tr></thead>\n",
-       "<thead><tr><th>int16</th><th>float64</th><th>float64</th><th>float64</th><th>str5</th><th>str3</th><th>int64</th><th>str8</th><th>str18</th></tr></thead>\n",
-       "<tr><td>1</td><td>-20.0</td><td>65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>2</td><td>-20.0</td><td>-65.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>3</td><td>80.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>4</td><td>-120.0</td><td>0.0</td><td>16.0</td><td>LST</td><td>LST</td><td>1</td><td>LSTCam</td><td>LST_LST_LSTCam</td></tr>\n",
-       "<tr><td>5</td><td>0.0</td><td>0.0</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>6</td><td>0.0</td><td>151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>7</td><td>0.0</td><td>-151.1999969482422</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>8</td><td>146.65599060058594</td><td>75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>9</td><td>146.65599060058594</td><td>-75.5999984741211</td><td>10.0</td><td>MST</td><td>MST</td><td>1</td><td>FlashCam</td><td>MST_MST_FlashCam</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>89</td><td>956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>90</td><td>956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>91</td><td>-239.19699096679688</td><td>1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>92</td><td>-239.19699096679688</td><td>-1109.7349853515625</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>93</td><td>-956.7870483398438</td><td>739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>94</td><td>-956.7870483398438</td><td>-739.822998046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>95</td><td>1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>96</td><td>1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>97</td><td>-1195.9840087890625</td><td>369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "<tr><td>98</td><td>-1195.9840087890625</td><td>-369.9119873046875</td><td>5.0</td><td>ASTRI</td><td>SST</td><td>2</td><td>ASTRICam</td><td>SST_ASTRI_ASTRICam</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=98>\n",
-       "tel_id        pos_x        ... camera_type  tel_description  \n",
-       "                m          ...                               \n",
-       "int16        float64       ...     str8          str18       \n",
-       "------ ------------------- ... ----------- ------------------\n",
-       "     1               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     2               -20.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     3                80.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     4              -120.0 ...      LSTCam     LST_LST_LSTCam\n",
-       "     5                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
-       "     6                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
-       "     7                 0.0 ...    FlashCam   MST_MST_FlashCam\n",
-       "     8  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
-       "     9  146.65599060058594 ...    FlashCam   MST_MST_FlashCam\n",
-       "   ...                 ... ...         ...                ...\n",
-       "    89   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    90   956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    91 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    92 -239.19699096679688 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    93  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    94  -956.7870483398438 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    95  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    96  1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    97 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam\n",
-       "    98 -1195.9840087890625 ...    ASTRICam SST_ASTRI_ASTRICam"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.to_table()"
    ]
@@ -149,38 +70,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=3</i>\n",
-       "<table id=\"table48080417512\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>description</th><th>name</th><th>type</th><th>mirror_area</th><th>num_mirrors</th><th>num_mirror_tiles</th><th>equivalent_focal_length</th></tr></thead>\n",
-       "<thead><tr><th></th><th></th><th></th><th>m2</th><th></th><th></th><th>m</th></tr></thead>\n",
-       "<thead><tr><th>str18</th><th>str5</th><th>str3</th><th>float64</th><th>int64</th><th>int64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>LST_LST_LSTCam</td><td>LST</td><td>LST</td><td>386.7332458496094</td><td>1</td><td>198</td><td>28.0</td></tr>\n",
-       "<tr><td>MST_MST_FlashCam</td><td>MST</td><td>MST</td><td>103.83055877685547</td><td>1</td><td>84</td><td>16.0</td></tr>\n",
-       "<tr><td>SST_ASTRI_ASTRICam</td><td>ASTRI</td><td>SST</td><td>14.562566757202148</td><td>2</td><td>2</td><td>2.1500000953674316</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=3>\n",
-       "   description      name type ... num_mirror_tiles equivalent_focal_length\n",
-       "                              ...                             m           \n",
-       "      str18         str5 str3 ...      int64               float64        \n",
-       "------------------ ----- ---- ... ---------------- -----------------------\n",
-       "    LST_LST_LSTCam   LST  LST ...              198                    28.0\n",
-       "  MST_MST_FlashCam   MST  MST ...               84                    16.0\n",
-       "SST_ASTRI_ASTRICam ASTRI  SST ...                2      2.1500000953674316"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.to_table(kind='optics')"
    ]
@@ -194,23 +86,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : SCTels\n",
-      "Num Tels : 69\n",
-      "Footprint: 4.92 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "  SST_ASTRI_ASTRICam   69   30 ..  98\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tab = subarray.to_table()\n",
     "sc_tels = tab[tab['num_mirrors'] == 2]['tel_id']  # select tel_id of entries where the mirror type is SC\n",
@@ -227,24 +105,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Subarray : SCTels\n",
-      "Num Tels : 29\n",
-      "Footprint: 1.06 km2\n",
-      "\n",
-      "                TYPE  Num IDmin  IDmax\n",
-      "=====================================\n",
-      "      LST_LST_LSTCam    4    1 ..   4\n",
-      "    MST_MST_FlashCam   25    5 ..  29\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "gtab = tab.group_by('num_mirrors')\n",
     "sc = gtab.groups[0]\n",
@@ -261,20 +124,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel = subarray.tel[5]\n",
     "tel"
@@ -282,142 +134,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$103.83056 \\; \\mathrm{m^{2}}$"
-      ],
-      "text/plain": [
-       "<Quantity 103.83055878 m2>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.optics.mirror_area"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "84"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.optics.num_mirror_tiles"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$16 \\; \\mathrm{m}$"
-      ],
-      "text/plain": [
-       "<Quantity 16. m>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.optics.equivalent_focal_length"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.camera"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[-0.028867999,~-0.072168998,~0.057735,~\\dots,~-0.54848301,~-0.50518101,~-0.54848301] \\; \\mathrm{m}$"
-      ],
-      "text/plain": [
-       "<Quantity [-0.028868  , -0.072169  ,  0.057735  , ..., -0.54848301,\n",
-       "           -0.50518101, -0.54848301] m>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tel.camera.pix_x"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb32234f60>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsnXeYVdW5/z/r9N7P9N47M8PA0HvvXXoXERETTYwmGrFEY6JGjTFG0343vd7E1JvE1JubYjSKFUE6DAwM03vZvz9OYe+zN0KMCpj9fR54OOdz9tn7nBn2u961vut9hSRJ6NKlS5cuXRcjw6W+AF26dOnSdeVIDxq6dOnSpeuipQcNXbp06dJ10dKDhi5dunTpumjpQUOXLl26dF209KChS5cuXbouWnrQ0KVLJiFEjhBCEkKY/s33OSSEmPZOXZcuXZeL9KCh6z9W0Rt7txCiI/YHSHuPzu0RQjwshDgSPff+6OPQe3F+XbrervSgoes/XfMlSXLF/gAn3u0TCiEswDNAOTAL8ABjgCZg5Lt9fl26/h3pQUOXrreQEGKTEOI1IUS7EOKAEOIaGQsJIX4qhGgRQpwVQvxJCCH/P1UthNgjhGgVQnxHCGGLPr8eyAIWS5L0qiRJQ5IkNUqSdLckST+PvvctQog3o+d9VQixWHbejUKIPwshPhM99wEhxJjo80eFEI1CiA3vxfej6z9PetDQpeut1QjMI5INbAI+I4SojbKbgGNAGEgGPgrI6/KsIJJJ5AJVwMbo89OAX0qS1PEW530TGA94gTuBrwshUmW8HtgDBIFvAt8GRgAFwFrgMSGE61//uLp0vbX0oKHrP10/io7WW4QQP0qEkiT9TJKkN6WI/gD8isjNHKAfSAWyJUnqlyTpT5KymNujkiSdkCTpLPAToDr6fBBoeKuLkiTpe9FjhyRJ+g6wD+XU1UFJkr4iSdIg8B0gE7hLkqReSZJ+BfQRCSC6dL2j0oOGrv90LZIkyRf9sygRCiFmCyH+Gp1+agHmALHF6k8D+4FfRaeIbkk4/KTs311AbOTfRCTYnFdCiPVCiBdiAQ2okJ0X4JTs390AkiQlPqdnGrrecelBQ5eu80gIYQV+ADwAJEuS5AN+DggASZLaJUm6SZKkPGA+cKMQYupFvPVvgJlCCOd5zpsNPAXsBILR874cO68uXZdSetDQpev8sgBW4DQwIISYDcyIQSHEPCFEgRBCAG3AYPTPhfQ14CjwAyFEiRDCIIQICiE+KoSYAziJrI2cjp5nE5FMQ5euSy49aOjSdR5JktQO7AK+CzQDq4GnZS8pJJI1dAB/AR6XJOn3F/G+vUQWw18Hfk0k4PydyPTT3yRJehV4MPqep4BK4M/vyIfSpevflNCbMOnSpUuXrouVnmno0qVLl66Llh40dOnSpUvXRUsPGrp06dKl66KlBw1dunTp0nXR+rfKP1+OCoVCUk5OzqW+DF26dOm6ovTcc8+dkSQpfKHXve+CRk5ODv/4xz8u9WXo0qVL1xUlIcThi3mdPj2lS5cuXbouWnrQ0KVLly5dFy09aOjSpUuXrouWHjR06dKlS9dFSw8aunTp0qXroqUHDV26dOnSddHSg4YuXbp06bpo6UFDly5dunRdtPSgoeuy1pnjTTxy7ZP89afPafKmhmYeve6L/PlHf9fkzada+OzOL/KnH/xVk7ecbuVzu77M77+j3a6iramdxz/wFX77zT9p8vbmDp648av8+r/+gFabgY6WTp788H/xy6/8TpN3tnXx1Ee+zs+f+g1DQ0Mq3tXezZc++k1+8sSvNHl3Zw9fvf3b/OixXzA4qO7/1NPVy/+74zv88JGfMTig5r3dvXz97u/z/Yd+wkD/gIr39fTxzXt/yHc+9WP6+/rVvLefb9//I75133/T16vmut5/et/106irq5P0HeHvD/3yK7/jc7u+RE9nLwAjZlVz148/gskcKWTwm6//kUd3PEV3Rw8AtdMqufvpW7DYLAD87tt/5uFrvkBXezcA1ZPLuevpW7A7bQD86Qd/5cGtn6eztQuAyvGl3PPTW3G47QD834+f5YHNn6O9uROA8rHF3POTW3H5Il1a//az5/jUxs/R1tQOQEl9IZ/46a14gm4Anv2fF7h/3aO0nonworp87vnprfiTvAD887cvce/qR2hpbAWgoCaXe356K8FUPwB7/vgqn1j5Gc6ebAEgb1g2dz99C0mZkVbhr/zfXu5e8SBNJ5oByKnI5O6nbyElJwmA1/++j7uWPcjpY00AZJWmc/fTt5CWnwLAvucPcOfSBzh1+DQAmcVp3Pmjm8ksTgfgzRcPsXvJpzl5sBGAtIIU7vrRzWSXZQJw6JWj3LHofk68GWlNnpqXzO4ffpi8qux/+Wet69JLCPGcJEl1F3rd+66MiK4rX//41YuU1hfw/G9ejAcMgGd/+QJ9Pf28+PtXKB5RwPPP7IkHDIDnf/MS3R09vPy/r1NQm8sLv30pHjAAXvjdK3S2dvH63/aRV5XNC797OR4wAF7602u0NbWz77kDZJVlsOcPr8QDBsArf95LS2MrB/YcJqMoNf76mF7/2z6aGpo58toxUvKSeeXPr8cDBsAb/3iTM8eaOLH/JElZIV79vzfiAQNg/z8PcurwaRqPnCGY6uP1v+2LBwyAAy8e5uTBRppPtuANe9j77P54wAA49PJRTuw/SVtTOy6fk33PHYgHDIAjrx3n6N4TdLV3Y3Pa4ueL6ejeExx57Tj9vQOYLCYO7DkcDxgAJ/af5NDLR5EkEAIOvXwkHjAAGg6c4sCew3rQeJ9LDxq6Lhsd2HOYz93wZfb84VV8SV6Ss0Oq19w+/5Ps+eOreENuUqMjZrnuXvEQL/7+FdwBF5nFaSp+/7rP8sLvXsblc5JdnqHiD279PC/89mUcHjv5w9Q3v0ev+yL/fOYlHG47BbW5Kv7EjV/l+d+8hN1lo6guX8W/eOs3eP7Xe7A5rJTUF6r4f+3+Ds/9ag9Wu4XyMcUq/s17f8jzv96D2WqiYlypin/vgad57td7MFlMVE1Q8/9+9Of88zd7MJqMVE0qV/GfPvErnn/mJQwGwbDJ6rbkv/zyb3n+mZcQQlAzRW9b/p+oSzo9JYT4MjAPaJQkSfUbKIQQwCPAHKAL2ChJ0vNv9Z769NSVq3tWPsQfvvsXxXPekJvWM+0IIUjJDdNwoFHJwx5aT7cBkemRhgOnFNyX5I2P5tPykxUjYwB/spfmU+fngVQfZxsio/20ghRO7D+p4KE0P2eio31Nnh7gzPGz5+cZQc5Es4H0whSO71PypMwgjUebznt8UlaIxiNnzsuTs0OcOvwWPCfMqUOnz/v5U3KT4tmG1vebmpcU/5kUDs/jo9+4gYwidbDWdfnrYqenLvVC+FeBWW/BZwOF0T/bgM+/B9ek6zLSoutnY7GZqZ5STp7GyH/R9bOx2i1UTSijUGPkv3DnLKwOKxVjSygeUaDiC66bhc0ZGfWXjVaP7BdcOzOSNYzIp3JciYrP3T4Dh8dOQU0u1Roj97nXTMfpdZBblc3waVUqPufqqZGspyyDupnVKj5ry9RI1lSSzqh5w9V88xQ8ITfpBSmMXqD+/z594yR8SV5S85IZt6RezddPxJ/iIzk7zPhlo1R8yprxBNP8hDODTFo5VsUnrxxLKCNAKD3AlntX6wHjP0CXfCFcCJED/PQ8mcYXgN9LkvSt6OO9wCRJkhrO9356pnHl6qmbv8Z3H3g6/tjmsNLTdW5Nw2gyKhxAVoeF3q6++GOD0cDQ4DmHkdVuobf77XOL3UKfnBsEQ0Pn/r9YbGb6es45hoRBIMm42Wam/6241Uy/zHEUSawlYv8lzVYT/b0yR5MAAXFuspgY6Evg4tw5zBYT/X1KR5T8MxrNRgb7B8/PE77vyHMGBgeGVP+OafcPP8zYRSPRdeXpSsk0LqR04Kjs8bHoc7reh7r6U+v4wBPbcPocjF00kpFzaxV8cGCQnZ/dgsvvpH5urermNDQ4xM7HIrxuZjXjl4/S5O6Ai9ppVUxePU7Fr39sC56gm+pJ5czYMFHJhyR2PrYZb9hD5fhSZm+ZquDSkMTOx7bgS/JQNrqIedunq/lnN+NP9lIysoBF1yuTbEmS2PHIZgKpfgqH57HsxvnKL0iCaz+ziVB6gPzqHK66eaGKb39wA+HMILmVWaz66GKN73gtydlhssoyWPfxZSq+9f41pOQmkVmSxoa7rlLxTfesIq0ghbSCFDbds0rF25ra+ert3+ZLt36D7o5uFdd15etyzzR+BtwnSdL/Rh8/A9wsSdJzCa/bRmT6iqysrOGHD19ULxFdl5l+9NgvePJD/xUfHcvXK2KSj859SR5aGhP5udG5L+yhJeF4eXagdbzVZqG3p++855dnP1rvL+dax9tdtrjjS4s73Da62qM85KH1TAL32Olq645yt8KdBeD02OmMck/QrXB3ATh9Djpbus7LXT4nHS0Rx5g74KL9bIeCu/3OuKNM/u84lx0TSPVz148/QrGGIUDX5af3S6ZxDMiUPc4ATiS+SJKkJyVJqpMkqS4cvmC3Ql2XkYaGhvjj9/9C65k2Xv7f1xTTKa2n25i+fiJCQGZJGjVTKxXTOS2NbczYMBFhEKQXpjJ8RpViOqfldBszNkxCGARp+cmMnF2jmE5qaWxjxsZJGIwGknPC1M+rjQeM2PlnRnlSVojRC+oU02Utp9uYtWkyRpORUEaQsYtHKnjr6TZmbpqM0WwkkOpj/NJRCotwa/R4k8WEP9nLxBWj4wEDoPVMG7M2TcFsMeENe5i0cmw8YER4OzM3TsZiM+MJupm8alw8YEBk1D9z4yQsdgtuv5Opa8bHA0aMz9gwCZvTitPnYNq6CfGAAdB+tiPOHW4b09dNVASJ9uZOpq+biMNtw+6yMWPDJEWQOdvQzOFX5BMFut4Putwtt08DO4UQ3wbqgda3Ws/QdWXp1b++wWM7v8i+5w/i8jk1LbaHXonsC2g60YzVYdXmQxJnG5pxeuwqfvjVYxF+sgV3wKXJhwaHaDnVSmt0051cR14/ztDgEK2n2xR7KuLHv36cwYFBWk+30nyqRcWP7T3BYP8gbU0dnG1oVvGjb5xgoG+AtqZ2xZ6L+PH7TtDfN0BHc2fchSXX8Tcb6OvpZ6B/kDPHm1T8xIFT9HX3MdA3QOPRMyrecPAUPZ29CAGNh9X85MFGerv6EALFno44P9xId0dv/LW63v+61JbbbwGTgBBwCrgDMANIkvRE1HL7GBGHVRewSZKkt1zl1hfCrxzdtfwB/vSDvymei1lUjSYjqblJHNunHCOEMgKcOXYWg9FAWkEKx/YqE8+YRdUQzT6OJvKoRdVgEGQUpXHk9eMKHrOgCiHILEnjyGtKHrOgCiHIKk3n8KvHFFxuS80uy1Bxue01uzxTNRKX226zyzM4/Iry+IzCFI7tO//xmcVp8c+sdf4L8azS9PhnvhDPKsvgSCKXPVc5vpQPf+U6UvOS0XX564qYnpIkaZUkSamSJJklScqQJOlLkiQ9IUnSE1EuSZJ0nSRJ+ZIkVV4oYOi68jV17QRMZiNlo4tIL1Jv3pu2dgImi4mSkQVklqjtnVPWTMBsNVNYl09Oeaaarx6PxWYmvzqH3KosNV81DqvdQm5VFgU1agvvpKvGYnVYyS7PoHB4ngYfg81lI6s0nZKRaovvhGWjsbtsZBSlUjaqSMXHLx2Fw+MgLT+FSo3Ne+OWjsLlc5KSm8SwiWUqPmbRCNwBF0lZIWqmVqr5whF4gm7CGUFqp6stwPVzh+MNewim+Rk+c5iaz6nFn+wlkOKjfnaNio+YWU0g1Yc37GHxrjl6wHgf6pIvhL/T0jONK0dfue1bfPPeH8Yf2902umVz+gaDQVGkz+620y0rC5JoYZUvMl8UF0JRRFCLyy2wNpeNHhlPtMDanFZF2ZNEC6yKo7S4Wh1WeruU3Gg0MBjjCRZhUNpiNbnMVptoEQYwmY0MRHmiBRiUtl6VBRilrVjr+I996wNMukq9v0PX5acrItPQ9Z+tTfes4gNf2IbL72T80nrqZihHtkNDQ+x6fCvugIsxC0dQn2DBlYYkbvj81XiCLurnDmfs4pEqvuvzV+MJuqmbWc3EFaOVXIpwb9hN7bRKpiRYcCVJYtfjV+NL8lA9uZwZGyYpP4AE1z++FX+yN2LB3TpVzR/bSiDFR9mYYuZfO0P1Hex4ZBPBND8lIwtYsmuOil/7yCZCGYGIBfem+Wr+0AbCmaGIBfcjC1X8mgfWk5wdJrcyi9W3LVXxrfevJSU3ieyyDNbdobbgbrl3NWkFKWQWp7HxrpUqvuHOq8goTiO9MIVNn1DzWBXgR3c8pXKC6boypWcaui6Zvv3J/+Yrt30rvmHO5XfSIbdwJozUVRbPC3GUI3ktLt+gpjo/ypG4NjfFS4rL7apxLhupu3wOOmTuJVCO/uV2WE3udSgKLIIyu3B4HHS1JXDZBki5HTcmefbjcNsVBR4TeWImmPhcYqYWec9zFmKXz8ndT39Es2aWrksvPdPQdVlqoH+AX375t5w53sQbz72p2GHd0dzJ/GtnYDAaKKjJZfj0KsX0UntzJ/N3zMRgNJBXlc2IWdWa3GgykFOeyah5wxU7vNubO1lw3UyMZiOZJemMWThCsaO5o7mTBdfNwmQ2kl6Yyvgl9fGAEeMLd87CbDWRlp/MxOWjFT0oOlpi3ExyTphJK8cqdmx3tHSxcOcsLDYzSVkhpq4er5gu6oxyq8NCKD3A9PUTlby1iwXXzcTmsBJM9TNjwyTFdFRXWxcLdkTKnvhTfMzaPFmxY76zrZv510bKnnjDHmZvmaKYLutq72be9hk4vQ48QTdzrp6m4N3tPczdNh2X34nL72TutumKINLd0cOcqyNlT5xeB/O2z1BYiDtaOjn2hm5+vNJ1uVtudb2P9PwzL/HZ657i2BsN2JxWkrPVe2pe+N0rDA0OcfT14wz0qxdRX/ztyxG+97hmU6M9v3+FwYEhju1rwGBSj4le/P0rDPYP0vDmSSw2s4q/9MdXGegf5OTBU9hdNjX/w6v09w5w8tBpnF6Hir/8v6/T39tP45Ez8b4aibyvp5/TR89w9A3VliNe+b+99Hb10dd9liOvHVPx1/66j56uXnq6ejmswV//+366O3ro7ujh4EvqPRJ7n90f3evRzYGXjqj4G/94M57NvPnCIRXf/8+D8Wxr/wsHVfzNFw7F92rse+5NFdd15UvPNHS9Z3r6c7+IjzR7Ons5/OoxUvMiDYMsNjNZpRkcjVpge7v7OPTyUdIKIg4qs9VMdnlG3CLb3zvAwZeOkF6YCkSmkXIrsuIW0YG+AQ68eDheHt1oMpBbmRW3sA70D/LmC4fIKolUpTEYDeQNy+Zg9EY6ODDE/n8eJLssUj5dGAT5w3LiN9qhwSH2PS/jAvKrc+M3WmlIYt9zB8ipyIzzghoZlyI36NzKcw6uwtpc9j9/MM73PvumojdFYW0e+547EH+89+/7yR+Wc44Pz+ONf5y7Ue99dj/51Yk84XgVVx4vd5AVDs9j77P7FcfLy8MX1uay91n58W8qikiOmFWt6ejSdWVJDxq6Lqnq5w2P3rBzCGcG1HxObfyGn5SlzkxGzqnBaDaSU5FJSo6aj5hVjcliIqssg7R8deYyfOYwTBYTmSVppBekqvmMYZitZjKKUsks1uYWm5m0ghSyStVl0WqnVWG1W0jJS9a0ANdMrcTmsJKcE9ZsXjRscgV2l42krJDiBh9T1cQy7G47ofSApkW4cnwpTo+DQKqfIg2LcMW4Elw+J74kL8Uj1OU+yscU4w648IY8lGr0/yitL8ITdOMOuCjVqBJcPLIQb9iDy+dkwvIxJGWpN3DqurKkL4Tres/0tbu+x9fu/F58Wilx4TfRApu4cJxogVUtLCcsjKsWli/EUS6cay08yxfOtbh84VxeJ+ocP7dwrsXltlathWmL1Rzvxa21MC23wGotTMsX1rW4fGFdyyIsf+7t8Ju/upPp65WFIHVdHtIXwnVddlr38eXsenwrLr+TiSvGUD1JWaMyYoHdhjvgYtziempnVKn549vwBF2MXjCCkXOUFlwkuOHxiMV25Jxaxi4cqcm9ITd1M4cxQaN/xM7HtuANe6iZUqGy4ALs/OwW/MleqiaWMX2D+ua349FNBFJ8VIwtUVtwgR2PbCSQ6qdUowouwPaHNhJKD1A8Ip9Fu9StZq55cD3hzCCFtXks++A8Fd/2qXUkZ4fJG5bNisQquMCWT0aq2OZUZLLqVnUV3I2fWEVafgrZZRms0aiCu373CjKKUskoTmP97hUqvvb2ZWSVpJNekKJp0W1v7uDha77AfWsfUbSi1XXlSM80dL1n+urt3+Ybn/hB/HHiSDtxM96/zAXAuWxFzZWZitZIX55pqEb6CZlK4mZDUGYiWpmAgmuM9OWZimozIcrNelojebnFV4vLN+BpbSaUZyJamwXl3GKz0NeTwO1m+rr7Va+NSW4Btjms3Pnjj1Crr3NcFtIzDV2XhXq6evnhIz+j4cApDr2idOt0tXWz7Kb5GE0GyseWMDxhc19XWzfLPzQfk9lI6agiRs6pUR//oQWYzCaKR+QzesEIxfRWV1s3K25eiNlqpqAml3GLRyIfI3W1dbP8wwswW83kVWUzacUYhUW3q72bq25eiMVuIac8kykrxymCVnd7Nys+vBCr3UJmSRrT1k1QWHi723tYcfNCbE4r6YWpzNw4Wck7eljx4QXYXTbS8pOZvXWqwuLb09HDig8twOG2k5KTxNxt0xRNk3o6e1l203ycHjvhzBDzr52hsPj2dPay/Kb5uHxOQhkBFl43S7Fju7erl6UfnIc74CKQ6mPR9bMVN/ne7j6WfmAu3pAbX7KXxTfMVfC+nj4W75qDL8mLL+xhyQfmxgNGhPez6PrZ+FN8eIIult04X2EB7unq5WRC+1hdl7+Mu3fvvtTX8I7qySef3L1t27ZLfRm6gP97+lk+Nude/vC9v/DTL/ya/r5+VX+GM8fP0tHcScupFkCirUnJm4430362I8qhLaF/xNmGZtqa2qN9MSRVf4mzDc20nmmP971I7F/RcqqV1tNttJ5uQ5JQ9cdoaWyLvOZMG5IkqfpvtJxpo/lUK+1NHUhDkqoSbuuZds42tNB+tiNSTTeBt53toOlEM+3NnQwNDMX7lcfU3twR+Y5aOhnsH1TxztYuTh87S1dbFwN9A2re1sXpo010tXXT39uv4t0d3TQePkN3Rw+9PX20JPCezl5OHjpNT2cvvV29quvv7erl5MHGiA24U4N399Fw4BS93X10tXervr/R8+s0a3jpeu915513NuzevfvJC71OzzR0vWv6xZeeic9b9/f2c3zfybhF1e62kVuZReORSDnu/r4Bju1tILciYkG1Oa3kDcuOl+Me6B/k6Osn4g4jq8NCfnVOvBz34MAgR147HregWu0WCmtzaTgQ4UODQxx+9Rj5UYeR2WqiaHgeJ96MVIwdGpI49MpRCmojNzCTJZK9HI9W2ZUkOPTy0bgDyWQ2UjKygONvxLjEwZeOUBRtOGQ0GSipL1RU4T340pF4n3KD0UDpqMK4xRjgwJ7DlNRHuDAIykYXKarsHthzmNJRhTJerKhCe2DPYUpHR4ogChFxPsmr5B7Yc5iyMeccTuVjijn08rm9HAf3HFHyscVxC3Ls+svHvjUvG1McnQaE8jFFCn7o5aOUjSmK8/FL61XZo67LX3rQ0PWeqnRUIUII0vJT8ATV/S2KRxYgDILUvGS8Yc95eUpOEr5kdf+LohH5GIwGwlkh/Mk+9fHD86JNlcIEUv3q4+vyMJqMhDOCBNPUFuCC2jyMZiPBtAChdDUvrM3FZDERSPWTlBlU8fzqHMxWM4EUH8nZSSqeV5WDxWbGn+wjJUfNcyuzsdot+MIeUvM1eHkmVocVT9CtaTHOLsvA7rLhDrjie1zkyipNx+624/I7ydDgmcXpODx2nF5HfA+Mghel4fTasbvtZJVkqHhGYRouvwOb00bF2FJ8Gj1MdF3e0hfCdb1r+vYn/5uv3P7t+DqBJ+hSTj+JaCXbOFe3H5UvHF+Qh9yq6Sv5wrAWl1tctd5fbnHV5LLFXk0uWxjWap8qbw+ryWWL2VpcvpiuVRtLvhivxeVmAK3aWHKuZVGW2461LMjyY7SMBzc+tV3Va13XpZG+EK7rkmvlLYu59jMbcfkcTLxqDOVjSpQvkOC6RzfFq9wOm6TuD3HdI5tx+Z2MWTBCs//DdY9uxh1wUT+3lhGz1FMdOx7eiCfoom7GMMYsUP9/2P7QJjwhN7VTKxm3tF7Fr/nMBrxhD8MmlTNp5Rg1f3ADviQvFeNKmLp2vJo/sAF/io+y0cXM3DRZxbd+ai2BVD8lIwqYu01twd1y3xpC6ZEqt/N3zFTxTZ9YSTgzSF51tmaV3I13rSQpO0RuZRbLblRXyV13x3JScpPIKstguYZFd+3ty+JVblfdorborrp1CRlFqaQXprBGo4ruVR9eSFZpOql5yay/Y7mKt51t55PrHuW2+fdxTKOsiq7LT3qmoetd0+c/+FV++MjP4o8TLaDyLEGLy+2v7wo3CEXBRPmoH9QWX7ldFNSbERMtqokWX6vdTK/MXZTYj0NlUU2w+Mo37ml9Rq1+F/J+HJpc9jMwW0yKHu2gtADLszYtLu/tEeeyY+R24Zjk12QyG9n9ww9TP3c4ut576ZmGrkuijpZOvn739zn86lFOHDipYD2dvay9fRkmi4nhM6qonValyc1WM9VTKlSLpD2dvaz7+HIsNjOVE0oZnZA59HT2svbjy7HYLZSPLWZcQn+Nns5e1t2xHKvDQkl9IRNXKDOHnq4ItzmtFNXlMXW1MnPo7epj3R3Lsbts5NfkMCNhc19vdx/r7liGw20ntzKLWVumKCy+vd39rLtjOU6vg+yyDOZtm6HgfT39rP34Mlw+J5nFaSzcMUsRtPp7+ll7+zLcARdpBSks3jVHERT7ewdYc9tSPCE3KblJLP3gvHjAiPFVH12CL+whOTvM8g/NVwTt/r4BVt66GF+yl3BmkKtuXqiwAA/0DXDVRxYRTPMTTPOz8pZFCj44MMh6lW4KAAAgAElEQVSKmxcSyggQSPGx6tbFiiAz2D/I8pvmk5QVwpfkZfXHliiC2ED/II1H9Q1/l7v0TEPXO6bffut/efyGL9N6pj2ymJwZ4OTB04rXeMMeWk+3YTAaSM4Oxd1NMfmSPLQ0tmEwCJJzk2h4U+nj96f4aD7ZgsEgSMlLjvfbjimY6qepoTmy2F6QHO+3HVOsB3mEp8TdUYkcIKMoVVXKO5wZ5HT0xqbFYz3IATKK01Q9zJOzw3FHmLxfd0wpOWFOHjo/l/cg1+T5yfHvTIvLe5RrXf+FeHphavw7k/87Jvkx8n7n8eOLUuOOM/m5Ytr1+NXM365uVqXr3Zeeaeh6z/XMN/4Y3ycxODDIqUNn4kXwvCE3+cNy4vskhgaHaDjQGLeYugMuCmtz4z7+oSGJhjdPxS2mLp+Dorp8mk+2xPmJ/Scpi1pMnV4HJSMLaGpoBiIW2OP7TsYtona3jdJRRfGAEOENVIyLcpeNsjHnOMCxNxqonBBpGGR1WCgfWxIPGDFeFeN2C5XjS+MBA+DY3hMMm1QOEM+OYgED4KiMm60mhk0qjweMGK+eEuEms5Fhk8rjASORG00GqqdUKILs0b0nqJkaKdViMEa4/CZ97I0GqmW8RoPXTKlEGESET61UBInj+xqonlKBMAiEQVAztUIRZI7vO0n1lAoMRkOUV8YDBsCJ/SepnlyB0WRECMH09RNV2aGuy0960ND1rkmSpHjPDG/Yi81lVb0mZiv1hjzYNPpXJOckIQR4Qh7s7vNzd8CFw21X8+wwwiDwBNw4NI5Pyopwl9+J06Puj5GUGcJgELh8Tlwa/TNCmSEMRgNOrwOnT4OnBzCaDDg8Djx+dX+NUHoAo9mIw23HHVBbkIOpAUwWE3a3HU9IfXwwNYDZYsLusmv27/Cn+DFbzdhdNnwaFuZAsg+L3YLNYcUbVttf/cleLFZzxAasYY/1J3mx2ixYbRb8SWqLsy/sxWq3YLaY8KeouTfsweqI8NTcZBwe9c9Q1+UlfXpK1zumH3zmp3zp1m/EF1N9yV7VDmN57SN/sle1Q1m+MKrF5YvFsakqueSL0VpcvtityWWL5VpcbnHV5LJ6VFpcbjv1J/toPqXkctuq1ueXt5TV4vKWtrGpPgWX2Xa1uNw2HJtKVHCZbdkb8qj6fsuf07I4+8Ke+K57LYvyDZ/fxrxr1C4yXe++9OkpXe+5ln5wHpvuXYXDbWfiijGKBjwxXX3/GhweO+OXjopPPSn4J9fi8NgZvaCOivElGsevxel1UD+3lmGTy1V8831rcPkc1M0YRp2GRXfLJ9fg8jupmVpJvcZu5C33rcYdcFE1sUzTorv53lV4gm4qxpUwQcOiu+melXjDHkpHFTFphdqiu/GulfiSPBSPKGDqWnUV3Q13rsCf4qOgNpcZGhbddXcsI5jmJ29YNnM0quiuuW0ZoYwAORVZzNNYG1h162KSskJklaaz8Dp1Fd0VNy8kOSdMRlEqS25QW3iX3zSf1Lxk0gpSWHaT2sK7+IY5pBemkpKbxIoPqy28C66fRWZJGknZIVbeoubNja3csfhT3Djx4+x7/oCK67r00jMNXe+YPrPtCX7+xWfijxMtqnJ7JqgtqomWTovdQp+MJ1o2Ey2qF+QJllA1V1qA5VkRqC28iRbWC/FEC2/i51XxhO8rVn4j9n9Wm5+z+GpZXOXn0LLIym3IiZ8nwg0MDQ2dl8u/Q2EQIEkKh1gil3/exGs2GAS3fedGxi9Vl7DX9c5LzzR0vSc6e7KZp27+Gm889yZnTpxVsL7ufjbevRKLzcLo+XXUJFhse7v72HTPKqx2CyPn1DBi5rCE4/vYfO8arA4rw2cMY/R85e9zX08/m+9dhc1ppWZKBeMTFlEjfDU2l42qiWVMumqMim+5bw12t53ysSVMSbDY9vf2s+W+1Tg8dkpHFTJj46QEPsCW+1bj9Dooqstj9pYpKr75vtW4/E4KanKYf61y5D/QN8DmT6zCHXCRW5nF4utnK3n/IJs/sQpvyE12WQZLb5yn2Bcy0D/IxnsimUtmcRrLPzRfcYMe7B9k490r8Sf7SC9MYeUtixQ36cGBQTbsXkEwzU9qXhKrP7ZEsW9laHCI9XcsJ5wRJDk7zLrbl8UDRoyv/fgykrJChDODrNu9XBF0pSGJ1R9dSkpOEsH0AOvvukrFV966mLT8ZPwpPjbevVIR5IaGJM4mTO/puvTSMw1db1s//+IzfOGm/0dXezdCCELpAVVjndgcvhCCUEZA4T4C5Ry+3K4ak3wOPik7ROPhBO530d4c4XI7a0zyefPknDCnDiVYgEPuuONLi8vn/VNyk+IFEs9xb7yya0pOEicPKbl8XUPr+GCqj6aGt+BpfppONF8U17r+UEaQM9GfiRYPZwTjPzOt7y8pM0Tj0TNRHuJUwvcv/5lp/fzk7ym3K18s3/nZLZrTaLreeemZhq53XX/6wV/iTYokSaLpZDNVEyOlQGLd5WKLvpIkcfpoU3wdItadTl6rqPHIGWqmRRryBFJ9lI4qVNRaajx8Jl5KxJfkoWxMUTxgAJw6fDrek8Mb9lAxrkSx0Hrq0GnqotmMJ+iiakKZopT6qUOnGTGrGojUaRo2qVyxUHzyYGN8w6HT46BmSoWiFPjJQ+e4w2OndlqVYiH85MFG6udGug3aXTaGTx8WDxhxHu1GaHNaqZtZHQ8IMT5qbi1CRKb2RsyuUfBTh05TP7cWYRBYbGZGzq6JB4wYHzU30pPdbDVRP6dWEeRPHY4cbzRF+dzaeMCI8DPUzx2O0WzEZDExam6tIkg0HjlD/ZxaTBYTRrORUfOGK4LQ6aNNjJxdg9lqwmgyaPIRs2uw2MwYjAbmXzuTySvHouvykh40dL1zkiLrBBCZrxdGoXqJ1WYBInPXBqP6189sjR5vNmlyS5Qbz8PNVlOEmwwYtXjs/Kbzn18IgdFkxGhSc5PZFOFmw/mPN0SON2gdbzFF9j2YDBjNRjW3Rj6XwWjQPr/VjDAaIseb1MebLWYMhujxGu9vtBgxRPddaJ7fYkIIA0IYMJlNGp/fgEEIBGC0qLnRbIxygUnr/GZj9P3Fed7fiDAYEAIs0eCi6/KSPj2l623rx5/7JU/d/LX4YrZ8qgQAEbW4Ri2swXQ/TcebFe8ht7jKd2PHJK/SKp9KiUluYdXi8ukvremPC3F5ZVgtLp8+0+Ly6TEtLp8e0+Ly6TGtzye33cqnorR5gDPHlN9vIMUXXzfQ+v5jO+xB4+eb8JwWl79nINXH2QblGoX8muTXElNsekqSpLgRQNe7I316Ste7rnnbp7Pqo0uwOiyMXzqKnPJMBRcI1ty2DKvDythFI+INkuRae/sybE4r9fOGxxsYybXmtggfMauGEg2L7prblmF32aidVknFOLVFd9XHlmB32xk2uTy++1qu1bctxeGxUzG+RFULCyJVXJ1eB2Vjihg5W23RXXnrYlx+J8UjC1QL9QBX3bwwstt9eB5jNXY7r7h5IZ6Qm7xh2UxYPlrFl920EF+Sh9zKLCavUlt0l944D3+Kl6zSdKatU1fZXXLDXAKpfjKK05i5YZKKL7x+NqH0AGkFycxKWMgHmL9jJuGsEKl5SZr7J+ZeM53knCSSs8MsuFZdhXfWlimk5icTzgiwcOdsFZ+xYTIZRakE0wOaFt+zDc18ZMZdXDv8Zl78wysqruu9l55p6Hrbum/tI/z2m/8bf5xokU20tCZaUFU8ocpqouU10aJ6QZ7wfokW1QvxxPdLtKgmvj7RspvIDSYDQzKeaImVV6TVOp/BKBgalGSPlZbXRAurFkc6Z9mV22c1j0+oAixE5K/Ya2ID/9gtRMU1LLeJ51Cf89w1JVqMAW752i6mrlEHR13/vvRMQ9e7ooYDp3j4mi+w54+vqnbzDvQNcPX9a7E5bUxYNoqqhJF9f+8A2x5Yj91lY+zikQxP2HzX3xflbhuj5g+nfq5yZD/QN8D2hzbgcNsZMauGMYtGqPmD6yOL0NOrVCP3gf5Btj+0AafXQfXkciavHqfJXT4nleNLmbFeWcV2cGCQax/agDvgomxMMbMTNtcNDgxxzYMb8ARdlIwsZG7CyHwoyr0hN4XD81h0nXLkPTg4xDUPrMeX5CW/OoelH5irPH5Q4upPryOQ4iOnIku1eU4akrj6/rUE0/xkl2Ww6tbFKr75vlWEMgJkFKex5rYlan7vapKyQqQVpLA2of+FJMHGO68iJSeJlNwkNtx1lSIgSBKs372CtPxkkrPDbPrEKhLHpGtvW0pGUSrhzCBbP7lWtU9j1a2LySpJJ5Qe4Or715A4qE38ndP13kvPNHRdtH748M/44q3fiI/uE+eghUFgtpji2YPWHLY8u9Di8jUOrTlyBddYI5GX+QimBWg6cf41Eq05fPkahyb3OemMlvHQ4vI1kGB6gCYVd9ERdXxpXZ+89IbW55d3P9Ti8tIfWlxuEQ6k+jnb8FZc/fORW4i1yqT4U7w0n4wcr1XmRH5O+bm0uFYZkx0Pb2KxRrMpXf++9ExD1zuuv/38OcV0UNvZDuqiFtX0olSKhucpppuaT7Yyan6koU5qfjKlowoV/GxDS7xUR0pumPKxxYomSU0nmuPZRFJ2iMoJpUp+vDm+ThDKCDBsUnk8YESOP8u4JZFSH8E0PzVTKuIBA+DM8bOMj5YC8Sd7GT69SmEBPnP8LBOWjkKISM2kupnD4gEjkXuCbkbOrlG0U206fpYJy0YjDAK330n93Np4wIhd34RloyMFD30ORs+vU9RqajrRzMTlozEaDTi9dsYsHKFol9t0opkJy0ZjNBmwu22MXTRScZNtOtHMhOWjMZlN2JxWxi2uV9ykzzY0M2HZKMxWEzaHlfFLE3kLE5aNwmIzY7VbmLBslCJINJ9sYfzSUVjsFiw2c5SfO775VCvjltRHChJaTUxcPloRpFoaWxm7uB6b04bJouatp9sYu2gkdpcNk9nIig8tUG2w1PXeS+1506XrIiVJEl3Rm2xvVy9Wu0XFYzfRvu4+Vdc3gPboTbi3u1/VVQ5QHC8PWDHFbuJ9Pf0X5H0aPNYTu6+3n96ePjVv7USSIlNnfT0a79/WFeX9ipIoCj4k0d8/qFjviamrvYuhwSEG+gbolXUNjB/f3s3QkER/36Ciq2BM3R3dDA1KDPQP0tPVo+bt3QwODiIGoKdTi/cw0D+INCQpAu659++hv28Ag0EoAq6cx36uWsf3dPYy0DfA0JAU39Oj5D0M9PUzODCozbt66e8bYHBgkLamds2fsa73Vvr0lK6L1i++9AxP3PT/6GrrxmA0EEzzKyyiBqMBh9tOR0snBoMglBFU7RB2+Rx0tHQhhCApK6TagRyzsAohSM4Oq3ZYe4NuWqPz2lo7pL1hN62nIzw1L0mjydO5KRF5Q6OY5FMq8oZGcS6bkknLT+ZEApdPCWlx+ZSW1vvLLahax8ttuVo8KStI45Gm835++Q5src8v3zWuxeXfudb3fyEuvyatHeryc2rtMI9NTw30D2ju89D19qVPT+l6xzV17QQW7pyN2Wpm9II60vKTVa9ZvGsOZpuZ+rnDyShOU/ElH5yHxWamblY12eUZKr70A3Ox2C3UTqskd1iW+v1vmIPVbqF6cgUFGlV0F++ai9VhpXJCGcUjClR80a7Z2JxWyscUxxs4ybXw+tnY3TZK6gupHFeqPv66WTjcdorq8jQtvAt2zMTpdZBfnaOqtQUwb/sMXD4nuZVZjJyltvDOu2Y67oCLrLIMRs1T98qes3Ua3pCbjOI0xiwcoeKztkzFl+QhrSBFs9DfjI2T8Cd7SclNYsJyNZ++fhLBVD/J2SEmrVRX6Z26Zjyh9AChjICmi2nKqnEkZYUIpvmZvm6iik9YPoaU3CQCKT5maFiAxy8dRWp+Mr4kr6qWF0R2nd8w7ja2VtzIX36iDw4vhfRMQ9dFa/fST/Pn//57/HGiZVa+SA1qy6rVYVVMwSRaThOr4l6QJ1atTbD8JlpcE6vqJlpSEz+Pmlvok01hJVpSVVVxEyytie+faDdNtAAnVq1VVc1N4OqqtygssFpVb+Wf8YI8wVIcee7cz+BCPPH7SLxmraq5ci4ijuHoXxHd+NR2Zm9Rl4jX9a/risg0hBCzhBB7hRD7hRC3aPCNQojTQogXon+2Xorr/E/WwZePcO+ah/n7L/4Zby4UkyTBtk+vw+GxM3nVONXmusH+QXY8vBGHx87EFaOpmVKu5o9uxul1MHbxSEYkjLwH+wfZ+dnNkUXiBXXxRfU4Hxhk56ObcfmcjJxdoxpZDw0MsfOzm3H7nQyfMYyJK5QW3KHBIa5/bAvugIvqyRVMXTdBxXc+tgVPyE3VxDJmbpqk5EMS1392C96wh/IxxczdNi2BD3Hdo5vxJXkpHVXI/ITNb9KQxI5HNuFP8VFUl8+SDyottpIkce1nNhJM9VNQk8uymxao+DUPbSCUHiCvKouVtyRYbCW45tPrCWcGyS7PZM1tS0nU1k+uITknTGZJOusTLLYAm+9dTWpeMulFqWy4e6WKb7z7KtILU0jNT2bTJ1ar+Prdy8ksTiMlN4mtn1qr4mtuW0p2WQZJWSG2fXqdiq+8dTG5lVmEM4Js/8xGRcAA4tUAdL13umSZhhDCCLwBTAeOAc8CqyRJelX2mo1AnSRJOy/2ffVM453TN+75Af9153fjo79EC2SkLpCIjyQTeaSGkyE+UtSyUMpH11qd5OTZihaXj961LJwX4vLsR5ufy260uDy70uJyC7AWl5dB0fp8Drc9vkCs9f3JLcJaXN7pT6uTntwirNVJT14mRW731eLyf8ckf095ReI4l12T/FpikncCdPocdLZ0Kfi1D21kScJ+Fl1vT1dCpjES2C9J0gFJkvqAbwPqVl66Lple+N1LiumCno4exi+LjObzq3MorM1XTA91NHfE58FzK7MoHV2kmC5pPd3G5NWRqqXZZRlUTihVTMe0NLYxZU1kw11mSRrDJpcrprdaGtuYunY8QkB6YQq106oU0z0tja1MXzcBISILrnUzhqn5+okIgyA5J8zIOTWK6bIYNxgMhDODjJpXq5gOa2lsZcaGiRiMBkLpAcYsHKGYjotxo8lAINXH2MUjFY6iCJ+E0WzEn+xl/NJRipFyS2MbMzdOwmQ24g17mLhitMJR1Hq6jRkbJmG2mPAEXUy6aozCIhzjFqsZt9/J5FXj4gEDoO1MO9PXT8Rqt+D0OZiyerziJt3W1M60dROxOqw4PHamrZ2gCAJtTR1MWzsBu8uG3W1T8fazHUxdMx67247NaWX6+omKINTe3MGU1eNxeh1Y7ZYIlwWxjuZOJq8ci8vvxGK3MGPDJEU72c6WLiZdNRZ30IXFZmb9HSuYe40yu9P17utSBo104Kjs8bHoc4laKoTYI4T4vhAiU4MjhNgmhPiHEOIfp0+f1nqJrndA0pDE0dePA5E9Ct2d6umqI69FeNOJZk0L5dHXTwBw9mSL4oYX07Eobz7ZqhpVAhzbewJJiuwBSBy1AhyN8pbT7efnQxKtp9tUo26A4/saGBoaoq2pg7Yz6uOP7zvJ0OAQ7Wc7VFkDwPH9pxgcGKKjuVOTn3jzJIP9g7Q3d6r6g0f4KQb6B+ls6VRtrANoOHiK/r4BOlu744UE5Tp5qJG+3n662ntUGwcBTh1upLe7j662bs4cb1LxxiOn6e3qpbu9m9NHz6j50TN0d/TQ09GjKJse0+ljTfR0dNPT2atyPgGcOdZEV3s3vd19KuccRH5vOlu76OvuUznnAJoaztLZ0kVfTz8HXz6synx0vfu6lNNTy4GZkiRtjT5eB4yUJOl62WuCQIckSb1CiO3ACkmS1JYKmfTpqXdOv/n6H3nixq/SeqYds9VMINWnsEgazUbcPictp9swmY2EM4I0yC2WAvxJEQuryWwknBU6r4XVaDKSnBPmxP6TCh6rsmowGkjNS+b4vgYFj1lUDQZBWkEKx95Q8phF1WAQpBemcnTvCQWP2TqFEGQUp8WDYkwxi6oQgsyStHhQjCklJ8zJ6HeSVZqu4nKLaVZZBkdePabgcttsdlkGhxN5QUr8O9Hi6YUpHN938rzvn1GUGv9ONHlxGsei30lWaQZHXlPyzOK0+Hem9fkyS9Lj35n83zFllaRzJMZl7xXnsnNmFKVx7I3z8/SiVI4n/Hy3P7iBxTfMob+3H6vdiq63rytheuoYIM8cMgDFb4wkSU2SJMXy/6cAtQdR17umsYtGMGX1eIwmA7XTKglnBBXcYDAwbV1kOmbYlAqScsIKLhCR6RiTkcqJZaTlqS26semY8nHFZBSmqvj0jZMwWUyUjS4iq1SdiE5fPwmz1URJfSE5FWqL7rS1E7HYzBTV5ZOnUWV32roJWO0WCmpyKKxRW3inrBmH1WEhtypLswrv5DUTsDmt5FRkUlKvtvBOXjkOu8tGVmk65WOKVXziVWNweOxkFKVSOV5t8Z24fAxOr4O0/GRNi++EpaNx+Z2k5CRRO7VSxccurscdcJGUFaJuxjAVH7NwBN6wh1BGgBGzq1V89II6fEkeAqm+eIMouUbNHU4gxYc/2cvoBer7zcg5NQTTA3jDHsYsUlf5rZtRRTgziCfoZtwSNa+dVklydhi336lpIT5x4CQ76j7CxqJd/Obrf1TVqtL1zutSZhomIgvhU4HjRBbCV0uS9IrsNamSJDVE/70Y+IgkSW/ZZV7PNN45fWzevfz95/+MP060lMoXcUFt+ZQv4oLaUimvAwVqC+sFuWyRGdQWVhVPqJr6r3MUFlab06baZS2/hkQLcuJ3kGhBBqVNONFiDEoLqyaX2WYTLb4Xw+XGg0SLr5qbVTu05c8lWq5VPOH3BZS26URL9cVwvT3s29dln2lIkjQA7AT+B3gN+K4kSa8IIe4SQsS8hbuEEK8IIV4EdgEbL83V/ufo1b/s5fYFn+QP3/uLquyF0WjgmgfW4/Q6mLZuIqX1yv4WkgQ7HtmE0+dg8qpxlI9XWnCHBofY9bmtuPxOJiwfTc3UCiUfktj1+NW4/E7GLR4Zb70q5zd8/mrcARej59cxaqHy91saktj1+avxBF2MmF3D+GjdqXPXJ3H941vxhNwRC+5VYzS5N+yhZkoF0xI2r0kSXP+5rfiSvFRNUFtwAa5/bCv+ZC/lY4uZc7V6kfa6RzbHW9ku2KG+uV338CaC6X6K6/I1XUHbH9pAOCOoacEFuOaB9SRlh8irylZVuQXY9ql1pOQkkXMeC+6W+1aTmp9MVmk663dfpeKbP7GS9MJUMopS2Xi3mq/fvYLMknTSClLYcp/agrv248vILssgJTeJq+9XW3BX3bKI3MoskrPDXPPgehVf8eEFFFTnEM4Mcu1nNqi4VqkWXe+s9M19uuJ66iNf57uf/nH8caKF0mQxMdg/GB+JJ3KD0YA0JJ2XCxEZzceyBZVFM8ql83GUI/W3w+UjbS0uH/26/U7aEyygcouwJpeNpLUspPLR/QW5zC4bkzw70eLy7EZux71YLs/uEjNJUGZfiZlk4jGJmWIit7ls9CTUq5Jfk1amJudamdr2Bzew9IPz0PWv67LPNHRdfnrtb28oHg/0DcRLQVSMLaawNlcxZ9zT2cPMjZMRAkpGFVI6ulDBO5o7mbN1KkIIikbkUzWxTDG91H62gznbIrygNpeaqZWK6aX2sx3M3TYdYRDkVWVTN3OYYnqr/WwH866ZjsEoyCnPoH5OjYrP3z4do9FAZkkaoxfUKXY8t5/tYN61MzCajKQXpjB20QjFdEl7cyfzr52B0WwkLT+Z8UtHKSzC7c2dLNgxC7PFREpOmIkrRiumazqaO1mwYyZmq4mkrBCTV41VTAfFuMVmJpQeYOra8UreEuV2C8FUH9PXT1TcJDtaItdndVjxJ3uZsXGS4ibb2drF/O0zsLtseMMeZm2arOLzrpmOw2PHE3Qze8tUxU2+q62budum4fQ6cAdczLl6qmK6rqu9mzlbp+L2u3D6HMzdNl0RZLrbe5i1ZQrugAun18Hca5S8p6OHmZsm4w17sLvtzNs+QxHEejp7mbEhUvbE5rQx/1ol7+3qZfr6iQRS/dicVrZ9ej0Ld+pTU++2jLt3777U1/CO6sknn9y9bdu2S30ZV6T+56u/o/HwOZuk0Wig7WwHHS2ddEaLFMotjsIg6Gzrov1sB11t3ZHXJ9hYuzt6aGtqj3CTIV5MMKbezj5az7TR1daNyWxUbW7r6+6jpbGNrvaeKFfaWHt7+mk51UpXezdmi0nVv6G/Z4Czp1robu/BZDGp+j8M9A1wtqGZno4eTFazyuY62D9I04lmujt6MFvNqv4TA/0DEftxRy9mq1nVv2JwYIgzx87S3dGDxaLmQ4MSp4820dPVi8VqVvXnkKRIvaXerl7MVpOKI6Dx8Gl6u/rOy08dOh09Xv3+wiA4eTBiwzVZjCpuMBpoOHCKvu4+TGb1+xtMRk68eZL+nn6MJoOKmywmTuw/SX9vP0ajmputJo6/0cBA3wBCoPp+zDYTx/Y2MNCvzS1WM8feOMFA3yASEhVjS/AE3Oj613XnnXc27N69+8kLvU6fntIV1x+//xce/8BXaDrRjN1lw5fkVVQ5NVvN+MIeTh9rwuawEkjzKyyysU1vjUfOYLVbCGeGVBbK5OwQpw6fwWIzk5wdVlkwYxZVs9VMal6yygIaqwxrtphIK0zh8CvaFlWjyUBmSTqHXj6q4OmFqRzf14DBaCC7LIODLx1R8JgFVRgEuRVZHNhzWMFjtlIhIK8qmzdfVPKYLfV8PKc8g0PRa86vzuHNFw4peUVm/JoLanLZ/8+DCp5bmRW/Zi2eV5Udv+a3w+XXdCGudf3yY7R5Dvv/GXkub1g2BxK+H/nx8mvV4rlVWRzco/z5bfvUOhbfMIeezl5cPie6Ll769JSuf1nDJpUzYnYNwiAoHV2EL6wcsRkMgrsz3a0AACAASURBVPq5tRgMguL6AgIpXgUXQjBq3nAMBkFRXT6BNJ/qHGMWjsRgNFBYm0c4M6ji9fPqMJgM5A/LJjk7pOKj59dhNBvJqcwiJTdJxUfNG47JbCSnIou0/BT1+8+txWQxkV2WQbqGxbd+Ti1mq4msknQyS9RVekfOrsZiM5NelEZWqbpKb92sGix2C6n5KZoW4OEzhmF1WEnNSya/KkfFa6dXYXPZSM4OU6BhAa6dVonDbSecGaRweJ6KV0+uwOGxE0zzUzxCbREeNqkcp9eBP8VHSYKRAaByfCkuvxNf2KNZBbhiXAmeoBtP0K2qNQZQOroIb9iDO+DUtBCX1hfhT/bi8jk1LcTFI/IJpPpxeBxUT65Q8cLheQTTAzjcNmo0LMZHXjvOtqqbWF+wkx899gsGBwdVr9H170nPNHTFdfP0u/jnMy/FHydaMhMXbhMtk4kLs4kW28SF10SLrIoLoVgjSaw9lFjlVbWwm7Cw/i/zhM/g9NrpbFUu/Moru2otHJtMRgaitlBNbjYx0D9wXi63vWotLFus5nhzqUSLMCh/hhfiWgvPcluvFrc5rPHmUFoWYPkxiVWGI/ycbVnLAiz/zBfiWhbhax5Yz7Ib56PrwtIzDV0XpWf/5wVunPRx/uerv6O/L8GzbzZFLLY+BzM3TlaNfIXBwI6HN+HyOZm6dgIlo5T9K6QhieujFtvJK8dSNbFMxXc9HrHQTlg2itppypGjJEnc8ESEj12ktuBKUsxi62bUvOGMTqiCiwQ3PH41npCbEbOqGbe0XsV3RS22tdOqVBZcOGexrZ5cwTSN/hDXfXYL/mQfleNLmbVpsorveHQzgVQ/5WOKmbNNbcHd8fBGgml+SuoLWaCxv2D7gxsJZwQpqstnqYYFd9sD60nKCpFfncPyD6ktuFvuX0tyTjhaBXeRiseq2GaXZbBaw4K78a6VpBemkFmSzrqPq6vgrr1jGZnFaaQXprLxLnUV3DUfi1SxTctPYdO9q1R81a0Ri21KbhJbNCy4y29aQP6wHJKyw1z9KXUV3CU3zKVweCRrvfYhtQU3cR+Irn9fF8w0hBAGYBiQBnQDr0iSdOotD7qE0jONi9ejO57iJ0/8Kv44MVNI3LyVONJPzDQSR+qJm/ESR9IXk2nAuc12To+DzrbzZyKq90+w+KpG8gmZhtZIX55pXJBrWFDlG9DsbruqvLw8E9HKBOQb5LS43AKslQmYbWb63yKTkI/etSysCq6RKcif08wkZJmIVqYgvyb5tWpyjc2E8u8ksR8J6JnGv6J/O9MQQuQLIZ4E9gOfBFYBO4BfCyH+KoTYFA0ouq5QHXhJucgoSVLc4lo3c5gqsxjoG2DBjpkYDIKaaZWqOfGezl4WXT8bg0FQNbFMlVl0tXWz5ANzMZgMVIwrUW3u62ztYukH52I0GSgbXcSIWdWKoNDZ1sWym+ZjMhspGpFP/bxa1fsvu3E+JrOJgtpcxiwaqQhaXW3dLP/QfMxWE3nDshm/ZJQiaHW1dbPsQ/OxWM3kVGQy6aqxium1CF+IxW4hszSdKavHKXl7N8s/tACr3UJ6USrT109U7Fjubo+c3+a0kpafwsyNk+MBAyJOs2U3zcfuspGSm8TsrVMVO6q7O3pYftP8yJpGVoi526YpbpI9nb0su3E+Tq+DcEaQ+dtnKG7CPZ29LP3gPFx+J8E0Pwuum6W4ifd29bLkhrm4Ay78KT4W7Zyt5N19LNo1B2/Igy/Jw+JdcxRBore7j4U7Z+FP9uINuVnygbmKvuZ9Pf0s2DGTQKoPd8DF/2fvvcPkuM4z39/pnOP05JwDMDMYDAY55xwGIBKRQQAkwSAGiRQpBolKVCZX9l3ttdf23Wyvvbb3+q591155LVmmIjMJksg5Y4DJHWr/qO6aqjoFAqBAiSLme555gO63T3d1dXedc77v/d63+zPLDJNYcjDJ8n0LyCuJEYj4WfvociM+lGTpnnkkyuL4Qj7WPbrCMIkmh1Ms3j2XgsoE3qCHB7+/m9UPLWE0bm98mMnuC8DvA3sV03ZECJEPbAK2AH/88R3eaPwmI5VM85O/+hlKRuHNH71LtMBY6M6kMvz4v/2UTEbh7R8fIF4cNeBKRuHHf6Hi777yvmWh+0d//gqZVIYDPztIQaVc6P7RX/yUdCrD+784RGG1XOj+0Z+/QiqZ5tCrRxislQvd//yXPyWVTHH49WPSqhXgx//tZySHUhx587jB1S8XP/mrnzM8lOTY2ycQCAn/l7/6KcMDw5w8cAqHwy7j//3nDA0Mc+r9M7g9Lgl/5f/9JYN9Q5w+dBZPQBbY+9n/9ysGegcZ6B3kvZ99ION/+yr91wbovzbAuz+V8Z//3av09fTT19PPWz85IOG//J+v03u5j97Lfbz5o3ck/Ff/6w2t4fH1f3pbwl//x7c0ufLXfvimjP/vdzTa86v/8IaEv/njdzVa8y//5+sS/tZPDmi03J//7asS/s4r72se6T/9H7+S8AM/+0AT1fy7P/lHxs5oprLFUhx7ND5iXHenoCjKRkVR/rd5wshi5xRF+a6iKKMTxu9wbPjcao2BFIoHiRdHuZTtYxjsG+LS6SsUZy/Mwaifgqp8jSc/NDDMuWMXKK1XGUj+sI/ShmLOn1B/0MODSU59cEYTGfSFvFS0lGly2cmhJCcOnKaiWWUgeQMeqsaWaz/45HCK4++eonKM+oP3+N1Ut1VwJquim0qmOfbOSarGqgwlt89NbXuVphibTqU5+vYJqtsqADU1UtdRpVGEM+kMR946Tk17JaCmPurH12gqqpmMwuE3j2k+5A6Xg4bOGk0xNpNROPzGMY3B5HDaaeiq1aTfFUXh0OtHNZFDu8NOY1etphKrKAqHXjtKfZbhZLPbaJpUZ1CxPfjaURq6anV4vYFCfPDVI9puz2YTNE824odeO0rTJBUXQtA8pd5AMVbx+hF8cr2BwnrotaMGBlXzlAYDRfbQ68do0uOT6zn8uhFvnlyvpRmbJ9cbxh9+w4g3TTLiR948TvPkemy2HF5nwI++dZymSSN448RaA/7uK+/zL//9FwwPDlvK0I/GR4sbppeEEHYhxAohxINCiEdyf7+JgxuNjzdq2itpzF6UyptL8Yd9Btxmt2l4aWOxxHsXNqFddMoaiwnGAqZXUHEhoLSuiHCe3HSVu2gU1xQQyQ9LeNNEFS+qLiBaIFN4mybVI2yCwsoEsSIZb+yqw2YX5FckiBfHZHxCLXa7arqUVyrjDRNqsTvs5JXESJTLO6OGzhocTjux4hgF5QkJrx9fg9PlIFYUsaQI13dU43Q7iBaEKbJQAa4bV4Xb6yKSCFFisbOqaavA7XMRygtRXCtTiKvHVuDxewjFA5TWyxTiqjFleAMeglE/ZY2yinBFcxm+kJdA1E+FhcpwRVMpgYgPf1hdFJijrLGEQMSHN+ixpCCX1qvfG4/fQ3WrjJfUFRGKB3H73JYqxcU1BYQToaxSsUxRPvzGUXY1P8y2ugf4D1/5c41pNhofPW6mEP43wCDwBqDt5xVFef7jPbSPFqOF8JuPR2Y+wxv/NJKicHmcJIdSWh3BbO/pcNrJpDNancCM2+w2UJTr4rnH5OoAVri+cGxlP6ovvn8kXFdYtsL1xVar49MXcy1xnQqrlbaVvlhshesLx5a4rjBspV2lp7Ba4frCsZV9qr5Yb0VB1pMBfCEf/VeNuD/kpU/DZeKA/jmtCvuBiI/e7DFZUYz178mqsK/XA7Mq7O/6yibJS3001LidlNtSRVHWKIryrKIoz+f+bsMxjsZvIf7xv/wz947/LH/5/f8hNT65PC52fmUT/rCPhTtmU2VaGTqcDu55cQv+sI/5W2ZS22FsLhNCsO/b2zWV28ZJcvPY/S+pFN2Z6yZbNofd//JOAlE/U1d30TZHbv6673s7NZXb8QtbLfAdBGMBuhaPY+JS2f/hvu9u11Rup66aIOH3fmcb4USI9tljmLFWVuHf9+3tRPJDtM5oZvamaRK+95tbVZXbKQ3M3ypTdPd8cwuxoihNk+pYtGuuhO/6+t3Ei6PUd9awfN98Gf/qZk3ldtUDiyV851c2kF+eR1VrOd0PyRTdbV/aoKncWlF0tz67TlO5Xf85maK7+em1msqtlUruhidXU9ZYTHFtIVueWSvhdz2+koqWMgqr8i1Vctd8ZrmmcrvjBZmiu2r/Ymrbq0iUxdn1tc0SvvzehdR31hAvibHnRZnCqydGjMZHi5vZaXwd+HtFUf7uQx/4CYnRncb142tbX+Lv/90/abfNzWr6VTLIK0UzJfJGfhqSH4bOKwLklabkt3ED3KySaqb4mleiZoqvhJsovla4/vei3xWoOAa/DWmlK0CA1oxoRVE1+G3cALf0y7DbSH8YrlP5taKwGvEP99Ow8ssw4BZ+GfrX1L+WJW7lp6F7T+bvw83goyq414/budP4F+AvhBADQoirQohrQoirNxw1Gp+4MFup2ux2Vj+wGLvDxtTVXdRki8a5UBSF7s8sw+6wM3l5Jw0m57rkUIr1n12Jw2lnwpJxjJlmlI0Y7B1i45OrcTjtdCxoZdwcI8V2oHeQTZ9fg8PloH3OGDoXtkv45qe6cboctM5slii2gznc46RlaoPkDDfYN8TmL3Tj8jhpnFgn7RwG+4bY/HQ3bq+L+s4aZm+cZlLxHWLzF9bi8bupHVfFvLuN/hqD/er4XBF/4Y45hklpqF8d7wt6qWgpZcnueejXaEMDw2x+uht/2EtZYzHL711ouMjl8EDET0ldESvvX2TAhweTbHpqDcFYgKLqAlY/tESbMHL4xs+vIZQXpKAiwdpHlhku0smhJBueWE0kP0SiLM66R5eb8BTrP7eKaGGEvJIYd312pWGSSA2nuOvxlcSLo8QKI2x4YpURT6ZZ99hy8krjRArCbHxytWGSSifTdH9mGfnleYTzQmz6/Bojnkqz+qElFFblE4oH2Px0t2ESzKQzrNy/iOKaAoJRvyW+/N6FlDYU4w/7eOwP77P0KBmNW4ub2WkcAlYBb1gxqT5pMbrTuH48OOXzvPMv72u3PX4PDqed3it9qhhhQYjzxy5quMvjxO1zc+1Sb7aYG+XsUZ1HuMNOIOKj58I1HE47eaUxzhw+b3jNSH6YK+d6sDvs5JeZPMQZ8Qi32W0UViY09lMuYkVRLp2+jM0mKKwukD3Ei6NcPKXiRTWFsod4SYwLJy8hhKCkzsJDvDTO+RMXVby+SPPLzkXOQxysPa5zHuKgkgFy7KlcFFbla4wvvV/2zeJF1QWaaKSVB7feY9wS13mMW+F6j3Gr49d7jFu9f73HuP7/VriVx7f+OXNikgZcd8z692KJ686FFV7ZUsbjf3Q/9eNlTa7RuL07jfeBN38XJozR+PDY/qWNGsU1XhwlrySqdYAnh5L0XurTKK7RQpXtkyvEJodTXD57RaOwRvJDlDUW05OVQk8l05w7dpG6LEU1nBekurVckzJPp9KcPnyO+k61DhKMBahpr9SkyjPpDKcOnqWhS/1BByI+6jqqNSnyTEbh1AdnNIqpP+yjYUKNRgHOZBROvn+apskq7g16aOyq1Tj/iqJw4r3TtExR2V7egIemSfUaRVhRFE4cOEXLVNXH2+1z0TylQZswAI4fOMXYrBuh2+uiZWqjYRI9/u4pxs5Qd1suj5Mx0xq1CQHg2LsntYZHp9vB2BlNMj5LxR1OO60zmw0qw8ffPUnb7BYNb5vVYrhI6nG7w0777BbDRfb4uydpnz0GIUQWH6NNGLnjb5/dghACm91G+5wxhkn2+IFTtM8Zg7AJhE2ouG6SOHHgFG2zr4+ffO80bbNbsNltCKHi+kno5PunaZvVgt1hH8F1k9ypD87QNrMFh1Ptj2mf3WLED56ldWYzDpfaftY2y4gfees4P//b1xjoHeDMEePiZTRuPm5m0jgN/FAI8eQo5fZ3O/LL4hRUqrTQeHEMp8dpwIUQGi00XhTF7TU1p2WprwCxwihun9y8VpjFo4UR3H6PhOeUZ6MFYbxBa1wIdYfiC1ngtQUIgWrcE/LKeHUhwiYI54UkCjFAYWUBwiYIxQPWeFUBNpsgFA8StJDWLijPx2a3EYj6CUYt8IoEdocNf8RPKC5TjPPL4tiddvxhH+F4yALPw5HD82Q8URLH4bKr0vUJa9zpcuAJuC0pzPHiKE63A7fPZUlhjhfHtB2mFR4rjOD2uHB7XcQLo9a4z43b4yJeZIEXRPD43TjdDksKtGq45MbpcpBXIuPh/BAev0fFS+Xm0XAihDfgwe60WzaXvv+LQ2yvf5CdjQ/xbz737yTZl9G4cdxMeupZq/s/qQyq0fTU9eOhqU/x9k9G3PncPhfJoZSWJw8nQvScHylXOd1OMumMVoyM5IcMJknqinBEFC6XisqFEAKH065JXZhxMBZOrXB9MTZaEJZMlvSFTytcX0y2wvXFbEtcVwy3wvXF+khBmCtmXEdhtRqvJxNE88NcNr1/PUXV6vzoKahWuJ6CGk4EJRMsPa3X/PmDkVYcygtKJlv6+6wozOG8oLYbDcb8XLtkpADrX9PKPleP+yN++kz2tvr3bEURvhG+/YsbLFlgd2LctvSUnmY7Srn93YpMJsPf/Jv/ybb6B/jPL/6lBdPExZZn1uINeli0czalDcbmMKfLwbbn1+MNepm3ZaYkx2Cz29j5lU34Ql5mb5xGzbhK6Rh2f20zvpCXmesm09gl55L3fkOl8E5d3cWYbGpIH/d8Yyv+sI/Jy8dLWlagmu4EIn66Fo+jw8Jf4Z4X7yYQ9TN+fisTFo+T8F1f30wwFqB9zhgmL5d/L7u+uplQPEjrjGamre6S8B1f2Ug4L0TL1AZm3SWr5O748gYi+SEaJ9UxZ+N0Cd/+pQ1EC8LUd9Ywf/ssCd/2/HriRVFqx1WxeLdM0b37C+vIK4lR3VrB0r0yRXfT090kyuJUtJSx8n6ZorvhidUUVCQoayxh9YOyTtNdn11JUXU+JXVFrHtUFv5b+8gyimsLKaopYN3jMoV39UNLKW0oprAyn41PrpHwlfcvpLy5lPzyPEuV3WX75lM1tpxEaZytz8oqu4t3zaGmvZJ4cZStz98l4Qu3z6JufDXRwoilCu9o1v3W47o7jaxY4cuKokgCMkIIP7AeGFIU5d9/vId4azG60xiJ57q/wY//4qfabbMKq5lSaqbImv0RzBRYM6XT/HxmSqaZQmqmXJpxM2XTTAk2UzJvFTdTMs3vx4ybKcdmiq+ZwirjRgqrmeJrVmk14+bzaab4WlFc9TRjK4qr/hitKK76c6D3DsmF/j4riqv+Oc3nw3xMVuP170nYBCiKgYGmPydmfxUwnlPz+QS49zvbWWPRz3Inxu3Yafwe8AUhxDtCiD8VQvyeEOIPhRD/BPwzEAT+7DYd72h8DHHhxEXDbZfXybpHV+B0OZizaZok62Cz29jwxCqcbicz75qiFbVzkckobH66G5fbybQ1k2iebNwZJIdSbHvuLlweJ5NXdNI2y7gzGBoYZvuXNuDyuJi4tIPOBW0SvuNLG3F7XXQuaqdriXFnMDwwzM4vb8TtczFu3lipOW94YJgdL2zE43fTNquZGSb/DHX8JjwBD2OmNTLH1Jw3PJhk55c34g16aJ5cz/wtM4zvbzDJji9vxBfy0jChhkW75pjef5KdX9mIP+KjtqNK8s9IDqXY8eVNBKJ+qlvLWXH/IsMFLDmcYscLGwnGAlS2lLL6oSUGPDWcYvsLGwgnQpQ1lrD20RUGim8qmWb7F9cTyQ9TUlfE+s+uMuDpZJptz68nVhihqKaAjU+uMVzE06k0W59bR7wkRmFlPpue6jZcxNOpDHc/s5ZEWZz88jzufmadYRLJpDNsemoN+RUJ8kpibH3+LsMklMkobHxS1TuLFUXZ9vxdhkksk86w/rMrKa4tJFoQYfuXNhgmQSWjsPbRFZQ2FBNJhNjxwgbDJKooCqsfXkpFcymheJAdL2w0TMKKorBy/yKqxpYTjAV46j8+PDphfIS4mZpGAOgEilD9NN5RFEWWz/yExOhOYyT2T3yCAz87qN32BjwoGYXB/iHsDjuR/JDGPgJ1pS9sgsG+IWx2G7HCiMY+AnVV53I76b82gM0miJfENMVRUFeC3oCH/qvWOIx4dgghSJTFDewkGMmxCyHIL49z9qg1DlBQmdAEDnOhz7EXViY4Y8L1OXI93TUX+hy4Fa6vS+T8zA14lkJ8vfE5ijBAUVW+REGOF8e4eEo954XV+ZwxPX9eaYwLJy5d9/lzFOLr4fllcc4dvz6eKI9rtGur85tfkce57GeipxvnQn+fnq6cC/1nkiiLS9+PwqqERtu2xkeOOUenvj4e5cLJywZcf84Lq/L53J88wJipsjLBnRi3s6bRqyjKDxVF+Y+Kovy3T/KEMRrG2Pft7dpuoaSukLySmFb0TafSDPYNaT7SRdX5FFbla+mlTDpD7+U+TSW1oDJBWUOxlt7KZBQun+3RKKr55XlUt1ZoRd1MRuHCiUtaHSJeEqNufLVG8VUUhXPHLmg+0bHCCA1dtdqEoCgKZ49eoD3bEBjJD9M0qd6gxXT2yHnNkyNXV9AXas8cOU/HfFVqJBQPMnZao6HQe+bwOcYvUPFg1E/rzGZDIfnM4XN0LlR3Q/6wj7ZZLYZC9ulD5+hcpOK+kJf2OWO1CSM3fsJitWHRG1A9rfWT9OnD51RPdiHw+N2Mn9+mTRgAZw6do2tJB0II3D4XnQvatAkj9/xdS1RPd5dH3Z2d1+0uVbwDm92G0+NkwqJ2bcKQcLeDrsXjDH06Z4+cZ+KSDuwOGw6Xg4lLOrQJA+Ds0fN0LR6H3WnH7rQzcUmHYRI5d+wCXYvH4XA5sDtsTFzaYZjEzx+/yIRF7TjdDmz2LH7YAvc4EVl/ev0kd+HkJToXtGmLnYlLzPhlxi9ow+NzI4Sga8k4wyR95vA5Xv2HN7l2uZcjb42oA4/Gh8eoidKnODw+N26f6tngcrsQNtPHLRjBPS5VcNCEe/y58U7sFv4R3oBKi3W6HJZ4brzTbY3nxjuugxvHy19XT8CbHW//0PEOlx27U7aP8WRpwXaXQ+P/6yN3fhwuu8b/N4z3uhFCzb07XRavn8XtTjtOy/EuEGptwOmW8dwF0e6wSxRpALfHhc0msDkELrcF7nVhEwK73YbLwt/D5XFis9kQNpvl8zuzuM0mPhwXAtf1cLsNIaxf3+lWcXW8NW63q6/vMlPAAYfbic2h9n24vPLrO1wO7E6b4buuj3deeZ9tdQ+wt/0xvrvvB5pXyGhcP26Ynvpdi9H0lLpKF0JI6SmP3006mSY5nEIIQSQ/ZFg5uzwuFEUhOZRECEG0IKz5a4B6YbTZbVqxOFYU0Qx1QE1PudxOrZgdK45y6ZQxPaAvlutTNbnQF9ut0g96iqo+VXOzuJ52mVcal+o+esvbRGmM86bxeoqrPhWUC336zOr59bRUK1xPUbU6fn16zer86NNrVrg+vRYviXHRjOvSa1afjx7PdevrQ3+f/rG50D+nFQVZn56zohDrj9lMATe/Z/251HDdObXCtzyzjq3PySysOyFuZ0f4aPyORCqZ4k+/+VdsKNnDHz3znyQmitvnZt2jqh3p/K0zJX8Hl8fJ+s+uxO1zM2fTNErqjP4NdoedTZ9fg9vnZtb6qVp3eS5sNht3f2Etbp+b6d2TLP0Rtjy7Do/fw5SVEzQDI33c/cw6vAEPE5d20DixVsafXYc36GHCwnYtNWbAv7AOX8jLuLljaZshU3Tv/sJaLdVkRdHd/PQa/GEfY6Y1MmGRTNHd/NQaAlE/zZPrmbRsvIRvelLVgmqYUGOporvhyVWE8oLUdVQxo1tW0V3/xGrCiRDVbZXM3iir6N71+AqiBWEqx5Qx11SoB5UCGyuKUt5UwoJtsspu98NLySuJUVpfzGJTIR9g1QOLyS/Po7imkKV7ZArvyvsXUVCZoLAqnxX3LZTwZfvmU1RdQH55HqstVHiX7J5LSV0hidI43RY6UAt2zKKssYR4cdSS4jt/ywwqW8qIFkYsVXrnbJpGdWsFkfwQ65+QVXpnrptC7bgqwnkhNjw5KpH+UeJmCuH1wONABTp7WEVR5G/cJyDu5J3Gk4tf4Od/+5p220yhlW6bKLTm22YKrVnV1UzJNVNazRRWMyX11m8bKavSbRNl1UxRveXbJgqr+baZwnoj3ExZNVNc9Qq1Vo83U1LNt80qvrf6eJXSOkJJtcZHKK3SbRMFWL6tyvxe7/bNHqPx8YJM+vrjpXNqum1WXt7/8i5W3r+IOzFu507jT4FfAk+jTh65v9H4hIW5m9cb8LDhiVW4vS4W7ZhNeaNxZ+B0O9n89FrcPnXnUWVSubXZbGx9bj1un4s5G6dq1qO5yKQVdrywEbfPzQwLf4zkUIp7vn43Hr+bqau7GGda2SeHktzzoopPXt7JhEVtEr7nG1vwBjx0LRknNd8lh1Lc880teINexs9vY9oaI8U2NZxizze3qjuPOWOYvWGqJe4P+xg7o4m5m43Nd6lkmr3f3Eog4qdlagMLdxrXSelkmr3f3EIw6qdxYi1L7plngW8lFA9Q31nNctPKPJ1Ks+ebWwnnBalpr2S1aeWdTmXY840tRPLDVLVWsPYR48o7k85wz9fvJlYYoaK5jA2mlXUmnWH31zYRL45S1ljMRtPKWsko7PzKJhJlcUrqitjyhXUGiq+SUT/f/IoERdUFbH12naEHQskobH1+PYVV+RRUJtj+pQ2GC7qiqOme4ppCEmVxdnzZjCts+nw3pfVF5JXE2P31zdLueMMTqyhvKiVWFOWeF+82jAdY99gKqsaUEy0Is+cbW6Xxqx9eSk17JeFEiL3f3GKYMED156gfX00oHuTZP3/sjp0wbiVuZqfxC0VR5H34JzTu5J3GfZ2f5f1fHtZuewMekkNJUsk0QgjC+SGDzIXb5yKTJHaeygAAIABJREFUyozUOApCXD4zgjuzhdXcat9cw7A5bDgc9uvWOMC4O4kXRbl4+qPXOKxy8PqGxY9SAzHWOGRcX8Owwo01jBvhFjUOHUXYsoahr3FYvD99jSNeEuWiiWKqrwtYnV+99MlHqmEURrS6l1UNQ/+diBZEJK9u/XfCSkblRjUO/TmJJEJcOX/9GoeVDIr+nEcLwjzx7x6yTFveCXE7dxp/LYS4TwhRJISI5f5uwzGOxm2Oz/xgn5bnr26tIK80rqVLFEUhnUxrFNjKljKKqgq0dI6iKAz1DWsU1/KmUsoaiw3pod4r/RqFtaS+mJrWSkP6qef8VU2qo6imkIauWkM66+Lpy5onRmFVgubJ9Yb018VTl5m8XF2f5FfkMWZqoyFddvHkJSavVOsEeaUxWmc0GTrcL5y8xJRsHSFeHKV9dovBJOrCiUuaFEi0MMy4uWMNWkQXTlzSdiuR/BDj57cZ7FIvnLjE9DUTEUK9AHUuajdQgPV4MKZKmxjxi0zvnoSwCfwRHxOXdhguYhdOXGL62knY7LasdEqnoVB74eQlZqydhN1hxxf0MmXlBMPu8uLJy0zP4p6Ah6mrJhgushdPXWZ69yQcLgcev5tpq7sMi4gcnhM0nLZmomESuHT6MtPXTMTlceLyOJnePdFAlLh85grT1kzE5XXhdDuYvnaSYRFx+ewVpq7qwu1z4XA5mLF2kmERcflcD1NWTcATUCX7Z6ybbKAgXznXw5QVnXiDHuwOOzPWTjJMolfOX2Xy8k58IR82u03Cr164xsRl4wlE/CO4bpK+fLaHN//pHS6ducw7r4xYCIyGMWSOnxzbsv/qU1IKIFcxR+O3GoN9Q9pFWGUwGXeRiqJoF+GhwWEcJgqqgqI54Q0NDGGzm1RmMyN4cnCYtIniqCho4nzJoWFJkgLQairJoRSpZErC+7XnT5FKyXju+VNDKZJJ+fn7dc9vdp1T8dz4NKnhpIRrzz+cJmmF9w6iKFl80ALvG8GHh2R8sG8QJaNO4FbjB/uGyKQzpJIpyXVPff0h0qk0qWRKcvUDGOobIpNOk04Khgcsnr9/UPtcLMf3D5FKprFnFIYHhiR8sH84u3PFUM/Sxg8Mk06mUBT1WCR8cJh0Mk06nZH8vQGGB5KkhlNqH5HJP1wdnySdTJNJp63HDyZJJ1URzoE+eXxycJjkcFLFLZ7/zR+/y3/9zn+n/9oAszZMZc+LW0hYqOneyTFKuf0URCqZwuF0SOkpX8hLJpUZ6QBPhAwru1wPQ64DPFoYMaR/XB61N2Ogd1DtEC+KGtIrdocdt891/Q5wAf6Qmv65Xgd4IOKj90r/R+8AjwW4msULK/MlnwR9eseqA/rGHeIjtE7rDvCwltLTGyblQp/SsRpv6BC3wPXpE6vnN3SIW3SQJ8ryOH/8wnXfn75r2+r86ju8rTrsDR3gum7xXOg/E8sOcd0x3Qi36hDXnzOr9J/+nFml9/TjrdKnm5/qZvuXZKHDT2PctvSUEMIphHhQCPFn2b/9Qgi5i2Y0fuMx2D/EH33hP9Gd2Mn/9cgfSUU+t8/Nkj3zcLoczNowhXiJ0d/A5XGy/N6FOF0OpndPIr88z4DbHXZW7l+M0+1g6qouiquNFF2b3cbqB5fgdDuZtLyT0nqjSi4KdD+yDJfHSdfSDomiC7D2keW4PE7GL2ylqrVCxj+zDLfXRce8VmrHVUl492eW4fa5aJvVonW362PNw0vx+N2Mmd5E86R6GX9oCZ6Ah6bJ9ZrBkj5WP7gUb9BLQ1et1r2uj1X7F+MLe6nrqKJjnpwLX3n/QgIRPzVtlUxYKFN4l9+7kGA0QOWYMiYtk3+vS/fMJxQPUt5UwpSVMoV32Z75hBMhSuuLmL5GpvAu3j2HaEGY4poCZq6bLOGLds0hVqQabs21UOGdv20meSUx8svzmHu3TPGdt2UG+WV55JXGWbh9toTP3jiVgsoEsaIIC3fK+My7plBUU0C0MMLiXbKK7/S1kyipKyKSCLHUpOUFMHVlF2UNxYTzgizfK+OTlo2noqWMYCzA8nsXSPiExR1Ut1UQiPpZsX+0CH4zcTOF8P8bcAJ/nL1rC5BWFGX3x3xsHynupJ3GIzOf4Y1/eke7babU6ovAAJ6Ax7DlN6veun1uhvqvr3prptSan89MkTU/n5mSaqbs3kj19oa4pGrrNKRoJPwGqra3jN9A1VZSzTWr2propLKqrVHF1Xw+zRRY8/kyU2DN50MIEMJGJnN9VVv9e7BWtdWp3tpGnmsEH3lNK9Va/TELkU2w6lVt9aq3AkAYGF/SOTOd0xudc/Nn9tDv72GZheT8pzFuZyF8gqIo2xRF+Yfs3w5AXvKMxm88+q4aDWX8YT+bnlqDN+Bh+b0LKa0vNuAen5st2ea4xbvnUjHG6I/hdDnY8YKq8rpg+yzqOoxlK5sQqj9G0MPczdNpzupS5SKTzrDvWyrFddb6KZLKbSqZ5r7vbscX8jK9eyLjs0X1XKSTae5/aQf+sI8pKycwcWmHJR7IFpGnmJrn0qk097+0k0DET+fCdmaumyLh+1/eRTAaYNzcsczeaKTgZtIZ7n95F8F4gLZZLczfNkvC97+8k1BekDHTGiWV20xGYf9LOwknQjRPrmf5voXS+Pu+t4NIfpiGrlpWmfwrlIzCfd/bQawwQl1HtUSxVRSFfd/eTrw4SnVbJes/t0oav/db20iUxqkaW86mz68xjYd7XtxCfnke5U2l3P3sWgnf9fXNFFblU9pQzLYvrsccO17YSHFNAcW1hex4QU7bbH1+PaX1RRRV57Pra5skfMszaylrLKGgIsGeb2zBvGbd9Pk1VLaUkSiLs/db28xlOdZ/bpVK8iiJce93d0h+GGsfWUZdRzWxoij3v7RDouiufmgJDRNqiBaE2f/STglfft9CmifVE8kP8cJfP3HHTBi3Ejez0/glsE5RlIPZ29XAnymK0vGhA39LcSftNPZ1PM7BV49ot71Bj1oIzf4QzDIJHr+b4YHhEdzk1ObyOEkl09d18nM47SgK13Xys9lUb+kRJz9Z5kG/0rN26hvZrVg54elX95a4bjdk6eSn2/18FKe+Gzr56XZnVu9Pv/uzxn30X8059cnnzx/20tejjrdy2tO721nhegqxFQVV755n5cSnryEF4wGuXew14rox+nqUhuteMxAN0HvZiOu/s3pJl1zoabWBsI9ekxOf/j3rz6U2XnfOfUGPRpzIhf4zDUT8fO5PHrDs/P80xu3caTwO/C8hxA+FEP8I/APw6K97gABCiEVCiANCiA+EEE9Y4G4hxH/O4q8IISpvx+t+WuLJf/8QHfPVPHrLlAbySuKG9IgQQqPANk6so7CqwOifkExrP4j6zhrKGksM6YahgWGmZimqteOqqG6rNKQz+q70M32tmkevaq2goavWkC7pOX+NWRvU1X5FSxljpjYaUgNXzvUwK7vaL2sspnVmsyG9deVsD7M3qXhJXSHtc8YY0kFXzvYwd/N0hFALmh3zWw3ps8tne5iXxQsqE3Quajekyy6f7WHelhkIm1qk71rSYWDkXD7bw/wtM7DZbOSVxJi0fLyMb52RJQlEmLJygiGdd+WcOt7usBEtCDN1dZchXXjlXA/zt87E4VRl6mesnWS4yF05d5X522bicDkI5QWZuW6yNmGo5/cq87fOxOl2EowFmLV+isEOtef8VeZtnYnL4yQQ8TN7w1QDhfjqhWvM2zIDt8+FL+RlzqZpBrvVqxevMffu6Xj8brxBL3M3T9cmDIBrF3uZu3k63oAHj9/NvLtnGCaZa5d6mbNxGr6gF7fPxbwtMwyTVO/lXmZvmIo/7MOVlbbRL3J6r/Qxa/0UAlE/Lo+T+VtnGvowenv6mbluMqF4AKfbyYJtMw2TZP/VfqZ3TyKcCOFw2pm/baZhku6/Nsi0NROJFoSxO+0s2DbLsAjovdLHu6+8z9mj5/nF/z+itHCnxw0pt4qi/L0Qog5oAATwrqIoMtftFkMIYQe+D8wHTgA/E0L8laIob+setgu4rChKrRBiA/B1VMfA0UCVrj57RGWbnD9xUVKpTacznMkyRy6evCSplGYyGY1ZcuHkJXwhrwFX0hlOvn9aHX/qEqF40DheUTT80unLRAvDxvGKwsn3VPzK2SuWKrWn3j+j4ueu4rZQMT31gXp8Peev4Qv5JPzkB2dQFOi5cI1QLCjjB8+iKHD1Yq+0qgU4ffAsSkbh2qVerl26JuGnDp0jk8lw7XKftKoGVR49k87Qe6XfUiH1zJHzpFMZ+nr6uXpefv6zR86TSqbpvdwnNbZp+HCKvivW+LljF0gOJUmn0oaeiVycP3aB4UG1wdMSP36Rof5hhE1IjX2g9o4M9g0hBBLzCNT7BrPUVrN4I6i9OQNZmrEVfunMFfqvDaBkFIk5BWrvR//VATLpjDV+roe+nn7SqYzE7AJ1Yu670kcqmeasiVkH6sR67XIf6WSa04fPSvhrP3yLP/3WXzE8mGTC4nHc/70dlNQWSY+7k+LD7F7nKIryD0II2dgXUBTlz3+tFxZiMvCcoigLs7efzD7vV3WP+dvsY34ihHAAZ4CE8iE5tTshPTXQN4jX72HvuMc49NpR7f5AxI+iKPT19OP2ugjGAoYfui/oxWa30XulD5fHSTgRMlAY3T43Lo+Ta5d6cbqdxAojBn8Ep8uBL+Sl58I1HE47eSUxww/VZrcRigW4cv4qDqedRFlcopDmUi52h538ijxOHzT+UHNdxTa7jaKqfE5+cMaA5yisNpugqKZQm7RykaNV2myC4tpCTrxnxHPKtUIISuuLOH7glBHPUlSFEJQ2FHP83ZMGPL8iwbnsOSlrLJFwPW21rKmE4+8YcT2FtLyphGMmvKimQDsnVnhxTSGnDp657vOX1BZq58xqfEldkXbOrPDS+iLtnFm9v9KGYk5kz1lZQ7F0/vS4/v+5KGss5vi7p6TXGsFHXlN/rLkobyzhWBYvri3klOn7oX9P+nNpiVtQmPW4FUV5wxOr2fUVuVbzaYjbkZ7KSWQut/hb9msfIZQAeueTE9n7LB+jKEoK6AGkThshxB4hxM+FED8/f15ebXxa4trlXr7/4B/SnbeT7+791wahNVDZSLM2TMXmsDFpeSfhRMiAOz1O5myaht1hp2tJB7HCiAF3OO3M2zIDu8POhEXtxEuMjf82h435W2did9oZP7+N/IqEdIwLd87G4bTTPmcsRdUFEr5491wcLgetM5sprZNXbEt2zcHpcjB2ehNljeavAyzaORun20nzlAYqW8okfOGO2bg8Thon1lHdVinhC7bPxu11Ud9ZY0nhXbB9Fh6fm9pxldR3yhTe+Vtn4PG7qW6toGlinYTP2zIDb8BD5ZgyxkyRVXjnbp6OL+SlrLGEsdNkFd7ZG9V0TUldEe2zx0j4rA1quqaopoCOua0SPnPdFEKxgJqOM9npAkzvnkg4ESK/PI+uxTIFeOrqiUTyQ2o6ziKXP3XFBGJFEeLFUUsK8OQVncSLo0QKwlr3vT4mLhlPoixOJBFiuoXK74RF7eRX5BGKB5mxTsY75rdSVJ1PMBpg9vqpEt4+eywldUX4Iz5LleDWGc2UNRTjD/kkrTGAlqmNVLSU4Q16mHe3jI/GzRXCqxRFOXyj+275hYVYByzMUXeFEFuALkVRHtA95q3sY05kbx/MPkbe52bj07zTkOxbTZRYvY4SyJRYM26mxJopui6Pi+HB4eviZvqi+XjMlE6ziq6Zsmk+XjOFVRpvwj0BN4O9I+/HTKc0q/aqFNYRVddbxzFQWM0UYvMxmM83Qn2NDxuvP0dmii8YVVvNlGgwfgZmSjQYKa5WuJ7iav68wUhxNdNdzWPMFGDza1rh+vdsVqg141YUYP05EbYsPVd3ydPTtq3G6z8Tm03w8L/ea9lP8mmI21kI/68W9/3ZrR+SFCcA/VKxFDh1vcdk01NhQE6s3iFhln0IxYJsemoNvpCXVQ8spqjGuLL3Bb1sff4ufCEvy/ctoKzRSMF1e13s+PJG/GEfi3fNoca0Mnc47dzz4t34wz4WbJ9Fg3nlLQT3fmc7/rC6ajN7LasU1V0EIj5mrZ9K+5wWCX/w+7sJRP1M757IhIXGlXEmo/Dg791DMOpnysoJdC3rsMZjASYu7WDaaqPKrZJRePD3dhOKB5mwSKbgKorCA7+3m3BekI65Y6WVp4YnQrTNapH8KRQFHvhXu4kUhBkzrVFSuQXY//JOYoURmic3yM1lCtz/0k7ixVEaumpZbaLgAtz33e3kZa1yrfwj9n1nO4myODVtldz12ZUSvvebWyioyKNqbDmbn+6W8HuyFNuK5lK2PLtOwnd9dRPFNYWUNRSz7UtyOXH7F9dTWl9MSW0hO7+8UcK3PHcX5U0lFFUXcM+Ld0v45qe7qRxTRkFlgr3f2CLhG55YTXVrBfnleez7zjYJv+uxFdR1VJNXGuf+7+6Q8DUPLaWhq5Z4cZT9L++SKLwr7l9E86R6YoUR9r+8Uxq/dO98xkxtJFIQ5kt//eSndsK4lfiwmkYj0AK8iFF3KgQ8riiK3B57Ky+sTgLvAXOBk8DPgE2Koryle8z9wFhFUfZlC+FrFEX5UFutT/NOY2/7Yxx6faSGYW7O09MlQV4ZmymQbq+L4cGktpI24063g9RwegQ3USztDjtKJqOt9s3jhRAIwXVxMK7urHD9StmKAqpfCVuN169+Q/EAV03FbH0zl55OOoKPrIStxutXulavfyNcv9K1xHUrXT1dNhf6z9iKourxe7RCtXmnCcbdmxWup6Wad5rm+26Ee4NeTdsrF/rXNO8kze/J/H2+GVz/mzA3g4IqLHnt0ofhI5+J2+vi8T/ab9lZ/2mI27HTaECtXUQw1jM6gHt+3QPM1ij2A38LvAP8F0VR3hJCfFEIkVtS/QEQF0J8ADwCSLTcOyme+4vHNRXWiUs7pJqD060qjwKMmztGqikIm2DGXeoXvnVmM2WNJYbmqHQqzZxN00DAmGmNVLdWGPDh/mHmZd3imibX0TChxpAe6uvpZ9HO2QghaJhQy5hpjQb82qVeFu2agxAqhbd9doshHXDtUi9L7pmHsAlq2iromN9qSG9dvXhNwyvHlDFhUbuB4nvtUi9L987DZrdR3lTKxKUdhnTJ1Yu9LNs7H7vdRkl9EZNXTDB0/1691MuyffOxO+0U1xQwdXWXIV1z9WIvy/ctwOG0U1iVz/S1kwzpomuXelm2bwEOl4P88jxm3jVFwpfvW4DT7SCvNM7sDdMMF6kc7vK4iBdHmbt5uiFd1Xu5j2X75uP2uYkWRJi3ZYbhItl7pY9le+fj8buJ5IdYsG2WNmHkPp+le+bhDXoI5QVZuGO24SLd19PPkt1z8QW9BGMBFu2aY+hj6L86wOLdc/GHfQQifhbvnmuYJPqvDrBo5xwCUT++kJcl98wz4APXBli4YzaheABv0MPSPfMMk9RA7yDzt80inAjhCXhYtne+YRIc7Bti/paZRArCuH1ulu2T8bmbpxMriuLyulh+7wLDImpoYJjZG6eRVxLLSugs0CaMHD5r/RQSZXk43Q5W3LvAMIkPDQzzwa9+raz8pyKuS7lVFOUvgb8UQkxWFOUnH8eLK4ryN8DfmO57Rvf/QUDeM9+hUVRVwLN/9hhnjpyjsDKfveMeM+CpZIp3f/oBAIdfP4Y7K0iYi3QyzYFXVPzIm8fxR4wU1kw6w9s/eQ8UOPrWcUJ5xkJ6JqOoOHD8nVMSxRYF3vzRuyiKwvEDJ8krkdVB3/7nAygKnPrgDPkVeRL+1j8fQMkonHj/tGHC0cb/RMVPHzonUYzV53+PTDrD6UNncLnlr/fb//Ie6XSGc0cv4PV7JPydf3mfdDLNuWMXCET8Mv7K+6SSaS6cuChRkAEO/PQDUsMpLpy8xBkLCue7P/uA5FCKS6cvc/rQGQl/7xcHGR4c5tKZpMQcA/jgl4cZ6h9ieGBIozPr4/1fHdLUjo8fOCnhB187ysC1QQauDXLsnRMSfuiNY9ru9ehbxyX8yJvHtAv9kTePyfjbx7Xd0GHdrjgXx945qe3WDr4m48cPnNR6Lawu0MffO0XPuR4UBYM4Zy5OfnCGy2cuoyjw3s8PSvjpg2e4ePoySkbhwM8+kPFD57h46hKZdIZ3firjo/Hh6anPKoryohDiZaRMICiK8uDHfXAfJT7N6Slz/N0f/5AfPP4n9Fy4hj/swxf0Grjw/ogPp8vJlXM92upRT6H1Bjx4Ax4unbmCN+AhnAgZKIYuj4tgzM/FU5fx+NzEiiKc0lEYHU470YII509cxO11kVcalyiSOeVSl8dJfnmeRLEsqMjj7NELON1OCisTEoUzp0LqdDkoqimQKapZ2qTDaaekroijbxsvhDkKqt1hp6yxmCNvGi+EJXWFnHz/DDa7jYqmUg6bLoQ52qjNJqgcU25ID8IIhfR6eI7CKYSgqrXcQJEGqGgu5ejbJxBCUN1WYejwB9X35Ej24l3TXinhVWPKtWO2xMeWc/iND8FbK7SL+43w6rYK6fj199W0VUgTQU1bJQdfU5+zurVCOj/616xqLefw68dMeAUHXz0qvRer8ZVjyqTPV4/nzrX5+A69fhRFUSwpyNWtFRx+4xiKolA7ropH/s0+SV7n0xK3Iz2VU8L7OfALi7/R+C3HhEXtdC5oQwhom9Us7RycLicTFrUjhGDsjEaCsYABd7gcTFzSgRCClqkNhE07C7vDxqSl4xE2QdOUeqIFRoqusAkmr5iAzSZomFhHvMiooguqCqnNbqNhQg2JMnlnMXV1FzaHjbqOKgoqZQrv5BUTsDts1LRXWlJ4p6ycgMNpp2psOcW1hRbjO3E4HVS2lEpaXACTlnXicDkobyqhrEmm+E5aOh6X20lpQ7GlSu/EJeNxeZwU1xZS1Vou4V1LOnD7XBTVFFDTXinhnYva8fjdFFQmLC9GnQvb8AY9FFQkLCnAHfNb8QW9JEpjNJrseAHGzR2LP+wjXhKzVPltn91CIOonWhCmxYIi3D6rhVA8SCQ/TOv0JgkfO72JcCJEKB5k7EyZQtwytYFoQZhgLGBJIW6eVE+sKEIg4qNjjqwS3NhVT15pDH/YpxmA6aOhs4b8sjjeoIfOhe0SXjuumsLKfLwBj6aOoA/1e5WPx+eia4msjDR5eScvv/JVHv2D+/j+z772qZ0wbiVuyU9DCGEDAoqiyK2vn5C4k3Ya93c9YdiCmwuJ5sKo3nrVCjdTNs24mVLpj/jouzKSkzaropoLq0IYFUmtcBihuMo46FVNrXAhRmi4vrCPflNhV0+BtSr86gvzVoVd/Xu0xHW0UTNRAYyFe2vcoZlTWRWGHS47qeH0dXGX26mZP1kVhp0ep2b+5PG5GDRRfPWFe4kijPE7YkXx1ReTrQrL+te0ovjqj/mGuAUFWE/71p8rS9xhJ2UyCtN/pg6nncf/7f3M2XRn9GvcTj+N/yCECAkh/MDbwAEhxOM3GjcaH3+Yne8CET9bnl2HP+xjxf2LKKkzrrw9AQ/bv7QBf9jH0r3zKWsyrrxdbie7v343/oiPRTvnSCtjh8POvm9tIxDxMX/rTAv/CsH+rMrsnE3TGDPNSMFVFIUHshTbmeumSBTcHMU1GPMzbfVEOk0UXEWBB39/N8F4gMkrOulaNk7CH/i93YTiAboWj7NsLnvg+yrFtnNBG9MtWDAPfH8XkUSIcXNkCi7A/pd3ESkI0zqzmQUmFVyA+7+3k2hhhDFTG1l8j0zPvPd7O4gVRWmaVM+yfbK/w33f3Ua8JEbDhBpWPyRTcO/9lkqxre2oYu0jco/tPS/eTUFFguq2CkkFF2D311SKbeWYMjY+JVNwd35FVbEtbyphyzNrJVyl2BZRWl/MdgsV3C3P3kV5Y4mqgvtlWQV301PdVLSUUVRdwO6vb5bwDU+oKrYFlaoKrjnWPbac2nFVJMrz2PutrRK++sElNHTWkFca497vyBTcFfctpGliHfHiKPe9JONL7plHy9RGYoURvvTXT94xE8atxM00972qKEq7EGIzMB74HPALRVHkveInIEZ3Gr+5nYYZ/13Yaeh3EjfaafhDXvo+dKchq6h+3DsN/er6RjsNb8DNQO+H7DQsdiKGncJH2WnoxnwcOw39e/5oO40R2q/+XOdCv9Nwuhw89of33TETx+1s7nNmnfpWAX+pKEoSi8L4aPzm44W/foJFO2ZjswlmrZ8i1QQcLgfzt85ECJWiW9pg3FkIm2DxrjmqGu6iNqrGGHPy6VSapXtUimvH3LFSTn1oYIgV9y3CZhO0zmqhZYpxZ9HX08/qB5ZgswnGTG+ifXaLjD+0BJvdRtPkesYvaDVMKn09/XR/Zhl2h42Grlq6lnRI+JqHl+Jw2qnrqGLS8k4D46q/p5+1jy7D4XJQ01bBtDUTDRTfvp5+1j6i4lVjypixbrIRvzqgOQuWN5Uwe8NUw6TYf7Vfw0vri5h793RDR3P/tQHWProct89FcU0B87fONFCE+68N0P2ZZXh8boqq8lm0Y7bhIjbQO8jaR5bjDXjIr0iweNdcw0VyoHeQ7s8swxfyklcaZ+meeQZf8oHeIdY8vFStaRRHWb5vgcGXfLBviNUPLSEQ9RMrjLDivoWGi/xQ/xCrH1ySrWmEWLV/kWGSGB4YZuX+RWpNIy/IqgcXGyaZoYFhVty3UKtprHloqSEdlhxKsnzfAmJFUQIRP90PLzVMYsmhJEv3zCevRK1pdD+yzDBJJodTLN49l/zyPHxBL2sfXW5QJEgNp1m4Yw6FVfl4Ah7WPrLM0CeSSqZYsG0WRTUFuH1u1j26wpBuTA6npML4aID9ueee+9AHPP/88w7UDvBLwFeff/75CmDpc889928//sO79fjBD37w3J49e37bh/EbCW/Aw5SVE1hx30Lmb53F//iDv+fS6RElU7vTzpnD5xnsG+Jv4YzOAAAgAElEQVTymSsoKIaVtd1u4+zR8wz0Dqo+1wLDzsFms3H++AX6rw5w+VwPQmDgvQshuHjyEn09/Vw524OwITWnXT57hd4rfVw514MQQmqOu3Kuh2uXeuk5fxUhkPwdrpzv4erFXq6evwoCg3Q2qOq3PReucfXCNYRNSP4RPReu0XP+Klcv9iIEkj/F1YvXuHIuhwvJ3+La5V4un1GPUQgk/4xrl/u4fOaKRjM14309/Vw8dZneK/0gVNVWffRfU/G+nn4URbHAB7lw4mL2c1MkpdqB3gHOH7+oKsFmMtL4wf5hzh27wMC1QTJpWel2eGBY+w6kkmlpfHIwyZnD5xjsGyI5nJLxoSRnDp1jqH+Y5JCMp5JpTh08y/DAMEODw9L5SafSnPrgDMODSYb6hyQ8k1VaTg4lGewblPxTlIzCiQOnSA6n6O8dkD5fUDj+7klSwyn6rw4YpNUBECoNOJ1M09vTJ31/Wmc00z5HLuB/GuP5558//dxzz/3gRo+74U5DUZSXFEUpURRliaLGUUA2+x2N31rkWE8bn1xDoiyevS9IIOLXLoL91wbou9JPQVZkMBQPEikIaxeRgd5BrpzrobBK9QEPRv0kyuKaXPZg3xDnT1zSGEr+sI/imgKN4js0MMzpQ+c0n3BfyEt5U4lG8R0eTHLivdOalInH76aypUyj+CaHkhx/9xQVTSpDye1zUTW2XFMpza36ciKFbq+LmrZKTfE1lUxz9K0TVI1Vd0tOt4Pa9kqNApxOpTny5nGqsz7kDpeDuo5qjQKcSWc4/MYxqrN1HIfTTv34ak2RNZNROPT6MWqyIod2h436zhpNkTWTUTj02lHqOlQ8xxjLUTwVReHgq0eoG6+yb4RN0NhVy9G3jHhuNydsgsaJdYZeiA9+dUSrI9lsgqZJdQaK6cFfHTEwqJom1Rl6JT741REaJ6q4EIKmSfUGCuzBV4/QqBNhbJpcr9FlLfFJdQYK7sFXj9A0yYjrKbyHXjtK06Q6LQ3ZNNGEv37MML7RhB9+/RiNE+uw2dTxDV21BvzIG8dpnFiXTWNCfWe1EX/rOI1ddVp/jxk/9vYJGrpqsTvsAIyd0SS5O47GzRXCw0KIb+dUZIUQ3wLkrqfR+K1Hw4QaGiaoF4Wa9ip8QaM/ht1h136UVWPL8Zv8KewOO82T60FA5ZhyAiYKr80mVFqmgPLmUonCK4RgzLRGhBCUN5ZIFF6AsdObETZBWWMJkfywhLdMb0TYBKV1RURNKrwALdMaVdn0mgJiRTLePKUBm91GcU2h1DGv4vXYHXaKqvK1CdaAT6rD7rSTX5EgUS5TgJsn1WVl3/MorMyX8MaJ9TjdDhKlcQqrZIpw44RanB4neSUximpkinBDZw1ur4tYYYQSCwpxXUc1bq+LcH7YkkJcO64KT8BDJD9MWYNMIa5pq8Qb8BCMB6iwoBhXt1bgC3kJxQOWFOOqseUEsh3h5nQmqGZbwVgAf9hH1dgKCS9vUr833qDHkoJc1lBCJNsRXmuBl9YXE0qEcPvc2gRswOuKiBVFcXtd2m9BH+r3JorL46ShS1Yp7lo0jn/96jd45s8e49s//CIVzbKS8p0eN1MI/6/Am8AfZ+/aArQpimLps/HbjjupEG4Oc2H8ZrSn9DnsG2pPmXC7w0YmrVwXv93aUx8J1xWmb6RNZYXri60fRVvKgJu0wcBYTLbSlrqR9pQBv5H2lIkiDcZiuRWFWF94tir864v5VvapRu0powoyGMkIVoX5G+K692SlEmzQnrLA9efU43Pzuf/nAUn48k6J21kIr1EU5VlFUQ5l/54HRjtcPoGhZIyyzr6Qj63P3YU/7GPZvgWSf4Xb52bHlzepKre751LRYlxZOl1Odn8tq3K7bZbkP2Gz29n3bZWCO3fzdBosmsvuy1JwZ62fKqnggkphVVVuJ9E2S24Ou/+lnQRjqsrteAt/iP0v78qq3I5n4hK5eWv/SzsJxYN0LmxjyirZ/+G+7+1QVW7njdV0u8x4JD9E++wWy1TFvu9sJ1oQZuz0RubdPUPGv7VNVbmdUs/CnXMkfO83t2gqt8v3zpfwe76+hbzSGPXjq1lx/0IJ3/21zarKbXslax6WKbo7v7yBgooEVa3lrHtkuYRve349hdWqyu2GJ1ZL+Nbn7qK4tpCyxmI2PyXjm57uprShmJK6QkuV3A1PrKK8qZSimgK2PS9rja57bAWVY1WVWyuV3O7PLKWmTVW53fVVmaK7av9i6jqqSJTGuedFmYK7bN8CTeV27zdkfMnuuTRPVhsMn/uLx+/YCeNW4mZ2Gj9BVbX9Ufb2VOCbiqJ8IqUe7+SdxsPTn+atHx/Qbt/IT8NMwTXjt+qnYaaQ3qqfxo38Mm4V//X9NEBP8b2Rn4bVSlj/Hm/kl3FD3ILCavDTsPLb0H0GlrjBT8NhEHAEk5+GFX4jPw3dGP1zjeA6Pw0TZdt8zObvkxm39MO4oV/GCEXYZrfx2B/cx/ytRgn8OyVu507jXuD7QogjQoijwL8C9v66Bzgatz9e+Osn6X54KU63k0U7Zks5cYfTwYr7FmJz2JjWPVHaWYDaHGV32JiyopPaDuPOIp1Ms/bR5diddiYu7aBpslGWYmhgmPWfXYXDaWf8wjZaTbISA72DbPz8GhwuB+PmjmX8vFYZf3K16uw3q1mSdRjoHWTz09043U7GTGtk8opOCd/01BpcHidNk+uYvsa4ahzsG2Lz0924vC4aJtQwc/0UA4V3sG+ITU+twe1zUTuuijmbpkv45i+sVZ372iqYv3WWYVIa7Bti81PdeAMeKlrKWLRrjuEiNdQ/zOanu1WSQGMJS/fMk/BNn+/WnPuW37vAiA8Ms+mpNQSifoprCli5f7HBlGh4MMnGJ1cTzDr3rXloieEiOzyYZMMTqwjnBUmU5dH9mWUGinByKMX6z64kkh8mryTGuseWGy7yyaEUdz2+glhhhFhRlLseX2mYJFLDKdY+upx4cYxoQZgNT6wyTDKpZJruzywjURonnAhl8ZFJLJ3KsPqhJRRUJAjFg2z6/BrDJJdOpVm5fxGFVfkEYwE2PmXEM+kMK+5dqDr3hX1semqNYZLNpDNqU2tjMb6Ql81PdxsowqrQpSwyORrGuGkZESFECOCTLCECd/ZOIxc5D3HZ6c+Lw2Hj2uWcR3iY88cvaLjb58Llcek8wsOcPTqC6z3CnS4H8eIYZ46MCBwKmyCcF+LKuR7VQ7wszhmTR3isMMKlM1ewO+wUVOQZBBAB4kVRLp6+jM1uo7AqX/KAjpfEuJj1ALf0CC+NceHEh3iEl8U5f/zidT3C8yvyOHc05xFepLGnclFQkdAYYVYe2jf0AM8KMF4Xv5FHuM4Xu7ypVFKqvRUPcEtc7wFu8f70vuCWuO4+a4/wD8f1x2TpEW7AVbHJ6+F6P3VrvED6/m15Zh1bn/tQy55PbdxOGZG4EOIl4IfA/xJCfE8IIdNORuMTEznJ721f3EBZtqEvr0Rd/eWKgsODSfp6+ijPMmhiRVESZXlaITc5lOTK+atUjlHZI9GCMEU1hVqfRHI4xfmTF6luUxky4USIyuYyjeKbSqY5e/i8RkENxYNUt1ZoFN90SuXv5xgwgaif2nFVXDytUnwz6QynPjijUVADET9146u5eFI1bsxkFE6+f1qro/hCXhom1HDhxAh+4r3TNGbZYt6Ah8auWs4fVynCqnz7KZUthppaappUz7nsJKkoCsffPUXLFBV3+9w0T24wqAQff/ckLdk6jdvromVqg0El+Ng7JxkzXcVzu6PTh4z42KwIoMPlYOyMJm3CyOG53ZrDaad1RrNhEj32zgkNt9lttM5sNlxkj71zktZZLRreNrPZMImquDpe2ARts1oMF/Hj756kbVYLQghsNkH77BbDJHv8XfX4chTXtlkthknkxIFTtM1qwWYTCCFomy3jrTNVNl1uvH4SO/n+aVpnNmsUWBk/Q+uMJuwO9TLWOrPZgJ86eIaxM5pwuFSJ/LEzmkz4WcZMa8TpdgIwadn4OzY1dStxM+mp/wScB7qBtdn//+eP86BG4/ZEUXUBhVll2ERZHLfXZcBtNhsltWpxPFEaw+Mz4sJmoyRbPI+XxPCY/Dlyq3WAeHEUT8CIA5Rk8WhhGF/IK+G5SS1aYI2XNqjjI/kh/GGfhJc1FCMERBIh/Bb+F6W1RQibIJQXJGCiCIO6mhU2QSgelCjEoK7sbTYboZifcJ4FXlOAzW4jEPVbUoyLqwqwO2wEo34iCZliXFiVj91pxx/2EbWgIBdUJHC47PhCXtm/JIu7PE78YR8xC4pyfnkeLo8TX9BDrFimIOeX5eH2ufAFvcSLZZXiRGkcl8+F2+e2pDAnSuN4/B48fjeJUnktGS+O4vk/7L13mBzXeeb7VnXOOU5PzjnngEkAJiDMAJgEzACDMEMSBMEABjATBEmToAJFUZKtsJKu7bXXe++15fV12HXc+9iy1/KKtgLFgDwIk3PsUPtHdReq6tQQFAUSpFTv80Bgz29OdXU1VKfO973n+wwaqHVqySrHDp8NerMOap0a7gSS27026E1aqDUqyf4rNo8VBoueLa2fTFqgrW4LDBY9lCoFfBIW6NKthfjOz76M1/77szj7p6clKynLEuqjJML/jWGYUtHPfvRRljF3Q3J46pYeqHqSa8oEsE/TG6sbXPLY4jILdsCqtSqEgmEuji7mSpUCDAMuTi7mNE2BVtBcHFzMAWHy3Oo2Ezt4+YlRq9tC7NDmJz4lOc/CKsX5iVEpzk9mfxzOt5VK81u1j6Q432wgdX0MFh2W51kudX35ZgaL00TsoDda9ezudABmp4nYgc+3oEq11+XbiqUsxvyWuFIWY/4xpSzE/HMyWA1YFlmI+Z+Zfy2kuJSFmH9NTTYDnvz9B1HeRrrufhN1JxPhf0dRVD9FUXT0Ty+A/+9XP0VZn7TEDwQavQYHnu2BzqRF+7EWIlGu0qhw6Ewv9CYdth1qRGKOcPOXUqXEkZf7oTfp0DLYgNTCJAGnaBrHXj0AvVmHxr4ayf4PI68PQW/RoX5vFXKqyf4NI+dYi2/N7nLkN5D9G0ZfH4LRqkdVZwmKW8j+C6OvD8JoM6BsexHKt5MW3WPnBmGyG1HSWoCqnaUEP/rqAZgdRhQ25qJWwqJ77NUDMDtNyK/PxpZe0kB45JX9sLrMyKnOQFM/adE98nI/bB4LMivSJEMhh17sh91nRXppCtokLLoHz/TBEWdHalESdkhYdIee74Er4EBSXjx2399G8APP7oM70YWEnAD2SFTRHXiyG95kN+Iz/dgrUUW377Fd8Kd54U/zou/x3QTf+8hOBDJ88KW40f8kadHd81AnErLj4Ely4cAzZJXd3fe3ISkvHu54Bw5KWHh33LMVKYWJcMbZcegMWUW3/VgL0ktTYPdZMXyW5NsONSKzPA02jwVP/cHD8oTxMfRRVhqLYHeAx2wUCgCx6Z9hGIZck99FySuNW3qs9Qze/tufcq/FFlz+Uy9AVjUVb8YSVzUVW0zFlkzx8fj2TpYLLaZiS+XtuPh8xJbK23KRpZjkQouq2OIrrsIqtvgSXGTxFVuWCS66nixnEPu/LGFxpQAK4Lj4eostwlIWVpqmEYnu95GywPKvkZSFlT+Gf6xb/NZ7UjQFMLc+j/icKTpqd+Zxvm1XbImWuibiysr8a05RFB759n1oOyxXRQLu4EqDYRgTwzA0wzCq6B86+jPTZ23CkCXU2T89jaHneqA369B1oh0JWeKVgwK9j+6GUq1EY18tUgvFZR8o9J/uhkqjRP3eKqJ/RigYxoFn9kGlUaFmdzny6oQrg43VDRw80wu1VoXKHSUoEa0M1lc2MHy2D2qtCmVtRShvLyL5SwNQ69Qo2ZpPrAw2VjcwfLYfGr0ahU25xOa8jVV2vEavQX59Nhr7aoR8bQOHX+qHzqhFTnUG0T9jYy2Iwy8NQGfSIrMiDduGhTeX4HoQh1/qh96sQ3pJMtqPtUjwARiseqQUJmLHvVsFN7DgRgjDZ/thshmQlBePrgfahXw9hOEX+2B2GJGQFYc9D3UIbrChjRAOnemDxWVGIMOHnlO7BDwcDOPgmV7YPBb4Uz3ofbxLMKmFQ2EMPdcDu88GbxK7MuDf5MOhCAaf2wdnnB3uBCcOPLNXMElEwhHsf3ovXPEOuAIODD67TzDJRCIRDDzZDU+iCw6/DUMv9AgmKSbCoPex3fCleGDzWHHwTK9gkmMiDHpO7UJcug9WtwXDZ/sFFmCGYVcu8Zl+mJ0mHD7bT+wT2f1AO5KipU2Gz/YLJmmGYTDFa48s66Ppl+rc93mQvNIgFQqGoFQpcbLmKbzzz+9zP48ltteW16FQKmDzWDAVdScBbG8GpVqJlcVV0AoaDp9N0INcoVRAo1djZWEVNE3BEWfn3EkxxUpb0DQFZ8CBiStTAh6Li1MUBXeCU+BOAm7FwCmKgjvRifFLIs6LgfPtrjHxY9xSnJ9XiPUb5ytmEd6U+2yYiTq+pLjDb+OKPvLttDE54+zcNZca7wo4uGsuyaMW4s14rEc7y90C9xZwy2K82fXhc0+yG+Mi7k1yc7ZrT5KL+H68yS7cvDhJHCsmX7IbN6LHlOLeFDdn23bFOwUWcfFn5l8LjvOuOf9ax3ToTB8GnyWbTf0m6k7mNGR9zqVUsZbD0dcPchZYb7IbrngnF14Kh8JYXljhVhOeRCf8aV5uh3ckHMH81AJX8NAZsCMxJ8AlGiMRBtPXZ5Fby+YpHH4b0oqTuVpIkQiDiStTXJ7C5rUioyyVS6QyDIPxy5OcBdTqNiOrIo1LmjIMg/FLkyiM9uSwOE3IrsoQJHJvXpzgylibHUbk1mYKEsU3L06gpJVd7RhtBuTXZwsS0TcujHN9qA0WPQq25AhKid+4MI7SbSzXm3UobMrlJowYj3Ub1Bm1KGrO4yYMALhxfhzlbexqSmvQoLglX3ATu3HhFtfo1CjZWiCYpFnOxuDVWhXKthUKbpIxTtEUVFoVyrYXCibpGxcmUNHOcqVaifK2IsFN+ubFCZS3FYFW0FCoFAQf53MljYr2YsE+nfFLkyhvK4JCpWB5RzE3YQDAxOUplG0vglKlAEVTqGgv5iYMPldplCzvKBbs85m8OoXSbYUsp4CK9iLBJDl5dRqlWwug0aujPWKKBJP01LUZlLQWQGvQgKIotByoR9tRMm8k68Ol3AxQFPXnAI4zDHPp0zsdWZ+k9CYd9NHKtjqjlkiUAxTHtUYt54+/hSkYLAZuvEIl4gBni9XqNVB+HG5mj6/RaTh/vXA8y9U6NVSSnD2+WquGSq0iuN6sA0VRUGvVkse/xVWcf1/AjTr2pqyR5jrTLa7WqgmuNWhBK2go1UrCAg0AOqPuNlwDhVIBpVoJ9WacZm/qGh1pgdYYouNVSmj0JI+dH62gNuHR742S5hq9BgolDSbMSI/XR697MAytUUuO16mhUCrAhBloDdJcpVYhEmagNZIWbbVODaVKgeB6CDoTyQsbc/HY9+7H1Ng0siSq3Mq6vTYNT0VdUi+BrW57Ltqx7zMvOTy1ucThKY1ejUgoguBGCBRFweo2C5rgqDRKABSXzOWHagCAVtJQKhVcstjuswqaQAFCi2tst7eA85Ll/FBOTPx6UrHd4JtxqfAD33b5cTi/iqoU59tGpTjflirF+RZUKc63zUpzM+an2NWU1PXjh+ekrr/VY+EaG/FDbTHZPBbu34T4+wfYFWOs8ZIU5/+bkLIY889JkvM+k5TF+Lac92/G7rPhqd9/EIWNwg6Sslj9yuEphmH+CEAxADOAH1EU9ShFUY/E/tzBc5V1l6TWqtH7RBc0ejVahxq4BksxKVVK7H+qG1q9Bs3767gGSjHRNI3BZ3ugNWiwpbdGsn/CwRd6oTVoULenEmnFSQQffrEPOqMW1bvKJKvkHjzTC51Ji8qOEm53tpjrzTqUbitEfgNZJffgC73Qm/Uobs5DsUQHtoPP93ChqLK2IoIPPbsPRpsBeXVZqOosIfjgs/tgshuRXZWO2q4Kgu9/eg/MThMyylNRv7eK4ANPdcPiMiOtJFmyim7fE12weSxIKUhEyyDZq7rvcbYWVFJuPLYeIl1APY/uhCPOhoTsOLSPtBB874OdcMU7EJfuQ+doK8G7TnbAk+SCP9WDXcdJC+/u49vhTXHDm+TG7hMk33HPNvjTvXAnOCUtvG3HWhDI9MMZcKDnFFmFd/twExJzAnD4bZIW39ahLUjOT4DNa0X/EyRv6q9FalESrG4zHvnWvfKEcQf0oYlwiqLUAE4D2A92FzhnjYiWSP/MSV5pbK5nd72Kf/6zf+Nei6vCil+LLbXi1+Kqq+LXYsuqSqsS9KgWW0rFFlWxJVXMxfZK8e+LOfFaVHX1l+Viy6rY4iq2rIq52LIqPh6toBAJMzwuPJ54/G1fiyywYgux+LXYEhsrF8K9FnOp36eENmS+LZntt0Jx50RRrGd4s9+X/ozCa0ReM+E1ffh37kHHCDk5yroDKw2KotoAvA1AD6Ak2lPjTOzPHTxXWZ+Snv9/HsW9XzwUrUDazdWViolW0Bh8bh80ejVaDtQjvUTYNoVhgEMv9kGj16CxrwY5oif/4EYIR17ZD41eg/q9VVzdI46vBTHy2iC0Bo1kf4zgehAj5wahM2pR2VmCyh2lJH99CDqjFmXbi4gn++BGCKOvD0Fv0qGkJR9beoSb70IbIYy+fhB6sw4FjTlo3l9P8Hu+cBAGix55dVnYeqhRYvwQjFYDsqvT0SGy2IaDYYy+PgST3YjM8lTsuHcbwUe+MASzw4S0kmTiyTwcCmPk3BAsLjNSChOx9+GdIh7BsdcGYfNYkJQbj55HhTwSjuDYawdg97Eri/4nuoQ8EsGRVwbgjLMjkOHDftHmukiEweGXB+COd8Kf6sXQcz0CCy/DsG4jT5IL3iQXDp3pE/IIg6Hne+FL8cCd4MTw2QHBDR8ADjy9F3FpXjgDdhx+ZUAwiTEMg4HT3YjP9MPht+HYqweI8b2P7kJiTgA2jxUj5wYFEwQA7HtkJ1IKEmF1mTH6+iCxD4XoES7rl9aH5TT+fwD3Mgzzs0/3lH41ySuN24thGFAURfTfUGvVYBgGwfUgKIqCzWsR5CiUKiVoBcWtHsQxdIqmoNGquR4dUjF2/mrldjmM2+YgohVtN+N8u2pM/DIbUpyfo5Di/BzFx+H8HIUk58XlXQE7JkWfjx/3dwYcxD4DAZe4fjaPFbPj7Hcqdf35OQqH347p68Lx/LyHVI6Ef0ypHAn/nPjvJcl5+RSO875zqRwI/5pIlWE5/NIA9j/1mWw6etd1J3Ia9Z+3CUPWR1Ns5/EDbx3jqqQmZMchLt3LhX8YhsHK/CpnYQ1k+pGYGxCEm+anFrnVgj/Ni/SSFEFTp+nrsyhvZy2ivhQ3sirSBOGt6euzqIz2zHAnOpFTnSEIj01dm0FVdLXhincgry5LUEtoamyG2/Dn8NtRsCVHwCfHplGzmy0FYvdZUdSUJ2gyxedWtwXFLfmCWkiTY9Oo7a4ARbEl30u3FghqLU2OTaO2i+UmhxFl24sIXrenEhRNwWgzoLy9WFALanJsGnXdFaAVNAwWPSo7SwSJ3MmxGdTtqQStoKE361C1o0xwk5wam0ZddyVoJQ1tNC8k4NfY8QolDY1ejZrd5dyEEbv+dXsqoVQpoNapUdtVIbiJT1+fQV13BZQqJVQaFWq7KgSTwPSNWdR2V3BOs7o9lYJJaObGLGq7KlinmkqJ+j2Vgkls9uYcanaXQ6NnHU/1e0V8fB7Vu8o4R1b93krBQ8LcxDyqdpRCZ9KC5vg0jy+gqrMURqsBtILGznu3SZZekfXLaVPLraxff22sBbkyG8H1IFeiOiYGEHApi2nM+RRcDxIlJYQ8JM2jxw9thAQNhSR56EN4MESEIgBwkxg7nuQbq+sfOn59ZQMMwyAcCiEkNX49yoNhoitd7PyYCMvDEnwjet3CoTBCGyQPrgfBRKI8GJLgG2DCEURCYUE+RzCeYUNP4t3SMR6JMEA4IsgXcXwjBIaJAAy9yfhb1y24Jj0+EomAYSLYkDh+aIP9dxEOR4iugiwPg4lEEIkw0jwYRiQUAbPJ+Ny6LDz63eOYHZ9HUm48wWX98pJ3hP8GiwhP6dSgaQpry+ugaQp2n03w5KdUK6FSK7G6tMZyv03w5EfRFHRGLVYWVkFRFJwBcod4LDxEURRc8eQOcX54SGqHMD/8I7UDmV9lVZLfwR3kUpwfcpHi/JCNFOeHd6Q4P3xzW57kwk3R5+eHb/gNpWLi76r2JDoFTbgA4Q5z/n/HxD+mK8GBySvC75//nUqF5/jfmVR4js+lwm/8a+JL8eD0751EThXpupNFSt4RLuuXlkqtRNeJdqg0KtTvqyL6EygUNPY82MHWmuqq4HptxERRFPY9shNqrQrVO8uQkE22k+15bBfUWjXKO4qRnE8++fU8ugsanRpl2wuRVpRM8lM7odFrUNySJ1lFd9+pndAaNChozOEaLAn4IzugNWqRV5eFvGgDJb72PrwDOpMW2VUZkvbMPQ92QG/WIaMslailBbDtcg0WPdJKkrnd3XztPtEOo82A5IJEVHWSVXZ33d8Gk8OIxNx4ySq7O+7dBovThPgsP1FrK8atbjPiMnzY0kdaeDtHt8LutcKf6iFqbQFA+9EWOPx2eJJcaBkiq/BuG26EK94Bd4IT2yQK/bUMNcCd6IIzYEf7EdLi23KgHt4UN+w+GzokLL6NfbXwp3lh81gIIwEANOyrRnymHxaXGTuPbyd4bVcFEnMDMDtMGDk3KE8Yn4DklcZvsF7q/xL+4Y9+yL0WV7UVV5kVV8kVW2q1eo0gpyG2qIotuWJL6+24uGqt2MIqPh+iKu5tuNjSK7Z33paLLL9EVVwxF41XqpSCEJS46q34ehBVbwkOYVVb0fUSn6Nk1SyuMSwAACAASURBVFveOUpVvRVUtZWoeksraUS4qrfC6yE+J7G9VvyZpKri8v+Nia8XAJz8+gh2Skw+skjJKw1Zt9VT//khnPr2ffCnejB8tp/oj0HTNI68PACdUYvWoQZklQs33zEMMHJuCDqTFk0DtVxr05jCwTDu/dIw9CYdGvZVEf0vQsEwjr9xGHqzDrVdFcTmulAwjONfOQyDRY+qHaWo3in89xwOhnH/m0dgsOhR3lZEbJ4Lh1hutBpQurUAjaL+FuFQGMffPAKjzYCiply0DgmfvCPhCO5/8whMDiPyG7Kx/UgTyb9yBGanCTk1megUJVkjEQb3v3kEFpcZWZXp2CWy2EbCERx/4zBsHgsySlOw56FO0fVlcM+XDsHusyKtOAk9j+0i+RcPwRFnQ3J+AvpEFluGAUbPDcEVcCAxJx4HniZdQ8deG4Qn0YX4TD8GJfpXHHl5AN5kN+LSfRg+00fwQy/2wZ/qhS/FgyOvDBD84PM9CGT44Uly4ehrBwh+4Om9SMgOwBXvxOjrQwTvO92NpLwEOOPsuOcLByF+xu05tROphUlw+G2478uHiNI4fOODrDsjeaUhi9OppufxH//wc+61SqNEJMxwT59ii6NCSYOiKO5JUMwpin165jr18UpW3HqPW0/vUhZL/upAkvNWH1KcX6ZEyuLJtwDz7ai3uBZry2ubcv7qTOr9+RZgqfF8C7DUeH4ZEynOzwFJWVBNNiMWZ5einLSgmuwGLM6w46XKcPDLnEhxvoWYn0/iOG+MNDdhfjLayc9uxJKoEyD/M0l1+hNwXlfCmI69Oii5k1wWKXmlIeuX1iPfupezsKYWJSEpN14QrlhZXEVNNM6eUpCItJIUQThkcWYRddE4e1JuPLKrMgThmLnxeTREu93FZ8Uhry5LEO6ZHZ/nel7EZfhQ0JgrCCfNjs+jaT+7WvClelDcnCcIV82Oz6N5oBYUxSZkS7cWCJpAzd6cQ8v+elAUm/AtbysSWIBnx6OcpuCMs6Oyo4SbMGK89UADaJqG3WdF1c5SQThvdnweLQcaQCtoWN0WVO8uF1iAZ8fn0DpYD4WShsVpQm13heBJeHZ8Hq2DDVCoFDA7jKjfV8VNGHyuVCtgtBnQ0FMtuInOTcyj5UA9VGolDFY9GvtquAmD5QtoOVDP9gw369DYX8tNGAAwP7mA5v310OjU0Bm1aB6oE7R7jXGtQQOtUYvm/XUCC/HC9BKaBmqhM2qh0bEbRPmTzML0Ehr7a6E3sT3BWwbruQkDAJZmlrCltwZ6ix5qjQqtgw2CSXBpdhkNPdUw2gxQqZVoHRLxuRXU762C1W2BSqNC/+lu7Douh6butGTLrSxOU9dmOGfK7Pg8jFa98BciDI/PweIS9uBiGHB8bnIBtIJ8Jon1Y1iYWoBaS1p4Y6W2F6YWoZeoUjoeLbW9OL0Es91Ijr88CYYBFmeXJEMTNy9PgGHYG4z4qRQAxq9OgYkwWJ5f4cq6C/kkIpEIludXBTfcmCavTiESjmBlcZV4agaAiavTCIciWF1aI/pvA8Dk2BTCwTBWl9axILF7efLaNEIbYaxhnXjqB9i9E6xNliFWFTG+sRZEKBgmVn0AMHOT5RRNYUa0KgLYvRexiVhcnBBg/92sr7I2ZPHGPwCYG5/D6vIamGgpfbHmJxewvryOSDiCKdHGwhhfXVxFOBQhnFMAkF2ZjlPfuQ+LM0vwJrkJLutX110JT1EUZQdbyyoJwCUAvQzDEP+CKIoKA/hJ9OUVhmF2iX9HLDk89fH1SONz+Mn/fId7rdaqoNGpsTi7DKVKAYffLrBoKpQKGCx6LEwvsjzOTlhcrS4z5iYXoFAq4Ip3kBbVaMiFVtDwJrlw/bx0EySapuBN8eD6BzeFPGphpSgK/jQPrr0v5LFdzRRFIS7di7H3bgg43/YZyPCRnNf4Jz7Tj6vvXhdwvu1UivMtovFZflz9hZDzmxhJcX6TofisOFz9xTUh5zUZkuL+NA+ufzC+6fnFpXu5axbI9GPsw3iGH2PvCTn/mkldP/7P4tJ9uPa+kMdn+nD13RvRc/US3y//mvhTvbh+fnOenJ+Ax79/QtJ1J+v2+qyHp04D+BuGYdIB/E30tZRWGYYpiv657YQh685KoVRg26FGKJQKlLcXwZXgFHCKptB2pBlKlQLFWwvgSyaf7NqPtUCpUqCoOQ8BkUWX5a1QqpUo2JKDQKZfcrxKo0Refbbk5iyWq5BdnYEUiSq77UeboNapkFWZhrRi8may/XATNHoNMspSJC2824cboTVokFachKxKsv/C1kON0Bq1SM5PQE5NJsmHtkBv0iExNyBZhbdlqB4Giw6BTD+KmsgqvE3762C0GuBP86I02iCKr+aBOpjsRvhS3FwDKL4ae2phdprgSXKhooOs0tuwrxpWlxmueAdhNACAuj1VsHktcPhtqO0mLcC13ZWw+22w+6yo3UNagGt2lcMVcMDqtqB+H8krO0vhTnDC4jSjsbeG4GXbi+BNdsPsMEpWAS5pLYQ/zQujzYC+J7rkCeNT0N1aabwLoJFhmBsURfkA/D3DMMT/4yiKWmIYhoxBfIjklcbH1xePfh1/+d2/417zk7gAaVnVm3RcZz+AtNiKq+aKLZtiC6/YsnlbLqq6ezsutnTejvOT6ABp6RRbksUWWDEXv4fYYgyKPUaMi6+3+DNKcYWC5nbWi6sKA8LvQGwhBoQWV3EVYjEXf9/in4ktwIDQdixlAeafs5QFWK1RcTvLpSy+D7x1DLsk9m/Iur0+6ysND8MwNwAg+vdmwUctRVE/oijqnymK6trkd2TdIZ36znE8919PIbUoCfd9eZiockvTNEajVWBbhxq41q8xMRGGs8g2DdRxda1iCocieOCtozBa2SRuaavwyTkSjuDk147BaDOgrrsCFe1FJP/6MZjsRlTtLOXqRknx8rYi1O8TWnCZCIOTXzsGs8OE0q0FxJMrE2Fw8hsjsDhNKGrKw9aDDULOMHjga0dhdZtR0JCD9qMtBD/x1aOweSzIrcnEjnvIJOz9bx6B3WtFVmU62X+CAU68eRQOvw0ZZamS/Sfue2MYroADacXJ6H2MdAWNfvEg3AlOpBQmYv/pboKPnBuCN8mFxNx4DD67l+BHXz0AX6oHCVlxOPQCabE9/PIA4tJ9iEv34fDZfoIfPNOL+Ew//KkeHH2VtNgOPrcPiTkBeJPdGD1HWmwHntyD5PwEuBNduPeLBwne+8RupBYlwRXvwH1fHiY4f5KX9cnoE1tpUBT11wC8EuhpAN9nGMbK+91ZhmFsEsfwMwxznaKoFAB/C6CFYZjzEr83CmAUABISEkovX758pz7Gb7Qe3/oifvw3P+FeK1UKRMIRboOW2EJJK2iAYXjcRCR7+U+HUpz/dCnF+U+vkpz3pCvF+U/P0vzW07cU5z/dS1lI+RZgKc5fffBLosTE3yApyXmrL76dNia+BVjKospf/RmtBiLZz19d8u2+t7geKwvsz/h24Zj4PzOYdVjmrVTFxxSvZMXnLF6pirl4JQoA93zhIPY9QjZzknV73fWVBsMwrQzD5En8+QGA8WhYCtG/JzY5xvXo3xcA/D3YToJSv/dNhmHKGIYpc7lcn8jn+U3U498/geb9dQAF5FRnIK0kRbCjd2VxDVsPbgEoIKsiDdlV6QK+OLOEtiPNoCgK6SXJKNiSIwgnLEwvov1YCyiKQmpREoqb8wThCI7TFJLzE1C6rVAQ7liYXkTHSAtoBY2EnAAq2osF4RKWt4JW0Ahk+lG1o1QQblmYXkTnPa1QKBXwp3lRvbtcEK5ZmF5E5+hWKFQK+FLcqNtTKQgHLUwvYcc9W6FUK+FOdKJhX7XAArwwvYTO0a1QqZVwxTuwpa9GEK5anGHHq7UqOOLsaN5fJ9hRz3GdGjavFS0HGgQ3ycXZJXSOtkKj18DqtmDrwS0CC/DS7DI6R1qhNWhgcZqw7VCj4Ca8NLeMjmMt0Bm1MNkN2H64SXATX55bQfvRZujNOhitBrQdaeYmDIDdONd2pBkGiw56sw7tR1sEk8jywiq2DzfBaDNAZ9Ki/ViLYBJaWVjFtkONMDuM0Bq06BxpFUxyq0traB1qgMVlhkavQeeokK8traFlsB6ugAN6kw5Hf+uAZPdAWXdWd8ty+6cADgF4Nfr3D8S/QFGUDcAKwzDrFEU5AdQCOPepnuVvuC7+5Ap+8b8+ABjg6i+uweK2CDjDMPjFv7wPMMDYezdg94kXiwx+/sN3wTAMxt6/AXcCOaG/88P3wDAMrn9wExGJRPo7//IemAiD6+dvElV4Wf4+IuEIxi9OQK0mLby/+F9RfmkCOoNGgn+AcCiMiStTMFoMBH/vRx8gHAxj8uo0zHYTwd/90XmENkKYvjaDcc8kwT/48QUEN0KYvj7L2Y35ev/HF7GxFsTMjVnOJSUY//ZFbKxuILgexI0LNwl+/t8vY31lHRur64QzCQAu/OQy1pbXsba8jrH3rxP84k+vYnVpDRRFEc4rALj88zFuIrkixd8Zw/L8avR3rxL86rvXuBv95Z+RfOy961icWQbDMLjwkysEv/7BTSxMLYBhgAv/QUYQ0otT8NBv34PVxVXYPFaCy7rzuluJcAeAPwKQAOAKgB6GYWYoiioD2/jpGEVRNQB+B2yLWRrAGwzDfOd2x5YT4XdOj7W8gLf/7lZLFZVaCbPThOnrs9Do1HD47QILJE3TcPhtmBybhlqrgiveQVhgYxZVlUYFT6KTsGjGqqSq1Ep4U9ykRTVaxVSpUsCf5sOVd8YEPGZRVSgVCGT4cPnnQh6zddIKGglZcbgkupHFLKY0TSExJx4Xfyq8kcUspDRNITE3HhdFN7qYBZSi2NWR+EYXs8VuxhNzAtw5pxYm4vy/b85TChNxQcST8uJx6adXNx3P55Lj8xNwKfqZpHhyfgL3mVMKEnDhP4SfP7kgERejn4n/uzGlFCRyn1mS896Tf65SPKcmE6e+fR8SsuIg61fXXQ9PfZgYhplmGKaFYZj06N8z0Z//iGGYY9H//ieGYfIZhimM/n3bCUPWJytaQaN2dwVomkJOTSbsftGTHQXURpsKZVWmwxlwEMeo31sFWkEjsyIVnkRy5VG3l20alFaaQlTZBcA1DUopSoI/zUPw2mjToOT8BAQySItvze5yKNVKJOXGIyGbvNnU7C6HWqNCQnYAiblkld6qneVQa1WIy/AjuYC0+FbtKINGp4Y/zYuUQpJXdpZAa9DAl+JBemkKwcvbi6EzauFNciNTVOsLAMraiqA36eBOcCJbwgJctq0IBosOzoAdOdWkBbi0tQBGqwF2vw15ddkEL2nOh9lhhM1jQUE9aREubMqDxWmC1WVGYSNpES5oyIbVbYbZYUJxM1kFOK8uC3avFUabASWtpIU4tzoTjjg7DBY9SreRVYKzqzLgindAb9Zh+3CT5Hcs65OVXHtK1qb62oP/CX/y1b/gXosTo+KqrOLEqNgSKU58ii2ut+Pi47MOWIqzwBLjRRZYqcQr/z0ILrLAii3GgNDCejsuriIMCBP7Uolfvi1VivMtrGIL8Ufh/MS+uEoxy9XYWGPzMIRFWPQzKQswP/EvxfnnJGURFnAJi/CJrx7F7vvlPMad0Gd6pSHr86H7v3IEr/7VM8ivz8bD37wXGaXCzW8UTeH4G4dhtBrQcqAe2aL+FUyEwQNRC21jXy3Rn4KJMHjwGyMw2Qyo31tFbF5jIgwe/O0RmOxG1Owu51rHcpwBTn79GMwOIyo7SQsuwzA4+fURmJ0mlLcVoUFkwQXY0tkWlxklrQVoGqgTQoblVrcFRU15aBVZcAHg/jdZi21+fTbajjRL8COw+6xRCy7ZavT4G4fh8NuQVZGG3Q+0E/y+Lw/DGXAgozQFex/uJPjoFw7CleBEalESeh8j97+OvD4ET5ILyfkJ6Jew4B75rf3wpbiRmBPAfokquMMv9SMuzYv4LD8OvtBL8KEzvQhk+tkquC+RFtzBZ/YhITvAWnB/i7TgDpzuRnJ+ArxJboy8Nkjw3sd2IbUwEe5EJ+75AmnRleomKOuTlbzSkPWR9VTHy/jXv3ybey3enCVeiRArBTEXbZYjOcBfSUhxirrVo0HKAspf7Xwczl8pSHLeNZDi/JWE1EqHbxGWWqnwn66lxvOf3nUmHVYXP4RLrFT4KwV+RV9uPM9CLN7syI65tRKQ5LzVi9RKhW+bFfdLEZ8zf2NfTPd/5Qi6JCZbWb+85JWGrDuu0793Ep2jW0HRFAqbcomY+trSOnYd3w6KppDfkI0CUdmM5bkVdD3QzuZEqjNQ3JIn6H+wPLeC7pMd0ZxHGkq3FxF8z4MdUCgVSC9NQUVHicDiuzy/gu6HOqBUKZBalISa3eWC8Njy/Ar2PNzJ5jTy4lG/p5LkD7E8ISeALb3Vgh3sy/Mr2PvwDqi1KgQy/WgaqBVMmizvhFqrgj/Ni5bBeoFFeGVhFXsf3gGNns1pbD20RfCkvLLIcq1BA3eiC21HmgXhmJWFVex9qBM6oxbOgAMdx1oE4Z7VxVWus6DDb0PnaKuQL61xnQVtXit23rtNcBNfW15D1wPtMNmNsLot2Hl8u+Amvr6yjt33t8HsMMLiNGH3iTZBuGt9hf3+LS4zTHYjuh5oF4S71lc3sOPebbC5LTBaDeg+2SGwEG+sbqBztBUOvw0Gix57HuoUTHIb60G0H2uBP80Li9PENliSq9h+6lK88MILd/sc7qi++c1vvjA6Onq3T+PXUv/23/8Df/zmn2N5fgXzkwugaEqw+YwChdnxeSzNLWNhchEURRGb42Yn5rE0u4z5qQVQNM31645pYWoBC9NLWJhaBE3TmJ8SVmqdn17AwtQiFqcXQSkootLr0swS5iYXWE5TRKXXxZllzE3MY3FmOcqFlV6X5lYwNz6PxZkl0DRN9K9YmlvG7M05LM0ugaYpgq8srmHmxiyW55ZBURTRv2N1cQXT12exPLcCiiIrxa4tr2FqbIZbUYj5+soGJq9OY2VhFQyAmRsivraBiStTWF1cA8MwBA+ub2D88hTWltYQiURIvhHCzYsTWFteRyQUId4/HArjxoUJrK9sIBwMEzwUCuPG+XFsrG4gFAwRPBKO4Pr5m9hYCyK4HiSuDxNhcO39GwiuB7G+ukFc320HG/HofzqOXfdtR15dNmhafu69Uzpz5syNF1544Zu3+z35isv6yPrB1/6Cqwi7tryOm5cm4U9lHUx6sw5xGT6uCu7ayjrG3rvOuVt0Ri0Sc+K4iq8ba0Fc/cU1xEeLFGoNGiTlxXNVboPrQVx5Z4zrM67RqZGcn8BVbA1uhHD5Z2NIjBYxVGtVSC1M4iy8oWAYl356Fcl5CQDYME9qURJXpTUcCuPiT64gOT/K1UqklyRzexUi4Qgu/MdlpEQdUkoVu7rheITB+X+/jNSiJADsTvaMslRuL0IkwuD825e4Iom0gkZmWSou/Yy1yzIMgw9+fIkr1ULTFDIr0jgLKssvcg4rmqaQVZEmsOh+8L8vckUWKYpCVmWawCL7wf++iMxyIT//tjQHgKzKdJx/+9It/uOLyKxI4/E0fPDji5vzijSc/zF//CVBkcesCuH4829fQlZlGhemzCwX8gv/flnAy9uKULWzFCq1CgaJPTWyPh3Jk4asjy2KolDQkAOKAhJz42FxkpvfWE4hIScAq2hzIAAUNuWCoinEZ/ph95Kbswq35ICiKQQyfHD4iUozKGjIBq2g4E/zwhmwEzyvIQsKBQ1fihvueNICnF+fDYVKAU+SC24JC3BeXRaUKgU8iS74JPoz5NZmcju+YxMoXzk1mVBplHAF7IiTqPKbXZUOtVYNh9+GQAZZ5Te7Mp3bER4vsR8hszwVWoMGVreZm2D5Si9Nhc6ohcVpQlJuAslLUqA36WB2mJCcR1YRTitKgsGih8luREpBEsFTCxJhtBlgsBq4CZSv5LwEmBwmGMw6pJWQFuPEnHiYnSbojFpklJE8ITseFpcJOqMGZduL4I53Er8j69OVnAiX9ZH13Wf+AH/wW3/M5RnEtZFoBQ0mwtziNgMWeWUfKIoCRYHLQ4h57BixPAO/FSl7AHYD4aYcwtpV0vxWYluqthM/MS11fnwuVduJn3iWGs/nUrWf+Mng23OyvSk/MS2VmOdzqcS6zqDB6odxnm1YKnHP/5mUxZh/TKnaUXqLHivRc5ayCMsW209OciJc1h3X4ZcG8OYPX0bVjlI89Z8fEoQ2AHZSOP4V1oLbNFBH9JdgGAYn3joKo82ALb3VyN9Cbh478dZRmGwG1HVXorhFtPmLAR742lGY7EZU7ypDeTvZH+L+rx6B2WFERXsxqneR/R9OfPUozE4TyrYVom5PBcGPf+UwLC4zipvz0NhP9m84/pVhWN0WFGzJQetgPcHv+dIwbF4L8mozsW24ieD3fvEQ7D4bsqsy0DHSQvDRLwzBEWdHRlkqdt5PlvgefX0QrngH0kqS0X2yg+BHXtkPd6ITKQWJ2HeKLNx35OUBeJPdSMqLR98TZJXcgy/2wZ/qQUJOAP1PkhbdwWd7EMjwIZDhw+Cz+wi+/+k9iM+Kgz/Ni0MSFt2+x3cjMTcAX4obh8+SVXR7T+1Ecn4CPEkuHH1lP8HFpdBlffqSVxqyPrae7z6Hf/rBv3KvxRZcsQVUvNlP/CRK05TADSW2iBJcNF5s8RWPF1t8SQ7wLb5iCypFsf8Tew+pJ2H+Z5TaLMfnUhZVISf7cfBXUlIWVv53ILWZjm8Bvh2X2kzH/xl/4+AtfquKsFQ/Dv57SvXTuB1/6LdH0TlK7neR9atLXmnI+sR1+vdOoufRnVAoFSjbXoS82iwBX11cRd8TXVCoFChuyUdxc56Ir6H/yS4oVQoUNuaibLuwbMTq0hoGntoDlVqJvLosVHaWEuMHnuyGSqNCTnUGakWb+1aX1rD/qT1Qa1XIrEhDw74qgYV3dWkN+5/eA7VOjfSSFDT21wn42vIa9j+9Fxq9BimFiWgZbBBMSmvL6xh4ag+0Ri2S8uKxbbhRMCmuraxj/1N7oDNqkZAdh7ajzQK+vrKOgae6oTfrEMjwofOerSK+gYEnu2Gw6OFP9WDX8e2CKsDrqxvoP90Fo80Ab7IbXQ+0C26yG2tB9D3RBbPDBHeCE3se7BRYgDfWguh9fDcsTjOccXbsfXiHgAfXg+h9bBesbgvsPit6Tu0UTCLBjRD2ndoJu88Km8eC3sd2CSaJ4HoIex/eAYffBovLjL4nugSTVDgYxp4HO+CKd8DsNKH/NMl3n2hHUl48XPEOPPn7D8oTxmdAsuVW1sfWP/7xv+APX/sBVhdXMXl1CgwDIsZ/4/xNrCysYmpsGpEIQ/Dr529ieX4VU2MzYCIRIsdw88I4luaWMXVtBpGwBL80gaXZZUxfn0E4zBAW3/HLk1iYXsLsjVmEQ2GCT1yZxMLUImZvziEUChMW4MmxacxPLmBuYgGhjRDmRXxqbBpzE/OYm1hAcCNEWICnr89gdnwe81OLCK4HCT5zfRYzN+ewML2EjdUNgs+Oz2H6+iwWZ5extrJO8ol5TF+bwdLcMlaX1gg+P7WAyavTWJ5fwcriKsEXphYxcXUKK4urWFlYIfnMEiYuT2J1aQ1Lc8vE51+aW8bNi5NYW17H4uwSwZcXVnDzwgTWV9axML1IXN+VxVVcPz+O9RX2s4u/n61DW/DIt+/Frvu2I72YTJTLunOSLbeyPnH91ff+jtvnENwIYfzyJFekj3XjJHA+/VCQ9e+nlbAWVKPNgJTCRG6fQDgUxrUPbnIWVKPVgLTiZExdmwHAxrKvvX+Ds5jqzTqkl6ZgaizKIwzG3rvOFfnTGbXILE/FxJUpjl999zqyKlmuNWiQVZGG8cssZxgGV9+5xpVC0eg1yK7KwM1oOXOGYXDlnWvIqYlynRo51bc4AFz5+Rhyo3kclUaF3JpMzkIMsGXG8+rY1ZgyunralKsUyKvPFlQJvvyzMeQ3sEUGFUoF8huycY1XJfjyz29xWkEjvyEbY+9eF/BYN0VaQaNgSw6uEjwbFEWBpikUbskRlEu/8s415Ec5RVEo2JKDK+8IeUFDDmia5YWNubjCqzJ89RfXWLdbtMR9wZYcQRXiq+9eR35DDtvMC0BjXw1quyugUCig0ZFl7WXdHcmThqw7qljlWGecDXqzjuCJUVtobNcvMT6HHW/zsruGpY5PUYDda4XJtgmnKdg8Fpgk+l8kZAVA0RQsLrYSq1jxmX7QNA2L0yRpIQ6k+0EraJgdRkkLcVyGDwpllEv0d/CneaFQKWC2GyX7P/jTvFCqFDBYDXD4SO5L9kClUcFg0cHhJy3GvmQP1FoVDGYdnHGkxdiT6IJap4bepIVLogqxJ9ENtU4NrVELl4S91RPvgkavhtaggUeiP4orwQmtQQO1Tg13AjneGXBCZ9JBo1fDI2FhdsbZYTDroNaqkJSXALPdSPyOrLsrOREu62PrD1/9Y3zvuf/CxdktLrMgvEFR7BNxLE4u5oDQAivF+YlXq8uMOYLfSrZa3WZiBzjfoirFNVo11tc+hPOS0VKcn+yWOn++rVTq/PnJeKnxfIuqxWkiwj/8lqqSnGe7lWpfy6/nJdWelm8rlrIo838m1X6W/55SFmU+N1gNWBZZjB946xh2HSddZLLuvOREuKxPXP2nu/E7b7+OpoFavPiDJwgLLkBh5PWDMFj02NJbjexKsj/EvV8ehsGqR92eSuTXZxH8ni8chNFqQPWuMhQ2k/0b7v3iIRhtBlR0lKB0ayHJXx+CyW5E6bZCVHaQFt3RLw7B7DCiuDkfNbtJC+7ouSFYnCYUbslB/d5qgh87Nwiry4y82iw0D5AW3aO/dQA2jwXZVRloGSSr5B55ZT9sXisyy1Mlq+QOn+2Hw29DWkkKOiWq5B56sR/OgB0pBYmSN9eh53vgTnAiKS8eXSfJwn4H+fxJPQAAIABJREFUntkHT5ILCVlx2PPwDoIPnO6GL9WDQIZPsopuz6O7EJfugz/Vg/7TXQTf+3An4rP88Ca7Javodp3sQGJuPNyJTgw9R1p4f90ean8dJK80ZN0xvTzwZfz9f/kn7jXfvgmQFlO+ffTjcLGFV2xRJbjIonpbLrL48ntLAKTFV2xhFVt8b8fFFlexxVfKwso/BykLLP8zir8PMZeyuPJXguLvQ8zF11N8zNtxiqYA5lb/EwB4/Hsn2D70sj5xySsNWZ+6Hv/+CQw+uw8qjRJVO0uJ/hnrK+s4eKYXKo0K5e3FKN1WQPBDL/ZCrVWhZGsBKjqKCT78Yh/UOjWKmvNQ21Uh4hs49GIfNHo18htyiP4Z66sbGD7bD61Bg5yaTDSJNu/FuM6oRVZlOlqHhDerjbUNDL/UB71Ji/TSFGw/3CTiQQy/2AeDWY/UoiR0jLYKnpQ31oIYPtsHg1WP5PwE7Dy+XcCD60EMn+mDyW5EQnYcuk52CCal4HoIh870wewwIZDhx95Hdgj5RghDL/TC4jLDn+ZFz2O7BDfpUDCMwef2weaxwJvsRv/pLgEPB8MYfHYfHD4bPIlODDzZLajyGw6Fsf/pPXDG2eGKd+DAM3sFPBKOYODJbrjiHXD4bRh8rkcwCUXCEfQ93gVvkhs2rxVDzws5E2Gw79FdyKpIQ3ymHy/92ZPyhPEZlLzSkHXH9D/+r3/A1x/6LpbmlkHTFJwBB+deiikWA6dpCq54J1fgMKZYXJ2iKHgSXbh5aULAY3F7iqLgSXIJ3EsAYHGZMD/Jxshj/cL5snosmItWTpXidq+Vc3z5Uz0CdxPAJvCnr8+yPM3DFVCU5KleQQ91gE30xhxhsX7lfLkCDq4opBSP9Vjf7Pz43JfqwQ0R9yS5uKKRUp/fm+TCzQ/j0R7t4v+OyZfixo0LH43zzyWmk18fwY7ofhWFUgFZn57klYasT11//0f/yNVKikQYTFyZQm4ta0G1+6xIK0nmkqaRCIPxy5PIr2ctojaPBRllqVwilmEY3Lw0wfXksLjMyKpM5xK9DMPg5sUJzkJqdhiRU53BTRgAcOPCOIqa2DyI0WZAbm0WN2FwPJonMVj1yKvPEpTyvn5+HCWtbJ9rvVmHgoYcbkIAgOsfjHN9rnUmLQobc4X8/E2UbmPzLFqDBkVNedyEwY6/xTV6NUpa8rkJI8bLtheCoiiodWqUtOYLJuHr58dR3lbEcq0KpdsKBPzG+XGUtRWBoiko1UqUbisU3KRvXGDH0woaCpUCZdsLuQkjxsu2F3K8vK1IMAncvDiBsu2FUChpKJQ0yrcXcRMCx7cVQqFSgFbQKG8T8vFLkyjdVgilWgmKptBxrAUN+6pAUZQ8YXyGpbzbJyDr11sxW6vOqIVKTf5zi3GNQQOVhuQmB2u51Bo0UGlUBI/ZYrV6DdQS3BS1bGp0aqi1JOfeX6uGRqsmuNFmBEWx+Qy1XoobWK5RQSPFrXpQNBXl5F4Do1UPWkFDpVZBYyC5wWIATVNQqZXQGUkLs96sg0JBQ6lSQmvQkuPNeigUCijVCuiNJNeZdKAVNJQqxSbH10OhpEHRFHQmkutMOihUCoCBpMVaZ9JBqVIgEo5Ic6MWyuh4s9Ms+R3J+mxJDk/JumP6k7f+At96/He5ZC8/1BMTP9ls99kwc2P2l+J8Cys/FBSTzqDF6vLmnG9hdfjtmL4+I+S8Kq1S4/kWVkecHdPXhOP5lWelxvMtqlLvb7YbscBxcrzZaeJ2VUtxvu1W6vrxbb12n5VowsS3Bdu8VqJJks1j4RojSXMrZsfZn1ndFqLJFX+MlIX55NdHsPNeuRvf3ZAcnpL1qavrRDu+8/M30Dm6Fef++jlkEBZccInm2q4KZJZtwk1aVO0o5XZfC/iLfdCbdahoL0Z+PVkl99BZNhFdsrWAC03xdfAMm4guaspF2XbSonvwTC+MNgPy67NR2UladA++0AOjzYjcmkyi1hUADD7XA7PDhKyKdNTvrSL4gWf2wuI0Ib0sBY39NQQfeHoPrG4L0oqS0HKArKI7cLobdq8VyfkJ2HaokeB9T3TB4bchMSeA9qOkhbfn1E64Ag7EZ/kl6zjtfWQHPIkuxKV7ses+8ua9+4F2eJNd8KV40HWCLFG+6/g2+NO88CS5sPfhToLvuGcrAhk+uOKd6DlFWnhlffYlrzRkfWI6d/gt/I/v/wP3WmwJFVtMxVxsUeX3smDHCy2oYkupmIstpeLjiceLudhyKv59saX0dpxvV2U5hUiY4XHh+4ktvgoFjTDveGILr/j9WEsrj9M0IhH+eAgsvmLLcfTwnCVWfD7iMeLjid+TPV+hxfaZP3wYW3rJyVTWJy95pSHrruvR7xzH0VcPQKPXoLarAsXRpHJMwfUgRl4bhNagQdXOUpS3Cy22G2tBjJwbgs6oRXl7Map3lYnGhzBybhA6oxalWwuIJ/vgeggjrw9Cb9KhqCmPsNiGNkIYfX0QerMO+fXZxOY7lg/BYNUjtyaTsNiGgmGMvj4Eo82ArIo0dI62EnzkHLu5MKM0hdh8Fw5FMPLaIMxOE1ILk9D9YKeIhzHy2iCsbjOS8xPQI+qPEQ5HcPTVA7B5rEjIjkPfE7sFFt5IOIIjr+xnuwJm+jHwZLeQRyIYfmkAzjg7/GleHHh2n+AGH4kwGD7bD3eCE75kNw4+3yu4wTMRBgdf6IUnyQVPohPDZ/sEkwzDsCsrf6oHrngHDr88IJikGIbB/mf2obAxF+klyfjy/3xRnjA+B5JXGrI+Mf35t/4a33jke1zPCUecDdPXRDkGXg7BGbBzBQhj4vfM4NtRY+LnGFzxDkxeFXFemQxXvBOTV4UWYH5pC6nx/ByEK8GJSZGFmF8Gg2935TgvByHF+TkEqffnx/3d8Q5MiDg/RyB1ffh5JUnOy3tIXX9+3oRvF77Fb+VlpHI8/DFSOZiHf+cedIyw+1liKyVZd0fySkPWXdcP/+xHgiZF09dmUd7GribciS5kV6YL2oVOjc1wG/pc8Q7k1GQImixNjk2jcgfbU8MRZ0deXbagnenk1WlURbndZ0XBlhxuwmD5FLdasXksKGrOE9RCmrw6zXGLy4ySlnxBraXJK1Oo2V0OiqJgdrClSfi1nCauTKGmi+VGmwFl2wsFpcAnrkyhtrsCFE3BYNGjor1YUItq8uo0arsrQCto6M06VHaWCBLFEzGupKEzalG1o0yQiJ4cu8W1Bg2qd5YJjAgxrlAqoNapUbOrXJAonxqbQW1XBZQqBdRaFWp2lwtu8lPXZlCzuxxKtRIqjQq1XRWCRP50lKu1KijVStR1Vwgmmenrs6jeVQa1Tg2lSoGeUzuxpY9dWcgTxudHsuVW1qeqUJDNEURCYUGo4hZnY/jhUJiIlwNAKJoDiYTCYCTHs8cPByOSrUFjOY5wMCzJY+8fCUU2Ob8QGIZhuaikRuy4HJc6/kYITITl/HwG//2ZSGTT8eFgGEyYPTdxSQ+ORxhEwhGEw5ufH7PZ+FCYDTFRzCY8wl53ikI4GJIeH46AYRiiZEmMM5EIIhEGwfWQ5Hcs67MtOTwl6xPTX3737/CNh7+LlYVVUBQFZ8BOho944SV3ggMTV4Scb2F1JzoxcXnz8JIn0UXsMDfZDVic2Zzzw0dSO5T5FlYpzreVSnGb24LZKOfvtuY4L7wkNZ5vi5Xi/JCP1Ofjh4fciS5MiDkvJCUVPuOHzKQ4/2dS4TUBlwiPxcJTsu6+5PCUrLuutsNN+N67b6Ln1E688Y8vIaOU7LzW93gXNHo1KjpKkFqUtAnXoHRbITJKSYtu72O72d3WzXmSVXR7H90NnVGLgoYc5EV3p/PVc2ondCYtcmsyud3lfO17ZCf0Zh2yKtNR0pJP8L0Pd8Jg0SOjNAXlona1ALDn4U4YbWxDKXG7WgDoPtkBk92I5PwE1EpU2e16oAMWpwmJuQFJC++u+9tgdVsQyPRzoR6+dt63DXavFXHpPrTsJy28naNb4fDb4EvxSNZ5aj/aDGfAAU+iC9uGGwm+dbgR7gQnXPEOSYtv69AWeJPdcMTZ0THSQnBZnz/JKw1Zn5revP/b+G/f+Cvu9e0stQQXWVjFXGypVWlVCH4YF1l+xRZXwrIrssiKLcKE5Vb0eUhLrpILp0lz4eclLLeiz0NRlMAdJWXZ5VeRJSy5Ysvt7bjIsiv+mdiyCwC0kkYkdIs///8+hppd5H4XWZ++5JWGrM+cTn7tGO778mHoTDrU7alE6Tbhk3loI4T73hiG3qxD9a4y4sk8FAzj+FeG2SRyRzFqu4VP5uFgGPe9wfbnKNtWiC091QQ//pXDMNoMKG7OIzbPhUMsN9kNKNiSQ2yeC4ciOP6VwzA7TMirzUK76Mk5Ema5xWlCdlUGdoo2x0XCERx/4zCsbjMyy1OJ/haRcAT3fmkYNo8F6SXJ2PeI0GLLRBjc86VDsPtsSClIRN/ju4WcYTD6xYNwxNmRlBePgae6ifEj54bgincgISsOg6L+FQwDHH3lADxJLsRl+HDoTB/BD58dgC/FDX+qF8Mv9UOsgy/2wp/mhTfZjSOv7Cf4oRf6UNlZgoItOfjaj16TJ4zPoeSVhqxPTX/y1l/gm4/9Lvd0zy9JERN/9SBVpoLPpcqU8Dvp3ZZLlNHglymRen9+pz0pzi9TIsX5ORwpzs/R2LwWzN4UXh+j1cAVhZS6fnyL8O24VBkPfg5HqpOgxWnG/NTC5pz3M36+KKZT3zmONtF+F1mfDckrDVmfOb39tz8RhINmx+expZddDQQy/MhvyBaEm2ZvzqGxrwYUxZYBL2zMFfCZm3No6q8FRQHeJDeKW/K5CYHjA7WgaAruBCdKtxYI+Y05NO+vA0VTcAUcKG8r4iaM2Ps3768DTVNw+G2o7CjhJgyOH6gHraBh81hQtbOUmzD4XKGkYXWZUbO7XGARnr05h5YD9VCoFLA4TajbUymwAM/enEfLgXoo1UqYbEbU763iJozY9Ws5UA+VWgmj1YCGnmqBRXh2fB7N++ug0qigN+uxpbdGwOcmFtC8vw5qrQo6kxaNfbWCdrHzkwtoGqhje4IbtWjqr+UmDI7310Jr0ECj16B5f51gElmYWkRjXy10Ji00OjWGX+yX7G4o6/Ml2XIr664q5qxZmF6ATqIK68SVKTAMsDCzBGO0Yq2AX2X54uwSrIsWgk9enQYTYbA0tyzYE8LxsVt8eYHkU9dmEIkwWJ5fwfLCCsnHphEJR7CysCrYExLT9LUZhEMRrCyuEv2xAXbvQjgYxsriKhZnFgk+c2MWoY0QVrEmzW/OIbjB2oDFT/UAO3EE14OIhMNYmFqQ5BtrQdDBMOYn5wk+PzHP9linKKK/OQDMTc6zBSYZhljVAMD81AK7V4dhcPPiOFaX1qCWqCYs6/MjOTwl61PTP/zXH+KtE9/G3OQCaAUNd4KTaNITa5JE0xQ8yW6iiVCsiipFUfCleIgmR7EdzhRFwZ/mxbX3bwi534aZqEU1Lt1HcGfAgamoLTSQ4cPYe0LOt41Kcb7FNJDpx9i71wXck+jE+OUP4TxbrRT3Jrtw8+LmnN84Ser8+I2bJDmv8VNchg/XPoxLXL+4dC+uvX+T+O+YTn37Psle6LLuvuTwlKzPnLb0VON7772JQ2f68I1/O4f0kmTid3aMboVKo0RBYy4ScwIkv6cVaq0KefVZSC5IIHjHKMtzqjOQVkwev3OkFRq9BlmV6cgoIy3A7UebodVrkFGagqxKsspu29Fm6IxapBYlIbc2i+DbhhuhN2mRnJ+AgoZsCd4Eg0WPxJyAZBXerUNbYLTqEZ/pR+nWAoK3Dm2ByW6EP82L8jbS4ts0UAezwwRfipvbHc9XY18trG4zPIkuVEskoRt6qmHzWOAMOFDXXUnyfVVw+G1w+G2o30vyuu5KOOPssHutaBAZEWT9ekheaci6a/rW47+LP/rCn3KvtQYt1pZv5QzElk+tQSMoS3JbLrJ88pPgAGlh1eg1WBdxflVYfq8PqfFqnZoN5cS4yKJKjBdVeRVbiMWfUWwhBhW1uMa4yCIMCG230vyWjVhsEQaEtl+xBfgjcd4xVWolXvzT0yjbRpakl3X39ZleaVAU1UNR1M8oiopQFLXpSVIU1UZR1LsURX1AUdTpT/McZX3yGjk3hAe/MQKj1YC6PZUobxPeTCLhCB742jEYbQbU7C5H1c4ySW6yG1HZUYK6PcIn30iEwcmvH4PJYWQtuKLNb0yEwQNfOwaz04Tilny0DNaT/K2jsLjMKGzMxfYjTRLjj8LqNiOvLouocsswwIk3j8LmsSCnOgM7RVVuGYbBia8ehd1nQ2Z5GvY8RPafuO/Lw3DE2ZFekoKeR0X9Jxjg3i8dgivegdTCJAyc7ibGj7w+BHeCE0l5CTjw9F6SvzYIb7IbCdkBDL3QQ/DDL++HP9WDQKYfw2dJi+3w2X4EMnzwp3lx5OUBgh99ZT+29FajamcpvvXTL8kTxq+B7spKg6KobAARAL8D4FGGYYilAUVRCgDvAdgKYAzAvwIYYBjm5x92bHml8fnR//2l/4Zvn/597klYyqLJf3r9OJz/dM23k0pxqfH8p39JrlNhYzXKeRVvY+KvXswOI9cDPSb+6sfkMGJRxPkWX75d9qNyfhVhvp2X4zyLsBTnW4QNVgOW5z6M6wkzwOPfP4GtQ+ROc1mfPX2mVxoMw7zDMMy7t/m1CgAfMAxzgWGYDQB/CGD3bcbI+hzp5z98V7BjeWFqEduPNIGiKCTlxaOkNV8Q7liYWkTb0WZQNIWE7ABKtxcSvP1oM2gFjUCGHxXtxYJwzPzUItqPtYBW0PCneVG1o1TAF6YW0THSAoVSAW+yGzW7ywXhIpa3QqFSwJPoQl13BTdhAMDCNMuVaiVcAQfq91UJwl0L00voGGnF/2nv3sOjqs8Ejn/fcklIiCQhkAC5wYMgN2+g622FQr3AtvXS6pZtBYRKqbZ9cB/axbpVa0XKFmupFZRaCq3XB3m2RdcuihW3cjUgIYQkJORCQiCEO4GQBHj3j3MSZjJJOIFkZgLv53nmmTPznjnzzi/z5HfO+f3mPV26dqZn3zjGPHiL3+my4/XxiC7EJ8UyduJtflN8jx+qYsIj4+jarSuxvXsw7tv/HBAf/91xRER1pUdCDF95aLTfjLGqwycYP20ckdERxMR3545Jo/2mCFcdPsHdU50xm+5x0dw1ZYzfFOETR05w98NfJuqKbkT3iOKuh7/cKH6SOyePITo2iqiYbjy2YCpjJ97W7N/fdEzhPOW2H1Dq87gMCBx5A0RkOjAdIDU1cHDUdBw7MwpRVSqKK/lSp8B9mvyMQvSsUlGyny6RgV/f/C1FnD1zlsrSA01O4S3YUsjZM2c5UHaQ7rFRTcSLOHP6DAfLD9EjISYgvuuLIs7UOfG4xMApvoWZxZyuPc2hfYc50Kh4H0DhthLqak9zuOIoFY2K/wEUZZVQV1PHkcpjAcUNnXgptdW11NXUsbfRzDOAkuxSak7WUltdy95GM8sASnLKOHWihpqTNQEzzwBKc/c0dERl+U3E88obOpqyneUB8T0FexuONrLX5XL7AzcRnxQXsJ7puNrtSENEVovI9iZuXo8Wmiqw3+S5NFVdrKqjVHVUr169LjxpE1R3PTyW3qkJgDNImjyoL0XbSgCorjpFYWYJvdOcv2fnLp1IuaofuzKLAag5WcuuL4pJdOOdOncidUg/Cr4ocuLVteRvKaTPgN6AM6CcNjSZ/C1OvPZUHTszCukzINGJf0lIH5bMzs2FgFNCPe/zXfQdmHQuPjyFvIxdgFPSJHdTAf2u7AM4g9r9R6SSu6kAcEqO5GzMJ3lQo/jGfMAZj8nZsJOUwX0b2qP/1ankbDgX37E+j9QhyT7xNHI27ASc8ZQd6/JIHdKvIT7g6lR2rHfjCtnr8kgbluK3/R3r8s7F1+aR7hsfkUr2unMnALLX5pI+PLWFeB7pwxu9fu25+Jp31pGxKhNzaWm3Iw1Vvdh6x2VAis/jZCBw18Z0WP804XqW5PyG/1m8mhsnXM/Sn70VsPe6aPM8Pn79H4y88xrefH4Fpbl7/OIL1s/hH8s3cO3Y4az49XvszvGPv/DJz1m3MoOrbx/CyoWrKNlR5hef9+HPyFi1lSE3D2LVHz+hONs//tx7s8lcs4NBowaw5u21FG8v9Ys/vWIWOet3MuCaNNb99XOKsnb7xX/61kwKthSRNjSZzR9uC4j/eOlj7M7ZQ7+BSWz/LJc/bHvTLz7z1ensK9xP77QE8jcX8uqsP/nFf/DSNA7tPUJcUiy7c8p4+UdL/OLfmz+JqsMniInvTkXxfn4zY7FffOrz/0btqToioyM4sv8o86cu9ItPevoBEKFzl05UH69m7nd+6xef+MT9REZHoGed62/84sFfYy5t4Xx66nPgShHpD+wBvgUEVkAzHVpEtwjud6+NnTY0BVjfEEsZ3JeomG7c96MJAKQPTfGr5Np3YBLde0Rx7w+dwn+pjeJJ/XsTHRvNPY/d7cSHJPtNw01M60X3uGi+9n1nVlPOkHy/eK+UnlzRM4avfu8OAHZtLfabApvQL54eCTEN14MozS33m+Ia3yeO2F49GD/NKWy4r7jSb+A+LrEHcYmxDHF/D3K44qhf5dzYXlcQnxTLiNuc33ucOHrSrzLvFT1jiO8Tx3VjnZLtp2tP+w3cx8RFk9A3rqFk+5bV2/ym/XaPjaZXcs+G37NkfprtN2056opu9E5NYPANTsn57Wtz/Qbeu3WPJDGtF8NucUrO527K9xtYj4yOIDHdjvwvOaoa9BtwH86RRA1QAaxyn+8LfOCz3gScGVS7gCe9bHvkyJFqOq6sz3L038c8pctfWKl1tXUB8ez1eTpr7NP69ry/aG1NbUA8d1O+zhr3jL4xZ4XWnAqM79y8S39yx8/1z88u15rqmoB4wdYi/Y+7fqHLnn5Hq0+cCogXZpXoE+Of0yVPvqknq6oD4sXZu/Wn/zJHX5v9up48fjIgvju3TP/za3P11VnLtOroiYB4WX65PnXvPF30+B+16khVQLx81z595hu/0t/98A967NDxgPjeogp99sEXdMGjv9ejB44FxCt2V+pzE1/UF6e/oof3HwmIV5Yd0LnfWaDzpy3UQxWB8QPlh3Te5Jd03pSX9ED5oYD4oX2Hdf7Ul3XuQwu0cs/BgLgJX0CGevgfaz/uM8YYE95Tbo0xxnRM1mkYY4zxzDoNY4wxnlmnYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPLNOwxhjjGeX3C/CRaQSKAnBWycAgbWuw5/lHXwdNXfLO7iCnXeaqp63WNgl12mEiohkePkJfrixvIOvo+ZueQdXuOZtp6eMMcZ4Zp2GMcYYz6zTaDuLz79KWLK8g6+j5m55B1dY5m1jGsYYYzyzIw1jjDGeWadhjDHGM+s0LoCIPCAi2SJyVkSanRInIsUikiUiW0UkLC4n2Irc7xaRPBEpEJHZwcyxmXziReQjEcl37+OaWe+M295bRWRlsPP0yaPF9hORCBF5x41vFJH04GfZNA+5TxGRSp92/m4o8myU0xIR2S8i25uJi4j81v1M20Tk+mDn2BwPuY8RkaM+7f1UsHP04+WasHYLuMb5EGAwsAYY1cJ6xUBCqPNtbe5AJ5zrsg8AugKZwNAQ5/1fwGx3eTYwr5n1qsKgjc/bfsCjwCvu8reAd0KddytynwL8LtS5NsrpduB6YHsz8QnA3wABbgI2hjrnVuQ+Bng/1HnW3+xI4wKoao6q5oU6jwvhMfcbgQJVLVTVWuBt4J72z65F9wDL3OVlwL0hzOV8vLSf7+d5FxgnIhLEHJsTjn/781LV/wMOtbDKPcCf1LEBiBWRPsHJrmUecg8r1mm0LwU+FJHNIjI91Mm0Qj+g1OdxmftcKCWq6l4A9753M+tFikiGiGwQkVB1LF7ar2EdVT0NHAV6BiW7lnn923/DPc3zroikBCe1ixKO3+nWuFlEMkXkbyIyLJSJdA7lm4czEVkNJDURelJV/+pxM7eqarmI9AY+EpFcd6+iXbVB7k3t8bb73OyW8m7FZlLdNh8A/F1EslR1V9tk6JmX9gtJG3vgJa/3gLdUtUZEZuAcMY1t98wuTri2txdbcOpCVYnIBOAvwJWhSsY6jWao6lfaYBvl7v1+EflvnEP/du802iD3MsB37zEZKL/IbZ5XS3mLSIWI9FHVve5phf3NbKO+zQtFZA1wHc45+mDy0n7165SJSGegB+FxiuK8uavqQZ+HvwfmBSGvixWS73RbUNVjPssfiMhCEUlQ1ZAUYbTTU+1ERKJFJKZ+GbgTaHJ2RBj6HLhSRPqLSFecgdqQzURyrQQmu8uTgYAjJhGJE5EIdzkBuBXYEbQMz/HSfr6f55vA39Ud9Qyx8+beaCzg60BOEPO7UCuBSe4sqpuAo/WnO8OdiCTVj3eJyI04/7cPtvyqdhTqkfiOeAPuw9lzqQEqgFXu832BD9zlATgzTzKBbJxTQx0id/fxBGAnzl56yHPHOd//MZDv3se7z48CXnOXbwGy3DbPAqaFMN+A9gOeBb7uLkcCy4ECYBMwINRt3Irc57rf6UzgE+CqMMj5LWAvUOd+v6cBM4AZblyAl93PlEULsx7DMPcf+LT3BuCWUOZrZUSMMcZ4ZqenjDHGeGadhjHGGM+s0zDGGOOZdRrGGGM8s07DGGOMZ9ZpmEueiKSISJGIxLuP49zHae30fjNEZJK7PEVE+vrEXhORoW30Pve2tuKpiKxurkKwMV7YlFtzWRCRnwADVXW6iLwKFKvq3CC87xpglqq2eWl8EVmH89sJz78MFpHJQLKqzmnrfMzlwY40zOXiReAmEZkJ3Aa80HgFEUkXkVwRWeZTjC/KjY0TkS/EuT7KEp9fnv9SRHa46893n3tGRGaJyDdxfnw321hTAAACiklEQVT4hnsdhG4iskbc65iIyER3e9tFZJ5PHlUiMsctULdBRBKbyHUQUFPfYYjIUhFZJCKfiEihiIx288wRkaU+L10JTGyTFjWXJes0zGVBVeuAH+N0HjPVKfvdlMHAYlW9GjgGPCoikcBS4F9VdQROzbbvu6e77gOGues/1+g93wUygG+r6rWqWl0fc09ZzcMp9HctcINPVd5oYIOqXoNTq+yRJvK8FaeQna84d3uP4xQVfBEYBowQkWvdnA4DESISDhV1TQdknYa5nIzHKdcwvIV1SlV1rbv8Os5RyWCgSFV3us8vw7lwzjHgFPCaiNwPnGxFLjcAa1S1Up3S6G+42wSoBd53lzcD6U28vg9Q2ei599Q535wFVKhqlqqexSlB4buN/ThlY4xpNes0zGXB3dO+A+eqbY+3cAGexoN8StNltXH/2d8IrMC5KNT/tialFmJ1em6w8QxNV6Ouxqlf5avGvT/rs1z/2Hcbke7rjWk16zTMJc+tELoI57TUbuBXwPxmVk8VkZvd5YnAZ0AukC4iA93nHwI+FZHuQA9V/QCYiXOaqbHjQEwTz28ERotIgoh0ct/r01Z8rBxg4HnXasRtiyScSxEb02rWaZjLwSPAblX9yH28ELhKREY3sW4OMFlEtgHxwCJVPQU8DCwXkSycPfdXcDqD9911P8UZS2hsKfBK/UB4/ZPqlOV+AqdKbCawRb1f3AucsY7r6ktmt8JInPGS0618nTGATbk1poGIpAPvq2pLYx5hQ0QW4IxjrG7la1aq6sftl5m5lNmRhjEd1/NAVCtfs906DHMx7EjDGGOMZ3akYYwxxjPrNIwxxnhmnYYxxhjPrNMwxhjjmXUaxhhjPPt/4+W6FhppJ+AAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "from ctapipe.visualization import CameraDisplay\n",
@@ -426,32 +190,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<ctapipe.visualization.mpl_camera.CameraDisplay at 0xb1f185c18>"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEWCAYAAACaBstRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGAVJREFUeJzt3XuYJXV95/H3BxBQEeQmojCMl9EsKOBug/FRYVeYDVk3QIwoeGF0jUSMy6pPzLIPxhhidr3Fja6IsK5hNCo6GGVQvAwDqNmIoVEER0QuGpkFYfCKclGc7/5xasKx7cuvZ/pcZvr9ep7z9KmqX1d9Ts88/emqOqcqVYUkSS22G3UASdLWw9KQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDS1qSS5P8qMkO/XN2y/Jx5PcmeQnSa5N8pIkz0zys+7x8yTVN/2zJEu69d3bTd+Z5O+T7Nu37jcm+bu+6SQ5Lck3unWuT7IqyZOH/bOQWlgaWrSSLAWeCRRwbN+iDwK3AAcAewInA7dX1Zeqapeq2gU4qBv78E3zqup73bxXdWMeD+wCvH2WGO8E/gtwGrAH8ATgk8Czt/wVSgvP0tBidjJwBXAesKJv/mHAeVX186q6v6q+VlWfme/Kq+rH9Arg0OmWJ1kG/DFwUlVdWlX3VdXdVfWhqnpzN+bZSb6W5KdJbknyxr7vX9rt7by0W/ajJK9IcliSa5L8OMm755tbms0Oow4gjdDJwDuArwBXJNmnqm6nVyRnJflfwD/27UHMS5I9gecAN84w5ChgfVX90yyr+XmXcx3wJGBNkqur6pN9Y54KLAOOAFYDnwWOBh4EfC3Jqqr6wua8Bmkq9zS0KCV5Br3DTx+rqquAm4AXdItPAL4E/BnwnSRXJzlsHqt/V5KfAHcCewH/eYZxewK3zbaiqrq8qq6tqo1VdQ3wEeDIKcP+sqrurarP0yuZj1TVHVX1/7rX8ZR5ZJdmZWlosVoBfL6q7uymP9zNo6p+VFWnV9VBwD7A1cAnk6Rx3adV1W7AwcDuwH4zjPsBsO8MywBI8tQklyXZ0BXRK+gVUb/b+57fM830Lo25pTlZGlp0kjwYeB5wZJLvJ/k+8BrgkCSH9I/tSuXtwKPonahuVlXXAm+id6hrusJZC+yXZGKW1XyY3iGn/bsiei/QWl7SgrM0tBgdD/wKOJDeSepDgX9F71DOyUnekuRJSXZI8jDgVODGqvrBZmxrJfAIfv3dWQBU1Q3Ae4CPJPm3SXZMsnOSE5Oc3g17GPDDqro3yeE8cAhNGglLQ4vRCuBvq+p7VfX9TQ/g3cALgV2BTwA/Bm6md+7jN37pt6iqXwDvond+ZDqndds9q9veTcDvAxd1y18JnJnkLuANwMc2J4e0UOJNmCRJrdzTkCQ1szQkSc0sDUlSM0tDktRsm7uMyF577VVLly4ddQxJ2qpcddVVd1bV3nON2+ZKY+nSpUxOTo46hiRtVZL8c8s4D09JkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSp2UhLI8kxSa5PcmPf/QP6l782yTeTXJNkbZIDRpFTktQzsg/3Jdme3j0ElgPrgSuTrK6qb/YN+xowUVV3JzkVeCvw/OGn1bhbvt0JQ9vWmo2rhrq9UVizcdWoI2hMjXJP43B6d0O7ubtRzfnAcf0Dquqyqrq7m7yCme+1LEkaglGWxqOBW/qm13fzZvIy4DMDTSRJmtUorz2VaeZNexvBJC8CJoAjZ1h+CnAKwJIlSxYqnyRpilHuaawH9u+b3g+4deqgJEcDZwDHVtV9062oqs6tqomqmth77zkv0ihJ2kyjLI0rgWVJHpNkR+BEYHX/gCRPAc6hVxh3jCCjJKnPyEqjqu4HXgV8DrgO+FhVrUtyZpJju2FvA3YBViW5OsnqGVYnSRqCkd5Po6ouBi6eMu8Nfc+PHnooSdKM/ES4JKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmO4w6gLQQ1mxctU1vTxoXloYW3PLtThjq9tZsXDXUbQ57e6Mwip+ptg4enpIkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzUZaGkmOSXJ9khuTnD7N8iOSfDXJ/UmeO4qMkqQHjKw0kmwPnAX8LnAgcFKSA6cM+x7wEuDDw00nSZrODiPc9uHAjVV1M0CS84HjgG9uGlBV3+2WbRxFQEnSrxvl4alHA7f0Ta/v5s1bklOSTCaZ3LBhw4KEkyT9plGWRqaZV5uzoqo6t6omqmpi77333sJYkqSZjLI01gP7903vB9w6oiySpAajLI0rgWVJHpNkR+BEYPUI80iS5jCy0qiq+4FXAZ8DrgM+VlXrkpyZ5FiAJIclWQ+cAJyTZN2o8kqSIFWbdRphbE1MTNTk5OSoY0jSViXJVVU1Mde4Ub7lVkOyfLsTRh1hoNZsXDXU1zjs7Y3CYviZrtm4aqjb21Z4GRFJUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc3m/HBfku2AQ4BHAfcA66rq9kEHkySNnxlLI8njgP8KHA3cAGwAdgaekORu4BxgZVV5gyRJWiRm29N4E3A28Ec15QJVSR4BvAB4MbBycPEkSeNkxtKoqpNmWXYH8DcDSSRJGlst5zS2B54NLO0fX1XvGFwsSdI4arnK7UXAvcC1gOcvJGkRaymN/arq4IEnkSSNvZbPaXwmyb8feBJJ0thr2dO4AvhE93mNXwIBqqp2HWgySdLYaSmNvwaeBlw79a23kqTFpeXw1A3ANywMSVLLnsZtwOVJPgPct2mmb7mVpMWnpTS+0z127B6SpEVqztKoqr8YRhBJ0vib8ZxGknOTPHmGZQ9N8p+SvHBw0SRJ42a2PY33AH/WFcc3eOAqt8uAXYH3Ax8aeEJJ0tiY7YKFVwPPS7ILMAHsS+9+GtdV1fVDyidJGiMt5zR+Blw++CiSpHHn7V4lSc0sDUlSM0tDktSs5SZMTwBeBxzAr9+E6VkDzCVJGkMtnwhfBbwX+N/ArwYbR5I0zlpK4/6qOnvgSSRJY6/lnMZFSV6ZZN8ke2x6DDyZJGnstOxprOi+vq5vXgGPXfg4kqRx1vLhvscMI4gkafy1vHvqQcCpwBHdrMuBc6rqlwPMJUkaQy2Hp84GHkTvAoYAL+7m/eGgQkmSxlNLaRxWVYf0TV+a5OuDCiRJGl8t7576VZLHbZpI8lgW6PMaSY5Jcn2SG5OcPs3ynZJ8tFv+lSRLF2K7kqTN07Kn8TrgsiQ3A6H3yfCXbumGk2wPnAUsB9YDVyZZXVXf7Bv2MuBHVfX4JCcCbwGev6XbliRtnpZ3T61Nsgx4Ir3S+FZV3bcA2z4cuLGqbgZIcj5wHNBfGscBb+yeXwC8O0mqqhZg+5KkeZqxNJI8q6ouTfKcKYsel4Sq+vst3PajgVv6ptcDT51pTFXdn+QnwJ7AnVOyngKcArBkyZItjCVJmslsexpHApcCvzfNsgK2tDQyw3rnO4aqOhc4F2BiYsK9EEkakNlu9/rn3dMzq+o7/cuSLMQH/tYD+/dN7wfcOsOY9Ul2AHYDfrgA25YkbYaWd099fJp5FyzAtq8EliV5TJIdgROB1VPGrOaBy5g8F7jU8xmSNDqzndP4LeAgYLcp5zV2BXbe0g135yheBXwO2B54f1WtS3ImMFlVq4H/A3wwyY309jBO3NLtSpI232znNJ4I/Efg4fz6eY27gJcvxMar6mLg4inz3tD3/F7ghIXYliRpy812TuNC4MIkT6uqLw8xkyRpTM12eOpPq+qtwAuSnDR1eVWdNtBkkqSxM9vhqeu6r5PDCCJJGn+zHZ66qPu6ctO8JNsBu1TVT4eQTZI0ZuZ8y22SDyfZNclD6V3i4/okr5vr+yRJ256Wz2kc2O1ZHE/vnU5L6N1TQ5K0yLSUxoO6u/cdD1zY3bHPD9hJ0iLUUhrnAN8FHgp8MckBgOc0JGkRyuZclSPJDlV1/wDybLGJiYmanPQNX5I0H0muqqqJucbNeT+NJLsBfw4c0c36AnAm8JMtSqihWb7dtv2h+jUbVw31NQ57e6OwGH6mazauGur2thUth6feT+/SIc/rHj8F/naQoSRJ46nldq+Pq6o/6Jv+iyRXDyqQJGl8texp3JPkGZsmkjwduGdwkSRJ46plT+NUYGV3biP0LlG+YvZvkSRti+Ysjaq6Gjgkya7dtG+3laRFquUyInsmeRdwOXBZkncm2XPgySRJY6flnMb5wAbgD+jdcnUD8NFBhpIkjaeWcxp7VNVf9k2/KcnxgwokSRpfLXsalyU5Mcl23eN5wKcHHUySNH5aSuOPgA8D93WP84HXJrkriSfFJWkRaXn31MOGEUSSNP5a9jQkSQIsDUnSPMxYGkkuTrJ0eFEkSeNutj2N84DPJzmju3OfJGmRm/FEeFV9LMmngTcAk0k+CGzsW/6OIeSTJI2Rud499Uvg58BOwMPoKw1J0uIzY2kkOQZ4B7Aa+NdVdffQUkmSxtJsexpnACdU1bphhZEkjbfZzmk8c5hBJEnjz89pSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmqapRZ1hQExMTNTk5OeoYkrRVSXJVVU3MNa7lHuHSvCzf7oShbm/NxlVD3eawtzcKo/iZauvg4SlJUrORlEaSPZKsSXJD93X3GcZ9NsmPk3xq2BklSb9pVHsapwNrq2oZsLabns7bgBcPLZUkaVajKo3jgJXd85XA8dMNqqq1wF3DCiVJmt2oSmOfqroNoPv6iC1ZWZJTkkwmmdywYcOCBJQk/aaBvXsqySXAI6dZdMZCb6uqzgXOhd5bbhd6/ZKknoGVRlUdPdOyJLcn2beqbkuyL3DHoHJIkhbOqA5PrQZWdM9XABeOKIckaR5GVRpvBpYnuQFY3k2TZCLJ+zYNSvIlYBVwVJL1SX5nJGklScCIPhFeVT8Ajppm/iTwh33T3j1QksaInwiXJDWzNCRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDUlSM0tDktTM0pAkNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVIzS0OS1MzSkCQ1G8md+7RtW7Nx1agjaAH476jpuKchSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJamZpSJKaWRqSpGaWhiSpmaUhSWpmaUiSmlkakqRmloYkqZmlIUlqZmlIkppZGpKkZpaGJKmZpSFJajaS0kiyR5I1SW7ovu4+zZhDk3w5ybok1yR5/iiySpIeMKo9jdOBtVW1DFjbTU91N3ByVR0EHAP8TZKHDzGjJGmKUZXGccDK7vlK4PipA6rq21V1Q/f8VuAOYO+hJZQk/YZRlcY+VXUbQPf1EbMNTnI4sCNw0xCySZJmsMOgVpzkEuCR0yw6Y57r2Rf4ILCiqjbOMOYU4BSAJUuWzDOpJKnVwEqjqo6eaVmS25PsW1W3daVwxwzjdgU+Dby+qq6YZVvnAucCTExM1JYllyTNZGClMYfVwArgzd3XC6cOSLIj8AngA1W1arjxtLVZs3G4/0WGvT1pXIzqnMabgeVJbgCWd9MkmUjyvm7M84AjgJckubp7HDqauJIkgFRtW0dzJiYmanJyctQxJGmrkuSqqpqYa5yfCJckNbM0JEnNLA1JUjNLQ5LUzNKQJDWzNCRJzSwNSVKzbe5zGkk2AP88oNXvBdw5oHUPw9aeH7b+12D+0dra88PgXsMBVTXnlcS3udIYpCSTLR9+GVdbe37Y+l+D+Udra88Po38NHp6SJDWzNCRJzSyN+Tl31AG20NaeH7b+12D+0dra88OIX4PnNCRJzdzTkCQ1szQkSc0sjVkk2SPJmiQ3dF93n2bMAUmu6m4StS7JK0aRdTqN+Q9N8uUu+zVJnj+KrDNpeQ3duM8m+XGSTw0743SSHJPk+iQ3Jjl9muU7Jflot/wrSZYOP+XMGvIfkeSrSe5P8txRZJxNQ/7XJvlm939+bZIDRpFzJg35X5Hk2u73zj8kOXBo4arKxwwP4K3A6d3z04G3TDNmR2Cn7vkuwHeBR406+zzyPwFY1j1/FHAb8PBRZ5/Pa+iWHQX8HvCpMci8PXAT8Nju/8fXgQOnjHkl8N7u+YnAR0ede575lwIHAx8AnjvqzJuR/98BD+men7oV/vx37Xt+LPDZYeVzT2N2xwEru+crgeOnDqiqX1TVfd3kTozX3ltL/m9X1Q3d81uBO4A5PxU6RHO+BoCqWgvcNaxQczgcuLGqbq6qXwDn03sd/fpf1wXAUUkyxIyzmTN/VX23qq4BNo4i4Bxa8l9WVXd3k1cA+w0542xa8v+0b/KhwNDe0TROv+DG0T5VdRtA9/UR0w1Ksn+Sa4Bb6P0lfOsQM86mKf8mSQ6n95fNTUPI1mper2FMPJre/4VN1nfzph1TVfcDPwH2HEq6ubXkH2fzzf8y4DMDTTQ/TfmT/HGSm+jtjZ82pGzsMKwNjasklwCPnGbRGa3rqKpbgIOTPAr4ZJILqur2hco4m4XI361nX+CDwIqqGupfjwv1GsbIdHsMU/8SbBkzKuOcrUVz/iQvAiaAIweaaH6a8lfVWcBZSV4AvB5YMehgYGlQVUfPtCzJ7Un2rarbul+qd8yxrluTrAOeSe+Qw8AtRP4kuwKfBl5fVVcMKOqMFvLfYEysB/bvm94PmLr3uWnM+iQ7ALsBPxxOvDm15B9nTfmTHE3vD5Mj+w4xj4P5/vzPB84eaKI+Hp6a3WoeaO8VwIVTByTZL8mDu+e7A08Hrh9awtm15N8R+ATwgapaNcRsreZ8DWPoSmBZksd0P98T6b2Ofv2v67nApdWd1RwDLfnH2Zz5kzwFOAc4tqrG7Q+RlvzL+iafDdwwtHSjfqfAOD/oHWNe2/2DrAX26OZPAO/rni8HrqH3DodrgFNGnXue+V8E/BK4uu9x6Kizz+c1dNNfAjYA99D7S+13Rpz7PwDfpnd+6Ixu3pn0fkkB7AysAm4E/gl47Kh/1vPMf1j3c/458ANg3agzzzP/JcDtff/nV4868zzzvxNY12W/DDhoWNm8jIgkqZmHpyRJzSwNSVIzS0OS1MzSkCQ1szQkSc0sDW3zusu8fCfJHt307t30QK5s2l2B9OTu+Uu6KwVsWva+hboiaZLjk7xhnt9zyUxXCpZa+JZbLQpJ/hR4fFWdkuQc4LtV9T+GsN3LgT+pqskBrPsf6b1v/855fM8KYL+q+quFzqPFwT0NLRb/E/jtJK8GngH89dQBSZYm+VaSld19Fi5I8pBu2VFJvtbdw+D9SXbq5r+5774Mb+/mvTHJn3T3mZgAPtTd9+DBSS5PMtGNO6lb3zeSvKUvx8+S/FWSrye5Isk+02R9AnDfpsJIcl6Ss5NcluTmJEd2Oa9Lcl7ft64GTlqQn6gWJUtDi0JV/RJ4Hb3yeHX1Ljk9nScC51bVwcBPgVcm2Rk4D3h+VT2Z3jXbTu0Od/0+vU/jHgy8aco2LwAmgRdW1aFVdc+mZd0hq7cAzwIOBQ5Lsumy7w8FrqiqQ4AvAi+fJufTga9Ombd7t77XABd1r/Ug4MlJDu0y/QjYKcm4XFFXWxlLQ4vJ79K7ydSTZhlzS1X93+7539HbK3ki8J2q+nY3fyVwBL1SuRd4X5LnAHdPXdksDgMur6oN1bs0+oe6dQL8Ath0B8Kr6N3waKp96V02pd9F1TvefC1we1VdW70rFq+bso476N1wS5o3S0OLQveX9nLgt4HXdFfMnc7Uk3zF9JeqpvtlfzjwcXo3h/rsfCLNsuyX9cDJxl8x/dWo76F3/ap+m67UurHv+abp/nXs3H2/NG+WhrZ53R3xzqZ3WOp7wNuAt88wfEmSp3XPTwL+AfgWsDTJ47v5Lwa+kGQXYLequhh4Nb3DTFPdBTxsmvlfAY5MsleS7bttfWEeL+s64PFzjpqi+1k8kt5tiaV5szS0GLwc+F5Vremm3wP8VpLpbrxzHbCiuxPjHsDZVXUv8FJgVZJr6f3l/l56ZfCpbuwX6J1LmOo84L2bToRvmlm9uxD+N3pXKP068NWqms9l378IPKUrgfn4N/TOl9w/z++TAN9yK/2LJEuBT1XVbOc8xkaSd9I7j3HJPL9ndfXuqS7Nm3sa0tbrvwMPmef3fMPC0JZwT0OS1Mw9DUlSM0tDktTM0pAkNbM0JEnNLA1JUrP/D36ums6OBsFpAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "CameraDisplay(subarray.tel[98].camera)"
    ]
@@ -469,45 +210,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAI4CAYAAABndZP2AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3Xl8lOW99/HPNZPJHpKQBLKx73uQCIhVUauotVpr1WIr4lJ7Wqu+OH1OtZvahed1Wmlt1T7HqqfFWqVorUcPbaWIBVzRYNn3JZCQhZB9z0zmev64QyQQlmzcyeT79jWvZK77nuv+3ZPI/HKtxlqLiIiISCjxuB2AiIiISHdTgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCIiIhIyFGCIyIiIiFHCY6I9CvGmDXGmLvdjkNEepYSHBFpZYzJNcY0GWOSTyjfaIyxxpjhXay/w8mFMWamMeZvxpgKY0yZMeYjY8wdXYmjg9ePMcbUGGP+dq6uKSJdpwRHRE50AJh/7IkxZgoQ5UYgxpgLgLeBtcBoIAn4BnB1J+oyxpjO/Jv3JaARuNIYk3aa+sPOpkxEzg0lOCJyoheABcc9vx34w7Enxph4Y8wfjDElxpiDxpgfHEscjDELjTHvGmOWGGPKjTEHjDFXtxxbDFwEPNXSIvJUS/l4Y8yqltaZXcaYm4+79mPA89ban1lrj1rHBmvtzS2vTTTGrGiJpbzl+8zjYl1jjFlsjHkPqANGHn+jxhhPS/wHjTFHWu4r/oT343bgaWAz8JUTXp9rjHnQGLMZqDXGhJ2i7CFjzD5jTLUxZrsx5oaW10e03PeU4+ocZIypN8aknOXPS0TaoQRHRE70ITDAGDPBGOMFbgH+eNzxJ4F4nGThEpxk6Pguo1nALiAZ+Dnw38YYY639PvAO8C1rbay19lvGmBhgFfASMAin5ej/GWMmGWOigQuAP58mVg/we2AYMBSoB5464ZzbgHuAOODgCccWtjwubbmf2ONfb4wZCswFXmx5LOBk84HPAQnW2sApyvbhJHfxwI+APxpj0qy1jcCfgK+eUN9b1tqS09y3iJyBEhwRac+xVpwrgJ3A4ZbyYwnPd6211dbaXOAXOEnEMQettc9aa5uB54E0YPAprnMtkGut/b21NmCt/QR4FadbKBHn36jCUwVprS211r5qra2z1lYDi3GSruMttdZua6nff8KxrwC/tNbut9bWAN8Fvnxc19ICYLO1djuwDJhkjJl+Qh1PWGvzrLX1pyqz1r5irS2w1gattcuBPcDMlnOfB249rvvsNpz3X0S6QP3DItKeF4B1wAiO657CaZUJp21LyEEg47jnRce+sdbWGWPAaRlpzzBgljGm4riysJbrlwNBnARpZ3svbmnleRy4CichAogzxnhbEiyAvFNcGyC9nXsJw0nIDuMkOM+23EuBMWYtTpfVv457TXv1tykzxiwA/h0Y3lIUi/NeYq1db4ypBS4xxhTijDV64zQxi8hZUAuOiJzEWnsQZ7DxNcBfjjt0FPDjJCbHDOXTFp4zVn3C8zxgrbU24bhHrLX2G9baOuAD4MbT1PdtYBwwy1o7ALi4pdyc5prHK+DkewkAxcaYOcAY4LvGmCJjTBFO99v8EwYPt1d/a5kxZhhOkvQtIMlamwBsPSHG53G6qW4D/mytbThNzCJyFpTgiMip3AVcZq2tPa6sGXgZWGyMiWv58P532o7ROZ1i2g70XQGMNcbcZozxtTzON8ZMaDn+HWChMeY/jDFJAMaYacaYP7Ucj8MZd1NhjBkIPNLBe1wGLDLGjDDGxAL/F1jeMm7mdpzxQROBrJbHZCCajs3iisFJeEpa4r+jpZ7jvQDcgJPk/AER6TIlOCLSLmvtPmttTjuH7gNqgf3AuzgDhH93ltX+GvhSy4ynJ1rGzVwJfBmnNaUI+BkQ0RLD+8BlLY/9xpgy4Bng2Jo0v8KZwn4UZ3D0mx28zd/xaXfcAaABuM8YEwncDDxprS067nGg5fzbz/YCLeN3foHTGlUMTAHeO+GcfOATnETonQ7eg4i0w1h7utZbERE5F4wxvwMKrLU/cDsWkVCgQcYiIi5rWSH6i8CJM7REpJPURSUi4iJjzE9wBh0/1tIFJiLdQF1UIiIiEnLUgiMiIiIhp9+OwUlOTrbDhw93OwwRERHpgA0bNhy11p5xr7Z+m+AMHz6cnJz2ZsCKiIhIb2WMOXFPuXapi0pERERCjhIcERERCTlKcERERCTk9NsxOCIi0rP8fj/5+fk0NGjvUOm4yMhIMjMz8fl8nXq9EhwREekR+fn5xMXFMXz4cIwxZ36BSAtrLaWlpeTn5zNixIhO1aEuKhER6RENDQ0kJSUpuZEOM8aQlJTUpdY/JTgiItJjlNxIZ3X1d0cJjoiIiIQcjcERERHXWWvJL69nY14F5XVNJEaHkzUkgczEKLUCSaeoBUdERFzV4G9m6fu5/Oqt3by7t4S9xTW8u7eEX721m6Xv59Lgb+503bGxsSeV7dq1i7lz55KVlcWECRO45557WLlyJVlZWWRlZREbG8u4cePIyspiwYIF7da7Zs0arr322pPKV6xYwfTp05k2bRoTJ07kt7/9LYsXL26t2+v1tn7/xBNPtFv3o48+ypIlS04qX7x4MZMmTWLq1KlkZWWxfv16brjhBrKyshg9ejTx8fGtdb///vv4/X4eeughxowZw+TJk5k5cyZ///vfO/gO9l1qwREREddYa1n20SG2FlSSkdC2tcZay9aCSpZ9dIiFc7pvJtb999/PokWLuP766wHYsmULU6ZMYd68eQDMnTuXJUuWkJ2d3aF6/X4/99xzDx999BGZmZk0NjaSm5vLuHHj+P73vw84CdfGjRs7HPMHH3zAihUr+OSTT4iIiODo0aM0NTXx2muvAU7CtWTJElasWNH6moceeojCwkK2bt1KREQExcXFrF27tsPX7qvUgiMiIq7JL69n6+FKMuJP7ooyxpARH8W2gkoOV9R32zULCwvJzMxsfT5lypRuqbe6uppAIEBSUhIAERERjBs3rlvqLiwsJDk5mYiICACSk5NJT08/5fl1dXU8++yzPPnkk62vGTx4MDfffDMA3/jGN8jOzmbSpEk88sgjra8bPnw43/ve97jgggvIzs7mk08+Yd68eYwaNYqnn366W+7lXFGCIyIirtmYV0GY15yydcYYg8cY/nWootuuuWjRIi677DKuvvpqHn/8cSoquqfugQMHct111zFs2DDmz5/Piy++SDAY7Ja6r7zySvLy8hg7dizf/OY3z9gSs3fvXoYOHcqAAQPaPb548WJycnLYvHkza9euZfPmza3HhgwZwgcffMBFF13EwoUL+fOf/8yHH37Iww8/3C33cq4owREREdeU1zUR4fWe9pyIMC/ldU3dds077riDHTt2cNNNN7FmzRpmz55NY2Njt9T93HPPsXr1ambOnMmSJUu48847u6Xe2NhYNmzYwDPPPENKSgq33HILS5cu7XR9L7/8Mueddx7Tp09n27ZtbN++vfXYddddBzgtW7NmzSIuLo6UlBQiIyO7LRk8F5TgiIiIaxKjw2lsPv0g4sZAM4nR4d163fT0dO68805ef/11wsLC2Lp1a7fVPWXKFBYtWsSqVat49dVXu61er9fL3Llz+dGPfsRTTz112rpHjx7NoUOHqK6uPunYgQMHWLJkCatXr2bz5s187nOfa7Og3rEuLY/H0/r9seeBQKDb7qenKcERERHXZA1JINBssda2e9xaS9Bapg9N6LZrvvnmm/j9fgCKioooLS0lIyOjy/XW1NSwZs2a1ucbN25k2LBhXa4XnJlfe/bsOeu6o6Ojueuuu7j//vtpanJavwoLC/njH/9IVVUVMTExxMfHU1xcHLIzqzSLSkREXJOZGMXkjHhnFlX8ybOoDlfWMzk9noyEqE7VX1dX12ZA8b//+7+Tn5/PAw88QGRkJACPPfYYqampHa579erVbepetmwZP//5z/n6179OVFQUMTExne5G+ulPf8qvfvWr1uevv/469913HxUVFYSFhTF69GieeeaZM9bxgx/8gIkTJxIZGUlMTAw//vGPmTZtGtOnT2fSpEmMHDmSCy+8sFMx9nbmVFlzqMvOzrY5OTluhyEiErJ27NjBhAkTznheg7+ZZR8dYltBJR5jiAjz0hhoJmgtk9LjmT9zKJG+04/TkdDU3u+QMWaDtfaMc/jVgiMiIq6K9HlZOGc4hyvq+dehT1cynj404aS1cUTOlhIcETmlhoAz8DAyLNLlSEKXtZb6QD0+jw+f1+d2OK4xxpCZGE1mYrTbobSxcuVKHnzwwTZlI0aMaF1grysWL17MK6+80qbspptual0UULpGXVQicpKgDbLywEreL3gfi+XCjAuZN3weHqN5Cd2pIdDAy7teZnf5brweL9eNuo4Zg2e4HVa3OdsuKpFT6UoXlf61EpGT7Cjbwdr8tQyKGcTg6MGsy1vHzrKdbocVctblO+9rWkwaiRGJvLbnNY7UHXE7LJGQoARHRE5ytO4oPq8Pr/Hi9XgJ84RRWl/qdlghp7C2kLjwOIwxhHvDMcZQ0dh3FlIT6c2U4IjISdJi0wgEAzQ1N9HU3ESzbSY1puPTaOX0hscPp6qpiuZgM3X+OgyG5Khkt8MSCQlKcETkJGMSxvD5kZ+nqqmKqqYqrh15LaMTRrsdVsiZkz6H2WmzKakvodk285UJX2Fg5EC3wxIJCUpwROQkxhjmZMzhh7N/yA9n/5A5GXM0VbcH+Dw+rh99PT+a8yMenPkg4wZ2z87TfZa1UHEICjc5X7thEowxhttuu631eSAQICUlhWuvvRaA4uJirr32WqZNm8bEiRO55ppr2LJlC1lZWWRlZTFw4EBGjBhBVlYWn/3sZ9u9Rm5uLsYYfvjDH7aWHT16FJ/Px7e+9S3AWYl47ty5ZGVlMWHCBO655x5WrlzZep3Y2FjGjRtHVlYWCxYsaPc6a9asIT4+vvU1x+J59NFHWbJkSYffm6VLl7bGd6Kamhq+/vWvM2rUKCZNmsTFF1/M+vXrO3wNN2mauIickpKac0PvM1BfAR8/B6X7wHjABiFpFJx/N0R1fpuGmJgYtm7dSn19PVFRUaxatarNtgwPP/wwV1xxBQ888AAAmzdvZsqUKWzcuBGAhQsXcu211/KlL33ptNcZOXIkK1as4Cc/+QkAr7zyCpMmTWo9fv/997No0SKuv/56ALZs2cKUKVOYN28eAHPnzmXJkiVkZ59+ctBFF13EihUrOvgudNzdd9/NiBEj2LNnDx6Ph/3797Njx44ev253UguOiIi4y1onuak4BPFDID7T+Vp+ED7+7y635Fx99dX89a9/BZztFObPn996rLCwsM12C1OnTu3UNaKiopgwYQLHlh9Zvnw5N9988ymvM2XKlE5d50yeffZZzj//fKZNm8aNN95IXV0d4CRckydPZtq0aVx88cWt5xcUFHDVVVcxZswYvvOd7wCwb98+1q9fz09/+lM8HidNGDlyJJ/73OcA+MIXvsCMGTOYNGlSm+0iYmNjefDBB5kxYwaf/exn+eijj5g7dy4jR47kjTfe6JH7PR0lOCIi4q7KPKflJjYVjrVmGQNxaVC6Fyrzu1T9l7/8Zf70pz/R0NDA5s2bmTVrVuuxe++9l7vuuotLL72UxYsXU1BQ0OXr5Ofn4/V6SU9Pbz22aNEiLrvsMq6++moef/xxKio6N1vunXfeae2iWrx48UnHv/jFL/Lxxx+zadMmJkyYwH//938D8OMf/5iVK1eyadOmNsnGxo0bWb58OVu2bGH58uXk5eWxbds2srKy8Hrb3x7jd7/7HRs2bCAnJ4cnnniC0lJnhmVtbS1z585lw4YNxMXF8YMf/IBVq1bx2muv8fDDD3fqfrtCCY6IiLirvtzpljqxq84Yp7y+vEvVT506ldzcXJYtW8Y111zT5ti8efPYv38/X/va19i5cyfTp0+npKSkU9e56qqrWLVqFcuWLeOWW25pc+yOO+5gx44d3HTTTaxZs4bZs2fT2NjY4WtcdNFFbNy4kY0bN7a74vHWrVu56KKLmDJlCi+++CLbtm0D4MILL2ThwoU8++yzNDc3t55/+eWXEx8fT2RkJBMnTuTgwYNnjOGJJ55g2rRpzJ49m7y8vNZdzsPDw7nqqqsAp4XqkksuwefzMWXKFHJzczt8r12lBEdERNwVleiMuTmxK8papzwqscuXuO666/g//+f/tOmeOmbgwIHceuutvPDCC5x//vmsW7euU9cIDw9nxowZ/OIXv+DGG2886Xh6ejp33nknr7/+OmFhYWzdurVT1zmdhQsX8tRTT7FlyxYeeeQRGhqc7VaefvppfvrTn5KXl0dWVlZrq0tERETra71eL4FAgEmTJrFp0yaCweBJ9a9Zs4a33nqLDz74gE2bNjF9+vTWa/h8vtbxZB6Pp7Vuj8dDIBDo9ns9EyU4IiLirvghzoDi6sJPkxxrnefJY5wxOV1055138vDDD5809uXtt99uHadSXV3Nvn37GDp0aKev8+1vf5uf/exnJCUltSl/88038fv9ABQVFVFaWtpmsHN3qa6uJi0tDb/fz4svvthavm/fPmbNmsWPf/xjkpOTycvLO2Udo0aNIjs7m0ceeYRj2znt2bOH119/ncrKShITE4mOjmbnzp18+OGH3X4P3UWzqERExF3GOLOlTppFNRqy7zy566oTMjMzW2dKHW/Dhg1861vfIiwsjGAwyN13383555/f6etMmjSpzeypY/7xj3/wwAMPEBnpbFz72GOPkZra/Ytn/uQnP2HWrFkMGzaMKVOmUF1dDcB//Md/sGfPHqy1XH755UybNq11plh7nnvuOb797W8zevRooqOjSUpK4rHHHmPq1Kk8/fTTTJ06lXHjxjF79uxuv4fuos02RUSkR3R4s01rnQHH9RVOt1R8ZrckN9J3dWWzTbXgiIhI72AMJAx1HiJdpARHRETkLGzZsqXNqsjgDNLt7hV+V65cyYMPPtimbMSIEbz22mvdep1QpwRHRETkLBy/wnFPmjdvXusKx9J5mkUlIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiFt8eLFTJo0ialTp5KVlcX69etZsWIF06dPZ9q0aUycOJHf/va3LF68uHUjS6/X2/r9E088cdr6p02bdtIWEB9++CGzZs0iKyuLCRMm8Oijj/L73/++tc7w8HCmTJlCVlYWDz30EEuXLiUlJYWsrCzGjx/P448/3lrXo48+ypIlS04bQyAQIDk5me9+97ttyjt6n48++igZGRlkZWUxceJEli1b1lrXwoUL+fOf/wyA3+/noYceYsyYMUyePJmZM2fy97///ax+HueMtda1B/A74Aiw9biygcAqYE/L18SWcgM8AewFNgPnHfea21vO3wPcfjbXnjFjhhURkZ6zffv2Dr8mGAzapkCTDQaD3RLD+++/b2fPnm0bGhqstdaWlJTY3Nxcm5aWZvPy8qy11jY0NNidO3e2eV1MTMxZ1b99+3Y7efJkm56ebmtqalrLx44dazdu3GittTYQCNht27a1ed2wYcNsSUlJ6/Pf//739t5777XWWnv06FGblJRkDx06ZK219pFHHrGPPfbYaeP461//aufMmWNHjhzZ+t41NTV1+D6Pv9bu3bttXFycbWpqstZae/vtt9tXXnnFWmvtgw8+aBcsWND6vhYVFdnly5efNsbOaO93CMixZ/E573YLzlLgqhPKHgJWW2vHAKtbngNcDYxpedwD/BeAMWYg8AgwC5gJPGKM6frObCIick4drT/Kk/96kkc/eJQn//UkR+uPdrnOwsJCkpOTWzd+TE5OJi4ujkAg0LpfVEREBOPGjetU/S+99BK33XYbV155JW+88UZr+ZEjR0hLSwOcTSwnTpx41nUmJSUxevRoCgsLz/o1y5Yt44EHHmDo0KGt+0NVV1d36T7HjBlDdHQ05eVtd3Ovq6vj2Wef5cknn2x9XwcPHszNN98MwDe+8Q2ys7OZNGkSjzzySOvrhg8fzve+9z0uuOACsrOz+eSTT5g3bx6jRo3i6aefPuu4zparCY61dh1QdkLx9cDzLd8/D3zhuPI/tCRwHwIJxpg0YB6wylpbZq0tx2n1OTFpEhGRXsxay0s7XqKysZKM2AwqGyt5acdLrZs9dtaVV15JXl4eY8eO5Zvf/CZr165l4MCBXHfddQwbNoz58+fz4osvtrtz9tlYvnw5t9xyC/Pnz2/TnbNo0SLGjRvHDTfcwG9/+9vWHbfPxqFDh2hoaGDq1KlndX59fT2rV6/m2muvbRNHV+/zk08+YcyYMQwaNKhN+d69exk6dCgDBgxo93WLFy8mJyeHzZs3s3btWjZv3tx6bMiQIXzwwQdcdNFFrV1eH374IQ8//PBZx3W23G7Bac9ga20hQMvXY+9sBnD89qf5LWWnKj+JMeYeY0yOMSanpKSk2wMXEZHOCQQDFNcVkxTltDYkRSVRXFdMIBjoUr2xsbFs2LCBZ555hpSUFG655RaWLl3Kc889x+rVq5k5cyZLlizhzjvv7HDdH3/8MSkpKQwbNozLL7+cTz75pLW14+GHHyYnJ4crr7ySl156iauuOvPf3cuXL2fSpEmMHDmyzcacZ7JixQouvfRSoqOjufHGG3nttddobm4G6NR9Pv7444wbN45Zs2bx6KOPnlUMx3v55Zc577zzmD59Otu2bWP79u2tx6677jrAWTRx1qxZxMXFkZKSQmRkJBUVFR2+1un0xgTnVNrbcc2epvzkQmufsdZmW2uzU1JSujU4ERHpvDBPGIOjB1NaXwpAaX0pg6MHE+bp+oL7Xq+XuXPn8qMf/YinnnqKV199FXA+ZBctWsSqVatayzpi2bJl7Ny5k+HDhzNq1Ciqqqra1DNq1Ci+8Y1vsHr1ajZt2kRpaelp67vlllvYtm0b77zzDt/+9rcpKio66zjeeusthg8fzowZMygtLeWf//xn6/GO3ueiRYvYtWsXy5cvZ8GCBSe1Po0ePZpDhw617lR+vAMHDrBkyRJWr17N5s2b+dznPtfm9ce6tDweT+v3x54HAl1LZk/UGxOc4pauJ1q+HmkpzweGHHdeJlBwmnIREekjjDHcOuFW4iPiOVxzmPiIeG6dcCumi7uJ79q1iz179rQ+37hxI4MHD2bNmjVtyoYNG9aheoPBIK+88gqbN28mNzeX3NxcXn/99dbuob/+9a+t3Wt79uzB6/WSkJBwVnVfcMEF3Hbbbfz6178+47lVVVW8++67HDp0qDWO3/zmNyxbtoyampou3ecXv/hFsrOzef7559uUR0dHc9ddd3H//ffT1NQEOGOd/vjHP1JVVUVMTAzx8fEUFxe7OrOqN+5F9QbOrKj/bPn6+nHl3zLG/AlnQHGltbbQGLMS+L/HDSy+EvguIr1QXnUeZQ1lJEclkxHbbk+qSK9lrWV/5X5q/DVkxGaQHJXcrfUnRyVz3/T7CAQDhHnCupzcANTU1HDfffdRUVFBWFgYo0eP5te//jVf//rX+frXv05UVBQxMTEsXbq0Q/WuW7eOjIwMMjI+/f/44osvZvv27RQWFvLCCy+waNEioqOjCQsL48UXX8Tr9Z51/Q8++CDnnXce3/ve90573l/+8hcuu+yyNq0h119/Pd/5znf45S9/yc9//vMu3efDDz/Mrbfeyte+9rU25T/96U/5wQ9+wMSJE4mMjCQmJoYf//jHTJs2jenTp7d2tV144YUdul53Ml0dwNWlixuzDJgLJAPFOLOh/gd4GRgKHAJustaWGec3/SmcAcR1wB3W2pyWeu4Ejv0WLLbW/v5M187OzrY5OTnde0Mip/FhwYf8777/xRiDxXLD6BvITs12OyyRs2KtZcX+FXxQ8AEe48FrvCycvJAR8SNO+ZodO3YwYcKEcxilhJr2foeMMRustWf8x9PVFhxr7fxTHLq8nXMtcO8p6vkdzpo6Ir1SIBjgbwf+xqDoQfi8PhqbG/nr/r8yY/CMbvkrVaSnlTWUsb5wPemx6XiMh8rGSlbmruTfpv2b26GJtKs3dlGJhBxrLUEbxOtxmqjDTBgBG3DKzNk3W4u4JRAMYFr+A/B5fDQGGl2O6txYvHgxr7zySpuym266ie9///vnNI57772X9957r03ZAw88wB133HFO4+grlOCInAM+r4/s1GzWF6wn2hdNXaCOizIuak14RHq75KhkhsUPY3/FfqLCoqgL1PHFMV884+ustX2+lfL73//+OU9m2vOb3/zG7RDOqa4OoVGCI3KOXDvyWlJjUimoKWBI3BDOG3Se2yGJnDWvx8tXJ3yV9YXrKWsoY2ziWCYmnX513sjISEpLS0lKSurzSY6cW9ZaSktLz3otoPYowRE5R8I8YcxOm+12GCHLWsuG4g28d/g9wr3hzBsxj5HxI90OK6REhkVyyZBLzvr8zMxM8vPz0cKq0hmRkZFkZmZ2+vVKcEQkJGwv3c6ru19lYNRA6gP1LN26lPum30dKtBb1dIvP52PEiFPPshLpSb1xoT8RkQ7bW7GXKF8UMb4YBkQMIGiDHK457HZYIuISteCISEhIjEykIdCAtRaLpdk2E+uLdTssEXGJEhwRCQkzU2eyp3wPByoPADA7bTajEka5HJWIuEUJjoiEhMiwSBZOWsjR+qOEecIYGDlQM3dE+jElOCISMrweL4NjBrsdhoj0AhpkLCIiIiFHCY6IiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCIiIhIyNFmm9JnWWspriumLlBHanQq0b5ot0MSkV6moqGCssYyEiISGBg50O1w5BxSgiN9krWWtw6+xZr8NXiNl2hfNHdNvouU6BS3QxORXmJ32W5e3PkiQRvEYLh57M1MTpnsdlhyjqiLSvqko/VHWZu/ltToVFJjUmkKNPGP3H+4HZaI9BLWWl7d8ypxvjjSYtJIiEjgL3v/QnOw2e3Q5BxRgiN9UkOgAY/x4PV4AYj0RVLVVOVyVCLSWwRtkDp/HZFhkQC1maqhAAAgAElEQVREeCNoam7CH/S7HJmcK0pwpE9KiU4hPiKe4rpiqpuqKasvIysly+2wRKSX8Hq8TE2ZSkFNAdVN1RTUFjBu4DgivBFuhybniMbgSJ8UGRbJnZPvZPWh1VQ0VnDJkEuYmTrT7bBEpBe5fvT1xEfEc7DqIFNTpnLpkEsxxrgdlpwjxlrrdgyuyM7Otjk5OW6HISIiIh1gjNlgrc0+03nqohIREZGQowRHREREQo4SHBEREQk5SnBEREQk5GgWlYicleLaYioaK0iKSiI5KtntcPq0Y1OXB0cPJiEywe1wREKSEhwROaOPiz7m9b2vY4zBYPjKhK8wbuA4t8Pqk9bmreUfB//hLFRpvNwx+Q6GDRjmdlgiIUddVCJyWv5mPyv2ryA5Kpm0mDQGhA/gf/b+j9th9UnVTdW8degtBkcPJi0mjQhvBCv2rXA7LJGQpARHRE7LH/TTHGzG5/EBzpL3df46+usaWl3R2NyIxeI1LVuMeCOpC9S5HJVIaFKCIyKnFRUWxbiB4zhcc5iKxgoKago4P/V8rQjbCYkRiQyJHUJhbSEVjRUcqT9C9uAzrlcmIp2gMTgiclrGGG4edzPv5L9DYW0hIzJGMDt9ttth9Ulej5fbJt7Guvx1lNSXMCZxjLYYEekhSnBE5IwivBF8dthn3Q4jJET7orlqxFVuhyES8tRFJSIiIiFHCY6IiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUezqPo5f9DP1pKtVPurGTFgBEMGDHE7JBGRfs9ay+7y3RTVFjEoehDjB47X2lMdpASnH2sONrNsxzJ2lO0gzIQRJMiCiQu0x5CIiMvW5q9lZe5Kwjxh+Jv9fHbYZ7VUQwepi6ofK6kvYVf5LjJjM0mLTSPOF8c/8/7pdlgiIv1ac7CZtw+9TVpMGmkxaaTHprM2fy2BYMDt0PoUteBIGwY1gUrfFbRBKhor8BovA8IHqElfpB9TgtOPHevX3V66vXXzvxvG3OByVCKd09TcxJ92/ond5bsB+EzGZ5g3fJ6SHOlzvB4vlw+9nDdz3yTMhBGwAT479LOEefSR3RF6t/oxj/Hw5fFfZtvRbdQ01TAsfhhD4jTIWPqmjwo/YmfZTjJiMwjaIOvy1zE2cSwjE0a6HZpIh12ceTGpMakU1xUzOHowYxPHuh1Sn6MEp5/zeXxkDcpyOwyRLittKCUyLBJjDF7jxWM8VDVVuR2WSKcYYxg3cJwmfXSBBhmLSEgYGT+S+kA9DYEGappqMBhSY1LdDktEXKIER0RCwuTkyXx+5OfxB/2Ee8P56sSvKsER6cfURSUiIcEYw5yMOczJmON2KCLSC6gFR0REREKOEhwREREJOUpwREREJOQowREREZGQo0HGIr3A0fqjvH3ober8dUwfNJ2pKVO1Aq+4IhAM8H7B++wp38Pg6MFcNvQyon3Rbocl0mFKcERcVtNUw3NbnqMh0ECEN4Jdu3bh9XiZnDzZ7dCkH1p9cDX/zP8nCREJHKg8QEFNAXdPvRuPUYO/9C36jRVx2eGaw9Q21TIoehDxEfHE+mLZdGST22FJP7XhyAZSo1MZED6AtJg08mryqGysdDsskQ5TgiPissiwSII2SNAGAWhsbiQ2ItblqKS/ivXF0hBoAJzuKoMhwhvhclQiHacER8RlQ+OGMiN1BoW1hRTWFjIgfACXZFzidljST10/+nqagk0U1hZSUl/CNSOu0Rgc6ZOMtdbtGFyRnZ1tc3Jy3A5DBABrLfk1+fib/aTFphEVFuV2SNKPVTZWUlJXwoCIAQyKHuR2OCJtGGM2WGuzz3SeBhmL9ALGGIbEDXE7DBEA4iPiiY+IdzsMkS5RF5WIiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCIiIhIyFGCIyIiIiFHCY6IiIiEHCU4IiIiEnKU4EhIq/XXcrjmMDVNNW6HIiI9oLyhnIKaAhqbG90ORXqZMLcDEOkpuZW5vLD9BfxBP17j5dYJtzImcYzbYYlIN3nv8Hu8mfsmAAkRCdwx+Q4GRg50OSrpLdSCIyHJWsvLu14mwhtBakwqMb4Ylu9aTtAG3Q5NRLpBaX0pfz/wd5KjkkmLSaO6qZqVuSvdDkt6ESU4EpKCNkhVUxUxvhgAosKiaAg00NTc5HJkItId6vx1eIwHn8cHQIwvhrKGMpejkt5ECY6EJK/Hy/ik8RTUFFAfqKewtpAR8SOI8Ea4HZqIdIPk6GRifDGU1pdS56+jrKGMyUmT3Q5LehElOBKybhxzI9mp2XiNl6xBWXx5/Jcxxrgdloh0g6iwKO6cfCdDBwwl3BvOlcOu5DMZn3E7LOlFjLXW7RhckZ2dbXNyctwOQ0RERDrAGLPBWpt9pvPUgiMiIiIhRwmOiIiIhBwlOCIiIhJylOCISEgJ2iD9dWyhiHxKKxmLSEgI2iD/yP0H7xW8h8/j45oR15CdesZxiCISotSCIyIh4ZPiT1iTt4ZBUYOIC4/jtb2vkV+d73ZYIuISJTgiEhIO1xwm2heN1+MlwhuBwXC0/qjbYYmIS3ptgmOMyTXGbDHGbDTG5LSUDTTGrDLG7Gn5mthSbowxTxhj9hpjNhtjznM3ehE511JjUqkP1BO0QfzNfoI2qI0XRfqxXpvgtLjUWpt13II+DwGrrbVjgNUtzwGuBsa0PO4B/uucRyoirpoxeAaz0mZRVFtEaUMp1468lqEDhrodloi4pK8NMr4emNvy/fPAGuDBlvI/WGfqxIfGmARjTJq1ttCVKEXknAvzhPGF0V/g6hFXt9mEUUT6p97cgmOBfxhjNhhj7mkpG3wsaWn5OqilPAPIO+61+S1lItLPRHgjlNyISK9uwbnQWltgjBkErDLG7DzNue3toHjSQhgtidI9AEOHqulaREQkVPXaFhxrbUHL1yPAa8BMoNgYkwbQ8vVIy+n5wJDjXp4JFLRT5zPW2mxrbXZKSkpPhi8iIiIu6pUJjjEmxhgTd+x74EpgK/AGcHvLabcDr7d8/wawoGU21WygUuNvuoe1lsrGSqqbqrU6rIhINwraIJWNldT569wOJST11i6qwcBrxhhwYnzJWvumMeZj4GVjzF3AIeCmlvP/BlwD7AXqgDvOfcihJxAM8Nqe19hUsgmA2emzuWbENXhMr8yLRUT6jIZAA8t2LmN/xX4wcMWwK7g482K3wwopvTLBsdbuB6a1U14KXN5OuQXuPQeh9SubSjaxoXgDmXGZWCzvHX6P0QmjGT9wvNuhiYj0ae8efpc95XvIiM2g2Taz8sBKRiWMIiNW82O6i/4Ul1MqrS8lIiwCj/HgNV68xktlY6XbYYmI9HlH6o4Q44vBGEOYJwxjDFWNVW6HFVJ6ZQuO9A7DBgzjn3n/pCHQ4OzQjCUtJs3tsKQrmv2Q+x7sXwNN1ZAyAcbOg4QhZ3ypuKh4O+xZCZX5EDsIRl8J6Vlg2ptAKn3BqIRRbC7ZTIwvhqbmJjzGQ0q0Jr90J7XgyCmNTRzL9aOvpynYhMVy09ibtDJsXxYMQs7vYNNLTqITEQ9FW2Dtz6B0n9vRyakceAfe+xVUFjg/s9oyWP9fsOtNtyOTLjg/9XyuGHYFdYE6fB4fCyYuIDkq2e2wQorprzNjsrOzbU5OjtthiJw7Jbvh3V9C/NC2f/nXlUFMElzyoFoEeht/Pfz9IYhKhLCIT8uDAagugnmLISrBvfhEXGCM2XDcFk6npBYckf6ieCt4fCcnMVGJUHEI1P/f+1QccpKZ45MbAE8YYKFsvythifQFSnBE+otjH4rtsqDp/72P8XDqnxn6mYmchv7vEOkvUqc4rQE22La8tgRSxkNEnDtxyaklDANfFDSdsBBcoBGMF5JGuxOXSB+gBEekv0gcDiPmQsVBqCuFxmpnVo7HA5O/1G2XaWxuZG/5XvZX7Mcf9Hdbvb1dnb+O3eW7ya3MJXhiEtlZYeEwfQHUl0J1ITTVOGNvaopg2nyIiO2e64iEIE0TF+kvjIGpN8PgCc7MnMZqGDILRlwE0QO75RJ1/jp+t/V3FNUWYbEMHzCc2yfdTrg3vFvq760qGip4dsuzVDZWYrFMSZ7CzeNu7p5Vv9OnwdzvOlP7K/MgaRSMuMT5KiKnpARHpD/xeCBtmvPoAf868i8Kagqc1a+tZX/lfnaU7WBaSs9cr7d45/A7VDdVkx6bjrWWzSWbmZk2k5HxI7vnAglD4LzbuqcukX5CXVQi0m0aAg2EeZy/m4wxeIyHpkCTy1H1vLpAXWsrVet9N4f+fYv0ZkpwRPqQ3r5u1fik8VgspfWllNSVEO4JZ0TCCLfD6nFZKVnU+esobyjnSO0RYsNjyYzNdDus0+rtv0siXaWF/kT6gKLaIpbvWk5JXQljEsdw45gbiQ3vnQNMD1Yd5IOCD/AYD5/J+Azpseluh3RO7CzdyYbiDUT7orko86JeuyptcW0xL+9+meLaYkYljOJLY79EXLhm0EnfcbYL/SnBEenl/M1+Hv/kcfzNfhIiEiiqLWJ80ni+MuErbocmfUwgGOBXG35FQ3MDiRGJFNcVMzphNAsmLXA7NJGzppWMRUJEtb+a6qZqEiMTMcaQHJ3MgcoDboclfVCtv5bKpkoGRg7EGENKVIp+lyRkKcER6eVifbFEeCOoaaoBoLyhnIzYDJejkr4o2hdNdFg01U3VAJQ1lPWbLkTpf5TgiPRy4d5wbpt4GwEboLC2kJSoFG4YfYPbYUkf5PP4+OqEr2KtpbC2kMTIRG4ce6PbYYn0CI3BEekjmoPNNDY3EhUWhdGu39IFx36XIsMiu2cxQpFz6GzH4Gihvx5grdUHkHQ7r8dLtCfa7TAkBOh3SXpSb/kMVILTjfrSVF4REZHu1NuWIFDbZDfxN/t5ftvz1DTVkBqTyt7yvby+73W3wxIREelxgWCAF7a/QGVjJWkxaRyoPMBf9vzF1ZiU4HSTan81Nf4aEiMT8RgPyVGayisiIv1De0sQ5FbmuhqTEpxuctJU3kZN5RURkf6hNy5BoASnm4R7w/nKhK+0TuVNjkrWVF4REekXeuMSBJom3s00lVdERPqrc7EEgaaJu0TTL0VEpL/qTZ+B6qISkdDir4dAo9tRiIjL1IIjIqGhbD9sfQ1K94EB0s+DSV+AmGS3IxMRF6gFR0T6vvKD8M4voboQ4jMhLh2KNsE7v4CGKrejExEXKMGRfq3OX8eusl3sq9hHIBhwOxzprF1/B08YRCeBMeDxOklOQyUcWu92dNJJ9YF6dpXtYm/5XvxBv9vhSB+jLirptyobK3l287NUNFZgsYxLHMetE24lzKP/Lfqc4m0QO/jk8og4KN4CY6849zFJl9Q01fDslmc5Wn8UgJHxI1kwcQE+r8/lyKSvUAuO9FsfFHxARVMF6bHppMeks7NsJ/sr97sdlnRGeDQ0t/MXfrMftB9cn5RTnMPRuqNkxGaQHpPOvop97Crf5XZY0ocowZF+qy5QR7gnHABjDB7jwd/eh6T0fiMugdoiOH5dLxuEphoYNse9uKTT6gP1hHmd1lRjDAajbirpECU40m9lpWTR2NxIaX0pxbXFxPhiGDJgiNthSWeMugySx0HlIagphqpC5/uRl8KgiW5HJ50wOXkyQRuktL6UI3VHiPJFMXzAcLfDkj5EKxlLv7a3fC8bjmwgwhvBZzI+Q3KUphT3Wc0BOLIdijaDxwcZMyBplDPoWPqk3MpcPir6CJ/Hx5z0OQyOaWeclfQ7Z7uSsRIcERER6TPONsFRF5WIiIiEHCU4IiIiEnKU4IiIiEjIUYIjIiIiIUcJjoiIiIQcJTgiIiIScpTgiIiISMhRgiMiIiIhRwmOiPQMa6GhChqr3Y6kZ1kL9RXQVOt2JCJynDC3AxCREFS2Hza/DBWHnOfJY2HKTRCf4W5c3a14G2x5FWqKnOepU2HKlyBGW36IuE0tOCLSvSrz4Z1fQm0pDMh0HuUH4Z1fOGWhomQ3vP8k+Ota7jPD2Qvr3V9CY43b0Yn0e0pwRKR77f4HGC9ED3Q2ujQGYgdBoBFy17kdXffZ/jqEx0FkfMt9eiAuDerKIV/73Im4TQmOdEp1UzXvH36fdfnrOFp/1O1wpDcp2eEkNyeKSoDi7ec+np7QHICyfRCVePKx8FjnPRBpkVeVx5q8NeQU5eBv9rsdTr+hMTjSYbX+Wn676beUNZThMR7W5a/j36b9G8lRGncgOB/wgSbwhrctDzRB7GB3YupuHi/4oqC5CcIi2h5rboKIAe7EJb3OrrJd/GH7H/AYD4FggC1Ht7Bg4gK8Hq/boYU8teBIh+0p30NZQxmZcZmkx6bTFGjiX0f+5XZY0luMnAu1Jc7somNsEBorYcTFbkXVvYyBEXOdwcXH32cwAIEGGDrbtdCkd1mXt45YXyxpMWlkxmayr2IfRXVFbofVL6gFRzrFYtt871GuLMcMmwMlu6BgA3jCAet88I+8xJllFCrGXul0Ux3d7bRWBYNgAzDh8zBwpNvRSW9h2j61WMyJhdIjlOBIh41NHMug6EHkV+djjCHGF0PWoCy3w5LewuuD8++G0rlQvNUZfJs2FRJHOC0focIXBXPuh5KdcGQH+CIhLQviM0PrPqVLLh1yKc9ve55afy3NwWYmJk9kcHSIdNX2csYe37zaj2RnZ9ucHM106Kxafy3bS7fTbJsZnziehMgEt0MSEemVCmoKyK3MJSY8holJE/F5fG6H1KcZYzZYa7PPdJ5acKRTYnwxnJ96vtthiIj0eumx6aTHprsdRr+jgRMiIiIScpTgiIiISMhRgiMiIiIhRwmOiIiIhBwlOCIiIhJyNItKJJRZ6+zuXVMMvmhIHuOsUyN9X1MtHN0DwWZIHA4xSW5HJNKrKMERCVX+esj5PRRtcVZTtTg7X8/+N+cDUfquvI/hXy84K0RjAQOjLodJN4BHDfMioC4qkdC19S9OchM/BOKHQsJQwML7v4Gmui5VXVRbxL6KfVQ3VXdPrN0p0AihvGNzZT5s+D1EJn76s41Lh90r4dAHbkcn0muoBUckFDXWwKH3YUBG220DIhOg4pCzhcKQmZ2qek3eGlYdXIXXeAn3hnPn5Dt7xyJm5bmw7TUo2e20YmRkw8TrIXqg25F1r9z3wHidrSGO8XghJsVJcoZf6F5sIr2IWnBEQlFjNWCcD74TGQ/UlXaq2oqGCt46+BaDoweTGpMKwN8O/K0LgXaTijxYtwQq8p1Wjdg0OPwJvLOk5b0IIdVFEB59cnl4DNQdbbu7uUg/pgRHJBRFJTgtN+111dggxKV2qtqG5gaMMYR5nMbfqLCo3tFNtetv4AmDmGTnvj1eGJAOdeWQ95Hb0XWvxKHOAOMTNVY596yNPkUAJTgiockXBSMvharDziwbcP6yry1xumwGTexUtUlRSQyKHkRhTSFVjVUcrT/KeYPP68bAO6loK0Qnn1weOQAKN537eHrSsAsB07ZlqrnJaZUbe41rYYn0NhqDIxKqJnzeGXCb+27LLCoL8ZmQfReERXSqSp/Hx8JJC3n70NuUNZRxSeYlzEqf1b1xdyqwKKe16sQuueaA03UTSmIHwQX3woalUJlHa1fktPmQMd3t6ER6DWP7aX9tdna2zcnJcTsMkZ5XXw41R5x1cOIzQ7MLY8dfYccbkDDs0/uzQag4CHPug9Qp7sbXE5oDzv0Fm52fa3vjckRCkDFmg7U2+0znqQVHJNRFJTqPUDb6MijZ4Sx854t2kpvmBhhxMQya5HZ0PcMbBkmj3I5CpNdSgiMifZ8vCi58wBmLU7TZWa05IxuSRmvhO5F+SgmOiIQGr88Zg6JxKCKCZlGJ9BhrLWUNZRytP0rQBt0OR6RH+Jv9FNcWU9VU5XYoIm2oBUekBwRtkP/d9798XPQxAGMSxzB//HzCveEuRybSfSoaKli6bSmlDc7CkdeOvJZZab1gVp0IasER6RF7yvfwYeGHpMakkhaTxq6yXeQUa9aehJY3c9+kvLGctJg0kiOTWbF/BeUN5W6HJQIowRHpEbX+WrzGi8d4MMYQ4Y2grKHM7bBEulVpQymxvlgAfF4fBkONv8blqEQcSnBEekB6bDoGQ3VTNXX+OhqaGxgdP9rtsM49fwMUbHQWGyzZDUGNRQolEwZOoKy+jIZAA6X1pUSHRZMUmeR2WCKAxuCI9IjUmFRum3gbKw+uJBAMcOOYGxk3cJzbYZ1bZQfgw//n7Gx+TOJwmP1vEBnvWljSfS7OvJhAMMCWo1tIi03j8yM/T7RPCw5K76CVjEWk+/kbYNUPwXjbJjNVh2HwZCfJ6euCzVC2HxqqnP29EoeH5irRIr2MVjIWEfcc2e603CQMbVsel+YsxFdX5iQFXWCtJb+8ngNHawkEg6TFRzFmUCxh3nPQ815dDOufhpoiwDj7fCWNgpn3OBt8iojrlOCISPdrrAbaaR02HufRWN2lBKestokX1x8k92itU60xWGBARBhfnjmEcak9mGQEm+HD/3LuIb4lgbMWynPhkz/AnG/13LVF5KxpkLGIdL/Ywe131wQDztfozg9ErWkM8PTafRRWNJCREEVmYrTzNSEKr8fw7DsH2F/SgzN5SvdCbTHEJH9aZgzEpcORbU7rjoi4TgmOiHS/5DHODtfVhU7rBjjJTWU+jLoMImI7XfX6/aWU1TSREheBOSGJiokIIybcy+sbC+ix8YUNle2XG+O0Tp3quIicU0pwRKT7ebww+5uQPBaq8qAq3xmvMuYKmPD5TldrreWdPUdJij31itDxUT4OV9RTVNXQ6eucVtTAdnvfsEEnmetC65SIdB+NwRGRnhGV6IxHqT3qjFeJSYaIuC5V2dQcpKYhQHxi1CnPMcbgMVBVHyCtJ2ajDxzpDJ6uKoS4VKflxgadJC49G2KU4Ij0BmrBEZGeFZMMA0d0ObkB8Hk8eL2GQPPpFwy0FsLDeuifN4/HmeY+cLjTOlWZ35LcnAdZ83vmmiLSYWrBEZE+w+MxZA9LZMPBcgYPiGz3nAZ/M9HhXoacppWny6IS4TOLnDFGDZUQnQyxKT13PRHpMLXgiEif8pkxyQStpa4pcNKx5qDlSHUDV0wc3PPr4RgDA9Jh0AQlNyK9kBIcEelT0uKjWDhnONUNAQ5X1FPTEKCuKUBxVQOFlfVcNn4wc0Yln7kiEQlp6qISkT5nYno8D109nk8OlbMpr5LmoGXc8DhmjUgiMzHqpOnjItL/KMERkT4pITqcy8YP5rLxg90ORUR6IXVRiYiISMhRC46InHNNgSBNzUEiwzznZnPMs2Ctpd7fjMEQ6fOom0ukj1OCIyLnTF5ZHWt3l7A5rwKLs1bNhaOSuXB0MvHRPldi8jcH2ZBbzj93HaGstpEgMCQhmkvHpzA1M0GJjkgfpQRHpD01R+Dge1C6D2IHwfDPOCvY9kWBRjj8L8j/2HmemQ0Z50FYxDkNY0t+Bc9/cBCfxzBoQCRej6EpEOSfu47wcW4Z37h0FIPi2l/b5qw01Tn3WPAv8IbD0NmQOhW8p/5nrikQZOn7B9hRWE1STDjpCdFYa6mo9/P793K5eGwKN0zP6F1JTkMVHFoPxVsgPAaGXQiDJjoLEPY1waCzQenB96GpFtKmwZCZ3bIopIg504Z0xphs4PvAMJyEyADWWju158M7e8aYq4BfA17gOWvtf57u/OzsbJuTk3NOYusoay0Hqg5Q1VhFakwqqTGpbofUZXX+OvZX7sdgGJUwisiwLnyQ9bTSffDer53l98NjwV8PgQbIuhVGXuJ2dB3jb4APfgNHd0Nky74FjZWQNBYuuBd85+bnUFHXxH/+fScDonxE+bwnHS+tbSQxOpx/v2Js55KJxmp493GoKoCIeLDN0FgFGTMg+65TJjn/2FbEm1uL2p15FQxa8ivqWThnGNOGJHY8pp5QexTe+QU0VEDEAGj2Q1MNjJwL0+a3v4N7bxUMwqaX4MA6CI9zfkYNVRA9EC76tvO1l6psrORg1UF8Hh+jE0fj87jT+thd+tpnjjFmg7U2+0znnU0LzovAfwBbgNOvj+4SY4wX+A1wBZAPfGyMecNau93dyDpn9aHVvH3obTzG+Yts/vj5TEqe5HJUnVfdVM0zm5+hrL4MiyUtJo27p95NVFgPrjTbWcEgfPI8+KIgMsEpi4yH5ibY/IrzF2ZUgrsxdsShD53kJmHYpx9+kQlO2aH3nZ29z4ENB8sJBG27yQ3AwOhwDlc0kFtax4jkmI5fYM8qZ2+ohGGflkUNhMMbIPN8p8XqBI2BZtbtKWHQgJN3JQdn1eT4KB9v7yzpPV1V2193Epr4oZ+WRSfB/rXOfSaPcS+2jirdAwfeafndbGl9ikxwktTtb0D2QlfDO5WSuhKe2fwMdf46ggQZlziOr078KmGevtshEmqfOcecTZtmibX2DWvtAWvtwWOPHo+sY2YCe621+621TcCfgOtdjqlT6vx1rMlbQ1pMGumx6SREJPC3A39zO6wu2VSyidL6UjLiMsiMy6SgtoCdZTvdDqt91QXOX8mRJyQx3nCwASjZ5U5cnXXwXecD8PgPZ2Ocstz3zlkY2woqGRB56g8AYwwGOHC0pnMXOPgexJ4wXdwYp5Xj0P9v786D47zv+46/v3tgF4v7JIiDBE9IpCjREkQdVmRFlqMj8dC3ZbeJldiR04madjqdaZP8kbRpZtJMM07aSTNWfNR2GjuKY7uMLZuSbUWydVgkRdk8RJEUSYm4iPtYnHv8+sezlHiAB8AFnt0Hn5cGI+K3B7777GL3g9/zO16a9yb947PMprLEIvOHLoDKeITu0Smm5jKLqyuf0rNeYCu78HGGIByD7lf8qWuxuvdBJP5OuDmrfBV07/F6pwrQT7t/Siqb8t7Pyls5NnKMN8cL7SPx6k2mJi/6zPn+ye/7Xd72S68AACAASURBVFZeXE3k/CMz+wLwI2D2bKNz7ltLVtXCtQCnz/m+C7jtwiuZ2aPAowBr1qy58OKCkHbe8vNnk3QkFGEyNelnSdcsnU2//XgADCOduXiZ/YKQzeCdhb0EVwAfdAuRSYHN8wEeCi/rB0gmC6Er9ICYeVstLO4HpL3HdNGdhr3et3lknbviGR0veBnZK5zKXxYu14F+YSAAb/zNJR5nwcrMzf9YLOQ9VleQJwyYy84Rzv1OmRlmRjpboO9nV+Fs7Wffo8OhMNPpaT9Lypur6cH5TWA78ADw/tzXry1lUYsw39vURe9IzrnHnXOdzrnOhobC3DumIlrBlrotdCW7GJwe5MzUGe5qucvvsq7JlrotlIRL6Jvso2+yj7JoGRtrNvpd1vwqm73TU6kLfsFdFrDiG2jccgtMDV3cPjXkDTZeJusbyhifufyHQNY5WqoTi/sBLTfD5MDF7bNj3jGYR325N8g6nb30B+nkbJrK0ghlJQVw+iFaCnUbYHr4/HbnvDFiqwtqWOSVNd0E6Wmv/nNNDUF9x7IPgr9atzbdymxmloGpAXqTvdTGa2mraPO7rEWrLKlkS90WupPdDE4P0j/VX/SfOWddzW/tTc65bUteybXpAs59hbUCPT7Vck3MjI9u/ijtVe0MTA2wtnItNzXc5HdZ16Qx0cijNz7KK2deIWQhOps6qYkXyKDNC4WjsO0jsPfL3tibeJU3O2dyADbcAxWFPfjuIuvuhrdehLEubzYYeDPE4lWw7peWrYzb1tXxk6MDpDPZede9Sc6kqYhH2byqfHE/YPP90Ptzb3fvsgavJ27yjBdYLxFwymIRbm2v5eWTwzRXXzwezDnH0OQsH765lVCoAMbfAGz9kDfIOHnG28E8k4JkHzR0eDOpiknTDVC7AYbf8E67haMwNeg9d1s/4Hd1l7S+aj2f2fYZDgweoDRSyo7VO0hEFxnMC8DZz5y1lWsZnB4MxGfOWVczi+pvgc8V8oBdM4sAR4H3At3AHuCTzrlDl7pNIc+ikgJw5jC8/iSMnPLGq2x8H6y9Y/7TIIVuahiOPeVNLQZvGu7m+5d9lsrTh/t48kAfdWUllMW8v62cc4xMpZhJZfjse9azsfEapgdP9MHR3d5YlHDEm9q/8b7LTjkem07x188cZ3RqjoaKGJHcVOu5dJb+iRk2NJbz6bvWXXaczrIbfQte/z70HYSSBKx7D2z4Za+Hp9ikpuH4j+Hks14vVNM22PwAVBdvj4gsvaudRXU1Aec1YANwEm8MTqFOE38I+Eu8aeJfcs796eWur4Ajsrycc+x7c4Tdh/oYmZojZEbWwbq6Mn7tptWsrVvE7Kk8GJtO8YODvex7cyRXKETCId69sY73Xr+K+CVmfomIP/IZcNbO116AM6kWRAFHxB/ZrKN3fIbZVIaKeJSGisIYa5GcTTM4MYsZrKqMK9iIFKi8rYNT7EFGRApLKGS0zDPmxW/lsQjlsQIYTCwieVGEa3uLiIiIXJ7+XBGRopTJOo73JznSN04642irLeWGlioShTClW0R8p3cCESk6fWMzfPn5kwwmZ4mGQ4TMePHEEN96pZuPdbZx89oCXYZARJaNAo6IFJXRqTn+5l+O4xy01py//shsKsPXXnqTWCTE1pYqnyoUkUKgMTgiUlRefGOIqbkMNWUlF10Wi4apSUT57i96udIM0bxIz8L0SMHumySykqkHR0SKhnOO548PUld+cbg5qzwWoWdsmu7R6Yt6ePImPQtHvuft4p1Ne5tGdjzg7c5ejItBigSQAo6ILK1sxuvhiMS44u6WVzCXyTKTylJXfukQYWaEzJicXaKNUZ2DV74KXXuhssXbYiA9Awf+EVJTsGXn0vxcEVkQBRwRWRrpOW+LiDd+DKkZKKuH638NWm9ddNCJhkJEI0YqkyU6z55WZzkHpUu1UN94N3Tvg+q17zyOSByq2rzHu+Hey24PISLLQ2NwRCT/nIN9X4bX/hlild7eQtk07PkCnPrJou82FDJuX1/HYHLukteZnE1TVRqlpWaJFhMc7wHs4pAWioDD2xNLRHyngCMi+Tf6JvS86vVyRHJbMcQqoGI1HPqO17uzSHduqCccgomZiwf2pjJZhiZneeCGJsJLtQN4JO7tyHch5/A2soovzc8VkQVRwBGR/Bt9C3AX93JE4t4A3eTiezkaKmJ89u4NpLOO7pEpRibnGJtO0TM6zcDELDu3t3DLUq6DU78ZIgmYTZ7fPj3sBbiq1qX72SJy1TQGR0TyL3yJDTTP9nJc6vKr1F5fxh88dD0Hu8c40D1GOutor0twy9paaueZPp5X0Tjs+G342d/AzAiEopCZ83qoOn/rmgdSi0h+KOCISP41XueNSUnPnH/KZmrIG4xb3njNPyIeDdPZXktne+0139eCNV4H9/0X6NkPkwNQ2QrNN0FJ2fLXIiLzUsARWSKD04O82PMi6WyazlWdtFW2+V3S8olXwbt+HV75CljI67FJT0FJOdz8G8Ho5Sithg2/7HcVvnLOcXjoMIeHDlMdr+bO5jspiyrkSWFQwBFZAqMzo3z+559nLjNHyELs79/Pozc+SmvFChqfseY2qF4Dp38Gk0NQtw5aOiFe6Xdlkiev9L/CN49+k0QkwWxmlqMjR3l026NEw1G/SxNRwBFZCifHTzKVnqKlvAWAM5NnODB4YGUFHIDK1bD1A35XIUvk5d6XqYnVUF5SDkBPsof+6f63X/ciftIsKpElEA1Fz9sLKe3SxDV9WAImHokzl/Wm/GddFoCI6e9mKQwKOCJLYHPNZtor2+lOdtOT7KE2Xsstq27xuyyRvHrf2veRdVl6k730Jnu5telWGhPXPoBcJB9sWXbcLUCdnZ1u7969fpchAZbKpDgxdoKMy9Be2U4iukQbP4r4aGRmhJ5kD6XRUtZVrsOCMIBcCpqZ7XPOdV7peupLFFki0XCUjtoOv8sQWVI18Rpq4ku4sKLIIingiEhwTPTB8AlvDZ76zd5UbhFZkRRwRKT4ZTPwiyfg5LPvtFkEbvoYrLvbv7pExDcKOCJBl83A7ARES9/Z+DJo3nwB3ngGatZ6CwuCt33Cq3/v7Q1Vu97f+pbK3KT3/MYqgrF4okgeKeCIBJVz8OaLcGQXzIxDKAxtt3vr0lzDlgKpbIqDAwcZmxujvbKd9qr2/NW8WMeehrKGd8INQLjEW0H51E99DzjOOQ4PH2ZgaoCmsiY6ajqubTBucgAOfhP6DnjfVzbDto9Cg8Z8iZylgCMSVKd+Aq/8HZSv8vZ/yqa9D/uJPrjr33uBZ4GyLssTrz/BwcGDRENRMi7DJ677BDfU37AED2ABzu7kfaFoKST7l7+eCzx16imeOf0MJeES5rJzPND+APe03bO4O5sZh5/8BaSmobIFMJgZg5/+Jdz9H6FuQz5LFylaWgdHJIgyKTi8y/vQL8lNTw9FvKAzdAwGjy3qboemh3ht6DVay1tpKmuiqqSKH7/14zwWvkjVa70P+QvNJX3/wE9lUvyk5ye0lLfQVNZEc1kzz5x+5u2F8Rbs9MswOw4VTV6PlZk3mDqagCPfy2/xIkVMAUckiKaGvL/woxesnmwGFoaRU4u62wtPqzhcYax70vGgF3BS0++0zYx6AWDtXf7VBWBgGA5vzbFrXnvszCEoqbi4PVELA0e8U5MiooAjEkiRGODm/7BzmUWPwamL17GtfhtdE130JHsYnxvnvjX3XVut+dB0A9zyiDfodqwLxk57Y3De/e+gvMHX0qKhKPe03kPvZC89yR7OTJ3hvjX3EbJFvv3GKyEze3F7Zg6iZRpsLJKjMTgiQVRaA41bvFNRFU3vtKdnvFNVTYsbM2NmfHjzh9lSt4XxuXHWVKyhrbItT0Vfo7V3QMstMNHjPcaKZggVxt9w9665l9aKVganB2lMNLKxeuPi72ztnfDWS97sqbPjqJzzxlZt2ZmfgkUCQAFHJKhu+gQ8/5cw+pbXm5FNAeb1dJQufuXZSCjCtoZteSszryIlUNPudxUXMTM6ajvoIA+znOo3Q8cDcPQpL+BYyOu9adwCG+699vsXCQgFHJGgKquDX/5Dbyrx8BteqGm5Bcrq/a5MroUZbPkANN8MvT+H9Cys2upNEV/EzDiRoFLAEQmyaBzabvW+JDjMvEUNa9b6XYlIwSqME9QiIiIieaSAIyIiIoGjgCMiIiKBo4AjIiIigaOAIyIiIoGjWVSyKJlshu5kNxmXoaW8hZJwid8liYgUpMnUJH2TfSQiCZrKmgpje5MVQAFHFiyVTfH1177O6yOvYxiry1fzm1t/k0Q04XdpUkimR2H4hDeluW4jxObZPykIJgdh5E0IR6F+k7eDuUhO/1Q/XzzwRabT02Rdlrtb7+Z9a9+nkLMMFHBkwY6OHOXI8BFaylswM7onutl3Zh+/1PpLfpcmhcA5eP0HcOS7QBZvt8kQ3PhxWBeg10g2Awf/CU48A5j3uCMxuPkRaNnud3VSIHaf2k0qm6KprIlMNsNzXc/xrsZ30ZDwd4+0lUBjcGTBZtIzmNnbf4FEw1GSqaTPVUnB6H0VDn8byldB1RqoaoNEPbz6f2HoDb+ry59TP4FjP4SKFu8xVq+BWCXs+VtvXygRYGJugng4DkA4FMYwZjIzPle1MijgyIKtrVxLNBRlaHqIkZkRUtkU19de73dZUiiOPQ3xGu+UzVmRGETicOJffCsrr5yDo7u9EHfu9gjRUq+36q0X/atNCsrNjTczMjvC+Ow4fZN91MRraEw0+l3WiqBTVLJg9aX1fGbbZ3iu6znS2TS3r76d9qp2v8uSQpHs93oyLlRSDhO9y1/PUshmYGbU66G6ULQUxtWDI57bVt9GKBTi0OAhqmJV3Nt2L7FwzO+yVgQFHFmU1opWPnn9J/0uQwpRVSuMdUGi7vz22Qlo2OxPTfkWCkOiwXtMFw6eTk1CdZs/dUnBMTN2NO1gR9MOv0tZcXSKSkTya/P93gd/+pxxBnNTkE3B+nv8qiq/zOC6h2BqEDKpd9pnxsHCsOYO/2oTEUA9OCKSb43Xw82fggNPQGYQcN5pmx2f9QbiBkXbbTA95s0WcxmvLV4Fd/5bKKu7/G1FZMkp4IhI/rXfCS03w+hb3qDb6jUQCdhikGbQcT+su8s7JReKQE37+YOORcQ3CjgisjSi8eCMubmckjJo6PC7ChG5gMbgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgaKE/WdGGZ4Y5PnKcknAJ19VeRzwS97skuRbJfhg+6a0mXL8Z4vPsai5FY3RmlGMjxwiHwlxXex2JaMLvkqSIKODIitU/1c/jv3ic6fQ0zjlaKlr4zLbPEAvH/C5NFiqbhYP/CG/8C+C8tlAYbvoEtN/lZ2WySMMzw3z+559nYm4CgMZEI4/e+KhCjlw1naKSFevl3pdJZVK0lLfQWtFKT7KHk2Mn/S5LFuOtF+H4j6CyBarXel+JBtj/d16PjhSd/Wf2M5WaorWildaKVvqn+jk2eszvsqSIKODIipVxGczsnQYHWZf1ryBZvGNPQ6L+/I0uIzHv69RP/atLFi3jMmDntznn/ClGipICjqxYtzbdCkBvspfuZDf1iXrWVa3zuSpZlKlBb9PLC0VKYbJ/+euRa7a9cTsloZK3fz9r47VsrN7od1lSRDQGR1as5vJmfuem3+HI8BGioSjbG7dTGin1uyxZjOo1MDkIpTXnt88loWaHPzXJNWlMNPI7N/0Oh4YOEQlFuLHhRspLyv0uS4qIAo6saE1lTTSVNfldhlyrjgfhhf8F0VI4OxNuZgzMNMi4iDUkGrgncY/fZUiR0ikqESl+Tdvg5kdgdgLGumDstDce587fg/JGv6sTER+oB0dEgqH9Tmi9Bca7IRTxZlSdO+hYRFYUBRwRCY5IDGrX+12FiBQAnaISERGRwFEPTh4Nzwyz6/guzkydYXPNZh5c96CW/hcRkRVhdGaUXSd20ZvsZVPNJh5c96CvM1PVg5Mn6Wyarxz6CqfGT1ESLmFP3x6ePPmk32WJiIgsuUw2w9de+xpvjL5BSbiEfWf2sev4Ll9rUsDJk/G5cYZnhmlMNBILx1iVWMVrQ6/5XZaIiMiSS6aS9E/1syqxilg4RlOiiSPDR3ytSQEnTxKRBGELM52eBrzAU19a73NVIiIiS680Uko0FGUqNQV4n4F1pXW+1qSAkyfxSJyPdXyMibkJ+ib7iEVifHDTB/0uS0REZMmVhEv4eMfHmUxN0jfZRyQU4SObP+JrTbZSNy/r7Ox0e/fuzfv9TqWmSKaSVMeqKQmX5P3+RURECtVyfAaa2T7nXOeVrqdZVHmWiCZIRBN+lyEiIrLsCukzUAFHpAhoCQLJl0KbyiuyVDQGR6TApbNpvnroq1qCQK7Z2am8J0ZPFMxUXpGlooAjUuAm5iYYmhnSEgRyzc5O5T37WiqEqbwiS0UBR6TAlUZKiVhESxDINZtvKq9eSxJUCjgiBS4eifPRjo8WzRIEY7NjvNT7Ent695CcS/pdzrIZmBrgxe4X2de3j5n0jN/lzGu+qbwf3vxhv8sSWRKaJi5SJIphCYKRmRE+//PPMz43DkBdvI7P3vRZykvKfa5safUme3n8F48zl5kjS5a2ijY+s+0zBfs8FcNrSeRSrnaauHpwRIpEIpqgMdFY0B9Ivxj4BclUktaKVlorWhmaHeLoyFG/y1pyL/S8AEBLRQttFW10J7s5NX7K36IuoxheSyLXSgFHRPLG4S5sIOuy/hSzjOZ73Cu1d1ykUGgdHJGVZuIM9OyH2Qmo2wirtkIkP3/Jb6vfxvPdz9Od7MY5R3W8mo7ajrzcdyG7ffXtHBg8QE+yh6zL0lzeTHtVe/5+wNwk9LwK491Qvgqat0O8Kn/3LxJAGoMjspKc/An8/OuAQSgCmTmoaoE7/23ePjCHZ4Y5PHiYkIW4oeEGKksq83K/ha5vso+jI0eJhWPc2HBj/hbPGz0NL/xPmE1CuASycxCOwR2PQf3G/PwMkSKirRpE5HwTZ7xwU9YIkdg77WPdcOg7cMun8vJjauO13NV6V17uq5g0lTXRVNaU3zvNZmHPF8AB1WveaZ8dh5c/D7/yp3nrfRMJGo3BEVkpevYDdn64Aahogq49kJr2pSy5jNE3YXIAErXnt8cqvdNWQ8f8qUukCCjgiKwUsxPeaakLhcLgHBTo2i0rWnoGsEtfntJzJnIpCjgiK0XdRsjMXtw+l4TSaohp0GrBqViNNxUtc367c+Cy3vgpEZmXxuDIZZ0aO8WLPS8SCoW4q+UuWsr1hlq0Vm2FqlZvzE1Fk9dzMzfpnQK59bchpL93Ck5pNWy4F4497YWdSMwbGD7eA2tu955HKVqHhw6z78w+yiJl3N12t7bNyDMFHLmkrokuvnjwi5SESnA4Xht6jcfe9Zh+CYtVpMSbLXXw296YG/A+QG/9bWi94oQE8cvWD0JJORx7CiZnIRyFjgeh4yG/K5Nr8Prw6/zd4b+jLFpGKpvi6MhRHnvXY4Ff9Xs5KeDIJb0+/DqGUVdaB0B3spsToycUcIpZvAo6H4EbP+adropVqeem0IXC0PEAbHyvdzoxWqaZUwHw6sCrJKIJauI1APQke+hKdnFd7XU+VxYcCjhySaWRUjLOO/fvnCPrssQunIEjxakkAST8rkIWIhyF0hq/q5A8KYuUMZeZA955f9XWGfmlgCOXtL1xO/sH9tM90Q0GG6o3sKV2i99liYgUvbta7uLI8BF6JntwWcdNDTfRXtnud1mBUnArGZvZHwO/DQzkmv7AOfdk7rLfBz4NZIDfc87tzrU/APwVEAa+4Jz7syv9HK1kfHXmMnOcnjiNmdFW0UY0FPW7JBGRQJhKTdGd7KYkXEJbRRsh0+niq1HsKxl/zjn3P85tMLMtwMPAVqAZ+KGZbc5d/NfA+4AuYI+Z7XLOHV7OgoOqJFzChuoNfpchIhI4iWiCTTWb/C4jsAo14MxnJ/AN59wscNLMjgM7cpcdd86dADCzb+Suq4AjIiKyQhVqf9hjZvYLM/uSmZ0dVdcCnD7nOl25tku1i4iIyArlS8Axsx+a2cF5vnYCfwNsALYDvcBfnL3ZPHflLtM+38991Mz2mtnegYGB+a4iIiIiAeDLKSrn3H1Xcz0z+1vgu7lvu4C2cy5uBXpy/75U+4U/93HgcfAGGS+gZBEpcM45Xu57mRd6XqAkVML97fezsWaj32WJiE8K7hSVma0+59sPAgdz/94FPGxmMTNbB2wCXgb2AJvMbJ2ZleANRN61nDWLiP8ODx3mO8e/QyabYWJugq8e/ir9U/1+lyUiPinEQcZ/bmbb8U4znQI+C+CcO2RmT+ANHk4Dv+uctwqdmT0G7MabJv4l59whPwoXEf8cHz1OaaSURNRbwDCZStKT7KEx0ehzZSLih4ILOM65X7/MZX8K/Ok87U8CTy5lXSJS2GriNcykZ3DO4fBWhi2Pal8fkZWq4AKOiMhi3Lb6No6NHOPk2EkA7mi+Q2s4iaxgCjgiEgixcIxHtj7C0MwQkVCEmlgNZvNNshSRlUABR0QCIxwKa8yNiAAFOItKRERE5Fop4IiIiEjgKOCIiIhI4GgMjgRWJpthf/9+upPdNJU1ccuqW4iE9JIXCYqp1BQv973M2OwY19VeR0dth98lSQHRu70E1lNvPsWzXc+SiCR4qfcleid7+cDGD/hdlojkQSqb4iuHv0LXRBexcIyXel/i4Y6HuanxJr9LkwKhU1QSSFmX5YWeF2gpa6G+tJ6W8hb29u1lLjPnd2kikgdnJs/QPdFNS7n3O14dq+bF3hf9LksKiAKOBJJhRENR0i4NeKerQhYiZHrJiwTB2dPNWZcFIJ1NEwvH/CxJCoze7SWQzIyH1j3E4PQgPckezkyd4cH2BzUGRyQgViVWsb1xOz3JHnqSPaSyKe5bc5/fZUkB0bu9BFZnUydNZU0MTg9SG69lTeUav0sSkTwxMz606UPc2HAj0+npt09ViZylgCOB1lrRSmtFq99liMgSCFmIzTWb/S5DCpROUYmIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiBSImfQM43PjOOf8LkVWuEw2w9jsGKlMyu9SRBYt4ncBIgIv9bzEkyefJOuybKzeyMPXPUw8Eve7LFmBhmeG+eqhrzI0M0RJuIRPdnySDTUb/C5LZMHUgyPis77JPr574rvUxetYXbaao6NHea7rOb/LkhXq28e+zdjsGKvLVhMPx/n6ka8zm5n1uyyRBVPAEfHZ2OwYZkY0HMXMqIhWcGbqjN9lyQrVN9lHdawagLJoGbPZWSZTkz5XJbJwCjgiPmtINBAiRDKVJJVNMT43zrqqdX6XJSvUxuqNDEwPkMlmGJoeorKkkoqSCr/LElkwBRwRn9XGa/nXW/41IQsxPjvOe1rfwx2r7/C7LFmh3r/h/Wyt28rwzDD1pfV8auuniIaifpclsmC2UmdsdHZ2ur179/pdhoiIiCyAme1zznVe6XrqwREREZHAUcARERGRwFHAERERkcBRwBEREZHA0UrGIhIYJ8ZOsKdvDyWhEt7d8m4aE41+lyQiPlHAEZFAODV2ii8d+BKxcIyMy3B46DCPvesxqmJVfpcmIj7QKSoRCYQDgweIhqLUldbRmGhkKjXFm+Nv+l2WiPhEPTgrnHOOnskeplJTNJU1acVSKVrxSJx0Ng14r2uH0wJ1UtSGpocYnhmmJl5DfWm93+UUHQWcFcw5x9NvPs2zp58lFAoRD8f59LZP01TW5HdpIgt22+rbODBwgJ5kDw7H5prNbKzZ6HdZIotyaPAQ//D6P+DwFuP92OaPsa1hm89VFRcFnBVsaGaI57qeo6msiXAozND0ED849QMe2fqI36WJLFhlSSX/Zvu/4a3xt4iEIqytXEskpLc4KT7OOb517FtUxaoojZQyk57hW8e+xdb6rYRMI0uuln77V7DZzCxmRjgUBrwu/uRc0ueqRBavNFJKR22H32WIXJOMyzCbmaUmXgNALBxjODtMJpshFFbAuVo6UitYQ2kDdfE6+ib7GJsdY3hmmFsab/G7LBGRFS0SirC9cTs9yR7GZ8fpnuzmhvobiIY1pmwh1IOzgpWES/itbb/FM6efYXRmlPfWvZdbV93qd1kiIivezg07qYnVcHriNJ0VndzderffJRUdBZwVrrKkkp0bdvpdhoiInCMajvLete/1u4yiplNUIiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4mkUlIlfknOPI8BGGZ4ZpKmtifdV6zMzvsopSJpvhteHXGJsdo7WilbWVa/0uSSSQFHBE5Ip2n9rNs13PErYwGZdh58ad3L76dr/LKjrOOb5z/DvsObOHiEVwOD7e8XFubLjR79JEAkenqETksmbSMzzf/TzNZc00lzezKrGKp089jXPO79KKztjsGPv799Na3kpzeTPVsWp++NYP/S5LJJAUcETkslzuP+z8Nlm4s8fNcgfTMAVFkSWigCMil1UaKeWO5jvoSfbQN9nHmakz3Nt2r8bgLEJ1rJpt9dvoSnbRN9nH8Mww97bd63dZIoGkMTgickUPrnuQ9sp2BqYHWF22ms01m/0uqSiZGR/e/GE6ajsYnR1lTcUa1lev97sskUBSwBGRKwpZiK31W/0uIxDO7hQtIktLp6hEREQkcBRwREREJHAUcERERCRwFHBEREQkcDTIWIrWXGaO/f37Sc4l2VizUUvei8h5nHMcHjpMz2QPqxKruKH+BkKmv+tXCgUcKUrpbJqvHf4ax0ePEw1F+fHpKRRrbQAADE9JREFUH/MbW36DjtoOv0sTkQLxzOlneOrUU8TCMeayc9zdcjcPrn/Q77JkmSjKSlE6M3WGk2MnaS1vpamsiYpoBc+dfs7vskSkQGRdlme7nvW2FylbRXNZM8/3PM9cZs7v0mSZKOBIUTLsvO0CsmS1sq6IvM1y/53dCsPhMLO3t8mQ4NMpKilKTWVNXF97PYeHDmNmhCzEvWu15L2IeMyM+9fez64TuwhbmIzL8L617yMajvpdmiwTBRwpSiEL8fB1D/Pa0GtMpadYW7mWprImv8sSkQJye/PtrCpbRf9UP3WldWys3uh3SbKMFHCkaEVCEbY1bPO7DBEpUGbG+ur12u9rhdIYHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEREQkcBRwREREJHAUcERERCRwFHBEJlEw2Q9Zl/S5DRHym3cRFJBAy2QxPnXqKF3pfIGIRfnX9r9LZ1Ol3WSLiE/XgiEgg7O/fz7Pdz9JY2khVrIpvH/82XRNdfpclIj5RwBGRQOhOdpOIJAiHwpSESzCMwelBv8sSEZ8o4IhIIKwuW81Ueoqsy5LKpMi6LHXxOr/LEhGfaAyOiATCLatuoXeylz19ewhZiPevfz9tlW1+lyUiPlHAEVlGb46/yfDMMPXxen345lk4FGbnxp08tO4hzIxISG9v+ZZ1WY6PHmcqNUVzeTONiUa/SxK5JL0DiCyT57uf53snvkfIQjjn2LlpJzuadvhdVuBEw1G/Swgk5xz//MY/87Pen2FmhC3MI1sfYX31er9LE5mXxuCILIN0Ns3uU7tZlVhFc3kzDYkGvn/i+1qvRYrG0MwQe/r20FzeTEt5C4lIgt2ndvtdlsglKeCILAPnHFmXJRwKAxC2MGmXxjnnc2UiV+dsGDcM8E4JprIpP0sSuSwFHJFlEA1H2dG0g+6JbganB+lOdvPu5ne/HXhECl1dvI71VevpTnYzMDXA8Mwwdzbf6XdZIpekMTgiy+RX1/8qq8tX05vspaW8hXetepffJYlctXAozL/a8q/Y07uHkdkRNlVvoqO2w++yRC7Jl4BjZh8F/hi4HtjhnNt7zmW/D3wayAC/55zbnWt/APgrIAx8wTn3Z7n2dcA3gFrgFeDXnXNzy/doRK5OOBTm1qZb/S5DZNFi4Rh3td7ldxkiV8WvU1QHgQ8Bz53baGZbgIeBrcADwP82s7CZhYG/Bh4EtgCfyF0X4L8Dn3PObQJG8MKRiIiIrGC+BBzn3GvOudfnuWgn8A3n3Kxz7iRwHNiR+zrunDuR6535BrDTzAy4F/hm7vZfAT6w9I9AREREClmhDTJuAU6f831Xru1S7XXAqHMufUH7vMzsUTPba2Z7BwYG8lq4iIiIFI4lG4NjZj8Emua56A+dc//vUjebp80xfxBzl7n+vJxzjwOPA3R2dmp+roiISEAtWcBxzt23iJt1AeeuX98K9OT+PV/7IFBtZpFcL8651xcREZEVqtBOUe0CHjazWG521CbgZWAPsMnM1plZCd5A5F3OWyXtGeAjudt/CrhU75CIiIisEL4EHDP7oJl1AXcA3zOz3QDOuUPAE8Bh4AfA7zrnMrnemceA3cBrwBO56wL8J+A/mNlxvDE5X1zeRyMiIiKFxlbqUvGdnZ1u7969V76iiIiIFAwz2+ec67zS9QrtFJWIiIjINVPAERERkcBRwBEREZHAUcARERGRwFHAERERkcBRwBEREZHAUcARERGRwFHAERERkcBRwBEREZHAUcARERGRwFHAERERkcBRwBEREZHAUcARERGRwFHAERERkcCJ+F2AiBSmE6MneLbrWQDe0/Ye1let97mi4HHOse/MPvb376e8pJz71txHQ6LB77JEAkE9OCJyke5kN18++GV6J3vpSfbw5YNfpifZ43dZgbO/fz//dOyfGJ4Z5tjwMb5w4Ask55J+lyUSCAo4InKRN0bfwOGojlVTE6/BOceJ0RN+lxU4BwcPUlFSQUVJBfWJeqbSU/RO9vpdlkggKOCIyEXKImVkXAbnHM45Mi5DIprwu6zAqYxVMpOeASDrsmSyGeKRuM9ViQSDxuCIyEW2NWzj54M/543RNzCMzTWb2Va/ze+yAuee1nt4Y/QNeid7cc5xZ/OdtJa3+l2WSCCYc87vGnzR2dnp9u7d63cZIgUrnU3Tm/ROl6wuX00kpL+HlsJMeoa+yT5i4RhNZU2Ymd8liRQ0M9vnnOu80vX0jiUi84qEIrRVtvldRuDFI3Haq9r9LkMkcDQGR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCRwFHREREAkcBR0RERAJHAUdEREQCx5xzftfgCzMbAN70u45lVA8M+l3ECqTj7g8dd3/ouPtjpR33tc65hitdacUGnJXGzPY65zr9rmOl0XH3h467P3Tc/aHjPj+dohIREZHAUcARERGRwFHAWTke97uAFUrH3R867v7QcfeHjvs8NAZHREREAkc9OCIiIhI4CjgiIiISOAo4AWFmHzWzQ2aWNbPOCy77fTM7bmavm9n957Q/kGs7bmb/+Zz2dWb2MzM7Zmb/YGYly/lYipWZ/bGZdZvZq7mvh865bEHPgSyOjufSMrNTZnYg9/rem2urNbOnc+8XT5tZTa7dzOx/5p6LX5jZzf5WXzzM7Etm1m9mB89pW/BxNrNP5a5/zMw+5cdj8ZMCTnAcBD4EPHduo5ltAR4GtgIPAP/bzMJmFgb+GngQ2AJ8InddgP8OfM45twkYAT69PA8hED7nnNue+3oSFv0cyALpeC6bX869vs/+IfWfgR/l3i9+lPsevOdhU+7rUeBvlr3S4vV/8N4rzrWg42xmtcAfAbcBO4A/OhuKVgoFnIBwzr3mnHt9not2At9wzs06504Cx/Fe7DuA4865E865OeAbwE4zM+Be4Ju5238F+MDSP4JAW9Bz4GOdxU7H0x878d4n4Pz3i53AV53nJaDazFb7UWCxcc49Bwxf0LzQ43w/8LRzbtg5NwI8zcWhKdAUcIKvBTh9zvddubZLtdcBo8659AXtcnUey3UTf+mcv5YW+hzI4uh4Lj0HPGVm+8zs0VzbKudcL0Du/425dj0f+bXQ47zij3/E7wLk6pnZD4GmeS76Q+fc/7vUzeZpc8wfbt1lri9c/jnA6xr+E7zj9SfAXwC/xcKfA1kcvXaX3rudcz1m1gg8bWZHLnNdPR/L41LHecUffwWcIuKcu28RN+sC2s75vhXoyf17vvZBvC7OSK4X59zrr3hX+xyY2d8C3819u9DnQBbncsdZ8sA515P7f7+ZfRvvtOAZM1vtnOvNnRrpz11dz0d+LfQ4dwH3XND+L8tQZ8HQKarg2wU8bGYxM1uHNxDtZWAPsCk3Y6oEbxDsLuet/PgM8JHc7T8FXKp3SM5xwfiCD+IN/IYFPgfLWXPA6HguITMrM7OKs/8GfgXvNb4L730Czn+/2AX8Rm6Wz+3A2NlTLLIoCz3Ou4FfMbOa3OnyX8m1rRjqwQkIM/sg8L+ABuB7Zvaqc+5+59whM3sCOAykgd91zmVyt3kM7wUfBr7knDuUu7v/BHzDzP4bsB/44jI/nGL152a2Ha8b+BTwWYBFPgeyQM65tI7nkloFfNubh0AE+Hvn3A/MbA/whJl9GngL+Gju+k8CD+ENqp8CfnP5Sy5OZvZ1vN6XejPrwpsN9Wcs4Dg754bN7E/wgj/Af3XOXThwOdC0VYOIiIgEjk5RiYiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IiIiEjgKOCIiIhI4CjgiIiISOAo4IhIUTOzdjM7YmZfMLODZvZ/zew+M3vezI6Z2Q6/axSR5aeAIyJBsBH4K+BG4Drgk8BdwH8E/sDHukTEJwo4IhIEJ51zB5xzWeAQ8KPcvmoHgHZfKxMRXyjgiEgQzJ7z7+w532fRnnsiK5ICjoiIiASOAo6IiIgEjnYTFxERkcBRD46IiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEjgKOiIiIBI4CjoiIiASOAo6IiIgEzv8HXx7EmX8ffqIAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 576x576 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.peek()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$4.9235437 \\; \\mathrm{km^{2}}$"
-      ],
-      "text/plain": [
-       "<Quantity 4.92354368 km2>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.footprint"
    ]
@@ -521,210 +235,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[TelescopeDescription(type=LST, name=LST, optics=LST, camera=LSTCam),\n",
-       " TelescopeDescription(type=MST, name=MST, optics=MST, camera=FlashCam),\n",
-       " TelescopeDescription(type=SST, name=ASTRI, optics=ASTRI, camera=ASTRICam)]"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.telescope_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[CameraGeometry(cam_id='LSTCam', pix_type='hexagonal', npix=1855, cam_rot=0.0 rad, pix_rot=100.89299992867878 deg),\n",
-       " CameraGeometry(cam_id='FlashCam', pix_type='hexagonal', npix=1764, cam_rot=0.0 rad, pix_rot=0.0 deg),\n",
-       " CameraGeometry(cam_id='ASTRICam', pix_type='rectangular', npix=2368, cam_rot=0.0 rad, pix_rot=0.0 deg)]"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.camera_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[OpticsDescription(name=ASTRI, equivalent_focal_length=2.15 m, num_mirros=2, mirror_area=14.56 m2),\n",
-       " OpticsDescription(name=MST, equivalent_focal_length=16.00 m, num_mirros=1, mirror_area=103.83 m2),\n",
-       " OpticsDescription(name=LST, equivalent_focal_length=28.00 m, num_mirros=1, mirror_area=386.73 m2)]"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.optics_types"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "[$95^\\circ38{}^\\prime18.0015{}^{\\prime\\prime}$\n",
-       " $117^\\circ35{}^\\prime31.273{}^{\\prime\\prime}$\n",
-       " $15^\\circ56{}^\\prime32.527{}^{\\prime\\prime}$\n",
-       " $166^\\circ24{}^\\prime15.7253{}^{\\prime\\prime}$\n",
-       " $90^\\circ00{}^\\prime00{}^{\\prime\\prime}$\n",
-       " $78^\\circ42{}^\\prime54.1682{}^{\\prime\\prime}$\n",
-       " $101^\\circ17{}^\\prime05.8318{}^{\\prime\\prime}$\n",
-       " $16^\\circ19{}^\\prime25.416{}^{\\prime\\prime}$\n",
-       " $38^\\circ42{}^\\prime43.3493{}^{\\prime\\prime}$\n",
-       " $138^\\circ18{}^\\prime26.2816{}^{\\prime\\prime}$\n",
-       " $160^\\circ45{}^\\prime08.6066{}^{\\prime\\prime}$\n",
-       " $45^\\circ50{}^\\prime11.5818{}^{\\prime\\prime}$\n",
-       " $68^\\circ26{}^\\prime09.4249{}^{\\prime\\prime}$\n",
-       " $11^\\circ27{}^\\prime33.9556{}^{\\prime\\prime}$\n",
-       " $111^\\circ33{}^\\prime50.5751{}^{\\prime\\prime}$\n",
-       " $134^\\circ09{}^\\prime48.4182{}^{\\prime\\prime}$\n",
-       " $168^\\circ32{}^\\prime26.0444{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime43.7281{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime16.2719{}^{\\prime\\prime}$\n",
-       " $16^\\circ02{}^\\prime24.2016{}^{\\prime\\prime}$\n",
-       " $38^\\circ36{}^\\prime32.8491{}^{\\prime\\prime}$\n",
-       " $141^\\circ23{}^\\prime27.1509{}^{\\prime\\prime}$\n",
-       " $163^\\circ57{}^\\prime35.7984{}^{\\prime\\prime}$\n",
-       " $45^\\circ48{}^\\prime42.2049{}^{\\prime\\prime}$\n",
-       " $68^\\circ25{}^\\prime33.0227{}^{\\prime\\prime}$\n",
-       " $11^\\circ21{}^\\prime07.5916{}^{\\prime\\prime}$\n",
-       " $111^\\circ34{}^\\prime26.9773{}^{\\prime\\prime}$\n",
-       " $134^\\circ11{}^\\prime17.7951{}^{\\prime\\prime}$\n",
-       " $168^\\circ38{}^\\prime52.4084{}^{\\prime\\prime}$\n",
-       " $49^\\circ01{}^\\prime53.8821{}^{\\prime\\prime}$\n",
-       " $130^\\circ58{}^\\prime06.1179{}^{\\prime\\prime}$\n",
-       " $153^\\circ34{}^\\prime33.8961{}^{\\prime\\prime}$\n",
-       " $57^\\circ29{}^\\prime13.3129{}^{\\prime\\prime}$\n",
-       " $80^\\circ06{}^\\prime19.0782{}^{\\prime\\prime}$\n",
-       " $99^\\circ53{}^\\prime40.9218{}^{\\prime\\prime}$\n",
-       " $122^\\circ30{}^\\prime46.6871{}^{\\prime\\prime}$\n",
-       " $1^\\circ21{}^\\prime19.7674{}^{\\prime\\prime}$\n",
-       " $23^\\circ51{}^\\prime29.0911{}^{\\prime\\prime}$\n",
-       " $156^\\circ08{}^\\prime30.9089{}^{\\prime\\prime}$\n",
-       " $178^\\circ38{}^\\prime40.2326{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime26.1515{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime33.8485{}^{\\prime\\prime}$\n",
-       " $34^\\circ34{}^\\prime02.3914{}^{\\prime\\prime}$\n",
-       " $57^\\circ11{}^\\prime07.3317{}^{\\prime\\prime}$\n",
-       " $122^\\circ48{}^\\prime52.6683{}^{\\prime\\prime}$\n",
-       " $145^\\circ25{}^\\prime57.6086{}^{\\prime\\prime}$\n",
-       " $15^\\circ57{}^\\prime57.3762{}^{\\prime\\prime}$\n",
-       " $38^\\circ34{}^\\prime56.9335{}^{\\prime\\prime}$\n",
-       " $141^\\circ25{}^\\prime03.0665{}^{\\prime\\prime}$\n",
-       " $164^\\circ02{}^\\prime02.6238{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime25.2281{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime34.7719{}^{\\prime\\prime}$\n",
-       " $11^\\circ18{}^\\prime54.9244{}^{\\prime\\prime}$\n",
-       " $168^\\circ41{}^\\prime05.0756{}^{\\prime\\prime}$\n",
-       " $45^\\circ48{}^\\prime11.2618{}^{\\prime\\prime}$\n",
-       " $68^\\circ25{}^\\prime20.4612{}^{\\prime\\prime}$\n",
-       " $111^\\circ34{}^\\prime39.5388{}^{\\prime\\prime}$\n",
-       " $134^\\circ11{}^\\prime48.7382{}^{\\prime\\prime}$\n",
-       " $63^\\circ12{}^\\prime03.8214{}^{\\prime\\prime}$\n",
-       " $85^\\circ49{}^\\prime13.7063{}^{\\prime\\prime}$\n",
-       " $29^\\circ21{}^\\prime33.4806{}^{\\prime\\prime}$\n",
-       " $51^\\circ58{}^\\prime41.6293{}^{\\prime\\prime}$\n",
-       " $3^\\circ09{}^\\prime32.0002{}^{\\prime\\prime}$\n",
-       " $25^\\circ45{}^\\prime53.6564{}^{\\prime\\prime}$\n",
-       " $94^\\circ10{}^\\prime46.2937{}^{\\prime\\prime}$\n",
-       " $116^\\circ47{}^\\prime56.1786{}^{\\prime\\prime}$\n",
-       " $128^\\circ01{}^\\prime18.3707{}^{\\prime\\prime}$\n",
-       " $150^\\circ38{}^\\prime26.5194{}^{\\prime\\prime}$\n",
-       " $154^\\circ14{}^\\prime06.3436{}^{\\prime\\prime}$\n",
-       " $176^\\circ50{}^\\prime27.9998{}^{\\prime\\prime}$\n",
-       " $78^\\circ41{}^\\prime24.8214{}^{\\prime\\prime}$\n",
-       " $101^\\circ18{}^\\prime35.1786{}^{\\prime\\prime}$\n",
-       " $15^\\circ57{}^\\prime47.4141{}^{\\prime\\prime}$\n",
-       " $38^\\circ34{}^\\prime53.4825{}^{\\prime\\prime}$\n",
-       " $141^\\circ25{}^\\prime06.5175{}^{\\prime\\prime}$\n",
-       " $164^\\circ02{}^\\prime12.5859{}^{\\prime\\prime}$\n",
-       " $11^\\circ18{}^\\prime46.4095{}^{\\prime\\prime}$\n",
-       " $168^\\circ41{}^\\prime13.5905{}^{\\prime\\prime}$\n",
-       " $52^\\circ49{}^\\prime06.0105{}^{\\prime\\prime}$\n",
-       " $75^\\circ26{}^\\prime16.4206{}^{\\prime\\prime}$\n",
-       " $38^\\circ57{}^\\prime04.2653{}^{\\prime\\prime}$\n",
-       " $61^\\circ34{}^\\prime14.3105{}^{\\prime\\prime}$\n",
-       " $104^\\circ33{}^\\prime43.5794{}^{\\prime\\prime}$\n",
-       " $127^\\circ10{}^\\prime53.9895{}^{\\prime\\prime}$\n",
-       " $118^\\circ25{}^\\prime45.6895{}^{\\prime\\prime}$\n",
-       " $141^\\circ02{}^\\prime55.7347{}^{\\prime\\prime}$\n",
-       " $66^\\circ31{}^\\prime35.8563{}^{\\prime\\prime}$\n",
-       " $89^\\circ08{}^\\prime46.5312{}^{\\prime\\prime}$\n",
-       " $26^\\circ24{}^\\prime12.8535{}^{\\prime\\prime}$\n",
-       " $49^\\circ01{}^\\prime22.348{}^{\\prime\\prime}$\n",
-       " $90^\\circ51{}^\\prime13.4688{}^{\\prime\\prime}$\n",
-       " $113^\\circ28{}^\\prime24.1437{}^{\\prime\\prime}$\n",
-       " $130^\\circ58{}^\\prime37.652{}^{\\prime\\prime}$\n",
-       " $153^\\circ35{}^\\prime47.1465{}^{\\prime\\prime}$\n",
-       " $5^\\circ52{}^\\prime51.9148{}^{\\prime\\prime}$\n",
-       " $28^\\circ29{}^\\prime50.4816{}^{\\prime\\prime}$\n",
-       " $151^\\circ30{}^\\prime09.5184{}^{\\prime\\prime}$\n",
-       " $174^\\circ07{}^\\prime08.0852{}^{\\prime\\prime}$]"
-      ],
-      "text/plain": [
-       "<Angle [ 95.63833374, 117.59202028,  15.94236861, 166.40436814,\n",
-       "         90.        ,  78.71504671, 101.28495329,  16.32372666,\n",
-       "         38.71204146, 138.30730046, 160.75239071,  45.8365505 ,\n",
-       "         68.43595137,  11.45943212, 111.56404863, 134.1634495 ,\n",
-       "        168.54056788,  78.69548002, 101.30451998,  16.04005599,\n",
-       "         38.60912476, 141.39087524, 163.95994401,  45.81172359,\n",
-       "         68.42583965,  11.35210877, 111.57416035, 134.18827641,\n",
-       "        168.64789123,  49.03163391, 130.96836609, 153.57608224,\n",
-       "         57.48703137,  80.10529951,  99.89470049, 122.51296863,\n",
-       "          1.35549094,  23.85808087, 156.14191913, 178.64450906,\n",
-       "         78.69059764, 101.30940236,  34.56733094,  57.18536991,\n",
-       "        122.81463009, 145.43266906,  15.96593785,  38.58248153,\n",
-       "        141.41751847, 164.03406215,  78.69034114, 101.30965886,\n",
-       "         11.31525677, 168.68474323,  45.80312828,  68.42235035,\n",
-       "        111.57764965, 134.19687172,  63.2010615 ,  85.82047396,\n",
-       "         29.35930018,  51.97823035,   3.15888895,  25.76490456,\n",
-       "         94.17952604, 116.7989385 , 128.02176965, 150.64069982,\n",
-       "        154.23509544, 176.84111105,  78.69022816, 101.30977184,\n",
-       "         15.96317058,  38.58152291, 141.41847709, 164.03682942,\n",
-       "         11.31289154, 168.68710846,  52.81833625,  75.4378946 ,\n",
-       "         38.95118481,  61.5706418 , 104.5621054 , 127.18166375,\n",
-       "        118.4293582 , 141.04881519,  66.52662676,  89.14625866,\n",
-       "         26.40357041,  49.02287445,  90.85374134, 113.47337324,\n",
-       "        130.97712555, 153.59642959,   5.88108744,  28.497356  ,\n",
-       "        151.502644  , 174.11891256] deg>"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from astropy.coordinates import SkyCoord\n",
     "from ctapipe.coordinates import GroundFrame\n",
@@ -744,20 +284,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 0,  4, 22])"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_ids_to_indices([1,5,23])"
    ]
@@ -771,85 +300,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([-1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,\n",
-       "       16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,\n",
-       "       33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,\n",
-       "       50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66,\n",
-       "       67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83,\n",
-       "       84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97])"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_index_array"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 0,  4, 22])"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_index_array[[1,5,23]]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_indices[1]  # this is a dict of tel_id -> tel_index, so we can only do one at once"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[1, 2, 3, 4]"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ids = subarray.get_tel_ids_for_type(subarray.telescope_types[0])\n",
     "ids"
@@ -857,20 +337,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0, 1, 2, 3])"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "idx = subarray.tel_ids_to_indices(ids)\n",
     "idx"
@@ -878,22 +347,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<SkyCoord (GroundFrame): (x, y, z) in m\n",
-       "    [( -20.,  65., 16.), ( -20., -65., 16.), (  80.,   0., 16.),\n",
-       "     (-120.,   0., 16.)]>"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.tel_coords[idx]"
    ]
@@ -907,23 +363,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[-20,~65,~16] \\; \\mathrm{m}$"
-      ],
-      "text/plain": [
-       "<Quantity [-20.,  65.,  16.] m>"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "subarray.positions[1]"
    ]

--- a/docs/tutorials/calibrated_data_exploration.ipynb
+++ b/docs/tutorials/calibrated_data_exploration.ipynb
@@ -262,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cam_ids = set(sub.get_tel_ids_for_type(\"MST:FlashCam\"))"
+    "cam_ids = set(sub.get_tel_ids_for_type(\"MST_MST_FlashCam\"))"
    ]
   },
   {
@@ -357,6 +357,13 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -375,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/ctapipe_handson.ipynb
+++ b/docs/tutorials/ctapipe_handson.ipynb
@@ -526,7 +526,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subarray.get_tel_ids_for_type(\"LST:LSTCam\")"
+    "subarray.get_tel_ids_for_type(\"LST_LST_LSTCam\")"
    ]
   },
   {
@@ -649,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
+++ b/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
@@ -57,22 +57,7 @@
    "source": [
     "plt.rcParams['figure.figsize'] = (12, 8)\n",
     "plt.rcParams['font.size'] = 14\n",
-    "\n",
     "plt.rcParams['figure.figsize']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "notes"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%javascript\n",
-    "$.getScript('https://kmahelona.github.io/ipython_notebook_goodies/ipython_notebook_toc.js')"
    ]
   },
   {
@@ -335,7 +320,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tel_id = 17"
+    "tel_id = 2"
    ]
   },
   {
@@ -1100,7 +1085,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
+++ b/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
@@ -217,7 +217,7 @@
     "\n",
     "# event_source() automatically detects what kind of file we are giving it,\n",
     "# if already supported by ctapipe\n",
-    "source = event_source(input_url, max_events=9)\n",
+    "source = event_source(input_url, max_events=49)\n",
     "\n",
     "print(type(source))"
    ]
@@ -320,7 +320,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tel_id = 2"
+    "tel_id = 4"
    ]
   },
   {
@@ -333,6 +333,15 @@
     "dl1 = event.dl1.tel[tel_id]\n",
     "\n",
     "camera, dl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dl1.image"
    ]
   },
   {
@@ -418,6 +427,7 @@
     "d2.image = dl1.pulse_time[0] - np.average(dl1.pulse_time[0], weights=dl1.image[0])\n",
     "d2.cmap = 'RdBu_r'\n",
     "d2.add_colorbar(ax=ax2)\n",
+    "d2.set_limits_minmax(-20,20)\n",
     "\n",
     "d1.highlight_pixels(clean, color='red', linewidth=1)"
    ]

--- a/docs/tutorials/raw_data_exploration.ipynb
+++ b/docs/tutorials/raw_data_exploration.ipynb
@@ -509,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/theta_square.ipynb
+++ b/docs/tutorials/theta_square.ipynb
@@ -235,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   },
   "toc": {
    "nav_menu": {


### PR DESCRIPTION
- telescope names are now normalized to `TYPE_OPTICS_CAMERA` (usable as an output file or group name)
- `SubarrayDescription.get_tel_ids_for_type()` was broken due to the previous name change, this fixes it
- added a lot of unit tests to prevent regression
- added a function and property to map telescope *IDs* to telescope *indices* (useful for creating things like trigger patterns or packing telescope data)