### PR TITLE
Add gain selection to calibration chain

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -135,7 +135,7 @@ class CameraCalibrator(Component):
         ndarray
         """
         try:
-            gain_selection = event.mon.tel[telid].gain_selection
+            gain_selection = event.r1.tel[telid].gain_selection
             shift = self.image_extractor.window_shift
             width = self.image_extractor.window_width
             shape = event.mc.tel[telid].reference_pulse_shape
@@ -185,12 +185,12 @@ class CameraCalibrator(Component):
         # waveform dimensions.
         waveforms_gs, pixel_channel = self.gain_selector(waveforms)
         if pixel_channel is not None:
-            event.mon.tel[telid].gain_selection = pixel_channel
+            event.r1.tel[telid].gain_selection = pixel_channel
         else:
             # If pixel_channel is None, then waveforms has already been
             # pre-gainselected, and presumably the gain_selection container is
             # filled by the EventSource
-            if event.mon.tel[telid].gain_selection is None:
+            if event.r1.tel[telid].gain_selection is None:
                 raise ValueError(
                     "EventSource is loading pre-gainselected waveforms "
                     "without filling the gain_selection container"

--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -135,7 +135,7 @@ class CameraCalibrator(Component):
         ndarray
         """
         try:
-            gain_selection = event.r1.tel[telid].gain_selection
+            selected_gain_channel = event.r1.tel[telid].selected_gain_channel
             shift = self.image_extractor.window_shift
             width = self.image_extractor.window_width
             shape = event.mc.tel[telid].reference_pulse_shape
@@ -144,7 +144,7 @@ class CameraCalibrator(Component):
             time_slice = event.mc.tel[telid].time_slice
             correction = integration_correction(n_chan, shape, step,
                                                 time_slice, width, shift)
-            pixel_correction = correction[gain_selection]
+            pixel_correction = correction[selected_gain_channel]
             return pixel_correction
         except (AttributeError, KeyError):
             # Don't apply correction when window_shift or window_width
@@ -183,17 +183,17 @@ class CameraCalibrator(Component):
         # simtelarray do not have the gain selection applied, and so must be
         # done as part of the calibration step to ensure the correct
         # waveform dimensions.
-        waveforms_gs, pixel_channel = self.gain_selector(waveforms)
-        if pixel_channel is not None:
-            event.r1.tel[telid].gain_selection = pixel_channel
+        waveforms_gs, selected_gain_channel = self.gain_selector(waveforms)
+        if selected_gain_channel is not None:
+            event.r1.tel[telid].selected_gain_channel = selected_gain_channel
         else:
             # If pixel_channel is None, then waveforms has already been
-            # pre-gainselected, and presumably the gain_selection container is
-            # filled by the EventSource
-            if event.r1.tel[telid].gain_selection is None:
+            # pre-gainselected, and presumably the selected_gain_channel
+            # container is filled by the EventSource
+            if event.r1.tel[telid].selected_gain_channel is None:
                 raise ValueError(
                     "EventSource is loading pre-gainselected waveforms "
-                    "without filling the gain_selection container"
+                    "without filling the selected_gain_channel container"
                 )
 
         reduced_waveforms = self.data_volume_reducer(waveforms_gs)

--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -45,14 +45,18 @@ class GainSelector(Component):
             Shape: (n_pix, n_samples)
         """
         if waveforms.ndim == 2:  # Return if already gain selected
-            return waveforms
+            n_pixels = waveforms.shape[0]
+            pixel_channel = np.zeros(n_pixels)  # TODO: Sourced elsewhere?
+            return waveforms, pixel_channel
         elif waveforms.ndim == 3:
             n_channels, n_pixels, _ = waveforms.shape
             if n_channels == 1:  # Reduce if already single channel
-                return waveforms[0]
+                pixel_channel = np.zeros(n_pixels)
+                return waveforms[0], pixel_channel
             else:
                 pixel_channel = self.select_channel(waveforms)
-                return waveforms[pixel_channel, np.arange(n_pixels)]
+                gain_selected = waveforms[pixel_channel, np.arange(n_pixels)]
+                return gain_selected, pixel_channel
         else:
             raise ValueError(
                 f"Cannot handle waveform array of shape: {waveforms.ndim}"
@@ -92,7 +96,8 @@ class ManualGainSelector(GainSelector):
     ).tag(config=True)
 
     def select_channel(self, waveforms):
-        return GainChannel[self.channel]
+        n_pixels = waveforms.shape[1]
+        return np.full(n_pixels, GainChannel[self.channel])
 
 
 class ThresholdGainSelector(GainSelector):

--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -45,17 +45,19 @@ class GainSelector(Component):
             Shape: (n_pix, n_samples)
         """
         if waveforms.ndim == 2:  # Return if already gain selected
-            pixel_channel = None  # Provided by EventSource
-            return waveforms, pixel_channel
+            selected_gain_channel = None  # Provided by EventSource
+            return waveforms, selected_gain_channel
         elif waveforms.ndim == 3:
             n_channels, n_pixels, _ = waveforms.shape
             if n_channels == 1:  # Reduce if already single channel
-                pixel_channel = np.zeros(n_pixels, dtype=int)
-                return waveforms[0], pixel_channel
+                selected_gain_channel = np.zeros(n_pixels, dtype=int)
+                return waveforms[0], selected_gain_channel
             else:
