### PR TITLE
Add deviation parameter to timing_parameters

### DIFF
--- a/ctapipe/image/tests/test_timing_parameters.py
+++ b/ctapipe/image/tests/test_timing_parameters.py
@@ -13,20 +13,26 @@ def test_psi_0():
     """
     grad = 2.0
     intercept = 1.0
+    deviation = 0.1
 
     geom = CameraGeometry.from_name("LSTCam")
     hillas = HillasParametersContainer(x=0 * u.m, y=0 * u.m, psi=0 * u.deg)
 
+    random = np.random.RandomState(1)
+    pulse_time = intercept + grad * geom.pix_x.value
+    pulse_time += random.normal(0, deviation, geom.n_pixels)
+
     timing = timing_parameters(
         geom,
         image=np.ones(geom.n_pixels),
-        peakpos=intercept + grad * geom.pix_x.value,
+        pulse_time=pulse_time,
         hillas_parameters=hillas,
     )
 
     # Test we get the values we put in back out again
-    assert_allclose(timing.slope, grad / geom.pix_x.unit)
-    assert_allclose(timing.intercept, intercept)
+    assert_allclose(timing.slope, grad / geom.pix_x.unit, rtol=1e-2)
+    assert_allclose(timing.intercept, intercept, rtol=1e-2)
+    assert_allclose(timing.deviation, deviation, rtol=1e-2)
 
 
 def test_psi_20():
@@ -34,30 +40,41 @@ def test_psi_20():
     # Then try a different rotation angle
     grad = 2
     intercept = 1
+    deviation = 0.1
 
     geom = CameraGeometry.from_name("LSTCam")
     psi = 20 * u.deg
     hillas = HillasParametersContainer(x=0 * u.m, y=0 * u.m, psi=psi)
 
+    random = np.random.RandomState(1)
+    pulse_time = intercept + grad * (np.cos(psi) * geom.pix_x.value
+                                     + np.sin(psi) * geom.pix_y.value)
+    pulse_time += random.normal(0, deviation, geom.n_pixels)
+
     timing = timing_parameters(
         geom,
         image=np.ones(geom.n_pixels),
-        peakpos=intercept + grad * (np.cos(psi) * geom.pix_x.value
-                                    + np.sin(psi) * geom.pix_y.value),
+        pulse_time=pulse_time,
         hillas_parameters=hillas,
     )
 
     # Test we get the values we put in back out again
-    assert_allclose(timing.slope, grad / geom.pix_x.unit)
-    assert_allclose(timing.intercept, intercept)
+    assert_allclose(timing.slope, grad / geom.pix_x.unit, rtol=1e-2)
+    assert_allclose(timing.intercept, intercept, rtol=1e-2)
+    assert_allclose(timing.deviation, deviation, rtol=1e-2)
 
 
 def test_ignore_negative():
     grad = 2.0
     intercept = 1.0
+    deviation = 0.1
 
     geom = CameraGeometry.from_name("LSTCam")
     hillas = HillasParametersContainer(x=0 * u.m, y=0 * u.m, psi=0 * u.deg)
+
+    random = np.random.RandomState(1)
+    pulse_time = intercept + grad * geom.pix_x.value
+    pulse_time += random.normal(0, deviation, geom.n_pixels)
 
     image = np.ones(geom.n_pixels)
     image[5:10] = -1.0
@@ -65,10 +82,11 @@ def test_ignore_negative():
     timing = timing_parameters(
         geom,
         image,
-        peakpos=intercept + grad * geom.pix_x.value,
+        pulse_time=pulse_time,
         hillas_parameters=hillas,
     )
 
     # Test we get the values we put in back out again
-    assert_allclose(timing.slope, grad / geom.pix_x.unit)
-    assert_allclose(timing.intercept, intercept)
+    assert_allclose(timing.slope, grad / geom.pix_x.unit, rtol=1e-2)
+    assert_allclose(timing.intercept, intercept, rtol=1e-2)
+    assert_allclose(timing.deviation, deviation, rtol=1e-2)

--- a/ctapipe/image/timing_parameters.py
+++ b/ctapipe/image/timing_parameters.py
@@ -3,6 +3,7 @@ Image timing-based shower image parametrization.
 """
 
 import numpy as np
