### PR TITLE
Add Fields to calibration containers

### DIFF
--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -683,8 +683,13 @@ class FlatFieldContainer(Container):
 
     charge_median_outliers = Field(
         None,
-        "Boolean np array of charge (median) outliers (n_chan, n_pix)"
+        "Boolean np array of charge median outliers (n_chan, n_pix)"
     )
+    charge_std_outliers = Field(
+        None,
+        "Boolean np array of charge std outliers (n_chan, n_pix)"
+    )
+
     time_median_outliers = Field(
         None,
         "Boolean np array of pixel time (median) outliers (n_chan, n_pix)"

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -768,6 +768,12 @@ class WaveformCalibrationContainer(Container):
         "np array of (digital count) to (photon electron) coefficients (n_chan, n_pix)"
     )
 
+    pedestal_per_sample = Field(
+        None,
+        "np array of average pedestal value per sample (digital count) (n_chan, n_pix)"
+    )
+
+
     time_correction = Field(
         None,
         "np array of time correction values (n_chan, n_pix)"


### PR DESCRIPTION
This PR add two fields to the Monitoring containers that are necessary for the LST1 calibration.
Would be it possible to accept it fast? Otherwise I must double the containers in lstchain

Thanks very much