-                pixel_channel = self.select_channel(waveforms)
-                gain_selected = waveforms[pixel_channel, np.arange(n_pixels)]
-                return gain_selected, pixel_channel
+                selected_gain_channel = self.select_channel(waveforms)
+                selected_gain_waveforms = waveforms[
+                    selected_gain_channel, np.arange(n_pixels)
+                ]
+                return selected_gain_waveforms, selected_gain_channel
         else:
             raise ValueError(
                 f"Cannot handle waveform array of shape: {waveforms.ndim}"
@@ -77,7 +79,7 @@ class GainSelector(Component):
 
         Returns
         -------
-        pixel_channel : ndarray
+        selected_gain_channel : ndarray
             Gain channel to use for each pixel
             Shape: n_pix
             Dtype: int

--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -45,13 +45,12 @@ class GainSelector(Component):
             Shape: (n_pix, n_samples)
         """
         if waveforms.ndim == 2:  # Return if already gain selected
-            n_pixels = waveforms.shape[0]
-            pixel_channel = np.zeros(n_pixels)  # TODO: Sourced elsewhere?
+            pixel_channel = None  # Provided by EventSource
             return waveforms, pixel_channel
         elif waveforms.ndim == 3:
             n_channels, n_pixels, _ = waveforms.shape
             if n_channels == 1:  # Reduce if already single channel
-                pixel_channel = np.zeros(n_pixels)
+                pixel_channel = np.zeros(n_pixels, dtype=int)
                 return waveforms[0], pixel_channel
             else:
                 pixel_channel = self.select_channel(waveforms)

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -41,7 +41,7 @@ def test_select_gain():
 
     event = DataContainer()
     event.r1.tel[telid].waveform = np.ones((n_pixels, n_samples))
-    event.mon.tel[telid].gain_selection = np.zeros(n_pixels)
+    event.r1.tel[telid].gain_selection = np.zeros(n_pixels)
     calibrator._calibrate_dl0(event, telid)
     assert event.dl0.tel[telid].waveform.shape == (n_pixels, n_samples)
 

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -2,9 +2,11 @@ from ctapipe.calib.camera.calibrator import (
     CameraCalibrator,
     integration_correction,
 )
+from ctapipe.io.containers import DataContainer
 from ctapipe.image.extractor import LocalPeakWindowSum
 from traitlets.config.configurable import Config
 import pytest
+import numpy as np
 
 
 def test_camera_calibrator(example_event):
@@ -12,7 +14,36 @@ def test_camera_calibrator(example_event):
     calibrator = CameraCalibrator()
     calibrator(example_event)
     image = example_event.dl1.tel[telid].image
+    pulse_time = example_event.dl1.tel[telid].pulse_time
     assert image is not None
+    assert pulse_time is not None
+    assert image.shape == (1764,)
+    assert pulse_time.shape == (1764,)
+
+
+def test_select_gain():
+    n_channels = 2
+    n_pixels = 2048
+    n_samples = 128
+    telid = 0
+
+    calibrator = CameraCalibrator()
+
+    event = DataContainer()
+    event.r1.tel[telid].waveform = np.ones((n_channels, n_pixels, n_samples))
+    calibrator._calibrate_dl0(event, telid)
+    assert event.dl0.tel[telid].waveform.shape == (n_pixels, n_samples)
+
+    event = DataContainer()
+    event.r1.tel[telid].waveform = np.ones((n_pixels, n_samples))
+    with pytest.raises(ValueError):
+        calibrator._calibrate_dl0(event, telid)
+
+    event = DataContainer()
+    event.r1.tel[telid].waveform = np.ones((n_pixels, n_samples))
+    event.mon.tel[telid].gain_selection = np.zeros(n_pixels)
+    calibrator._calibrate_dl0(event, telid)
+    assert event.dl0.tel[telid].waveform.shape == (n_pixels, n_samples)
 
 
 def test_manual_extractor():
@@ -55,7 +86,7 @@ def test_integration_correction_no_ref_pulse(example_event):
     calibrator = CameraCalibrator()
     calibrator._calibrate_dl0(example_event, telid)
     correction = calibrator._get_correction(example_event, telid)
-    assert correction[0] == 1
+    assert (correction == 1).all()
 
 
 def test_check_r1_empty(example_event):

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -41,7 +41,7 @@ def test_select_gain():
 
     event = DataContainer()
     event.r1.tel[telid].waveform = np.ones((n_pixels, n_samples))
-    event.r1.tel[telid].gain_selection = np.zeros(n_pixels)
+    event.r1.tel[telid].selected_gain_channel = np.zeros(n_pixels)
     calibrator._calibrate_dl0(event, telid)
     assert event.dl0.tel[telid].waveform.shape == (n_pixels, n_samples)
 

--- a/ctapipe/calib/camera/tests/test_flatfield.py
+++ b/ctapipe/calib/camera/tests/test_flatfield.py
@@ -1,7 +1,19 @@
 import numpy as np
 from ctapipe.calib.camera.flatfield import *
-from ctapipe.io.containers import EventAndMonDataContainer
+from ctapipe.io.containers import DataContainer
 from traitlets.config.loader import Config
+
+
+# class FixedWindowSum2Chan(FixedWindowSum):
+#
+#     def __call__(self, waveforms):
+#         start = self.window_start
+#         end = self.window_start + self.window_width
+#         charge = waveforms[..., start:end].sum(2)
+#         pulse_time = extract_pulse_time_around_peak(
+#             waveforms, self.window_start, self.window_width, 0
+#         )
+#         return charge, pulse_time
 
 
 def test_flasherflatfieldcalculator():
@@ -22,7 +34,7 @@ def test_flasherflatfieldcalculator():
                                                sample_size=n_events,
                                                tel_id=tel_id, config=config)
     # create one event
-    data = EventAndMonDataContainer()
+    data = DataContainer()
     data.meta['origin'] = 'test'
 
     # initialize mon and r1 data

--- a/ctapipe/calib/camera/tests/test_flatfield.py
+++ b/ctapipe/calib/camera/tests/test_flatfield.py
@@ -1,19 +1,7 @@
 import numpy as np
 from ctapipe.calib.camera.flatfield import *
-from ctapipe.io.containers import DataContainer
+from ctapipe.io.containers import EventAndMonDataContainer
 from traitlets.config.loader import Config
-
-
-# class FixedWindowSum2Chan(FixedWindowSum):
-#
-#     def __call__(self, waveforms):
-#         start = self.window_start
-#         end = self.window_start + self.window_width
-#         charge = waveforms[..., start:end].sum(2)
-#         pulse_time = extract_pulse_time_around_peak(
-#             waveforms, self.window_start, self.window_width, 0
-#         )
-#         return charge, pulse_time
 
 
 def test_flasherflatfieldcalculator():
@@ -34,7 +22,7 @@ def test_flasherflatfieldcalculator():
                                                sample_size=n_events,
                                                tel_id=tel_id, config=config)
     # create one event
-    data = DataContainer()
+    data = EventAndMonDataContainer()
     data.meta['origin'] = 'test'
 
     # initialize mon and r1 data

--- a/ctapipe/calib/camera/tests/test_gainselection.py
+++ b/ctapipe/calib/camera/tests/test_gainselection.py
@@ -14,12 +14,15 @@ def test_gain_selector():
     waveforms[1] *= 2
 
     gain_selector = TestGainSelector()
-    waveforms_gs = gain_selector(waveforms)
+    waveforms_gs, pixel_channel = gain_selector(waveforms)
     np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
-    waveforms_gs = gain_selector(waveforms[0])
+    np.testing.assert_equal(pixel_channel, 0)
+    waveforms_gs, pixel_channel = gain_selector(waveforms[0])
     np.testing.assert_equal(waveforms_gs, waveforms[0])
-    waveforms_gs = gain_selector(waveforms[[0]])
+    np.testing.assert_equal(pixel_channel, 0)
+    waveforms_gs, pixel_channel = gain_selector(waveforms[[0]])
     np.testing.assert_equal(waveforms_gs, waveforms[0])
+    np.testing.assert_equal(pixel_channel, 0)
 
 
 def test_manual_gain_selector():
@@ -28,12 +31,14 @@ def test_manual_gain_selector():
     waveforms[1] *= 2
 
     gs_high = ManualGainSelector(channel="HIGH")
-    waveforms_gs_high = gs_high(waveforms)
-    np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs_high)
+    waveforms_gs, pixel_channel = gs_high(waveforms)
+    np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
+    np.testing.assert_equal(pixel_channel, 0)
 
-    gs_high = ManualGainSelector(channel="LOW")
-    waveforms_gs_low = gs_high(waveforms)
-    np.testing.assert_equal(waveforms[GainChannel.LOW], waveforms_gs_low)
+    gs_low = ManualGainSelector(channel="LOW")
+    waveforms_gs, pixel_channel = gs_low(waveforms)
+    np.testing.assert_equal(waveforms[GainChannel.LOW], waveforms_gs)
+    np.testing.assert_equal(pixel_channel, 1)
 
 
 def test_threshold_gain_selector():
@@ -43,6 +48,8 @@ def test_threshold_gain_selector():
     waveforms[0, 0] = 100
 
     gain_selector = ThresholdGainSelector(threshold=50)
-    waveforms_gs = gain_selector(waveforms)
+    waveforms_gs, pixel_channel = gain_selector(waveforms)
     assert (waveforms_gs[0] == 1).all()
     assert (waveforms_gs[np.arange(1, 2048)] == 0).all()
+    assert pixel_channel[0] == 1
+    assert (pixel_channel[np.arange(1, 2048)] == 0).all()

--- a/ctapipe/calib/camera/tests/test_gainselection.py
+++ b/ctapipe/calib/camera/tests/test_gainselection.py
@@ -17,12 +17,26 @@ def test_gain_selector():
     waveforms_gs, pixel_channel = gain_selector(waveforms)
     np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
     np.testing.assert_equal(pixel_channel, 0)
-    waveforms_gs, pixel_channel = gain_selector(waveforms[0])
-    np.testing.assert_equal(waveforms_gs, waveforms[0])
-    np.testing.assert_equal(pixel_channel, 0)
-    waveforms_gs, pixel_channel = gain_selector(waveforms[[0]])
-    np.testing.assert_equal(waveforms_gs, waveforms[0])
-    np.testing.assert_equal(pixel_channel, 0)
+
+
+def test_pre_selected():
+    shape = (2048, 128)
+    waveforms = np.zeros(shape)
+
+    gain_selector = TestGainSelector()
+    waveforms_gs, pixel_channel = gain_selector(waveforms)
+    assert waveforms.shape == waveforms_gs.shape
+    assert pixel_channel is None
+
+
+def test_single_channel():
+    shape = (1, 2048, 128)
+    waveforms = np.zeros(shape)
+
+    gain_selector = TestGainSelector()
+    waveforms_gs, pixel_channel = gain_selector(waveforms)
+    assert waveforms_gs.shape == (2048, 128)
+    assert (pixel_channel == 0).all()
 
 
 def test_manual_gain_selector():

--- a/ctapipe/calib/camera/tests/test_gainselection.py
+++ b/ctapipe/calib/camera/tests/test_gainselection.py
@@ -14,9 +14,9 @@ def test_gain_selector():
     waveforms[1] *= 2
 
     gain_selector = TestGainSelector()
-    waveforms_gs, pixel_channel = gain_selector(waveforms)
+    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
     np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
-    np.testing.assert_equal(pixel_channel, 0)
+    np.testing.assert_equal(selected_gain_channel, 0)
 
 
 def test_pre_selected():
@@ -24,9 +24,9 @@ def test_pre_selected():
     waveforms = np.zeros(shape)
 
     gain_selector = TestGainSelector()
-    waveforms_gs, pixel_channel = gain_selector(waveforms)
+    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
     assert waveforms.shape == waveforms_gs.shape
-    assert pixel_channel is None
+    assert selected_gain_channel is None
 
 
 def test_single_channel():
@@ -34,9 +34,9 @@ def test_single_channel():
     waveforms = np.zeros(shape)
 
     gain_selector = TestGainSelector()
-    waveforms_gs, pixel_channel = gain_selector(waveforms)
+    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
     assert waveforms_gs.shape == (2048, 128)
-    assert (pixel_channel == 0).all()
+    assert (selected_gain_channel == 0).all()
 
 
 def test_manual_gain_selector():
@@ -45,14 +45,14 @@ def test_manual_gain_selector():
     waveforms[1] *= 2
 
     gs_high = ManualGainSelector(channel="HIGH")
-    waveforms_gs, pixel_channel = gs_high(waveforms)
+    waveforms_gs, selected_gain_channel = gs_high(waveforms)
     np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
-    np.testing.assert_equal(pixel_channel, 0)
+    np.testing.assert_equal(selected_gain_channel, 0)
 
     gs_low = ManualGainSelector(channel="LOW")
-    waveforms_gs, pixel_channel = gs_low(waveforms)
+    waveforms_gs, selected_gain_channel = gs_low(waveforms)
     np.testing.assert_equal(waveforms[GainChannel.LOW], waveforms_gs)
-    np.testing.assert_equal(pixel_channel, 1)
+    np.testing.assert_equal(selected_gain_channel, 1)
 
 
 def test_threshold_gain_selector():
@@ -62,8 +62,8 @@ def test_threshold_gain_selector():
     waveforms[0, 0] = 100
 
     gain_selector = ThresholdGainSelector(threshold=50)
-    waveforms_gs, pixel_channel = gain_selector(waveforms)
+    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
     assert (waveforms_gs[0] == 1).all()
     assert (waveforms_gs[np.arange(1, 2048)] == 0).all()
-    assert pixel_channel[0] == 1
-    assert (pixel_channel[np.arange(1, 2048)] == 0).all()
+    assert selected_gain_channel[0] == 1
+    assert (selected_gain_channel[np.arange(1, 2048)] == 0).all()

--- a/ctapipe/calib/camera/tests/test_pedestals.py
+++ b/ctapipe/calib/camera/tests/test_pedestals.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ctapipe.calib.camera.pedestals import *
-from ctapipe.io.containers import EventAndMonDataContainer
+from ctapipe.io.containers import DataContainer
 
 
 def test_pedestal_calculator():
@@ -16,7 +16,7 @@ def test_pedestal_calculator():
                                         sample_size=n_events,
                                         tel_id=tel_id)
     # create one event
-    data = EventAndMonDataContainer()
+    data = DataContainer()
     data.meta['origin'] = 'test'
 
     # fill the values necessary for the pedestal calculation

--- a/ctapipe/calib/camera/tests/test_pedestals.py
+++ b/ctapipe/calib/camera/tests/test_pedestals.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ctapipe.calib.camera.pedestals import *
-from ctapipe.io.containers import DataContainer
+from ctapipe.io.containers import EventAndMonDataContainer
 
 
 def test_pedestal_calculator():
@@ -16,7 +16,7 @@ def test_pedestal_calculator():
                                         sample_size=n_events,
                                         tel_id=tel_id)
     # create one event
-    data = DataContainer()
+    data = EventAndMonDataContainer()
     data.meta['origin'] = 'test'
 
     # fill the values necessary for the pedestal calculation

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -22,6 +22,7 @@ import numpy as np
 from traitlets import Int
 from ctapipe.core import Component
 from numba import njit, prange, guvectorize, float64, float32, int64, int32
+import warnings
 
 
 @guvectorize(
@@ -51,7 +52,7 @@ def sum_samples_around_peak(waveforms, peak_index, width, shift, ret):
     ----------
     waveforms : ndarray
         Waveforms stored in a numpy array.
-        Shape: (n_chan, n_pix, n_samples)
+        Shape: (n_pix, n_samples)
     peak_index : ndarray or int
         Peak index for each pixel.
     width : ndarray or int
@@ -65,7 +66,7 @@ def sum_samples_around_peak(waveforms, peak_index, width, shift, ret):
     -------
     charge : ndarray
         Extracted charge.
-        Shape: (n_chan, n_pix)
+        Shape: (n_pix)
 
     """
     n_samples = waveforms.size
@@ -78,12 +79,16 @@ def sum_samples_around_peak(waveforms, peak_index, width, shift, ret):
 
 
 @njit([
-    float64[:, :, :](float64[:, :, :], int64[:, :], int64),
-    float64[:, :, :](float64[:, :, :], int32[:, :], int64),
-    float64[:, :, :](float32[:, :, :], int32[:, :], int64),
-    float64[:, :, :](float32[:, :, :], int64[:, :], int64),
+    float64[:, :](float64[:, :], int64[:, :], int64),
+    float64[:, :](float64[:, :], int32[:, :], int64),
+    float64[:, :](float32[:, :], int32[:, :], int64),
+    float64[:, :](float32[:, :], int64[:, :], int64),
+    float64[:, :, :](float64[:, :, :], int64[:, :], int64),  # TODO: deprecate
+    float64[:, :, :](float64[:, :, :], int32[:, :], int64),  # TODO: deprecate
+    float64[:, :, :](float32[:, :, :], int32[:, :], int64),  # TODO: deprecate
+    float64[:, :, :](float32[:, :, :], int64[:, :], int64),  # TODO: deprecate
 ], parallel=True)
-def neighbor_average_waveform(waveforms, neighbors, lwt):
+def neighbor_average_waveform_jit(waveforms, neighbors, lwt):
     """
     Obtain the average waveform built from the neighbors of each pixel
 
@@ -91,7 +96,7 @@ def neighbor_average_waveform(waveforms, neighbors, lwt):
     ----------
     waveforms : ndarray
         Waveforms stored in a numpy array.
-        Shape: (n_chan, n_pix, n_samples)
+        Shape: (n_pix, n_samples)
     neighbors : ndarray
         2D array where each row is [pixel index, one neighbor of that pixel].
         Changes per telescope.
@@ -105,19 +110,43 @@ def neighbor_average_waveform(waveforms, neighbors, lwt):
     -------
     average_wf : ndarray
         Average of neighbor waveforms for each pixel.
-        Shape: (n_chan, n_pix, n_samples)
+        Shape: (n_pix, n_samples)
 
     """
+    # TODO: deprecate
+    if waveforms.ndim == 3:
+        n_neighbors = neighbors.shape[0]
+        sum_ = waveforms * lwt
+        n = np.zeros(waveforms.shape)
+        for i in prange(n_neighbors):
+            pixel = neighbors[i, 0]
+            neighbor = neighbors[i, 1]
+            for channel in range(waveforms.shape[0]):
+                sum_[channel, pixel] += waveforms[channel, neighbor]
+                n[channel, pixel] += 1
+        return sum_ / n
+
     n_neighbors = neighbors.shape[0]
     sum_ = waveforms * lwt
     n = np.zeros(waveforms.shape)
     for i in prange(n_neighbors):
         pixel = neighbors[i, 0]
         neighbor = neighbors[i, 1]
-        for channel in range(waveforms.shape[0]):
-            sum_[channel, pixel] += waveforms[channel, neighbor]
-            n[channel, pixel] += 1
+        sum_[pixel] += waveforms[neighbor]
+        n[pixel] += 1
     return sum_ / n
+
+
+def neighbor_average_waveform(waveforms, neighbors, lwt):
+    if waveforms.ndim == 3:
+        warnings.warn(
+            "A 3 dimensional waveforms array was passed "
+            "to neighbor_average_waveform. "
+            "Waveforms should be shape (n_pixels, n_samples). "
+            "This will raise an error in future versions.",
+            DeprecationWarning
+        )
+    return neighbor_average_waveform_jit(waveforms, neighbors, lwt)
 
 
 @guvectorize(
@@ -147,7 +176,7 @@ def extract_pulse_time_around_peak(waveforms, peak_index, width, shift, ret):
     ----------
     waveforms : ndarray
         Waveforms stored in a numpy array.
-        Shape: (n_chan, n_pix, n_samples)
+        Shape: (n_pix, n_samples)
     peak_index : ndarray or int
         Peak index in waveform for each pixel.
     width : ndarray or int
@@ -161,7 +190,7 @@ def extract_pulse_time_around_peak(waveforms, peak_index, width, shift, ret):
     -------
     pulse_time : ndarray
         Floating point pulse time in each pixel
-        Shape: (n_chan, n_pix)
+        Shape: (n_pix)
 
     """
     n_samples = waveforms.size
@@ -188,7 +217,7 @@ def subtract_baseline(waveforms, baseline_start, baseline_end):
     ----------
     waveforms : ndarray
         Waveforms stored in a numpy array.
-        Shape: (n_chan, n_pix, n_samples)
+        Shape: (n_pix, n_samples)
     baseline_start : int
         Sample where the baseline window starts
     baseline_end : int
@@ -200,7 +229,7 @@ def subtract_baseline(waveforms, baseline_start, baseline_end):
         Waveform with the baseline subtracted
     """
     baseline_corrected = waveforms - np.mean(
-        waveforms[..., baseline_start:baseline_end], axis=2
+        waveforms[..., baseline_start:baseline_end], axis=-1
     )[..., None]
 
     return baseline_corrected
@@ -274,16 +303,16 @@ class ImageExtractor(Component):
         ----------
         waveforms : ndarray
             Waveforms stored in a numpy array of shape
-            (n_chan, n_pix, n_samples).
+            (n_pix, n_samples).
 
         Returns
         -------
         charge : ndarray
             Extracted charge.
-            Shape: (n_chan, n_pix)
+            Shape: (n_pix)
         pulse_time : ndarray
             Floating point pulse time in each pixel.
-            Shape: (n_chan, n_pix)
+            Shape: (n_pix)
         """
 
 
@@ -293,7 +322,7 @@ class FullWaveformSum(ImageExtractor):
     """
 
     def __call__(self, waveforms):
-        charge = waveforms.sum(2)
+        charge = waveforms.sum(axis=-1)
         pulse_time = extract_pulse_time_around_peak(
             waveforms, 0, waveforms.shape[-1], 0
         )
@@ -314,7 +343,7 @@ class FixedWindowSum(ImageExtractor):
     def __call__(self, waveforms):
         start = self.window_start
         end = self.window_start + self.window_width
-        charge = waveforms[..., start:end].sum(2)
+        charge = waveforms[..., start:end].sum(axis=-1)
         pulse_time = extract_pulse_time_around_peak(
             waveforms, self.window_start, self.window_width, 0
         )
@@ -335,13 +364,22 @@ class GlobalPeakWindowSum(ImageExtractor):
     ).tag(config=True)
 
     def __call__(self, waveforms):
-        peak_index = waveforms.mean(1).argmax(1)
+        peak_index = waveforms.mean(axis=-2).argmax(axis=-1)
+        if waveforms.ndim == 3:
+            warnings.warn(
+                "A 3 dimensional waveforms array was passed "
+                "to GlobalPeakWindowSum. "
+                "Waveforms should be shape (n_pixels, n_samples). "
+                "This will raise an error in future versions.",
+                DeprecationWarning
+            )
+            peak_index = peak_index[:, np.newaxis]
         charge = sum_samples_around_peak(
-            waveforms, peak_index[:, np.newaxis],
+            waveforms, peak_index,
             self.window_width, self.window_shift
         )
         pulse_time = extract_pulse_time_around_peak(
-            waveforms, peak_index[:, np.newaxis],
+            waveforms, peak_index,
             self.window_width, self.window_shift
         )
         return charge, pulse_time
@@ -361,7 +399,7 @@ class LocalPeakWindowSum(ImageExtractor):
     ).tag(config=True)
 
     def __call__(self, waveforms):