+from numpy.polynomial.polynomial import polyfit, polyval
 from ctapipe.io.containers import TimingParametersContainer
 from .hillas import camera_to_shower_coordinates
 
@@ -12,7 +13,7 @@ __all__ = [
 ]
 
 
-def timing_parameters(geom, image, peakpos, hillas_parameters):
+def timing_parameters(geom, image, pulse_time, hillas_parameters):
     """
     Function to extract timing parameters from a cleaned image
 
@@ -22,8 +23,8 @@ def timing_parameters(geom, image, peakpos, hillas_parameters):
         Camera geometry
     image : array_like
         Pixel values
-    peakpos : array_like
-        Pixel peak positions array
+    pulse_time : array_like
+        Time of the pulse extracted from each pixels waveform
     hillas_parameters: ctapipe.io.containers.HillasParametersContainer
         Result of hillas_parameters
 
@@ -36,14 +37,11 @@ def timing_parameters(geom, image, peakpos, hillas_parameters):
 
     # select only the pixels in the cleaned image that are greater than zero.
     # we need to exclude possible pixels with zero signal after cleaning.
-    mask = image > 0
-    pix_x = geom.pix_x[mask]
-    pix_y = geom.pix_y[mask]
-    image = image[mask]
-    peakpos = peakpos[mask]
-
-    assert pix_x.shape == image.shape, 'image shape must match geometry'
-    assert pix_x.shape == peakpos.shape, 'peakpos shape must match geometry'
+    greater_than_0 = image > 0
+    pix_x = geom.pix_x[greater_than_0]
+    pix_y = geom.pix_y[greater_than_0]
+    image = image[greater_than_0]
+    pulse_time = pulse_time[greater_than_0]
 
     longi, trans = camera_to_shower_coordinates(
         pix_x,
@@ -52,9 +50,16 @@ def timing_parameters(geom, image, peakpos, hillas_parameters):
         hillas_parameters.y,
         hillas_parameters.psi
     )
-    slope, intercept = np.polyfit(longi.value, peakpos, deg=1, w=np.sqrt(image))
+    intercept, slope = polyfit(
+        longi.value, pulse_time, deg=1, w=np.sqrt(image)
+    )
+    predicted_time = polyval(longi.value, (intercept, slope))
+    deviation = np.sqrt(
+        np.sum((pulse_time - predicted_time)**2) / pulse_time.size
+    )
 
     return TimingParametersContainer(
         slope=slope / unit,
         intercept=intercept,
+        deviation=deviation,
     )

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -618,6 +618,8 @@ class TimingParametersContainer(Container):
     """
     slope = Field(nan, 'Slope of arrival times along main shower axis')
     intercept = Field(nan, 'intercept of arrival times along main shower axis')
+    deviation = Field(nan, 'Root-mean-square deviation of the pulse times '
+                           'with respect to the predicted time')
 
 
 class FlatFieldContainer(Container):

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -95,7 +95,7 @@ def test_array_display():
     timing_rot20 = timing_parameters(
         geom,
         image=ones(geom.n_pixels),
-        peakpos=intercept + grad * geom.pix_x.value,
+        pulse_time=intercept + grad * geom.pix_x.value,
         hillas_parameters=hillas,
     )
     gradient_dict = {


### PR DESCRIPTION
Add the root-mean-square deviation of the pixel pulse timing to the predicted timing from the time gradient calculation.

This can be used as a measure of the quality of the time gradient extracted, and has potential to be useful in gamma-hadron discrimination (see Prokoph 2009, https://astro.desy.de/gamma_astronomy/theses/e234039/infoboxContent234040/Prokoph_Diplom_2009.pdf)