### PR TITLE
Add method to read bright star catalog and find bright stars in sky region

### DIFF
--- a/ctapipe/utils/__init__.py
+++ b/ctapipe/utils/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     'get_table_dataset',
     'get_dataset_path',
     'find_in_path',
+    'get_bright_stars'
     'CutFlow',
     'PureCountingCut',
     'UndefinedCut',

--- a/ctapipe/utils/__init__.py
+++ b/ctapipe/utils/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     'get_table_dataset',
     'get_dataset_path',
     'find_in_path',
-    'get_bright_stars'
+    'get_bright_stars',
     'CutFlow',
     'PureCountingCut',
     'UndefinedCut',

--- a/ctapipe/utils/__init__.py
+++ b/ctapipe/utils/__init__.py
@@ -6,7 +6,7 @@ from .table_interpolator import TableInterpolator
 from .unstructured_interpolator import UnstructuredInterpolator
 from .datasets import (find_all_matching_datasets, get_table_dataset, get_dataset_path,
                        find_in_path)
-from .astro import (get_bright_stars)
+from .astro import get_bright_stars
 from .CutFlow import CutFlow, PureCountingCut, UndefinedCut
 
 

--- a/ctapipe/utils/__init__.py
+++ b/ctapipe/utils/__init__.py
@@ -6,6 +6,7 @@ from .table_interpolator import TableInterpolator
 from .unstructured_interpolator import UnstructuredInterpolator
 from .datasets import (find_all_matching_datasets, get_table_dataset, get_dataset_path,
                        find_in_path)
+from .astro import (get_bright_stars)
 from .CutFlow import CutFlow, PureCountingCut, UndefinedCut
 
 

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -37,7 +37,7 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
     from astropy.table import Table
     from ctapipe.utils import get_table_dataset
 