-        peak_index = waveforms.argmax(2).astype(np.int)
+        peak_index = waveforms.argmax(axis=-1).astype(np.int)
         charge = sum_samples_around_peak(
             waveforms, peak_index, self.window_width, self.window_shift
         )
@@ -395,7 +433,7 @@ class NeighborPeakWindowSum(ImageExtractor):
         average_wfs = neighbor_average_waveform(
             waveforms, self.neighbors, self.lwt
         )
-        peak_index = average_wfs.argmax(2)
+        peak_index = average_wfs.argmax(axis=-1)
         charge = sum_samples_around_peak(
             waveforms, peak_index, self.window_width, self.window_shift
         )

--- a/ctapipe/image/muon/muon_diagnostic_plots.py
+++ b/ctapipe/image/muon/muon_diagnostic_plots.py
@@ -113,7 +113,7 @@ def plot_muon_event(event, muonparams):
             # from the calibration
             ax1 = fig.add_subplot(1, npads, 1)
             plotter = CameraPlotter(event)
-            image = event.dl1.tel[tel_id].image[0]
+            image = event.dl1.tel[tel_id].image
             geom = event.inst.subarray.tel[tel_id].camera
 
             tailcuts = (5., 7.)

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -76,7 +76,7 @@ def analyze_muon_event(event):
     for telid in event.dl0.tels_with_data:
 
         logger.debug("Analysing muon event for tel %d", telid)
