### PR TITLE
Close simtel eventsource in __exit__

### DIFF
--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -86,6 +86,12 @@ class SimTelEventSource(EventSource):
         )
         self.start_pos = self.file_.tell()
 
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        self.file_.close()
+
     @property
     def is_stream(self):
         return not isinstance(self.file_._filehandle, (BufferedReader, GzipFile))


### PR DESCRIPTION
Kai had problems with to many open threads, I think this was the reason (the zcat subprocess)