### PR TITLE
First version of the MARS tailcut (1st pass)

### DIFF
--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -87,7 +87,7 @@ def tailcuts_clean(
         )
 
 
-def mars_image_cleaning(
+def mars_cleaning_1st_pass(
     geom,
     image,
     picture_thresh=7,
@@ -133,9 +133,6 @@ def mars_image_cleaning(
 
     """
 
-    # For debug
-    # print("Original image: {}".format(image))
-
     pixels_from_tailcuts_clean = tailcuts_clean(
         geom,
         image,
@@ -143,27 +140,7 @@ def mars_image_cleaning(
         boundary_thresh[0],
         keep_isolated_pixels,
         min_number_picture_neighbors,
-    )  # this does checks for core pixels and first neighbors
-
-    # For debug
-    '''print(
-        "After tailcuts_clean [{},{}]: {}".format(
-            picture_thresh, boundary_thresh[1], pixels_from_tailcuts_clean
-        )
-    )'''
-
-    # ++++++++++++++++++++++++++++++++++++
-    # THIS PART IS NOT USED FOR THE MOMENT
-    # ++++++++++++++++++++++++++++++++++++
-    # Call dilate on this set of pixels and add all next neighbors,
-    # regardless of their value
-    # extended_image = dilate(geom, pixels_from_tailcuts_clean)
-    #
-    # if extended_image is None:
-    #     print("No extend image available!")
-    # else:
-    #     print("Extended image = {}".format(extended_image))
-    # ++++++++++++++++++++++++++++++++++++
+    )  # this selects any core pixel and first neighbors
 
     # At this point we don't know yet which ones should be kept.
     # In principle, the pixel thresholds should be hierarchical from core to
@@ -173,7 +150,7 @@ def mars_image_cleaning(
     # the mask we got from 'tailcuts_clean'.
 
     pixels_above_2nd_boundary = image >= boundary_thresh[1]
-    # print("pixels_above_2nd_boundary: {}".format(pixels_above_2nd_boundary))
+
     # and now it's the same as the last part of 'tailcuts_clean', but without
     # the core pixels, i.e. we start from the neighbors of the core pixels.
     pixels_with_previous_neighbors = geom.neighbor_matrix_sparse.dot(

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -2,7 +2,7 @@
 Image Cleaning Algorithms (identification of noisy pixels)
 """
 
-__all__ = ["tailcuts_clean", "dilate", "mars_cleaning_1st_pass", "fact_cleaning"]
+__all__ = ["tailcuts_clean", "dilate", "mars_cleaning_1st_pass", "fact_image_cleaning"]
 
 import numpy as np
 from scipy.sparse.csgraph import connected_components

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -91,7 +91,7 @@ def mars_cleaning_1st_pass(
     geom,
     image,
     picture_thresh=7,
-    boundary_thresh=[5, 5],
+    boundary_thresh=5,
     keep_isolated_pixels=False,
     min_number_picture_neighbors=0,
 ):
@@ -110,12 +110,12 @@ def mars_cleaning_1st_pass(
         Camera geometry information
     image: array
         pixel values
-    picture_thresh: float or array
+    picture_thresh: float
         threshold above which all pixels are retained
-    boundary_thresh: array
-        array of 2 thresholds, first the one above which pixels are retained if
-        they have a neighbor already above the picture_thresh, then the one
-        applied iteratively to the neighbor of the neighbor
+    boundary_thresh: float
+        threshold above which pixels are retained if
+        they have a neighbor already above the picture_thresh; it is then
+        reapplied iteratively to the neighbor of the neighbor
     keep_isolated_pixels: bool
         If True, pixels above the picture threshold will be included always,
         if not they are only included if a neighbor is in the picture or
@@ -137,19 +137,19 @@ def mars_cleaning_1st_pass(
         geom,
         image,
         picture_thresh,
-        boundary_thresh[0],
+        boundary_thresh,
         keep_isolated_pixels,
         min_number_picture_neighbors,
-    )  # this selects any core pixel and first neighbors
+    )  # this selects any core pixel and any of its first neighbors
 
     # At this point we don't know yet which ones should be kept.
     # In principle, the pixel thresholds should be hierarchical from core to
     # boundaries (this should be true for every type of particle triggering
     # the image), so we can just check which pixels have more than
-    # boundary_thresh[1] photo-electrons in the same image, but starting from
+    # boundary_thresh photo-electrons in the same image, but starting from
     # the mask we got from 'tailcuts_clean'.
 
-    pixels_above_2nd_boundary = image >= boundary_thresh[1]
+    pixels_above_2nd_boundary = image >= boundary_thresh
 
     # and now it's the same as the last part of 'tailcuts_clean', but without
     # the core pixels, i.e. we start from the neighbors of the core pixels.

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -227,7 +227,7 @@ def number_of_islands(geom, mask):
     return num_islands, island_labels
 
 
-def apply_time_delta_cleaning(
+def _apply_time_delta_cleaning(
     geom, mask, arrival_times, min_number_neighbors, time_limit
 ):
     """ Remove all pixels from selection that have less than N
@@ -342,7 +342,7 @@ def fact_image_cleaning(
         return pixels_to_keep
 
     # Step 4
-    pixels_to_keep = apply_time_delta_cleaning(
+    pixels_to_keep = _apply_time_delta_cleaning(
         geom, pixels_to_keep, arrival_times, min_number_neighbors, time_limit
     )
 
@@ -353,7 +353,7 @@ def fact_image_cleaning(
     pixels_to_keep = pixels_to_keep & (number_of_neighbors >= min_number_neighbors)
 
     # Step 6
-    pixels_to_keep = apply_time_delta_cleaning(
+    pixels_to_keep = _apply_time_delta_cleaning(
         geom, pixels_to_keep, arrival_times, min_number_neighbors, time_limit
     )
     return pixels_to_keep

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -276,6 +276,7 @@ def fact_image_cleaning(
     time_limit=5,
 ):
     """Clean an image by selection pixels that pass the fact cleaning procedure.
+
     Cleaning contains the following steps:
     1: Find pixels containing more photons than a threshold t1
     2: Remove pixels with less than N neighbors
@@ -284,13 +285,6 @@ def fact_image_cleaning(
     4: Remove pixels with less than N neighbors arriving within a given timeframe
     5: Remove pixels with less than N neighbors
     6: Remove pixels with less than N neighbors arriving within a given timeframe
-
-    Reference:
-        On the hunt for photons: analysis of Crab Nebula data obtained
-        by the first G-APD Cherenkov telescope, Thomas Fabian Temme
-        http://dx.doi.org/10.17877/DE290R-17773
-    Implementation:
-        https://github.com/fact-project/fact-tools
 
     Parameters
     ----------
@@ -313,11 +307,14 @@ def fact_image_cleaning(
 
     Returns
     -------
-
     A boolean mask of *clean* pixels.  To get a zero-suppressed image and pixel
     list, use `image[mask], geom.pix_id[mask]`, or to keep the same
     image size and just set unclean pixels to 0 or similar, use
     `image[~mask] = 0`
+
+    References
+    ----------
+    See  [temme2016]_ and for implementation [factcleaning]_
 
     """
 

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -183,11 +183,6 @@ def dilate(geom, mask):
     mask: ndarray
         input mask (array of booleans) to be dilated
     """
-    print("Dilate : input mask = {}".format(mask))
-    print(
-        "Dilate : mask + neighbors = {}".format(geom.neighbor_matrix_sparse.dot(mask))
-    )
-    print("Dilate : return = {}".format(mask | geom.neighbor_matrix_sparse.dot(mask)))
     return mask | geom.neighbor_matrix_sparse.dot(mask)
 
 

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -275,7 +275,6 @@ def fact_image_cleaning(
     min_number_neighbors=2,
     time_limit=5,
 ):
-
     """Clean an image by selection pixels that pass the fact cleaning procedure.
     Cleaning contains the following steps:
     1: Find pixels containing more photons than a threshold t1

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -133,7 +133,8 @@ def mars_image_cleaning(
 
     """
 
-    print("Original image: {}".format(image))
+    # For debug
+    # print("Original image: {}".format(image))
 
     pixels_from_tailcuts_clean = tailcuts_clean(
         geom,
@@ -144,11 +145,12 @@ def mars_image_cleaning(
         min_number_picture_neighbors,
     )  # this does checks for core pixels and first neighbors
 
-    print(
+    # For debug
+    '''print(
         "After tailcuts_clean [{},{}]: {}".format(
             picture_thresh, boundary_thresh[1], pixels_from_tailcuts_clean
         )
-    )
+    )'''
 
     # ++++++++++++++++++++++++++++++++++++
     # THIS PART IS NOT USED FOR THE MOMENT
@@ -171,7 +173,7 @@ def mars_image_cleaning(
     # the mask we got from 'tailcuts_clean'.
 
     pixels_above_2nd_boundary = image >= boundary_thresh[1]
-    print("pixels_above_2nd_boundary: {}".format(pixels_above_2nd_boundary))
+    # print("pixels_above_2nd_boundary: {}".format(pixels_above_2nd_boundary))
     # and now it's the same as the last part of 'tailcuts_clean', but without
     # the core pixels, i.e. we start from the neighbors of the core pixels.
     pixels_with_previous_neighbors = geom.neighbor_matrix_sparse.dot(

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -2,7 +2,7 @@
 Image Cleaning Algorithms (identification of noisy pixels)
 """
 
-__all__ = ["tailcuts_clean", "dilate"]
+__all__ = ["tailcuts_clean", "dilate", "mars_cleaning_first_pass", "fact_cleaning"]
 
 import numpy as np
 from scipy.sparse.csgraph import connected_components

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -2,7 +2,7 @@
 Image Cleaning Algorithms (identification of noisy pixels)
 """
 
-__all__ = ["tailcuts_clean", "dilate", "mars_cleaning_first_pass", "fact_cleaning"]
+__all__ = ["tailcuts_clean", "dilate", "mars_cleaning_1st_pass", "fact_cleaning"]
 
 import numpy as np
 from scipy.sparse.csgraph import connected_components

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -2,15 +2,20 @@
 Image Cleaning Algorithms (identification of noisy pixels)
 """
 
-__all__ = ['tailcuts_clean', 'dilate']
+__all__ = ["tailcuts_clean", "dilate"]
 
 import numpy as np
 from scipy.sparse.csgraph import connected_components
 
 
-def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
-                   keep_isolated_pixels=False,
-                   min_number_picture_neighbors=0):
+def tailcuts_clean(
+    geom,
+    image,
+    picture_thresh=7,
+    boundary_thresh=5,
+    keep_isolated_pixels=False,
+    min_number_picture_neighbors=0,
+):
 
     """Clean an image by selection pixels that pass a two-threshold
     tail-cuts procedure.  The picture and boundary thresholds are
@@ -58,7 +63,8 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
         # Require at least min_number_picture_neighbors. Otherwise, the pixel
         #  is not selected
         number_of_neighbors_above_picture = geom.neighbor_matrix_sparse.dot(
-            pixels_above_picture.view(np.byte))
+            pixels_above_picture.view(np.byte)
+        )
         pixels_in_picture = pixels_above_picture & (
             number_of_neighbors_above_picture >= min_number_picture_neighbors
         )
@@ -67,16 +73,121 @@ def tailcuts_clean(geom, image, picture_thresh=7, boundary_thresh=5,
     # matrix (2d), we find all pixels that are above the boundary threshold
     # AND have any neighbor that is in the picture
     pixels_above_boundary = image >= boundary_thresh
-    pixels_with_picture_neighbors = geom.neighbor_matrix_sparse.dot(
-        pixels_in_picture)
+    pixels_with_picture_neighbors = geom.neighbor_matrix_sparse.dot(pixels_in_picture)
     if keep_isolated_pixels:
-        return (pixels_above_boundary
-                & pixels_with_picture_neighbors) | pixels_in_picture
+        return (
+            pixels_above_boundary & pixels_with_picture_neighbors
+        ) | pixels_in_picture
     else:
         pixels_with_boundary_neighbors = geom.neighbor_matrix_sparse.dot(
-            pixels_above_boundary)
-        return ((pixels_above_boundary & pixels_with_picture_neighbors) |
-                (pixels_in_picture & pixels_with_boundary_neighbors))
+            pixels_above_boundary
+        )
+        return (pixels_above_boundary & pixels_with_picture_neighbors) | (
+            pixels_in_picture & pixels_with_boundary_neighbors
+        )
+
+
+def mars_image_cleaning(
+    geom,
+    image,
+    picture_thresh=7,
+    boundary_thresh=[5, 5],
+    keep_isolated_pixels=False,
+    min_number_picture_neighbors=0,
+):
+    """
+    Clean an image by selection pixels that pass a three-threshold tail-cuts
+    procedure.
+    All thresholds are defined with respect to the pedestal
+    dispersion. All pixels that have a signal higher than the core (picture)
+    threshold will be retained, along with all those above the boundary
+    threshold that are neighbors of a core pixel AND all those above
+    the boundary threshold that are neighbors of a neighbor of a core pixel.
+
+    Parameters
+    ----------
+    geom: `ctapipe.instrument.CameraGeometry`
+        Camera geometry information
+    image: array
+        pixel values
+    picture_thresh: float or array
+        threshold above which all pixels are retained
+    boundary_thresh: array
+        array of 2 thresholds, first the one above which pixels are retained if
+        they have a neighbor already above the picture_thresh, then the one
+        applied iteratively to the neighbor of the neighbor
+    keep_isolated_pixels: bool
+        If True, pixels above the picture threshold will be included always,
+        if not they are only included if a neighbor is in the picture or
+        boundary
+    min_number_picture_neighbors: int
+        A picture pixel survives cleaning only if it has at least this number
+        of picture neighbors. This has no effect in case keep_isolated_pixels is True
+
+    Returns
+    -------
+    A boolean mask of *clean* pixels.  To get a zero-suppressed image and pixel
+    list, use `image[mask], geom.pix_id[mask]`, or to keep the same
+    image size and just set unclean pixels to 0 or similar, use
+    `image[~mask] = 0`
+
+    """
+
+    print("Original image: {}".format(image))
+
+    pixels_from_tailcuts_clean = tailcuts_clean(
+        geom,
+        image,
+        picture_thresh,
+        boundary_thresh[0],
+        keep_isolated_pixels,
+        min_number_picture_neighbors,
+    )  # this does checks for core pixels and first neighbors
+
+    print(
+        "After tailcuts_clean [{},{}]: {}".format(
+            picture_thresh, boundary_thresh[1], pixels_from_tailcuts_clean
+        )
+    )
+
+    # ++++++++++++++++++++++++++++++++++++
+    # THIS PART IS NOT USED FOR THE MOMENT
+    # ++++++++++++++++++++++++++++++++++++
+    # Call dilate on this set of pixels and add all next neighbors,
+    # regardless of their value
+    # extended_image = dilate(geom, pixels_from_tailcuts_clean)
+    #
+    # if extended_image is None:
+    #     print("No extend image available!")
+    # else:
+    #     print("Extended image = {}".format(extended_image))
+    # ++++++++++++++++++++++++++++++++++++
+
+    # At this point we don't know yet which ones should be kept.
+    # In principle, the pixel thresholds should be hierarchical from core to
+    # boundaries (this should be true for every type of particle triggering
+    # the image), so we can just check which pixels have more than
+    # boundary_thresh[1] photo-electrons in the same image, but starting from
+    # the mask we got from 'tailcuts_clean'.
+
+    pixels_above_2nd_boundary = image >= boundary_thresh[1]
+    print("pixels_above_2nd_boundary: {}".format(pixels_above_2nd_boundary))
+    # and now it's the same as the last part of 'tailcuts_clean', but without
+    # the core pixels, i.e. we start from the neighbors of the core pixels.
+    pixels_with_previous_neighbors = geom.neighbor_matrix_sparse.dot(
+        pixels_from_tailcuts_clean
+    )
+    if keep_isolated_pixels:
+        return (
+            pixels_above_2nd_boundary & pixels_with_previous_neighbors
+        ) | pixels_from_tailcuts_clean
+    else:
+        pixels_with_2ndboundary_neighbors = geom.neighbor_matrix_sparse.dot(
+            pixels_above_2nd_boundary
+        )
+        return (pixels_above_2nd_boundary & pixels_with_previous_neighbors) | (
+            pixels_from_tailcuts_clean & pixels_with_2ndboundary_neighbors
+        )
 
 
 def dilate(geom, mask):
@@ -93,6 +204,11 @@ def dilate(geom, mask):
     mask: ndarray
         input mask (array of booleans) to be dilated
     """
+    print("Dilate : input mask = {}".format(mask))
+    print(
+        "Dilate : mask + neighbors = {}".format(geom.neighbor_matrix_sparse.dot(mask))
+    )
+    print("Dilate : return = {}".format(mask | geom.neighbor_matrix_sparse.dot(mask)))
     return mask | geom.neighbor_matrix_sparse.dot(mask)
 
 
@@ -123,8 +239,7 @@ def number_of_islands(geom, mask):
     island_labels = np.zeros(geom.n_pixels)
 
     num_islands, island_labels_compressed = connected_components(
-        neighbor_matrix_compressed,
-        directed=False
+        neighbor_matrix_compressed, directed=False
     )
 
     # count clusters from 1 onwards
@@ -133,8 +248,9 @@ def number_of_islands(geom, mask):
     return num_islands, island_labels
 
 
-def apply_time_delta_cleaning(geom, mask, arrival_times,
-                              min_number_neighbors, time_limit):
+def apply_time_delta_cleaning(
+    geom, mask, arrival_times, min_number_neighbors, time_limit
+):
     """ Remove all pixels from selection that have less than N
     neighbors that arrived within a given timeframe.
 
@@ -171,8 +287,15 @@ def apply_time_delta_cleaning(geom, mask, arrival_times,
     return mask
 
 
-def fact_image_cleaning(geom, image, arrival_times, picture_threshold=4,
-                        boundary_threshold=2, min_number_neighbors=2, time_limit=5):
+def fact_image_cleaning(
+    geom,
+    image,
+    arrival_times,
+    picture_threshold=4,
+    boundary_threshold=2,
+    min_number_neighbors=2,
+    time_limit=5,
+):
 
     """Clean an image by selection pixels that pass the fact cleaning procedure.
     Cleaning contains the following steps:
@@ -225,9 +348,11 @@ def fact_image_cleaning(geom, image, arrival_times, picture_threshold=4,
 
     # Step 2
     number_of_neighbors_above_picture = geom.neighbor_matrix_sparse.dot(
-        (pixels_to_keep).view(np.byte))
-    pixels_to_keep = pixels_to_keep & (number_of_neighbors_above_picture
-                                       >= min_number_neighbors)
+        (pixels_to_keep).view(np.byte)
+    )
+    pixels_to_keep = pixels_to_keep & (
+        number_of_neighbors_above_picture >= min_number_neighbors
+    )
 
     # Step 3
     pixels_above_boundary = image >= boundary_threshold
@@ -238,20 +363,18 @@ def fact_image_cleaning(geom, image, arrival_times, picture_threshold=4,
         return pixels_to_keep
 
     # Step 4
-    pixels_to_keep = apply_time_delta_cleaning(geom,
-                                               pixels_to_keep,
-                                               arrival_times,
-                                               min_number_neighbors,
-                                               time_limit)
+    pixels_to_keep = apply_time_delta_cleaning(
+        geom, pixels_to_keep, arrival_times, min_number_neighbors, time_limit
+    )
 
     # Step 5
-    number_of_neighbors = geom.neighbor_matrix_sparse.dot((pixels_to_keep).view(np.byte))
+    number_of_neighbors = geom.neighbor_matrix_sparse.dot(
+        (pixels_to_keep).view(np.byte)
+    )
     pixels_to_keep = pixels_to_keep & (number_of_neighbors >= min_number_neighbors)
 
     # Step 6
-    pixels_to_keep = apply_time_delta_cleaning(geom,
-                                               pixels_to_keep,
-                                               arrival_times,
-                                               min_number_neighbors,
-                                               time_limit)
+    pixels_to_keep = apply_time_delta_cleaning(
+        geom, pixels_to_keep, arrival_times, min_number_neighbors, time_limit
+    )
     return pixels_to_keep

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -275,8 +275,7 @@ def fact_image_cleaning(
     Cleaning contains the following steps:
     1: Find pixels containing more photons than a threshold t1
     2: Remove pixels with less than N neighbors
-    3: Add neighbors of the remaining pixels that are
-       above a lower threshold t2
+    3: Add neighbors of the remaining pixels that are above a lower threshold t2
     4: Remove pixels with less than N neighbors arriving within a given timeframe
     5: Remove pixels with less than N neighbors
     6: Remove pixels with less than N neighbors arriving within a given timeframe

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -100,15 +100,15 @@ def test_mars_cleaning_1st_pass():
         (b1, b1, b1): [False, False, False],
         (0, b1, 0): [False, False, False],  # to put in test_tailcuts_clean!
         # specific for 'mars_image_cleaning'
-        (p, b2, p): [False, False, False],
-        (p, b2, 0): [False, False, False],
+        (p, b2, p): [True, True, True],
+        (p, b2, 0): [True, True, False],
         (b1, b2, 0): [False, False, False],
         (b2, b2, 0): [False, False, False],
         (0, b2, 0): [False, False, False],
         (p, b1, b2): [True, True, True],
-        (p, b2, b1): [False, False, False],
+        (p, b2, b1): [True, True, True],
         (p, b1, b1): [True, True, True],
-        (p, b2, b2): [False, False, False],
+        (p, b2, b2): [True, True, True],
         (p, b1, b2 - 1): [True, True, False],
     }
 

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -80,7 +80,7 @@ def test_mars_cleaning_1st_pass():
 
     p = 10  # picture value
     b1 = 7  # 1st boundary value
-    b2 = 5  # 2nd boundary value
+    b2 = 7  # 2nd boundary value
 
     # The following test-cases are a superset of those used to test
     # 'tailcuts_clean': since 'mars_image_cleaning' uses it internally, so it
@@ -117,7 +117,7 @@ def test_mars_cleaning_1st_pass():
             geom,
             np.array(image),
             picture_thresh=10,
-            boundary_thresh=[7, 5],
+            boundary_thresh=7,
             keep_isolated_pixels=False,
         )
         assert (result == mask).all()

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -72,8 +72,8 @@ def test_tailcuts_clean():
         assert (result == mask).all()
 
 
-def test_mars_image_cleaning():
-    """Test the MARS-like cleaning."""
+def test_mars_cleaning_1st_pass():
+    """Test the MARS-like cleaning 1st pass."""
 
     # start with simple 3-pixel camera
     geom = CameraGeometry.make_rectangular(3, 1, (-1, 1))
@@ -113,7 +113,7 @@ def test_mars_image_cleaning():
     }
 
     for image, mask in testcases.items():
-        result = cleaning.mars_image_cleaning(
+        result = cleaning.mars_cleaning_1st_pass(
             geom,
             np.array(image),
             picture_thresh=10,

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -9,10 +9,16 @@ References
 	likelihood reconstruction of gamma-rays for imaging
 	atmospheric Cherenkov telescopes". Astroparticle Physics
 	32.5, (2009)
-	
+
 .. [vacanti94] G. Vacanti et. al., Astroparticle Physics 2, 1994, 1-11
 
 
 .. [mitchell15] A Generic Algorithm for IACT Optical Efficiency
     Calibration using Muons, Allison Mitchell et al. arXiv:
     1509.04258v1
+
+.. [temme2016] Temme T.F., "On the hunt for photons: analysis of Crab Nebula
+		data obtainedby the first G-APD Cherenkov telescope" 2016
+		DOI: 10.17877/DE290R-17773
+
+.. [factcleaning] https://github.com/fact-project/fact-tools


### PR DESCRIPTION
This is meant to be a first version of the tailcut used in CTA-MARS.
There are also many automatic PEP-8-compliant format changes due to _black_.

**For the moment:**
- it only implements the 1st pass,
- it is written in a way which is doesn't make easy to expand it later on.

I added also the associated unit test, with additional combinations.
This test is also back-compatible.

**What I plan to do next:**
- create a new _tailcut_double_bound_ method for a 2-boundary tailcut,
- call such function in place of this version of the mars 1st pass cleaning,
- the real final MARS cleaning should then be _tailcut_double_bound + (ctapipe's?) time-gradient + tailcut_double_bound_.