-    catalog = get_table_dataset("yale_bright_star_catalog5", 
+    catalog = get_table_dataset("yale_bright_star_catalog5",
                                 role="bright star catalog")
 
     starpositions = SkyCoord(ra=Angle(catalog['RAJ2000'], unit=u.deg),

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -6,17 +6,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-try:
-    import ctapipe_resources
-except ImportError:
-    raise RuntimeError("Please install the 'ctapipe-extra' package, "
-                       "which contains the ctapipe_resources module "
-                       "needed by ctapipe. (conda install ctapipe-extra)")
-
 __all__ = ['get_bright_stars']
 
 
-def get_bright_stars(pointing=SkyCoord(ra=0. * u.rad, dec=0. * u.rad, frame='icrs'), 
+def get_bright_stars(pointing=SkyCoord(ra=0. * u.rad, dec=0. * u.rad, frame='icrs'),
                      radius=180. * u.deg, magnitude_cut=7.96):
     """
     Returns an astropy table containing star positions above a given magnitude within
@@ -35,14 +28,15 @@ def get_bright_stars(pointing=SkyCoord(ra=0. * u.rad, dec=0. * u.rad, frame='icr
     Returns
     -------
     Astropy table:
-       List of all stars after cuts with names, catalog numbers, magnitudes, 
+       List of all stars after cuts with names, catalog numbers, magnitudes,
        and coordinates
     """
     from astropy.io import fits
     from astropy.table import Table
     from ctapipe.utils import get_dataset_path
 
-    hdulist = fits.open(get_dataset_path("yale_bright_star_catalog5.fits.gz"))
+    catalog = get_dataset_path("yale_brigh2t_star_catalog5.fits.gz")
+    hdulist = fits.open(catalog)
     table = Table(hdulist[1].data)
 
     starpositions = SkyCoord(ra=Angle(table['RAJ2000'], unit=u.deg),

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -42,7 +42,7 @@ def get_bright_stars(pointing=SkyCoord(ra=0. * u.rad, dec=0. * u.rad, frame='icr
     from astropy.table import Table
     from ctapipe.utils import get_dataset_path
 
-    hdulist = fits.open(get_dataset_path("brightstars.fits.gz"))
+    hdulist = fits.open(get_dataset_path("yale_bright_star_catalog5.fits.gz"))
     table = Table(hdulist[1].data)
 
     starpositions = SkyCoord(ra=Angle(table['RAJ2000'], unit=u.deg),

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -1,4 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module is intended to contain astronomy-related helper tools which are
+not provided by external packages and/or to satisfy particular needs of
+usage within ctapipe.
+"""
 from astropy.coordinates import Angle
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -22,7 +27,7 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
     Parameters
     ----------
     pointing: astropy Skycoord
-       pointing direction in the sky
+       pointing direction in the sky (if none is given, full sky is returned)
     radius: astropy angular units
        Radius of the sky region around pointing position. Default: full sky
     magnitude_cut: float

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -7,9 +7,6 @@ usage within ctapipe.
 from astropy.coordinates import Angle
 from astropy.coordinates import SkyCoord
 from astropy import units as u
-import logging
-
-logger = logging.getLogger(__name__)
 
 __all__ = ['get_bright_stars']
 
@@ -39,7 +36,6 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
        List of all stars after cuts with names, catalog numbers, magnitudes,
        and coordinates
     """
-    from astropy.table import Table
     from ctapipe.utils import get_table_dataset
 
     catalog = get_table_dataset("yale_bright_star_catalog5",

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -50,7 +50,8 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
 
     if radius is not None:
         if pointing is None:
-            raise ValueError('Sky pointing, pointing=SkyCoord(), must be provided if radius is given.')
+            raise ValueError('Sky pointing, pointing=SkyCoord(), must be \
+                              provided if radius is given.')
         separations = starpositions.separation(pointing)
         table['separation'] = separations
         table = table[separations < radius]

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -35,28 +35,28 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
        and coordinates
     """
     from astropy.table import Table
-    from ctapipe.utils import get_dataset_path
+    from ctapipe.utils import get_table_dataset
 
-    catalog = get_dataset_path("yale_bright_star_catalog5.fits.gz")
-    table = Table.read(catalog)
+    catalog = get_table_dataset("yale_bright_star_catalog5", 
+                                role="bright star catalog")
 
-    starpositions = SkyCoord(ra=Angle(table['RAJ2000'], unit=u.deg),
-                             dec=Angle(table['DEJ2000'], unit=u.deg),
+    starpositions = SkyCoord(ra=Angle(catalog['RAJ2000'], unit=u.deg),
+                             dec=Angle(catalog['DEJ2000'], unit=u.deg),
                              frame='icrs', copy=False)
-    table['ra_dec'] = starpositions
+    catalog['ra_dec'] = starpositions
 
     if magnitude_cut is not None:
-        table = table[table['Vmag'] < magnitude_cut]
+        catalog = catalog[catalog['Vmag'] < magnitude_cut]
 
     if radius is not None:
         if pointing is None:
             raise ValueError('Sky pointing, pointing=SkyCoord(), must be '
                              'provided if radius is given.')
-        separations = table['ra_dec'].separation(pointing)
-        table['separation'] = separations
-        table = table[separations < radius]
+        separations = catalog['ra_dec'].separation(pointing)
+        catalog['separation'] = separations
+        catalog = catalog[separations < radius]
 
-    table.remove_columns(['RAJ2000', 'DEJ2000'])
+    catalog.remove_columns(['RAJ2000', 'DEJ2000'])
 
-    return table
+    return catalog
 

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from astropy.coordinates import Angle
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import ctapipe_resources
+except ImportError:
+    raise RuntimeError("Please install the 'ctapipe-extra' package, "
+                       "which contains the ctapipe_resources module "
+                       "needed by ctapipe. (conda install ctapipe-extra)")
+
+__all__ = ['get_bright_stars']
+
+
+def get_bright_stars(pointing=SkyCoord(ra=0. * u.rad, dec=0. * u.rad, frame='icrs'), 
+                     radius=180. * u.deg, magnitude_cut=7.96):
+    """
+    Returns an astropy table containing star positions above a given magnitude within
+    a given radius around a position in the sky, using the Yale bright star catalog
+    which needs to be present in the ctapipe-extra package.
+
+    Parameters
+    ----------
+    pointing: astropy Skycoord
+       pointing direction in the sky
+    radius: astropy angular units
+       Radius of the sky region around pointing position. Default: full sky
+    magnitude_cut: float
+        Return only stars above a given magnitude. Default: 7.96 (all entries)
+
+    Returns
+    -------
+    Astropy table:
+       List of all stars after cuts with names, catalog numbers, magnitudes, 
+       and coordinates
+    """
+    from astropy.io import fits
+    from astropy.table import Table
+    from ctapipe.utils import get_dataset_path
+
+    hdulist = fits.open(get_dataset_path("brightstars.fits.gz"))
+    table = Table(hdulist[1].data)
+
+    starpositions = SkyCoord(ra=Angle(table['RAJ2000'], unit=u.deg),
+                             dec=Angle(table['DEJ2000'], unit=u.deg), frame='icrs')
+    table['ra_dec'] = starpositions
+
+    if radius < 180. * u.deg:
+        separations = starpositions.separation(pointing)
+        table['separation'] = separations
+        table = table[separations < radius]
+    if magnitude_cut < 7.96:
+        table = table[table['Vmag'] < magnitude_cut]
+    table.remove_columns(['RAJ2000', 'DEJ2000'])
+
+    return table
+

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -49,6 +49,8 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
         table = table[table['Vmag'] < magnitude_cut]
 
     if radius is not None:
+        if pointing is None:
+            raise ValueError('Sky pointing, pointing=SkyCoord(), must be provided if radius is given.')
         separations = starpositions.separation(pointing)
         table['separation'] = separations
         table = table[separations < radius]

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -15,8 +15,8 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
     a given radius around a position in the sky, using the Yale bright star catalog
     which needs to be present in the ctapipe-extra package. The included Yale bright
     star catalog contains all 9096 stars, excluding the Nova objects present in the
-    original catalog from  Hoffleit & Jaschek (1991), 
-    http://adsabs.harvard.edu/abs/1991bsc..book.....H, and is complete down to 
+    original catalog from  Hoffleit & Jaschek (1991),
+    http://adsabs.harvard.edu/abs/1991bsc..book.....H, and is complete down to
     magnitude ~6.5, while the faintest included star has mag=7.96.
 
     Parameters
@@ -41,14 +41,14 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
     table = Table.read(catalog)
 
     starpositions = SkyCoord(ra=Angle(table['RAJ2000'], unit=u.deg),
-                             dec=Angle(table['DEJ2000'], unit=u.deg), 
+                             dec=Angle(table['DEJ2000'], unit=u.deg),
                              frame='icrs', copy=False)
     table['ra_dec'] = starpositions
 
-    if magnitude_cut != None:
+    if magnitude_cut is not None:
         table = table[table['Vmag'] < magnitude_cut]
-        
-    if radius != None:
+
+    if radius is not None:
         separations = starpositions.separation(pointing)
         table['separation'] = separations
         table = table[separations < radius]

--- a/ctapipe/utils/astro.py
+++ b/ctapipe/utils/astro.py
@@ -50,9 +50,9 @@ def get_bright_stars(pointing=None, radius=None, magnitude_cut=None):
 
     if radius is not None:
         if pointing is None:
-            raise ValueError('Sky pointing, pointing=SkyCoord(), must be \
-                              provided if radius is given.')
-        separations = starpositions.separation(pointing)
+            raise ValueError('Sky pointing, pointing=SkyCoord(), must be '
+                             'provided if radius is given.')
+        separations = table['ra_dec'].separation(pointing)
         table['separation'] = separations
         table = table[separations < radius]
 

--- a/ctapipe/utils/tests/test_astro.py
+++ b/ctapipe/utils/tests/test_astro.py
@@ -2,16 +2,10 @@ from ..astro import get_bright_stars
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
-try:
-    import ctapipe_resources
-except ImportError:
-    raise RuntimeError("Please install the 'ctapipe-extra' package, "
-                       "which contains the ctapipe_resources module "
-                       "needed by ctapipe. (conda install ctapipe-extra)")
-
-
 def test_get_bright_stars():
 
+    # test that only Zeta Tauri is returned close to the Crab Nebula
+    # as object brighter than mag=3.5
     pointing = SkyCoord(ra=83.275 * u.deg, dec=21.791 * u.deg, frame='icrs')
 
     table = get_bright_stars(pointing, radius=2. * u.deg, magnitude_cut=3.5)

--- a/ctapipe/utils/tests/test_astro.py
+++ b/ctapipe/utils/tests/test_astro.py
@@ -1,0 +1,12 @@
+from ..astro import get_bright_stars
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+
+def test_get_bright_stars():
+
+    pointing = SkyCoord(ra=83.275 * u.deg, dec=21.791 * u.deg, frame='icrs')
+
+    table = get_bright_stars(pointing, radius=5. * u.deg, magnitude_cut=3.5)
+
+    assert len(table) == 1
+    assert table[0]['Name'] == '123Zet Tau'

--- a/ctapipe/utils/tests/test_astro.py
+++ b/ctapipe/utils/tests/test_astro.py
@@ -2,6 +2,14 @@ from ..astro import get_bright_stars
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
+try:
+    import ctapipe_resources
+except ImportError:
+    raise RuntimeError("Please install the 'ctapipe-extra' package, "
+                       "which contains the ctapipe_resources module "
+                       "needed by ctapipe. (conda install ctapipe-extra)")
+
+
 def test_get_bright_stars():
 
     pointing = SkyCoord(ra=83.275 * u.deg, dec=21.791 * u.deg, frame='icrs')

--- a/ctapipe/utils/tests/test_astro.py
+++ b/ctapipe/utils/tests/test_astro.py
@@ -6,7 +6,7 @@ def test_get_bright_stars():
 
     pointing = SkyCoord(ra=83.275 * u.deg, dec=21.791 * u.deg, frame='icrs')
 
-    table = get_bright_stars(pointing, radius=5. * u.deg, magnitude_cut=3.5)
+    table = get_bright_stars(pointing, radius=2. * u.deg, magnitude_cut=3.5)
 
     assert len(table) == 1
     assert table[0]['Name'] == '123Zet Tau'

--- a/ctapipe/utils/tests/test_astro.py
+++ b/ctapipe/utils/tests/test_astro.py
@@ -1,11 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module contains the utils.astro unit tests
+"""
 from ..astro import get_bright_stars
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
 def test_get_bright_stars():
-
-    # test that only Zeta Tau is returned close to the Crab Nebula
-    # as object brighter than mag=3.5
+    """
+    unit test for utils.astro.get_bright_stars(). Tests that only Zeta Tau is
+    returned close to the Crab Nebula as object brighter than mag=3.5.
+    """
     pointing = SkyCoord(ra=83.275 * u.deg, dec=21.791 * u.deg, frame='icrs')
 
     table = get_bright_stars(pointing, radius=2. * u.deg, magnitude_cut=3.5)

--- a/ctapipe/utils/tests/test_astro.py
+++ b/ctapipe/utils/tests/test_astro.py
@@ -4,7 +4,7 @@ from astropy import units as u
 
 def test_get_bright_stars():
 
-    # test that only Zeta Tauri is returned close to the Crab Nebula
+    # test that only Zeta Tau is returned close to the Crab Nebula
     # as object brighter than mag=3.5
     pointing = SkyCoord(ra=83.275 * u.deg, dec=21.791 * u.deg, frame='icrs')
 

--- a/docs/ctapipe_api/utils/index.rst
+++ b/docs/ctapipe_api/utils/index.rst
@@ -58,6 +58,9 @@ Reference/API
 .. automodapi:: ctapipe.utils
     :no-inheritance-diagram:
 
+.. automodapi:: ctapipe.utils.astro
+    :no-inheritance-diagram:
+
 .. automodapi:: ctapipe.utils.linalg
     :no-inheritance-diagram:
 

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - pytables
   - tqdm
   - conda-forge::nbsphinx
-  - ctapipe-extra=0.2.17
+  - ctapipe-extra=0.2.18
   - pytest-runner
   - pip:
     - eventio~=0.20.1

--- a/py3.6_env.yaml
+++ b/py3.6_env.yaml
@@ -40,7 +40,7 @@ dependencies:
   - tqdm
   - conda-forge::nbsphinx
   - pytest-runner
-  - ctapipe-extra=0.2.17
+  - ctapipe-extra=0.2.18
   - pyhessio=2.1
   - nbconvert>=5.4
   - pip:

--- a/py3.7_env.yaml
+++ b/py3.7_env.yaml
@@ -40,7 +40,7 @@ dependencies:
   - tqdm
   - conda-forge::nbsphinx
   - pytest-runner
-  - ctapipe-extra=0.2.17
+  - ctapipe-extra=0.2.18
   - pyhessio=2.1
   - nbconvert>=5.4
   - pip:


### PR DESCRIPTION
added a new 'astro' class in `ctapipe.utils` with a `get_bright_stars()` method, which returns the Yale bright star catalog (read from ctapipe-extra) into an astropy table, or with arguments
`get_bright_stars(pointing = astropy.SkyCoord(), radius = astropy.Angle(), magnitude_cut = float)`
selects stars brighter than the chosen magnitude in a region of given radius around a sky position