-        image = event.dl1.tel[telid].image[0]
+        image = event.dl1.tel[telid].image
 
         # Get geometry
         teldes = event.inst.subarray.tel[telid]

--- a/ctapipe/image/reducer.py
+++ b/ctapipe/image/reducer.py
@@ -27,13 +27,13 @@ class DataVolumeReducer(Component):
         ----------
         waveforms : ndarray
             Waveforms stored in a numpy array of shape
-            (n_chan, n_pix, n_samples).
+            (n_pix, n_samples).
 
         Returns
         -------
         reduced_waveforms : ndarray
             Reduced waveforms stored in a numpy array of shape
-            (n_chan, n_pix, n_samples).
+            (n_pix, n_samples).
         """
 
 

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -26,37 +26,29 @@ def camera_waveforms():
     n_samples = 96
     mid = n_samples // 2
     pulse_sigma = 6
-    r_hi = np.random.RandomState(1)
-    r_lo = np.random.RandomState(2)
+    random = np.random.RandomState(1)
 
     x = np.arange(n_samples)
 
     # Randomize times
-    t_pulse_hi = r_hi.uniform(mid - 10, mid + 10, n_pixels)[:, np.newaxis]
-    t_pulse_lo = r_lo.uniform(mid + 10, mid + 20, n_pixels)[:, np.newaxis]
+    t_pulse = random.uniform(mid - 10, mid + 10, n_pixels)[:, np.newaxis]
 
     # Create pulses
-    y_hi = norm.pdf(x, t_pulse_hi, pulse_sigma)
-    y_lo = norm.pdf(x, t_pulse_lo, pulse_sigma)
+    y = norm.pdf(x, t_pulse, pulse_sigma)
 
     # Randomize amplitudes
-    y_hi *= r_hi.uniform(100, 1000, n_pixels)[:, np.newaxis]
-    y_lo *= r_lo.uniform(100, 1000, n_pixels)[:, np.newaxis]
-
-    y = np.stack([y_hi, y_lo])
+    y *= random.uniform(100, 1000, n_pixels)[:, np.newaxis]
 
     return y, camera
 
 
 def test_sum_samples_around_peak(camera_waveforms):
     waveforms, _ = camera_waveforms
-    _, n_pixels, n_samples = waveforms.shape
+    n_pixels, n_samples = waveforms.shape
     rand = np.random.RandomState(1)
-    peak_index = rand.uniform(0, n_samples, (2, n_pixels)).astype(np.int)
+    peak_index = rand.uniform(0, n_samples, n_pixels).astype(np.int)
     charge = sum_samples_around_peak(waveforms, peak_index, 7, 3)
-
-    assert_allclose(charge[0][0], 146.022991, rtol=1e-3)
-    assert_allclose(charge[1][0], 22.393974, rtol=1e-3)
+    assert_allclose(charge[0], 146.022991, rtol=1e-3)
 
 
 def test_sum_samples_around_peak_expected(camera_waveforms):
@@ -105,14 +97,10 @@ def test_neighbor_average_waveform(camera_waveforms):
     waveforms, camera = camera_waveforms
     nei = camera.neighbor_matrix_where
     average_wf = neighbor_average_waveform(waveforms, nei, 0)
-
-    assert_allclose(average_wf[0, 0, 48], 28.690154, rtol=1e-3)
-    assert_allclose(average_wf[1, 0, 48], 2.221035, rtol=1e-3)
+    assert_allclose(average_wf[0, 48], 28.690154, rtol=1e-3)
 
     average_wf = neighbor_average_waveform(waveforms, nei, 4)
-
-    assert_allclose(average_wf[0, 0, 48], 98.565743, rtol=1e-3)
-    assert_allclose(average_wf[1, 0, 48], 9.578896, rtol=1e-3)
+    assert_allclose(average_wf[0, 48], 98.565743, rtol=1e-3)
 
 
 def test_extract_pulse_time_around_peak(camera_waveforms):
@@ -121,17 +109,16 @@ def test_extract_pulse_time_around_peak(camera_waveforms):
     pulse_time = extract_pulse_time_around_peak(
         y[np.newaxis, :], 0, x.size, 0
     )
-
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
 
 def test_baseline_subtractor(camera_waveforms):
     waveforms, _ = camera_waveforms
-    n_chan, n_pixels, n_samples = waveforms.shape
+    n_pixels, n_samples = waveforms.shape
     rand = np.random.RandomState(1)
-    offset = np.arange(n_pixels)[np.newaxis, :, np.newaxis]
+    offset = np.arange(n_pixels)[:, np.newaxis]
     waveforms = rand.normal(0, 0.1, waveforms.shape) + offset
-    assert_allclose(waveforms[0, 3].mean(), 3, rtol=1e-2)
+    assert_allclose(waveforms[3].mean(), 3, rtol=1e-2)
     baseline_subtracted = subtract_baseline(waveforms, 0, 10)
     assert_allclose(baseline_subtracted.mean(), 0, atol=1e-3)
 
@@ -140,44 +127,32 @@ def test_full_waveform_sum(camera_waveforms):
     waveforms, _ = camera_waveforms
     extractor = FullWaveformSum()
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 545.945, rtol=1e-3)
-    assert_allclose(charge[1][0], 970.025, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 46.34044, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 62.359948, rtol=1e-3)
+    assert_allclose(charge[0], 545.945, rtol=1e-3)
+    assert_allclose(pulse_time[0], 46.34044, rtol=1e-3)
 
 
 def test_fixed_window_sum(camera_waveforms):
     waveforms, _ = camera_waveforms
     extractor = FixedWindowSum(window_start=45)
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 232.559, rtol=1e-3)
-    assert_allclose(charge[1][0], 32.539, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 47.823488, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 49.370007, rtol=1e-3)
+    assert_allclose(charge[0], 232.559, rtol=1e-3)
+    assert_allclose(pulse_time[0], 47.823488, rtol=1e-3)
 
 
 def test_global_peak_window_sum(camera_waveforms):
     waveforms, _ = camera_waveforms
     extractor = GlobalPeakWindowSum()
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 232.559, rtol=1e-3)
-    assert_allclose(charge[1][0], 425.406, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 47.823488, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 62.931829, rtol=1e-3)
+    assert_allclose(charge[0], 232.559, rtol=1e-3)
+    assert_allclose(pulse_time[0], 47.823488, rtol=1e-3)
 
 
 def test_local_peak_window_sum(camera_waveforms):
     waveforms, _ = camera_waveforms
     extractor = LocalPeakWindowSum()
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 240.3, rtol=1e-3)
-    assert_allclose(charge[1][0], 427.158, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 46.036266, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+    assert_allclose(charge[0], 240.3, rtol=1e-3)
+    assert_allclose(pulse_time[0], 46.036266, rtol=1e-3)
 
 
 def test_neighbor_peak_window_sum(camera_waveforms):
@@ -186,19 +161,13 @@ def test_neighbor_peak_window_sum(camera_waveforms):
     extractor = NeighborPeakWindowSum()
     extractor.neighbors = nei
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 94.671, rtol=1e-3)
-    assert_allclose(charge[1][0], 426.887, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 54.116092, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+    assert_allclose(charge[0], 94.671, rtol=1e-3)
+    assert_allclose(pulse_time[0], 54.116092, rtol=1e-3)
 
     extractor.lwt = 4
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 220.418657, rtol=1e-3)
-    assert_allclose(charge[1][0], 426.887, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 48.717848, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+    assert_allclose(charge[0], 220.418657, rtol=1e-3)
+    assert_allclose(pulse_time[0], 48.717848, rtol=1e-3)
 
 
 def test_baseline_subtracted_neighbor_peak_window_sum(camera_waveforms):
@@ -207,11 +176,8 @@ def test_baseline_subtracted_neighbor_peak_window_sum(camera_waveforms):
     extractor = BaselineSubtractedNeighborPeakWindowSum()
     extractor.neighbors = nei
     charge, pulse_time = extractor(waveforms)
-
-    assert_allclose(charge[0][0], 94.671, rtol=1e-3)
-    assert_allclose(charge[1][0], 426.887, rtol=1e-3)
-    assert_allclose(pulse_time[0][0], 54.116092, rtol=1e-3)
-    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+    assert_allclose(charge[0], 94.671, rtol=1e-3)
+    assert_allclose(pulse_time[0], 54.116092, rtol=1e-3)
 
 
 def test_waveform_extractor_factory(camera_waveforms):
@@ -246,3 +212,201 @@ def test_waveform_extractor_factory_args():
             'FullWaveformSum',
             config=config,
         )
+
+# TODO: Deperacate 2 channel waveforms
+
+
+@pytest.fixture(scope='module')
+def camera_waveforms_2chan():
+    camera = CameraGeometry.from_name("CHEC")
+
+    n_pixels = camera.n_pixels
+    n_samples = 96
+    mid = n_samples // 2
+    pulse_sigma = 6
+    r_hi = np.random.RandomState(1)
+    r_lo = np.random.RandomState(2)
+
+    x = np.arange(n_samples)
+
+    # Randomize times
+    t_pulse_hi = r_hi.uniform(mid - 10, mid + 10, n_pixels)[:, np.newaxis]
+    t_pulse_lo = r_lo.uniform(mid + 10, mid + 20, n_pixels)[:, np.newaxis]
+
+    # Create pulses
+    y_hi = norm.pdf(x, t_pulse_hi, pulse_sigma)
+    y_lo = norm.pdf(x, t_pulse_lo, pulse_sigma)
+
+    # Randomize amplitudes
+    y_hi *= r_hi.uniform(100, 1000, n_pixels)[:, np.newaxis]
+    y_lo *= r_lo.uniform(100, 1000, n_pixels)[:, np.newaxis]
+
+    y = np.stack([y_hi, y_lo])
+
+    return y, camera
+
+
+def test_sum_samples_around_peak_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    _, n_pixels, n_samples = waveforms.shape
+    rand = np.random.RandomState(1)
+    peak_index = rand.uniform(0, n_samples, (2, n_pixels)).astype(np.int)
+    charge = sum_samples_around_peak(waveforms, peak_index, 7, 3)
+
+    assert_allclose(charge[0][0], 146.022991, rtol=1e-3)
+    assert_allclose(charge[1][0], 22.393974, rtol=1e-3)
+
+
+def test_sum_samples_around_peak_expected_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    waveforms = np.ones(waveforms.shape)
+    n_samples = waveforms.shape[-1]
+
+    peak_index = 0
+    width = 10
+    shift = 0
+    charge = sum_samples_around_peak(waveforms, peak_index, width, shift)
+    assert_equal(charge, 10)
+
+    peak_index = 0
+    width = 10
+    shift = 10
+    charge = sum_samples_around_peak(waveforms, peak_index, width, shift)
+    assert_equal(charge, 0)
+
+    peak_index = 0
+    width = 20
+    shift = 10
+    charge = sum_samples_around_peak(waveforms, peak_index, width, shift)
+    assert_equal(charge, 10)
+
+    peak_index = n_samples
+    width = 10
+    shift = 0
+    charge = sum_samples_around_peak(waveforms, peak_index, width, shift)
+    assert_equal(charge, 0)
+
+    peak_index = n_samples
+    width = 20
+    shift = 10
+    charge = sum_samples_around_peak(waveforms, peak_index, width, shift)
+    assert_equal(charge, 10)
+
+    peak_index = 0
+    width = n_samples*3
+    shift = n_samples
+    charge = sum_samples_around_peak(waveforms, peak_index, width, shift)
+    assert_equal(charge, n_samples)
+
+
+def test_neighbor_average_waveform_2chan(camera_waveforms_2chan):
+    waveforms, camera = camera_waveforms_2chan
+    nei = camera.neighbor_matrix_where
+    average_wf = neighbor_average_waveform(waveforms, nei, 0)
+
+    assert_allclose(average_wf[0, 0, 48], 28.690154, rtol=1e-3)
+    assert_allclose(average_wf[1, 0, 48], 2.221035, rtol=1e-3)
+
+    average_wf = neighbor_average_waveform(waveforms, nei, 4)
+
+    assert_allclose(average_wf[0, 0, 48], 98.565743, rtol=1e-3)
+    assert_allclose(average_wf[1, 0, 48], 9.578896, rtol=1e-3)
+
+
+def test_extract_pulse_time_around_peak_2chan(camera_waveforms_2chan):
+    x = np.arange(100)
+    y = norm.pdf(x, 41.2, 6)
+    pulse_time = extract_pulse_time_around_peak(
+        y[np.newaxis, :], 0, x.size, 0
+    )
+
+    assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
+
+
+def test_baseline_subtractor_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    n_chan, n_pixels, n_samples = waveforms.shape
+    rand = np.random.RandomState(1)
+    offset = np.arange(n_pixels)[np.newaxis, :, np.newaxis]
+    waveforms = rand.normal(0, 0.1, waveforms.shape) + offset
+    assert_allclose(waveforms[0, 3].mean(), 3, rtol=1e-2)
+    baseline_subtracted = subtract_baseline(waveforms, 0, 10)
+    assert_allclose(baseline_subtracted.mean(), 0, atol=1e-3)
+
+
+def test_full_waveform_sum_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    extractor = FullWaveformSum()
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 545.945, rtol=1e-3)
+    assert_allclose(charge[1][0], 970.025, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 46.34044, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 62.359948, rtol=1e-3)
+
+
+def test_fixed_window_sum_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    extractor = FixedWindowSum(window_start=45)
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 232.559, rtol=1e-3)
+    assert_allclose(charge[1][0], 32.539, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 47.823488, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 49.370007, rtol=1e-3)
+
+
+def test_global_peak_window_sum_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    extractor = GlobalPeakWindowSum()
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 232.559, rtol=1e-3)
+    assert_allclose(charge[1][0], 425.406, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 47.823488, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 62.931829, rtol=1e-3)
+
+
+def test_local_peak_window_sum_2chan(camera_waveforms_2chan):
+    waveforms, _ = camera_waveforms_2chan
+    extractor = LocalPeakWindowSum()
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 240.3, rtol=1e-3)
+    assert_allclose(charge[1][0], 427.158, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 46.036266, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+
+
+def test_neighbor_peak_window_sum_2chan(camera_waveforms_2chan):
+    waveforms, camera = camera_waveforms_2chan
+    nei = camera.neighbor_matrix_where
+    extractor = NeighborPeakWindowSum()
+    extractor.neighbors = nei
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 94.671, rtol=1e-3)
+    assert_allclose(charge[1][0], 426.887, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 54.116092, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+
+    extractor.lwt = 4
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 220.418657, rtol=1e-3)
+    assert_allclose(charge[1][0], 426.887, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 48.717848, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)
+
+
+def test_baseline_subtracted_neighbor_pw_sum_2chan(camera_waveforms_2chan):
+    waveforms, camera = camera_waveforms_2chan
+    nei = camera.neighbor_matrix_where
+    extractor = BaselineSubtractedNeighborPeakWindowSum()
+    extractor.neighbors = nei
+    charge, pulse_time = extractor(waveforms)
+
+    assert_allclose(charge[0][0], 94.671, rtol=1e-3)
+    assert_allclose(charge[1][0], 426.887, rtol=1e-3)
+    assert_allclose(pulse_time[0][0], 54.116092, rtol=1e-3)
+    assert_allclose(pulse_time[1][0], 62.038344, rtol=1e-3)

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -114,7 +114,7 @@ def test_extract_pulse_time_around_peak(camera_waveforms):
 
 def test_baseline_subtractor(camera_waveforms):
     waveforms, _ = camera_waveforms
-    n_pixels, n_samples = waveforms.shape
+    n_pixels, _ = waveforms.shape
     rand = np.random.RandomState(1)
     offset = np.arange(n_pixels)[:, np.newaxis]
     waveforms = rand.normal(0, 0.1, waveforms.shape) + offset

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -154,10 +154,11 @@ class R1CameraContainer(Container):
         "numpy array containing a set of images, one per ADC sample"
         "Shape: (n_channels, n_pixels, n_samples)"
     ))
-    gain_selection = Field(None, (
+    selected_gain_channel = Field(None, (
         "Numpy array containing the gain channel chosen for each pixel. "
         "Shape: (n_pixels)"
     ))
+
 
 class R1Container(Container):
     """

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -43,6 +43,7 @@ __all__ = [
     'WaveformCalibrationContainer',
     'MonitoringCameraContainer',
     'MonitoringContainer',
+    'EventAndMonDataContainer'
 ]
 
 
@@ -153,7 +154,10 @@ class R1CameraContainer(Container):
         "numpy array containing a set of images, one per ADC sample"
         "Shape: (n_channels, n_pixels, n_samples)"
     ))
-
+    gain_selection = Field(None, (
+        "Numpy array containing the gain channel chosen for each pixel. "
+        "Shape: (n_pixels)"
+    ))
 
 class R1Container(Container):
     """
@@ -406,6 +410,28 @@ class TelescopePointingContainer(Container):
     """
     azimuth = Field(nan * u.rad, 'Azimuth, measured N->E', unit=u.rad)
     altitude = Field(nan * u.rad, 'Altitude', unit=u.rad)
+
+
+class DataContainer(Container):
+    """ Top-level container for all event information """
+
+    event_type = Field('data', "Event type")
+    r0 = Field(R0Container(), "Raw Data")
+    r1 = Field(R1Container(), "R1 Calibrated Data")
+    dl0 = Field(DL0Container(), "DL0 Data Volume Reduced Data")
+    dl1 = Field(DL1Container(), "DL1 Calibrated image")
+    dl2 = Field(ReconstructedContainer(), "Reconstructed Shower Information")
+    mc = Field(MCEventContainer(), "Monte-Carlo data")
+    mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
+    trig = Field(CentralTriggerContainer(), "central trigger information")
+    count = Field(0, "number of events processed")
+    inst = Field(InstrumentContainer(), "instrumental information (deprecated")
+    pointing = Field(Map(TelescopePointingContainer),
+                     'Telescope pointing positions')
+
+
+class SST1MDataContainer(DataContainer):
+    sst1m = Field(SST1MContainer(), "optional SST1M Specific Information")
 
 
 class MuonRingParameter(Container):
@@ -749,16 +775,11 @@ class WaveformCalibrationContainer(Container):
         "Boolean np array of final calibration data analysis, True = failing pixels (n_chan, n_pix)"
     )
 
-
 class MonitoringCameraContainer(Container):
     """
     Container for camera monitoring data
     """
 
-    gain_selection = Field(None, (
-        "Numpy array containing the gain channel chosen for each pixel. "
-        "Shape: (n_pixels)"
-    ))
     flatfield = Field(FlatFieldContainer(), "Data from flat-field event distributions")
     pedestal = Field(PedestalContainer(), "Data from pedestal event distributions")
     pixel_status = Field(PixelStatusContainer(), "Container for masks with pixel status")
@@ -778,24 +799,8 @@ class MonitoringContainer(Container):
         "map of tel_id to MonitoringCameraContainer")
 
 
-class DataContainer(Container):
-    """ Top-level container for all event information """
-
-    event_type = Field('data', "Event type")
-    r0 = Field(R0Container(), "Raw Data")
-    r1 = Field(R1Container(), "R1 Calibrated Data")
-    dl0 = Field(DL0Container(), "DL0 Data Volume Reduced Data")
-    dl1 = Field(DL1Container(), "DL1 Calibrated image")
-    dl2 = Field(ReconstructedContainer(), "Reconstructed Shower Information")
-    mc = Field(MCEventContainer(), "Monte-Carlo data")
-    mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
-    trig = Field(CentralTriggerContainer(), "central trigger information")
-    count = Field(0, "number of events processed")
-    inst = Field(InstrumentContainer(), "instrumental information (deprecated")
-    pointing = Field(Map(TelescopePointingContainer),
-                     'Telescope pointing positions')
+class EventAndMonDataContainer(DataContainer):
+    """
+    Data container including monitoring information
+    """
     mon = Field(MonitoringContainer(), "container for monitoring data (MON)")
-
-
-class SST1MDataContainer(DataContainer):
-    sst1m = Field(SST1MContainer(), "optional SST1M Specific Information")

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -43,7 +43,6 @@ __all__ = [
     'WaveformCalibrationContainer',
     'MonitoringCameraContainer',
     'MonitoringContainer',
-    'EventAndMonDataContainer'
 ]
 
 
@@ -94,19 +93,13 @@ class DL1CameraContainer(Container):
     image = Field(
         None,
         "Numpy array of camera image, after waveform extraction."
-        "Shape: (n_chan, n_pixel)"
+        "Shape: (n_pixel)"
     )
     pulse_time = Field(
         None,
         "Numpy array containing position of the pulse as determined by "
         "the extractor."
-        "Shape: (n_chan, n_pixel, n_samples)"
-    )
-    #TODO: Remove when gain selection added?
-    gain_channel = Field(
-        None,
-        "boolean numpy array of which gain channel was used for each pixel "
-        "in the image "
+        "Shape: (n_pixel, n_samples)"
     )
 
 class CameraCalibrationContainer(Container):
@@ -133,7 +126,7 @@ class R0CameraContainer(Container):
     trig_pix_id = Field(None, "pixels involved in the camera trigger")
     waveform = Field(None, (
         "numpy array containing ADC samples"
-        "(n_channels x n_pixels, n_samples)"
+        "(n_channels, n_pixels, n_samples)"
     ))
 
 
@@ -158,7 +151,7 @@ class R1CameraContainer(Container):
 
     waveform = Field(None, (
         "numpy array containing a set of images, one per ADC sample"
-        "(n_channels x n_pixels, n_samples)"
+        "Shape: (n_channels, n_pixels, n_samples)"
     ))
 
 
@@ -413,28 +406,6 @@ class TelescopePointingContainer(Container):
     """
     azimuth = Field(nan * u.rad, 'Azimuth, measured N->E', unit=u.rad)
     altitude = Field(nan * u.rad, 'Altitude', unit=u.rad)
-
-
-class DataContainer(Container):
-    """ Top-level container for all event information """
-
-    event_type = Field('data', "Event type")
-    r0 = Field(R0Container(), "Raw Data")
-    r1 = Field(R1Container(), "R1 Calibrated Data")
-    dl0 = Field(DL0Container(), "DL0 Data Volume Reduced Data")
-    dl1 = Field(DL1Container(), "DL1 Calibrated image")
-    dl2 = Field(ReconstructedContainer(), "Reconstructed Shower Information")
-    mc = Field(MCEventContainer(), "Monte-Carlo data")
-    mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
-    trig = Field(CentralTriggerContainer(), "central trigger information")
-    count = Field(0, "number of events processed")
-    inst = Field(InstrumentContainer(), "instrumental information (deprecated")
-    pointing = Field(Map(TelescopePointingContainer),
-                     'Telescope pointing positions')
-
-
-class SST1MDataContainer(DataContainer):
-    sst1m = Field(SST1MContainer(), "optional SST1M Specific Information")
 
 
 class MuonRingParameter(Container):
@@ -778,11 +749,16 @@ class WaveformCalibrationContainer(Container):
         "Boolean np array of final calibration data analysis, True = failing pixels (n_chan, n_pix)"
     )
 
+
 class MonitoringCameraContainer(Container):
     """
     Container for camera monitoring data
     """
 
+    gain_selection = Field(None, (
+        "Numpy array containing the gain channel chosen for each pixel. "
+        "Shape: (n_pixels)"
+    ))
     flatfield = Field(FlatFieldContainer(), "Data from flat-field event distributions")
     pedestal = Field(PedestalContainer(), "Data from pedestal event distributions")
     pixel_status = Field(PixelStatusContainer(), "Container for masks with pixel status")
@@ -802,8 +778,24 @@ class MonitoringContainer(Container):
         "map of tel_id to MonitoringCameraContainer")
 
 
-class EventAndMonDataContainer(DataContainer):
-    """
-    Data container including monitoring information
-    """
+class DataContainer(Container):
+    """ Top-level container for all event information """
+
+    event_type = Field('data', "Event type")
+    r0 = Field(R0Container(), "Raw Data")
+    r1 = Field(R1Container(), "R1 Calibrated Data")
+    dl0 = Field(DL0Container(), "DL0 Data Volume Reduced Data")
+    dl1 = Field(DL1Container(), "DL1 Calibrated image")
+    dl2 = Field(ReconstructedContainer(), "Reconstructed Shower Information")
+    mc = Field(MCEventContainer(), "Monte-Carlo data")
+    mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
+    trig = Field(CentralTriggerContainer(), "central trigger information")
+    count = Field(0, "number of events processed")
+    inst = Field(InstrumentContainer(), "instrumental information (deprecated")
+    pointing = Field(Map(TelescopePointingContainer),
+                     'Telescope pointing positions')
     mon = Field(MonitoringContainer(), "container for monitoring data (MON)")
+
+
+class SST1MDataContainer(DataContainer):
+    sst1m = Field(SST1MContainer(), "optional SST1M Specific Information")

--- a/ctapipe/plotting/bokeh_event_viewer.py
+++ b/ctapipe/plotting/bokeh_event_viewer.py
@@ -28,9 +28,9 @@ class BokehEventViewerCamera(CameraDisplay):
         self._view_options = {
             'r0': lambda e, t, c, time: e.r0.tel[t].waveform[c, :, time],
             'r1': lambda e, t, c, time: e.r1.tel[t].waveform[c, :, time],
-            'dl0': lambda e, t, c, time: e.dl0.tel[t].waveform[c, :, time],
-            'dl1': lambda e, t, c, time: e.dl1.tel[t].image[c, :],
-            'pulse_time': lambda e, t, c, time: e.dl1.tel[t].pulse_time[c, :],
+            'dl0': lambda e, t, c, time: e.dl0.tel[t].waveform[:, time],
+            'dl1': lambda e, t, c, time: e.dl1.tel[t].image[:],
+            'pulse_time': lambda e, t, c, time: e.dl1.tel[t].pulse_time[:],
         }
 
         self.w_view = None
@@ -177,7 +177,7 @@ class BokehEventViewerWaveform(WaveformDisplay):
         self._view_options = {
             'r0': lambda e, t, c, p: e.r0.tel[t].waveform[c, p],
             'r1': lambda e, t, c, p: e.r1.tel[t].waveform[c, p],
-            'dl0': lambda e, t, c, p: e.dl0.tel[t].waveform[c, p],
+            'dl0': lambda e, t, c, p: e.dl0.tel[t].waveform[p],
         }
 
         self.w_view = None

--- a/ctapipe/plotting/event_viewer.py
+++ b/ctapipe/plotting/event_viewer.py
@@ -100,7 +100,7 @@ class EventViewer(Component):
             ax = plt.subplot(camera_grid[ii])
             geom = event.inst.subarray.tel[tel_id].camera
             self.get_camera_view(tel_id,
-                                 image=images.tel[tel_id].image[0],
+                                 image=images.tel[tel_id].image,
                                  axis=ax,
                                  geom=geom)
 

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -68,9 +68,9 @@ class ImagePlotter(Component):
         return event.inst.subarray.tel[telid].camera
 
     def plot(self, event, telid):
-        chan = 0
-        image = event.dl1.tel[telid].image[chan]
-        pulse_time = event.dl1.tel[telid].pulse_time[chan]
+        image = event.dl1.tel[telid].image
+        pulse_time = event.dl1.tel[telid].pulse_time
+        print("plot", image.shape, pulse_time.shape)
 
         if self._current_tel != telid:
             self._current_tel = telid
@@ -83,7 +83,7 @@ class ImagePlotter(Component):
             self.c_intensity = CameraDisplay(geom, ax=self.ax_intensity)
             self.c_pulse_time = CameraDisplay(geom, ax=self.ax_pulse_time)
 
-            tmaxmin = event.dl0.tel[telid].waveform.shape[2]
+            tmaxmin = event.dl0.tel[telid].waveform.shape[1]
             t_chargemax = pulse_time[image.argmax()]
             cmap_time = colors.LinearSegmentedColormap.from_list(
                 "cmap_t",

--- a/ctapipe/tools/display_events_single_tel.py
+++ b/ctapipe/tools/display_events_single_tel.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Tool
 from ctapipe.core.traits import Float, Dict, List
-from ctapipe.core.traits import Unicode, Int, Integer, Bool
+from ctapipe.core.traits import Unicode, Int, Bool
 from ctapipe.image import (
     tailcuts_clean, hillas_parameters, HillasParameterizationError
 )

--- a/ctapipe/tools/display_events_single_tel.py
+++ b/ctapipe/tools/display_events_single_tel.py
@@ -31,9 +31,6 @@ class SingleTelEventDisplay(Tool):
 
     infile = Unicode(help="input file to read", default='').tag(config=True)
     tel = Int(help='Telescope ID to display', default=0).tag(config=True)
-    channel = Integer(
-        help="channel number to display", min=0, max=1
-    ).tag(config=True)
     write = Bool(
         help="Write out images to PNG files", default=False
     ).tag(config=True)
@@ -56,7 +53,6 @@ class SingleTelEventDisplay(Tool):
         'infile': 'SingleTelEventDisplay.infile',
         'tel': 'SingleTelEventDisplay.tel',
         'max-events': 'EventSource.max_events',
-        'channel': 'SingleTelEventDisplay.channel',
         'write': 'SingleTelEventDisplay.write',
         'clean': 'SingleTelEventDisplay.clean',
         'hillas': 'SingleTelEventDisplay.hillas',
@@ -118,7 +114,7 @@ class SingleTelEventDisplay(Tool):
 
             if self.samples:
                 # display time-varying event
-                data = event.dl0.tel[self.tel].waveform[self.channel]
+                data = event.dl0.tel[self.tel].waveform
                 for ii in range(data.shape[1]):
                     disp.image = data[:, ii]
                     disp.set_limits_percent(70)
@@ -132,7 +128,7 @@ class SingleTelEventDisplay(Tool):
                         )
             else:
                 # display integrated event:
-                im = event.dl1.tel[self.tel].image[self.channel]
+                im = event.dl1.tel[self.tel].image
 
                 if self.clean:
                     mask = tailcuts_clean(

--- a/ctapipe/tools/display_integrator.py
+++ b/ctapipe/tools/display_integrator.py
@@ -18,10 +18,10 @@ from ctapipe.visualization import CameraDisplay
 
 def plot(event, telid, chan, extractor_name):
     # Extract required images
-    dl0 = event.dl0.tel[telid].waveform[chan]
+    dl0 = event.dl0.tel[telid].waveform
 
     t_pe = event.mc.tel[telid].photo_electron_image
-    dl1 = event.dl1.tel[telid].image[chan]
+    dl1 = event.dl1.tel[telid].image
     max_time = np.unravel_index(np.argmax(dl0), dl0.shape)[1]
     max_charges = np.max(dl0, axis=1)
     max_pix = int(np.argmax(max_charges))

--- a/ctapipe/tools/display_summed_images.py
+++ b/ctapipe/tools/display_summed_images.py
@@ -97,7 +97,7 @@ class ImageSumDisplayerTool(Tool):
 
             imsum[:] = 0
             for telid in event.dl0.tels_with_data:
-                imsum += event.dl1.tel[telid].image[0]
+                imsum += event.dl1.tel[telid].image
 
             self.log.info(
                 "event={} ntels={} energy={}".format(

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -86,7 +86,7 @@ class ChargeResolutionGenerator(Tool):
 
             for mc, dl1 in zip(event.mc.tel.values(), event.dl1.tel.values()):
                 true_charge = mc.photo_electron_image
-                measured_charge = dl1.image[0]
+                measured_charge = dl1.image
                 pixels = np.arange(measured_charge.size)
                 self.calculator.add(pixels, true_charge, measured_charge)
 

--- a/docs/tutorials/calibrated_data_exploration.ipynb
+++ b/docs/tutorials/calibrated_data_exploration.ipynb
@@ -160,7 +160,7 @@
     "tel_id = sorted(event.r1.tels_with_data)[1]\n",
     "sub = event.inst.subarray\n",
     "camera = sub.tel[tel_id].camera\n",
-    "image = event.dl1.tel[tel_id].image[0] "
+    "image = event.dl1.tel[tel_id].image"
    ]
   },
   {
@@ -293,7 +293,7 @@
     "image_sum = np.zeros_like(tel.camera.pix_x.value)  # just make an array of 0's in the same shape as the camera \n",
     "\n",
     "for tel_id in cams_in_event:\n",
-    "    image_sum += event.dl1.tel[tel_id].image[0]"
+    "    image_sum += event.dl1.tel[tel_id].image"
    ]
   },
   {
@@ -382,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/ctapipe_handson.ipynb
+++ b/docs/tutorials/ctapipe_handson.ipynb
@@ -398,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CameraDisplay(tel.camera, image=dl1tel.image[0])"
+    "CameraDisplay(tel.camera, image=dl1tel.image)"
    ]
   },
   {
@@ -407,7 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CameraDisplay(tel.camera, image=dl1tel.pulse_time[0])"
+    "CameraDisplay(tel.camera, image=dl1tel.pulse_time)"
    ]
   },
   {
@@ -432,7 +432,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = dl1tel.image[0]\n",
+    "image = dl1tel.image\n",
     "mask = tailcuts_clean(tel.camera, image, picture_thresh=10, boundary_thresh=5)\n",
     "mask"
    ]
@@ -557,8 +557,8 @@
     "    \n",
     "    for tel_id, tel_data in event.dl1.tel.items():\n",
     "        tel = event.inst.subarray.tel[tel_id]\n",
-    "        mask = tailcuts_clean(tel.camera, tel_data.image[0])\n",
-    "        params = hillas_parameters(tel.camera[mask], tel_data.image[0][mask])"
+    "        mask = tailcuts_clean(tel.camera, tel_data.image)\n",
+    "        params = hillas_parameters(tel.camera[mask], tel_data.image[mask])"
    ]
   },
   {
@@ -583,8 +583,8 @@
     "    \n",
     "        for tel_id, tel_data in event.dl1.tel.items():\n",
     "            tel = event.inst.subarray.tel[tel_id]\n",
-    "            mask = tailcuts_clean(tel.camera, tel_data.image[0])\n",
-    "            params = hillas_parameters(tel.camera[mask], tel_data.image[0][mask])\n",
+    "            mask = tailcuts_clean(tel.camera, tel_data.image)\n",
+    "            params = hillas_parameters(tel.camera[mask], tel_data.image[mask])\n",
     "            writer.write(\"hillas\", params)"
    ]
   },
@@ -649,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
+++ b/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
@@ -356,7 +356,7 @@
     "\n",
     "# right now, there might be one image per gain channel.\n",
     "# This will change as soon as \n",
-    "display.image = dl1.image[0]\n",
+    "display.image = dl1.image\n",
     "display.add_colorbar()"
    ]
   },
@@ -401,7 +401,7 @@
     "\n",
     "clean = tailcuts_clean(\n",
     "    camera, \n",
-    "    dl1.image[0],\n",
+    "    dl1.image,\n",
     "    boundary_thresh=boundary,\n",
     "    picture_thresh=picture,\n",
     "    min_number_picture_neighbors=min_neighbors\n",
@@ -420,11 +420,11 @@
     "d2 = CameraDisplay(camera, ax=ax2)\n",
     "\n",
     "ax1.set_title('Image')\n",
-    "d1.image = dl1.image[0]\n",
+    "d1.image = dl1.image\n",
     "d1.add_colorbar(ax=ax1)\n",
     "\n",
     "ax2.set_title('Pulse Time')\n",
-    "d2.image = dl1.pulse_time[0] - np.average(dl1.pulse_time[0], weights=dl1.image[0])\n",
+    "d2.image = dl1.pulse_time - np.average(dl1.pulse_time, weights=dl1.image)\n",
     "d2.cmap = 'RdBu_r'\n",
     "d2.add_colorbar(ax=ax2)\n",
     "d2.set_limits_minmax(-20,20)\n",
@@ -457,7 +457,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hillas = hillas_parameters(camera[clean], dl1.image[0][clean])\n",
+    "hillas = hillas_parameters(camera[clean], dl1.image[clean])\n",
     "\n",
     "print(hillas)"
    ]
@@ -471,7 +471,7 @@
     "display = CameraDisplay(camera)\n",
     "\n",
     "# set \"unclean\" pixels to 0\n",
-    "cleaned = dl1.image[0].copy()\n",
+    "cleaned = dl1.image.copy()\n",
     "cleaned[~clean] = 0.0\n",
     "\n",
     "display.image = cleaned\n",
@@ -488,8 +488,8 @@
    "source": [
     "timing = timing_parameters(\n",
     "    camera[clean],\n",
-    "    dl1.image[0][clean],\n",
-    "    dl1.pulse_time[0][clean],\n",
+    "    dl1.image[clean],\n",
+    "    dl1.pulse_time[clean],\n",
     "    hillas,\n",
     ")\n",
     "\n",
@@ -506,7 +506,7 @@
     "    camera.pix_x, camera.pix_y,hillas.x, hillas.y, hillas.psi\n",
     ")\n",
     "\n",
-    "plt.plot(long[clean], dl1.pulse_time[0][clean], 'o')\n",
+    "plt.plot(long[clean], dl1.pulse_time[clean], 'o')\n",
     "plt.plot(long[clean], timing.slope * long[clean] + timing.intercept)"
    ]
   },
@@ -516,7 +516,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "l = leakage(camera, dl1.image[0], clean)\n",
+    "l = leakage(camera, dl1.image, clean)\n",
     "print(l)"
    ]
   },
@@ -527,7 +527,7 @@
    "outputs": [],
    "source": [
     "disp = CameraDisplay(camera)\n",
-    "disp.image = dl1.image[0]\n",
+    "disp.image = dl1.image\n",
     "disp.highlight_pixels(camera.get_border_pixel_mask(1), linewidth=2, color='xkcd:red')"
    ]
   },
@@ -548,7 +548,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conc = concentration(camera, dl1.image[0], hillas)\n",
+    "conc = concentration(camera, dl1.image, hillas)\n",
     "print(conc)"
    ]
   },
@@ -616,8 +616,8 @@
     "\n",
     "        for telescope_id, dl1 in event.dl1.tel.items():\n",
     "            camera = event.inst.subarray.tels[telescope_id].camera\n",
-    "            image = dl1.image[0]\n",
-    "            pulse_time = dl1.pulse_time[0]\n",
+    "            image = dl1.image\n",
+    "            pulse_time = dl1.pulse_time\n",
     "\n",
     "            boundary, picture, min_neighbors = cleaning_level[camera.cam_id]\n",
     "\n",
@@ -790,8 +790,8 @@
     "        for telescope_id, dl1 in event.dl1.tel.items():      \n",
     "\n",
     "            camera = event.inst.subarray.tels[telescope_id].camera\n",
-    "            image = dl1.image[0]\n",
-    "            pulse_time = dl1.pulse_time[0]\n",
+    "            image = dl1.image\n",
+    "            pulse_time = dl1.pulse_time\n",
     "\n",
     "            boundary, picture, min_neighbors = cleaning_level[camera.cam_id]\n",
     "\n",
@@ -1095,7 +1095,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/theta_square.ipynb
+++ b/docs/tutorials/theta_square.ipynb
@@ -116,7 +116,7 @@
     "        camgeom = subarray.tel[tel_id].camera\n",
     "\n",
     "        # note the [0] is for channel 0 which is high-gain channel\n",
-    "        image = event.dl1.tel[tel_id].image[0]\n",
+    "        image = event.dl1.tel[tel_id].image\n",
     "\n",
     "        # Cleaning  of the image\n",
     "        cleaned_image = image\n",
@@ -235,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.2"
   },
   "toc": {
    "nav_menu": {

--- a/examples/plot_array_hillas.py
+++ b/examples/plot_array_hillas.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
             camgeom = subarray.tel[tel_id].camera
 
             # note the [0] is for channel 0 which is high-gain channel
-            image = event.dl1.tel[tel_id].image[0]
+            image = event.dl1.tel[tel_id].image
 
             # Cleaning  of the image
             cleaned_image = image.copy()

--- a/examples/plot_showers_in_nominal.py
+++ b/examples/plot_showers_in_nominal.py
@@ -38,7 +38,7 @@ with event_source(input_url=input_url) as source:
         for tel_id, dl1 in event.dl1.tel.items():
             camera = event.inst.subarray.tels[tel_id].camera
             focal_length = event.inst.subarray.tels[tel_id].optics.equivalent_focal_length
-            image = dl1.image[0]
+            image = dl1.image
 
             # telescope mc info
             mc_tel = event.mc.tel[tel_id]

--- a/examples/plot_theta_square.py
+++ b/examples/plot_theta_square.py
@@ -53,7 +53,7 @@ for event in source:
         camgeom = subarray.tel[tel_id].camera
 
         # note the [0] is for channel 0 which is high-gain channel
-        image = event.dl1.tel[tel_id].image[0]
+        image = event.dl1.tel[tel_id].image
 
         # Cleaning  of the image
         cleaned_image = image

--- a/examples/simple_event_writer.py
+++ b/examples/simple_event_writer.py
@@ -91,7 +91,7 @@ class SimpleEventWriter(Tool):
                 dl1_tel = event.dl1.tel[tel_id]
 
                 # Image cleaning
-                image = dl1_tel.image[0]  # Waiting for automatic gain selection
+                image = dl1_tel.image  # Waiting for automatic gain selection
                 mask = tailcuts_clean(camera, image, picture_thresh=10, boundary_thresh=5)
                 cleaned = image.copy()
                 cleaned[~mask] = 0

--- a/examples/stereo_reconstruction.py
+++ b/examples/stereo_reconstruction.py
@@ -41,8 +41,8 @@ for event in event_source:
     for telescope_id, dl1 in event.dl1.tel.items():
         camera = event.inst.subarray.tels[telescope_id].camera
 
-        image = dl1.image[0]
-        peakpos = dl1.peakpos[0]
+        image = dl1.image
+        peakpos = dl1.pulse_time
 
         # cleaning
         boundary, picture, min_neighbors = cleaning_level[camera.cam_id]


### PR DESCRIPTION
The gain is now selected in the R1 - DL0 calibration step. All waveforms and images at DL0 and above no longer have a gain channel dimension - they are shape (n_pixels, n_samples).

For the time being, the ImageExtractors work flexibly with waveform shapes (n_channels, n_pixels, n_samples) and (n_pixels, n_samples), but contain deprecation warnings if the former is used. 

This is a huge refactoring of ctapipe that has been intended for a long time. It is likely to break a lot of code. The most common break is when the first dimension was manually removed from waveform and image arrays, and can be addressed as follows:
```python
event.dl1.tel[telid].image[0] -> event.dl1.tel[telid].image
event.dl1.tel[telid].pulse_time[0] -> event.dl1.tel[telid].pulse_time
event.dl0.tel[telid].waveform[0] -> event.dl0.tel[telid].waveform
```

According to the CTA data model, the R1 waveforms should also have gain selection applied, and therefore only have 2 dimensions. This will likely be addressed in a future PR. A possible direction to take in this regard is to move gain selection from the CameraCalibrator to the EventSource. It becomes the EventSource's responsibility to provide properly calibrated and gain-selected waveforms to ctapipe, which is more inline with the intended CTA operation.