### PR TITLE
`timing_parameters` cleaning mask

### DIFF
--- a/ctapipe/image/tests/test_timing_parameters.py
+++ b/ctapipe/image/tests/test_timing_parameters.py
@@ -27,6 +27,7 @@ def test_psi_0():
         image=np.ones(geom.n_pixels),
         pulse_time=pulse_time,
         hillas_parameters=hillas,
+        cleaning_mask=np.ones(geom.n_pixels, dtype=bool)
     )
 
     # Test we get the values we put in back out again
@@ -56,6 +57,7 @@ def test_psi_20():
         image=np.ones(geom.n_pixels),
         pulse_time=pulse_time,
         hillas_parameters=hillas,
+        cleaning_mask=np.ones(geom.n_pixels, dtype=bool)
     )
 
     # Test we get the values we put in back out again
@@ -79,11 +81,14 @@ def test_ignore_negative():
     image = np.ones(geom.n_pixels)
     image[5:10] = -1.0
 
+    cleaning_mask = image >= 0
+
     timing = timing_parameters(
         geom,
         image,
         pulse_time=pulse_time,
         hillas_parameters=hillas,
+        cleaning_mask=cleaning_mask,
     )
 
     # Test we get the values we put in back out again

--- a/ctapipe/image/timing_parameters.py
+++ b/ctapipe/image/timing_parameters.py
@@ -36,19 +36,18 @@ def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask=
     timing_parameters: TimingParametersContainer
     """
 
+    unit = geom.pix_x.unit
+
     if cleaning_mask is not None:
         image = image[cleaning_mask]
         geom = geom[cleaning_mask]
+        pulse_time = pulse_time[cleaning_mask]
 
     if (image < 0).any():
         raise ValueError("The non-masked pixels must verify signal >= 0")
 
-    unit = geom.pix_x.unit
-
-    pix_x = geom.pix_x[cleaning_mask]
-    pix_y = geom.pix_y[cleaning_mask]
-    image = image[cleaning_mask]
-    pulse_time = pulse_time[cleaning_mask]
+    pix_x = geom.pix_x
+    pix_y = geom.pix_y
 
     longi, trans = camera_to_shower_coordinates(
         pix_x,

--- a/ctapipe/image/timing_parameters.py
+++ b/ctapipe/image/timing_parameters.py
@@ -13,9 +13,9 @@ __all__ = [
 ]
 
 
-def timing_parameters(geom, image, pulse_time, hillas_parameters):
+def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask):
     """
-    Function to extract timing parameters from a cleaned image
+    Function to extract timing parameters from a cleaned image.
 
     Parameters
     ----------
@@ -27,21 +27,23 @@ def timing_parameters(geom, image, pulse_time, hillas_parameters):
         Time of the pulse extracted from each pixels waveform
     hillas_parameters: ctapipe.io.containers.HillasParametersContainer
         Result of hillas_parameters
+    cleaning_mask: array, dtype=bool
+        The pixels that survived cleaning, e.g. tailcuts_clean
+        The non-masked pixels must verify signal > 0
 
     Returns
     -------
     timing_parameters: TimingParametersContainer
     """
 
+    assert (image[cleaning_mask] >= 0).all(), "The non-masked pixels must verify signal > 0"
+
     unit = geom.pix_x.unit
 
-    # select only the pixels in the cleaned image that are greater than zero.
-    # we need to exclude possible pixels with zero signal after cleaning.
-    greater_than_0 = image > 0
-    pix_x = geom.pix_x[greater_than_0]
-    pix_y = geom.pix_y[greater_than_0]
-    image = image[greater_than_0]
-    pulse_time = pulse_time[greater_than_0]
+    pix_x = geom.pix_x[cleaning_mask]
+    pix_y = geom.pix_y[cleaning_mask]
+    image = image[cleaning_mask]
+    pulse_time = pulse_time[cleaning_mask]
 
     longi, trans = camera_to_shower_coordinates(
         pix_x,

--- a/ctapipe/image/timing_parameters.py
+++ b/ctapipe/image/timing_parameters.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask):
+def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask=None):
     """
     Function to extract timing parameters from a cleaned image.
 
@@ -27,7 +27,7 @@ def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask)
         Time of the pulse extracted from each pixels waveform
     hillas_parameters: ctapipe.io.containers.HillasParametersContainer
         Result of hillas_parameters
-    cleaning_mask: array, dtype=bool
+    cleaning_mask: optionnal, array, dtype=bool
         The pixels that survived cleaning, e.g. tailcuts_clean
         The non-masked pixels must verify signal > 0
 
@@ -36,7 +36,10 @@ def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask)
     timing_parameters: TimingParametersContainer
     """
 
-    assert (image[cleaning_mask] >= 0).all(), "The non-masked pixels must verify signal > 0"
+    cleaning_mask = np.ones(image.shape, dtype=bool) if cleaning_mask is None else cleaning_mask
+
+    if (image[cleaning_mask] < 0).any():
+        raise ValueError("The non-masked pixels must verify signal >= 0")
 
     unit = geom.pix_x.unit
 

--- a/ctapipe/image/timing_parameters.py
+++ b/ctapipe/image/timing_parameters.py
@@ -36,9 +36,11 @@ def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask=
     timing_parameters: TimingParametersContainer
     """
 
-    cleaning_mask = np.ones(image.shape, dtype=bool) if cleaning_mask is None else cleaning_mask
+    if cleaning_mask is not None:
+        image = image[cleaning_mask]
+        geom = geom[cleaning_mask]
 
-    if (image[cleaning_mask] < 0).any():
+    if (image < 0).any():
         raise ValueError("The non-masked pixels must verify signal >= 0")
 
     unit = geom.pix_x.unit

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -97,6 +97,7 @@ def test_array_display():
         image=ones(geom.n_pixels),
         pulse_time=intercept + grad * geom.pix_x.value,
         hillas_parameters=hillas,
+        cleaning_mask=ones(geom.n_pixels, dtype=bool)
     )
     gradient_dict = {
         1: timing_rot20.slope.value,

--- a/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
+++ b/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
@@ -1,1116 +1,1052 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# 2018 LST Bootcamp walkthrough"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "# 2018 LST Bootcamp walkthrough"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "\u003cdiv align\u003d\"center\" style\u003d\"font-size: 2rem\"\u003e\n",
+        "\n",
+        "\u003cimg heoght\u003d\"300px\" src\u003d\"https://cta-observatory.github.io/ctapipe/_images/ctapipe_logo.png\" alt\u003d\"ctapipe\"/\u003e\n",
+        "\n",
+        "\n",
+        "\u003cp style\u003d\"text-align: center;\"\u003eLST Analysis Bootcamp\u003c/p\u003e\n",
+        "\n",
+        "\u003cp style\u003d\"text-align: center\"\u003ePadova, 26.11.2018\u003c/p\u003e\n",
+        "\n",
+        "\u003cp style\u003d\"text-align: center\"\u003eMaximilian Nöthe (@maxnoe) \u0026 Kai A. Brügge (@mackaiver)\u003c/p\u003e\n",
+        "\n",
+        "\u003c/div\u003e"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "slideshow": {
+          "slide_type": "skip"
+        },
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "\n",
+        "%matplotlib inline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "slideshow": {
+          "slide_type": "skip"
+        },
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "plt.rcParams[\u0027figure.figsize\u0027] \u003d (12, 8)\n",
+        "plt.rcParams[\u0027font.size\u0027] \u003d 14\n",
+        "plt.rcParams[\u0027figure.figsize\u0027]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "\u003ch1 id\u003d\"tocheading\"\u003eTable of Contents\u003c/h1\u003e\n",
+        "\u003cdiv id\u003d\"toc\"\u003e\u003c/div\u003e"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "## General Information"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "### Design\n",
+        "\n",
+        "* DL0 → DL3 analysis\n",
+        "\n",
+        "* Currently some R0 → DL0 code to be able to analyze simtel files\n",
+        "\n",
+        "* ctapipe is built upon the Scientific Python Stack, core dependencies are\n",
+        "  * numpy\n",
+        "  * scipy\n",
+        "  * astropy"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "### Developement\n",
+        "\n",
+        "* ctapipe is developed as Open Source Software (Currently under MIT License) at \u003chttps://github.com/cta-observatory/ctapipe\u003e\n",
+        "\n",
+        "* We use the \"Github-Workflow\": \n",
+        "  * Few people (e.g. @kosack, @mackaiver) have write access to the main repository\n",
+        "  * Contributors fork the main repository and work on branches\n",
+        "  * Pull Requests are merged after Code Review and automatic execution of the test suite\n",
+        "\n",
+        "* Early developement stage ⇒ backwards-incompatible API changes might and will happen \n",
+        "\n",
+        "* Many open design questions ⇒ Core Developer Meeting in the second week of December in Dortmund"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "### What\u0027s there?\n",
+        "\n",
+        "* Reading simtel simulation files\n",
+        "* Simple calibration, cleaning and feature extraction functions\n",
+        "* Camera and Array plotting\n",
+        "* Coordinate frames and transformations \n",
+        "* Stereo-reconstruction using line intersections\n",
+        "  \n",
+        " "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "### What\u0027s still missing?\n",
+        "\n",
+        "* Easy to use IO of analysis results to standard data formats (e.g. FITS, hdf5)\n",
+        "* Easy to use \"analysis builder\"\n",
+        "* A \"Standard Analysis\"\n",
+        "* Good integration with machine learning techniques\n",
+        "* IRF calculation \n",
+        "* Defining APIs for IO, instrument description access etc.\n",
+        "* Most code only tested on HESSIO simulations\n",
+        "* Documentation, e.g. formal definitions of coordinate frames \n",
+        " \n",
+        " "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "### What can you do?\n",
+        "\n",
+        "* Report issues\n",
+        "  * Hard to get started? Tell us where you are stuck\n",
+        "  * Tell user stories\n",
+        "  * Missing features\n",
+        "\n",
+        "* Start contributing\n",
+        "  * ctapipe needs more workpower\n",
+        "  * Implement new reconstruction features"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "slideshow": {
+          "slide_type": "slide"
+        },
+        "pycharm": {}
+      },
+      "source": [
+        "## A simple hillas analysis"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "### Reading in simtel files"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.io import event_source\n",
+        "from ctapipe.utils.datasets import get_dataset_path\n",
+        "\n",
+        "input_url \u003d get_dataset_path(\u0027gamma_test_large.simtel.gz\u0027)\n",
+        "\n",
+        "# event_source() automatically detects what kind of file we are giving it,\n",
+        "# if already supported by ctapipe\n",
+        "source \u003d event_source(input_url, max_events\u003d49)\n",
+        "\n",
+        "print(type(source))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "for event in source:\n",
+        "    print(\u0027Id: {}, E \u003d {:1.3f}, Telescopes: {}\u0027.format(event.count, event.mc.energy, len(event.r0.tel)))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "Each event is a `DataContainer` holding several `Field`s of data, which can be containers or just numbers.\n",
+        "Let\u0027s look a one event:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "event"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "event.inst.subarray.camera_types"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "len(event.r0.tel), len(event.r1.tel)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "### Data calibration\n",
+        "\n",
+        "The `CameraCalibrator` calibrates the event (obtaining the `dl1` images)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.calib import CameraCalibrator\n",
+        "\n",
+        "calibrator \u003d CameraCalibrator()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "calibrator(event)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "### Event displays\n",
+        "\n",
+        "Let\u0027s use ctapipe\u0027s plotting facilities to plot the telescope images"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "event.dl1.tel.keys()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "tel_id \u003d 4"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "camera \u003d event.inst.subarray.tel[tel_id].camera\n",
+        "dl1 \u003d event.dl1.tel[tel_id]\n",
+        "\n",
+        "camera, dl1"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "dl1.image"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.visualization import CameraDisplay\n",
+        "\n",
+        "display \u003d CameraDisplay(camera)\n",
+        "\n",
+        "# right now, there might be one image per gain channel.\n",
+        "# This will change as soon as \n",
+        "display.image \u003d dl1.image\n",
+        "display.add_colorbar()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "### Image Cleaning"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.image.cleaning import tailcuts_clean"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "# unoptimized cleaning levels, copied from \n",
+        "# https://github.com/tudo-astroparticlephysics/cta_preprocessing\n",
+        "cleaning_level \u003d {\n",
+        "    \u0027ASTRICam\u0027: (5, 7, 2),  # (5, 10)?\n",
+        "    \u0027LSTCam\u0027: (3.5, 7.5, 2),  # ?? (3, 6) for Abelardo...\n",
+        "    \u0027FlashCam\u0027: (4, 8, 2),  # there is some scaling missing?\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "boundary, picture, min_neighbors \u003d cleaning_level[camera.cam_id]\n",
+        "\n",
+        "clean \u003d tailcuts_clean(\n",
+        "    camera, \n",
+        "    dl1.image,\n",
+        "    boundary_thresh\u003dboundary,\n",
+        "    picture_thresh\u003dpicture,\n",
+        "    min_number_picture_neighbors\u003dmin_neighbors\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "fig, (ax1, ax2) \u003d plt.subplots(1, 2, figsize\u003d(15, 5))\n",
+        "\n",
+        "d1 \u003d CameraDisplay(camera, ax\u003dax1)\n",
+        "d2 \u003d CameraDisplay(camera, ax\u003dax2)\n",
+        "\n",
+        "ax1.set_title(\u0027Image\u0027)\n",
+        "d1.image \u003d dl1.image\n",
+        "d1.add_colorbar(ax\u003dax1)\n",
+        "\n",
+        "ax2.set_title(\u0027Pulse Time\u0027)\n",
+        "d2.image \u003d dl1.pulse_time - np.average(dl1.pulse_time, weights\u003ddl1.image)\n",
+        "d2.cmap \u003d \u0027RdBu_r\u0027\n",
+        "d2.add_colorbar(ax\u003dax2)\n",
+        "d2.set_limits_minmax(-20,20)\n",
+        "\n",
+        "d1.highlight_pixels(clean, color\u003d\u0027red\u0027, linewidth\u003d1)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "### Image Parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.image import hillas_parameters, leakage, concentration\n",
+        "from ctapipe.image.timing_parameters import timing_parameters\n",
+        "from ctapipe.image.cleaning import number_of_islands\n",
+        "from ctapipe.image.hillas import camera_to_shower_coordinates"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "hillas \u003d hillas_parameters(camera[clean], dl1.image[clean])\n",
+        "\n",
+        "print(hillas)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "display \u003d CameraDisplay(camera)\n",
+        "\n",
+        "# set \"unclean\" pixels to 0\n",
+        "cleaned \u003d dl1.image.copy()\n",
+        "cleaned[~clean] \u003d 0.0\n",
+        "\n",
+        "display.image \u003d cleaned\n",
+        "display.add_colorbar()\n",
+        "\n",
+        "display.overlay_moments(hillas, color\u003d\u0027xkcd:red\u0027)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": "timing \u003d timing_parameters(\n    camera,\n    dl1.image,\n    dl1.pulse_time,\n    hillas,\n    clean\n)\n\nprint(timing)"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "long, trans \u003d camera_to_shower_coordinates(\n",
+        "    camera.pix_x, camera.pix_y,hillas.x, hillas.y, hillas.psi\n",
+        ")\n",
+        "\n",
+        "plt.plot(long[clean], dl1.pulse_time[clean], \u0027o\u0027)\n",
+        "plt.plot(long[clean], timing.slope * long[clean] + timing.intercept)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "l \u003d leakage(camera, dl1.image, clean)\n",
+        "print(l)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "disp \u003d CameraDisplay(camera)\n",
+        "disp.image \u003d dl1.image\n",
+        "disp.highlight_pixels(camera.get_border_pixel_mask(1), linewidth\u003d2, color\u003d\u0027xkcd:red\u0027)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "n_islands, island_id \u003d number_of_islands(camera, clean)\n",
+        "\n",
+        "print(n_islands)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "conc \u003d concentration(camera, dl1.image, hillas)\n",
+        "print(conc)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "### Putting it all together / Stereo reconstruction"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": "import astropy.units as u\nfrom astropy.coordinates import SkyCoord, AltAz\n\nfrom ctapipe.io import event_source\nfrom ctapipe.utils.datasets import get_dataset_path\n\nfrom ctapipe.calib import CameraCalibrator\n\nfrom ctapipe.image.cleaning import tailcuts_clean, number_of_islands\nfrom ctapipe.image import hillas_parameters, leakage, concentration\nfrom ctapipe.image.timing_parameters import timing_parameters\n\nfrom ctapipe.reco import HillasReconstructor\n\nfrom ctapipe.io import HDF5TableWriter\n\nfrom copy import deepcopy\nimport tempfile\n\n# unoptimized cleaning levels, copied from \n# https://github.com/tudo-astroparticlephysics/cta_preprocessing\ncleaning_level \u003d {\n    \u0027ASTRICam\u0027: (5, 7, 2),  # (5, 10)?\n    \u0027LSTCam\u0027: (3.5, 7.5, 2),  # ?? (3, 6) for Abelardo...\n    \u0027FlashCam\u0027: (4, 8, 2),  # there is some scaling missing?\n}\n\n\ninput_url \u003d get_dataset_path(\u0027gamma_test_large.simtel.gz\u0027)\nsource \u003d event_source(input_url)\n\ncalibrator \u003d CameraCalibrator()\n\nhorizon_frame \u003d AltAz()\n\nreco \u003d HillasReconstructor()\n\nf \u003d tempfile.NamedTemporaryFile(suffix\u003d\u0027.hdf5\u0027)\n\nwith HDF5TableWriter(f.name, mode\u003d\u0027w\u0027, group_name\u003d\u0027events\u0027) as writer:\n    \n    for event in source:\n        print(\u0027Id: {}, E \u003d {:1.3f}, Telescopes: {}\u0027.format(event.count, event.mc.energy, len(event.r0.tel)))\n        \n        calibrator(event)\n\n        # mapping of telescope_id to parameters for stereo reconstruction\n        hillas_containers \u003d {}\n        telescope_pointings \u003d {}\n        time_gradients \u003d {}\n\n        for telescope_id, dl1 in event.dl1.tel.items():\n            camera \u003d event.inst.subarray.tels[telescope_id].camera\n            image \u003d dl1.image\n            pulse_time \u003d dl1.pulse_time\n\n            boundary, picture, min_neighbors \u003d cleaning_level[camera.cam_id]\n\n            clean \u003d tailcuts_clean(\n                camera, \n                image,\n                boundary_thresh\u003dboundary,\n                picture_thresh\u003dpicture,\n                min_number_picture_neighbors\u003dmin_neighbors\n            )\n\n            # require more than five pixels after cleaning in each telescope\n            if clean.sum() \u003c 5:\n                continue\n\n            hillas_c \u003d hillas_parameters(camera[clean], image[clean])\n            leakage_c \u003d leakage(camera, image, clean)\n            n_islands, island_ids \u003d number_of_islands(camera, clean)\n\n            # remove events with high leakage\n            if leakage_c.leakage2_intensity \u003e 0.2:\n                continue\n\n            timing_c \u003d timing_parameters(camera, image, pulse_time, hillas_c, clean)\n\n            hillas_containers[telescope_id] \u003d hillas_c\n\n            # ssts have no timing in prod3b, so we\u0027ll use the skewness\n            time_gradients[telescope_id] \u003d timing_c.slope.value if camera.cam_id !\u003d \u0027ASTRICam\u0027 else hillas_c.skewness\n\n            # this makes sure, that we get an arrow in the array plow for each telescope\n            # might have the wrong direction though\n            if abs(time_gradients[telescope_id]) \u003c 0.2:\n                time_gradients[telescope_id] \u003d 1.0\n\n            telescope_pointings[telescope_id] \u003d SkyCoord(\n                alt\u003devent.mc.tel[telescope_id].altitude_raw * u.rad,\n                az\u003devent.mc.tel[telescope_id].azimuth_raw * u.rad,\n                frame\u003dhorizon_frame\n            )  \n            \n        # the array pointing is needed for the creation of the TiltedFrame to perform the \n        # impact point reconstruction\n        array_pointing \u003d SkyCoord(\n            az\u003devent.mcheader.run_array_direction[0],\n            alt\u003devent.mcheader.run_array_direction[1],\n            frame\u003dhorizon_frame\n        )\n\n        if len(hillas_containers) \u003e 1:\n            stereo \u003d reco.predict(\n                hillas_containers, event.inst, array_pointing, telescope_pointings\n            )\n\n            writer.write(\u0027reconstructed\u0027, stereo)\n            writer.write(\u0027true\u0027, event.mc)\n    \n            print(\u0027  Alt: {:.2f}°\u0027.format(stereo.alt.deg))\n            print(\u0027  Az: {:.2f}°\u0027.format(stereo.az.deg))\n            print(\u0027  Hmax: {:.0f}\u0027.format(stereo.h_max))\n            print(\u0027  CoreX: {:.1f}\u0027.format(stereo.core_x))\n            print(\u0027  CoreY: {:.1f}\u0027.format(stereo.core_y))\n        \n        # save a nice event for plotting later\n        if event.count \u003d\u003d 3:\n            plotting_event \u003d deepcopy(event)\n            plotting_hillas \u003d hillas_containers\n            plotting_timing \u003d time_gradients\n            plotting_stereo \u003d stereo\n    "
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from astropy.coordinates.angle_utilities import angular_separation\n",
+        "import pandas as pd\n",
+        "\n",
+        "\n",
+        "df_rec \u003d pd.read_hdf(f.name, key\u003d\u0027events/reconstructed\u0027)\n",
+        "df_true \u003d pd.read_hdf(f.name, key\u003d\u0027events/true\u0027)\n",
+        "\n",
+        "\n",
+        "theta \u003d angular_separation(\n",
+        "    df_rec.az.values * u.deg, df_rec.alt.values * u.deg,\n",
+        "    df_true.az.values * u.deg, df_true.alt.values * u.deg,\n",
+        ")\n",
+        "\n",
+        "plt.hist(theta.to(u.deg).value**2, bins\u003d25, range\u003d[0, 0.3])\n",
+        "plt.xlabel(r\u0027$\\theta² / deg²$\u0027)\n",
+        "None"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "## ArrayDisplay\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.visualization import ArrayDisplay\n",
+        "\n",
+        "\n",
+        "angle_offset \u003d plotting_event.mcheader.run_array_direction[0]\n",
+        "\n",
+        "\n",
+        "disp \u003d ArrayDisplay(plotting_event.inst.subarray)\n",
+        "\n",
+        "disp.set_vector_hillas(\n",
+        "    plotting_hillas,\n",
+        "    time_gradient\u003dplotting_timing,\n",
+        "    angle_offset\u003dangle_offset,\n",
+        "    length\u003d500\n",
+        ")\n",
+        "\n",
+        "plt.scatter(\n",
+        "    plotting_event.mc.core_x, plotting_event.mc.core_y,\n",
+        "    s\u003d200, c\u003d\u0027k\u0027, marker\u003d\u0027x\u0027, label\u003d\u0027True Impact\u0027,\n",
+        ")\n",
+        "plt.scatter(\n",
+        "    plotting_stereo.core_x, plotting_stereo.core_y,\n",
+        "    s\u003d200, c\u003d\u0027r\u0027, marker\u003d\u0027x\u0027, label\u003d\u0027Estimated Impact\u0027,\n",
+        ")\n",
+        "\n",
+        "plt.legend()\n",
+        "plt.xlim(-400, 400)\n",
+        "plt.ylim(-400, 400)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "## LST Mono with output\n",
+        "\n",
+        "\n",
+        "* Let\u0027s use the `HDF5TableWriter` to save the dl1 Hillas parameter data to an hdf5 file\n",
+        "* This is not ideal yet and one of the major points to be discussed in two weeks"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": "from ctapipe.io import HDF5TableWriter\nfrom ctapipe.core.container import Container, Field\n\ninput_url \u003d get_dataset_path(\u0027gamma_test_large.simtel.gz\u0027)\n\nsource \u003d event_source(\n    input_url,\n    allowed_tels\u003d[1, 2, 3, 4], # only use the first LST\n)\n\ncalibrator \u003d CameraCalibrator()\n\nclass EventInfo(Container):\n    event_id \u003d Field(\u0027event_id\u0027)\n    obs_id \u003d  Field(\u0027obs_id\u0027)\n    telescope_id \u003d Field(\u0027telescope_id\u0027)\n    \n\nwith HDF5TableWriter(filename\u003d\u0027hillas.h5\u0027, group_name\u003d\u0027dl1\u0027, mode\u003d\u0027w\u0027) as writer:\n\n    for event in source:\n        print(\u0027Id: {}, E \u003d {:1.3f}, Telescopes: {}\u0027.format(event.count, event.mc.energy, len(event.r0.tel)))\n    \n        calibrator(event)\n    \n        for telescope_id, dl1 in event.dl1.tel.items():      \n\n            camera \u003d event.inst.subarray.tels[telescope_id].camera\n            image \u003d dl1.image\n            pulse_time \u003d dl1.pulse_time\n\n            boundary, picture, min_neighbors \u003d cleaning_level[camera.cam_id]\n\n            clean \u003d tailcuts_clean(\n                camera, \n                image,\n                boundary_thresh\u003dboundary,\n                picture_thresh\u003dpicture,\n                min_number_picture_neighbors\u003dmin_neighbors\n            )\n            \n            if clean.sum() \u003c 5:\n                continue\n            \n            event_info \u003d EventInfo(event_id\u003devent.r0.event_id, obs_id\u003devent.r0.obs_id, telescope_id\u003dtelescope_id)\n            hillas_c \u003d hillas_parameters(camera[clean], image[clean])\n            leakage_c \u003d leakage(camera, image, clean)\n            timing_c \u003d timing_parameters(camera, image, pulse_time, hillas_c, clean)\n\n            writer.write(\u0027events\u0027, [event_info, event.mc, hillas_c, leakage_c, timing_c])\n    \n"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "df \u003d pd.read_hdf(\u0027hillas.h5\u0027, key\u003d\u0027dl1/events\u0027)\n",
+        "df.set_index([\u0027obs_id\u0027, \u0027event_id\u0027, \u0027telescope_id\u0027], inplace\u003dTrue)\n",
+        "df.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "plt.scatter(np.log10(df.energy), np.log10(df.intensity))\n",
+        "plt.xlabel(\u0027log10(E / TeV)\u0027)\n",
+        "plt.ylabel(\u0027log10(intensity)\u0027)\n",
+        "None"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "## Isn\u0027t python slow?\n",
+        "\n",
+        "* Many of you might have heard: \"Python is slow\".\n",
+        "* That\u0027s trueish.\n",
+        "* All python objects are classes living on the heap, event integers.\n",
+        "* Looping over lots of \"primitives\" is quite slow compared to other languages.\n",
+        "\n",
+        "⇒ Vectorize as much as possible using numpy  \n",
+        "⇒ Use existing interfaces to fast C / C++ / Fortran code  \n",
+        "⇒ Optimize using cython or numba  \n",
+        "\n",
+        "**But: \"Premature Optimization is the root of all evil\" — Donald Knuth**\n",
+        "\n",
+        "So profile to find exactly what is slow.\n",
+        "\n",
+        "### Why use python then?\n",
+        "\n",
+        "* Python works very well as *glue* for libraries of all kinds of languages\n",
+        "* Python has a rich ecosystem for data science, physics, algorithms, astronomy\n",
+        "\n",
+        "### Example: Number of Islands\n",
+        "\n",
+        "Find all groups of pixels, that survived the cleaning"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from ctapipe.image import toymodel\n",
+        "from ctapipe.instrument import CameraGeometry\n",
+        "\n",
+        "\n",
+        "camera \u003d CameraGeometry.from_name(\u0027LSTCam\u0027)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "Let\u0027s create a toy images with several islands;"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "np.random.seed(42)\n",
+        "\n",
+        "image \u003d np.zeros(camera.n_pixels)\n",
+        "\n",
+        "\n",
+        "for i in range(9):\n",
+        "    \n",
+        "    model \u003d toymodel.Gaussian(\n",
+        "        x\u003dnp.random.uniform(-0.8, 0.8) * u.m,\n",
+        "        y\u003dnp.random.uniform(-0.8, 0.8) * u.m,\n",
+        "        width\u003dnp.random.uniform(0.05, 0.075) * u.m,\n",
+        "        length\u003dnp.random.uniform(0.1, 0.15) * u.m,\n",
+        "        psi\u003dnp.random.uniform(0, 2 * np.pi) * u.rad,\n",
+        "    )\n",
+        "\n",
+        "    new_image, sig, bg \u003d model.generate_image(\n",
+        "        camera, \n",
+        "        intensity\u003dnp.random.uniform(1000, 3000),\n",
+        "        nsb_level_pe\u003d5\n",
+        "    )\n",
+        "    image +\u003d new_image"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "clean \u003d tailcuts_clean(camera, image, picture_thresh\u003d10, boundary_thresh\u003d5, min_number_picture_neighbors\u003d2)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "disp \u003d CameraDisplay(camera)\n",
+        "disp.image \u003d image\n",
+        "disp.highlight_pixels(clean, color\u003d\u0027xkcd:red\u0027, linewidth\u003d1.5)\n",
+        "disp.add_colorbar()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "def num_islands_python(camera, clean):\n",
+        "    \u0027\u0027\u0027 A breadth first search to find connected islands of neighboring pixels in the cleaning set\u0027\u0027\u0027\n",
+        "    \n",
+        "    # the camera geometry has a [n_pixel, n_pixel] boolean array\n",
+        "    # that is True where two pixels are neighbors\n",
+        "    neighbors \u003d camera.neighbor_matrix\n",
+        "    \n",
+        "    island_ids \u003d np.zeros(camera.n_pixels)\n",
+        "    current_island \u003d 0\n",
+        "    \n",
+        "    # a set to remember which pixels we already visited\n",
+        "    visited \u003d set()\n",
+        "\n",
+        "    # go only through the pixels, that survived cleaning\n",
+        "    for pix_id in np.where(clean)[0]:\n",
+        "        if pix_id not in visited:\n",
+        "            # remember that we already checked this pixel\n",
+        "            visited.add(pix_id)\n",
+        "            \n",
+        "            # if we land in the outer loop again, we found a new island\n",
+        "            current_island +\u003d 1\n",
+        "            island_ids[pix_id] \u003d current_island\n",
+        "            \n",
+        "            # now check all neighbors of the current pixel recursively\n",
+        "            to_check \u003d set(np.where(neighbors[pix_id] \u0026 clean)[0])\n",
+        "            while to_check:\n",
+        "                pix_id \u003d to_check.pop()\n",
+        "                \n",
+        "                if pix_id not in visited:    \n",
+        "                    visited.add(pix_id)\n",
+        "                    island_ids[pix_id] \u003d current_island\n",
+        "                    \n",
+        "                    to_check.update(np.where(neighbors[pix_id] \u0026 clean)[0])\n",
+        "    \n",
+        "    n_islands \u003d current_island\n",
+        "    return n_islands, island_ids"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "n_islands, island_ids \u003d num_islands_python(camera, clean)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from matplotlib.colors import ListedColormap\n",
+        "\n",
+        "cmap \u003d plt.get_cmap(\u0027Paired\u0027)\n",
+        "cmap \u003d ListedColormap(cmap.colors[:n_islands])\n",
+        "cmap.set_under(\u0027k\u0027)\n",
+        "\n",
+        "disp \u003d CameraDisplay(camera)\n",
+        "disp.image \u003d island_ids\n",
+        "disp.cmap \u003d cmap\n",
+        "disp.set_limits_minmax(0.5, n_islands + 0.5)\n",
+        "disp.add_colorbar()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "%timeit num_islands_python(camera, clean)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "from scipy.sparse.csgraph import connected_components\n",
+        "\n",
+        "def num_islands_scipy(camera, clean):\n",
+        "    neighbors \u003d camera.neighbor_matrix_sparse\n",
+        "    \n",
+        "    clean_neighbors \u003d neighbors[clean][:, clean]\n",
+        "    num_islands, labels \u003d connected_components(clean_neighbors, directed\u003dFalse)\n",
+        "    \n",
+        "    island_ids \u003d np.zeros(camera.n_pixels)\n",
+        "    island_ids[clean] \u003d labels + 1\n",
+        "    \n",
+        "    return num_islands, island_ids"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "n_islands_s, island_ids_s \u003d num_islands_scipy(camera, clean)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "disp \u003d CameraDisplay(camera)\n",
+        "disp.image \u003d island_ids_s\n",
+        "disp.cmap \u003d cmap\n",
+        "disp.set_limits_minmax(0.5, n_islands_s + 0.5)\n",
+        "disp.add_colorbar()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "pycharm": {}
+      },
+      "outputs": [],
+      "source": [
+        "%timeit num_islands_scipy(camera, clean)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "pycharm": {}
+      },
+      "source": [
+        "**A lot less code, and a factor 3 speed improvement**"
+      ]
     }
-   },
-   "source": [
-    "<div align=\"center\" style=\"font-size: 2rem\">\n",
-    "\n",
-    "<img heoght=\"300px\" src=\"https://cta-observatory.github.io/ctapipe/_images/ctapipe_logo.png\" alt=\"ctapipe\"/>\n",
-    "\n",
-    "\n",
-    "<p style=\"text-align: center;\">LST Analysis Bootcamp</p>\n",
-    "\n",
-    "<p style=\"text-align: center\">Padova, 26.11.2018</p>\n",
-    "\n",
-    "<p style=\"text-align: center\">Maximilian Nöthe (@maxnoe) & Kai A. Brügge (@mackaiver)</p>\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.2"
     }
-   },
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "%matplotlib inline"
-   ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "plt.rcParams['figure.figsize'] = (12, 8)\n",
-    "plt.rcParams['font.size'] = 14\n",
-    "plt.rcParams['figure.figsize']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "<h1 id=\"tocheading\">Table of Contents</h1>\n",
-    "<div id=\"toc\"></div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## General Information"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### Design\n",
-    "\n",
-    "* DL0 → DL3 analysis\n",
-    "\n",
-    "* Currently some R0 → DL0 code to be able to analyze simtel files\n",
-    "\n",
-    "* ctapipe is built upon the Scientific Python Stack, core dependencies are\n",
-    "  * numpy\n",
-    "  * scipy\n",
-    "  * astropy"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### Developement\n",
-    "\n",
-    "* ctapipe is developed as Open Source Software (Currently under MIT License) at <https://github.com/cta-observatory/ctapipe>\n",
-    "\n",
-    "* We use the \"Github-Workflow\": \n",
-    "  * Few people (e.g. @kosack, @mackaiver) have write access to the main repository\n",
-    "  * Contributors fork the main repository and work on branches\n",
-    "  * Pull Requests are merged after Code Review and automatic execution of the test suite\n",
-    "\n",
-    "* Early developement stage ⇒ backwards-incompatible API changes might and will happen \n",
-    "\n",
-    "* Many open design questions ⇒ Core Developer Meeting in the second week of December in Dortmund"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### What's there?\n",
-    "\n",
-    "* Reading simtel simulation files\n",
-    "* Simple calibration, cleaning and feature extraction functions\n",
-    "* Camera and Array plotting\n",
-    "* Coordinate frames and transformations \n",
-    "* Stereo-reconstruction using line intersections\n",
-    "  \n",
-    " "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### What's still missing?\n",
-    "\n",
-    "* Easy to use IO of analysis results to standard data formats (e.g. FITS, hdf5)\n",
-    "* Easy to use \"analysis builder\"\n",
-    "* A \"Standard Analysis\"\n",
-    "* Good integration with machine learning techniques\n",
-    "* IRF calculation \n",
-    "* Defining APIs for IO, instrument description access etc.\n",
-    "* Most code only tested on HESSIO simulations\n",
-    "* Documentation, e.g. formal definitions of coordinate frames \n",
-    " \n",
-    " "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### What can you do?\n",
-    "\n",
-    "* Report issues\n",
-    "  * Hard to get started? Tell us where you are stuck\n",
-    "  * Tell user stories\n",
-    "  * Missing features\n",
-    "\n",
-    "* Start contributing\n",
-    "  * ctapipe needs more workpower\n",
-    "  * Implement new reconstruction features"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "## A simple hillas analysis"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Reading in simtel files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.io import event_source\n",
-    "from ctapipe.utils.datasets import get_dataset_path\n",
-    "\n",
-    "input_url = get_dataset_path('gamma_test_large.simtel.gz')\n",
-    "\n",
-    "# event_source() automatically detects what kind of file we are giving it,\n",
-    "# if already supported by ctapipe\n",
-    "source = event_source(input_url, max_events=49)\n",
-    "\n",
-    "print(type(source))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for event in source:\n",
-    "    print('Id: {}, E = {:1.3f}, Telescopes: {}'.format(event.count, event.mc.energy, len(event.r0.tel)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Each event is a `DataContainer` holding several `Field`s of data, which can be containers or just numbers.\n",
-    "Let's look a one event:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "event"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "event.inst.subarray.camera_types"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(event.r0.tel), len(event.r1.tel)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Data calibration\n",
-    "\n",
-    "The `CameraCalibrator` calibrates the event (obtaining the `dl1` images)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.calib import CameraCalibrator\n",
-    "\n",
-    "calibrator = CameraCalibrator()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "calibrator(event)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Event displays\n",
-    "\n",
-    "Let's use ctapipe's plotting facilities to plot the telescope images"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "event.dl1.tel.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tel_id = 4"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera = event.inst.subarray.tel[tel_id].camera\n",
-    "dl1 = event.dl1.tel[tel_id]\n",
-    "\n",
-    "camera, dl1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dl1.image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.visualization import CameraDisplay\n",
-    "\n",
-    "display = CameraDisplay(camera)\n",
-    "\n",
-    "# right now, there might be one image per gain channel.\n",
-    "# This will change as soon as \n",
-    "display.image = dl1.image\n",
-    "display.add_colorbar()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Image Cleaning"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.image.cleaning import tailcuts_clean"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# unoptimized cleaning levels, copied from \n",
-    "# https://github.com/tudo-astroparticlephysics/cta_preprocessing\n",
-    "cleaning_level = {\n",
-    "    'ASTRICam': (5, 7, 2),  # (5, 10)?\n",
-    "    'LSTCam': (3.5, 7.5, 2),  # ?? (3, 6) for Abelardo...\n",
-    "    'FlashCam': (4, 8, 2),  # there is some scaling missing?\n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "boundary, picture, min_neighbors = cleaning_level[camera.cam_id]\n",
-    "\n",
-    "clean = tailcuts_clean(\n",
-    "    camera, \n",
-    "    dl1.image,\n",
-    "    boundary_thresh=boundary,\n",
-    "    picture_thresh=picture,\n",
-    "    min_number_picture_neighbors=min_neighbors\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 5))\n",
-    "\n",
-    "d1 = CameraDisplay(camera, ax=ax1)\n",
-    "d2 = CameraDisplay(camera, ax=ax2)\n",
-    "\n",
-    "ax1.set_title('Image')\n",
-    "d1.image = dl1.image\n",
-    "d1.add_colorbar(ax=ax1)\n",
-    "\n",
-    "ax2.set_title('Pulse Time')\n",
-    "d2.image = dl1.pulse_time - np.average(dl1.pulse_time, weights=dl1.image)\n",
-    "d2.cmap = 'RdBu_r'\n",
-    "d2.add_colorbar(ax=ax2)\n",
-    "d2.set_limits_minmax(-20,20)\n",
-    "\n",
-    "d1.highlight_pixels(clean, color='red', linewidth=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Image Parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.image import hillas_parameters, leakage, concentration\n",
-    "from ctapipe.image.timing_parameters import timing_parameters\n",
-    "from ctapipe.image.cleaning import number_of_islands\n",
-    "from ctapipe.image.hillas import camera_to_shower_coordinates"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hillas = hillas_parameters(camera[clean], dl1.image[clean])\n",
-    "\n",
-    "print(hillas)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "display = CameraDisplay(camera)\n",
-    "\n",
-    "# set \"unclean\" pixels to 0\n",
-    "cleaned = dl1.image.copy()\n",
-    "cleaned[~clean] = 0.0\n",
-    "\n",
-    "display.image = cleaned\n",
-    "display.add_colorbar()\n",
-    "\n",
-    "display.overlay_moments(hillas, color='xkcd:red')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "timing = timing_parameters(\n",
-    "    camera[clean],\n",
-    "    dl1.image[clean],\n",
-    "    dl1.pulse_time[clean],\n",
-    "    hillas,\n",
-    ")\n",
-    "\n",
-    "print(timing)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "long, trans = camera_to_shower_coordinates(\n",
-    "    camera.pix_x, camera.pix_y,hillas.x, hillas.y, hillas.psi\n",
-    ")\n",
-    "\n",
-    "plt.plot(long[clean], dl1.pulse_time[clean], 'o')\n",
-    "plt.plot(long[clean], timing.slope * long[clean] + timing.intercept)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "l = leakage(camera, dl1.image, clean)\n",
-    "print(l)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "disp = CameraDisplay(camera)\n",
-    "disp.image = dl1.image\n",
-    "disp.highlight_pixels(camera.get_border_pixel_mask(1), linewidth=2, color='xkcd:red')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n_islands, island_id = number_of_islands(camera, clean)\n",
-    "\n",
-    "print(n_islands)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "conc = concentration(camera, dl1.image, hillas)\n",
-    "print(conc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Putting it all together / Stereo reconstruction"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import astropy.units as u\n",
-    "from astropy.coordinates import SkyCoord, AltAz\n",
-    "\n",
-    "from ctapipe.io import event_source\n",
-    "from ctapipe.utils.datasets import get_dataset_path\n",
-    "\n",
-    "from ctapipe.calib import CameraCalibrator\n",
-    "\n",
-    "from ctapipe.image.cleaning import tailcuts_clean, number_of_islands\n",
-    "from ctapipe.image import hillas_parameters, leakage, concentration\n",
-    "from ctapipe.image.timing_parameters import timing_parameters\n",
-    "\n",
-    "from ctapipe.reco import HillasReconstructor\n",
-    "\n",
-    "from ctapipe.io import HDF5TableWriter\n",
-    "\n",
-    "from copy import deepcopy\n",
-    "import tempfile\n",
-    "\n",
-    "# unoptimized cleaning levels, copied from \n",
-    "# https://github.com/tudo-astroparticlephysics/cta_preprocessing\n",
-    "cleaning_level = {\n",
-    "    'ASTRICam': (5, 7, 2),  # (5, 10)?\n",
-    "    'LSTCam': (3.5, 7.5, 2),  # ?? (3, 6) for Abelardo...\n",
-    "    'FlashCam': (4, 8, 2),  # there is some scaling missing?\n",
-    "}\n",
-    "\n",
-    "\n",
-    "input_url = get_dataset_path('gamma_test_large.simtel.gz')\n",
-    "source = event_source(input_url)\n",
-    "\n",
-    "calibrator = CameraCalibrator()\n",
-    "\n",
-    "horizon_frame = AltAz()\n",
-    "\n",
-    "reco = HillasReconstructor()\n",
-    "\n",
-    "f = tempfile.NamedTemporaryFile(suffix='.hdf5')\n",
-    "\n",
-    "with HDF5TableWriter(f.name, mode='w', group_name='events') as writer:\n",
-    "    \n",
-    "    for event in source:\n",
-    "        print('Id: {}, E = {:1.3f}, Telescopes: {}'.format(event.count, event.mc.energy, len(event.r0.tel)))\n",
-    "        \n",
-    "        calibrator(event)\n",
-    "\n",
-    "        # mapping of telescope_id to parameters for stereo reconstruction\n",
-    "        hillas_containers = {}\n",
-    "        telescope_pointings = {}\n",
-    "        time_gradients = {}\n",
-    "\n",
-    "        for telescope_id, dl1 in event.dl1.tel.items():\n",
-    "            camera = event.inst.subarray.tels[telescope_id].camera\n",
-    "            image = dl1.image\n",
-    "            pulse_time = dl1.pulse_time\n",
-    "\n",
-    "            boundary, picture, min_neighbors = cleaning_level[camera.cam_id]\n",
-    "\n",
-    "            clean = tailcuts_clean(\n",
-    "                camera, \n",
-    "                image,\n",
-    "                boundary_thresh=boundary,\n",
-    "                picture_thresh=picture,\n",
-    "                min_number_picture_neighbors=min_neighbors\n",
-    "            )\n",
-    "\n",
-    "            # require more than five pixels after cleaning in each telescope\n",
-    "            if clean.sum() < 5:\n",
-    "                continue\n",
-    "\n",
-    "            hillas_c = hillas_parameters(camera[clean], image[clean])\n",
-    "            leakage_c = leakage(camera, image, clean)\n",
-    "            n_islands, island_ids = number_of_islands(camera, clean)\n",
-    "\n",
-    "            # remove events with high leakage\n",
-    "            if leakage_c.leakage2_intensity > 0.2:\n",
-    "                continue\n",
-    "\n",
-    "            timing_c = timing_parameters(camera[clean], image[clean], pulse_time[clean], hillas_c)\n",
-    "\n",
-    "            hillas_containers[telescope_id] = hillas_c\n",
-    "\n",
-    "            # ssts have no timing in prod3b, so we'll use the skewness\n",
-    "            time_gradients[telescope_id] = timing_c.slope.value if camera.cam_id != 'ASTRICam' else hillas_c.skewness\n",
-    "\n",
-    "            # this makes sure, that we get an arrow in the array plow for each telescope\n",
-    "            # might have the wrong direction though\n",
-    "            if abs(time_gradients[telescope_id]) < 0.2:\n",
-    "                time_gradients[telescope_id] = 1.0\n",
-    "\n",
-    "            telescope_pointings[telescope_id] = SkyCoord(\n",
-    "                alt=event.mc.tel[telescope_id].altitude_raw * u.rad,\n",
-    "                az=event.mc.tel[telescope_id].azimuth_raw * u.rad,\n",
-    "                frame=horizon_frame\n",
-    "            )  \n",
-    "            \n",
-    "        # the array pointing is needed for the creation of the TiltedFrame to perform the \n",
-    "        # impact point reconstruction\n",
-    "        array_pointing = SkyCoord(\n",
-    "            az=event.mcheader.run_array_direction[0],\n",
-    "            alt=event.mcheader.run_array_direction[1],\n",
-    "            frame=horizon_frame\n",
-    "        )\n",
-    "\n",
-    "        if len(hillas_containers) > 1:\n",
-    "            stereo = reco.predict(\n",
-    "                hillas_containers, event.inst, array_pointing, telescope_pointings\n",
-    "            )\n",
-    "\n",
-    "            writer.write('reconstructed', stereo)\n",
-    "            writer.write('true', event.mc)\n",
-    "    \n",
-    "            print('  Alt: {:.2f}°'.format(stereo.alt.deg))\n",
-    "            print('  Az: {:.2f}°'.format(stereo.az.deg))\n",
-    "            print('  Hmax: {:.0f}'.format(stereo.h_max))\n",
-    "            print('  CoreX: {:.1f}'.format(stereo.core_x))\n",
-    "            print('  CoreY: {:.1f}'.format(stereo.core_y))\n",
-    "        \n",
-    "        # save a nice event for plotting later\n",
-    "        if event.count == 3:\n",
-    "            plotting_event = deepcopy(event)\n",
-    "            plotting_hillas = hillas_containers\n",
-    "            plotting_timing = time_gradients\n",
-    "            plotting_stereo = stereo\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from astropy.coordinates.angle_utilities import angular_separation\n",
-    "import pandas as pd\n",
-    "\n",
-    "\n",
-    "df_rec = pd.read_hdf(f.name, key='events/reconstructed')\n",
-    "df_true = pd.read_hdf(f.name, key='events/true')\n",
-    "\n",
-    "\n",
-    "theta = angular_separation(\n",
-    "    df_rec.az.values * u.deg, df_rec.alt.values * u.deg,\n",
-    "    df_true.az.values * u.deg, df_true.alt.values * u.deg,\n",
-    ")\n",
-    "\n",
-    "plt.hist(theta.to(u.deg).value**2, bins=25, range=[0, 0.3])\n",
-    "plt.xlabel(r'$\\theta² / deg²$')\n",
-    "None"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## ArrayDisplay\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.visualization import ArrayDisplay\n",
-    "\n",
-    "\n",
-    "angle_offset = plotting_event.mcheader.run_array_direction[0]\n",
-    "\n",
-    "\n",
-    "disp = ArrayDisplay(plotting_event.inst.subarray)\n",
-    "\n",
-    "disp.set_vector_hillas(\n",
-    "    plotting_hillas,\n",
-    "    time_gradient=plotting_timing,\n",
-    "    angle_offset=angle_offset,\n",
-    "    length=500\n",
-    ")\n",
-    "\n",
-    "plt.scatter(\n",
-    "    plotting_event.mc.core_x, plotting_event.mc.core_y,\n",
-    "    s=200, c='k', marker='x', label='True Impact',\n",
-    ")\n",
-    "plt.scatter(\n",
-    "    plotting_stereo.core_x, plotting_stereo.core_y,\n",
-    "    s=200, c='r', marker='x', label='Estimated Impact',\n",
-    ")\n",
-    "\n",
-    "plt.legend()\n",
-    "plt.xlim(-400, 400)\n",
-    "plt.ylim(-400, 400)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## LST Mono with output\n",
-    "\n",
-    "\n",
-    "* Let's use the `HDF5TableWriter` to save the dl1 Hillas parameter data to an hdf5 file\n",
-    "* This is not ideal yet and one of the major points to be discussed in two weeks"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.io import HDF5TableWriter\n",
-    "from ctapipe.core.container import Container, Field\n",
-    "\n",
-    "input_url = get_dataset_path('gamma_test_large.simtel.gz')\n",
-    "\n",
-    "source = event_source(\n",
-    "    input_url,\n",
-    "    allowed_tels=[1, 2, 3, 4], # only use the first LST\n",
-    ")\n",
-    "\n",
-    "calibrator = CameraCalibrator()\n",
-    "\n",
-    "class EventInfo(Container):\n",
-    "    event_id = Field('event_id')\n",
-    "    obs_id =  Field('obs_id')\n",
-    "    telescope_id = Field('telescope_id')\n",
-    "    \n",
-    "\n",
-    "with HDF5TableWriter(filename='hillas.h5', group_name='dl1', mode='w') as writer:\n",
-    "\n",
-    "    for event in source:\n",
-    "        print('Id: {}, E = {:1.3f}, Telescopes: {}'.format(event.count, event.mc.energy, len(event.r0.tel)))\n",
-    "    \n",
-    "        calibrator(event)\n",
-    "    \n",
-    "        for telescope_id, dl1 in event.dl1.tel.items():      \n",
-    "\n",
-    "            camera = event.inst.subarray.tels[telescope_id].camera\n",
-    "            image = dl1.image\n",
-    "            pulse_time = dl1.pulse_time\n",
-    "\n",
-    "            boundary, picture, min_neighbors = cleaning_level[camera.cam_id]\n",
-    "\n",
-    "            clean = tailcuts_clean(\n",
-    "                camera, \n",
-    "                image,\n",
-    "                boundary_thresh=boundary,\n",
-    "                picture_thresh=picture,\n",
-    "                min_number_picture_neighbors=min_neighbors\n",
-    "            )\n",
-    "            \n",
-    "            if clean.sum() < 5:\n",
-    "                continue\n",
-    "            \n",
-    "            event_info = EventInfo(event_id=event.r0.event_id, obs_id=event.r0.obs_id, telescope_id=telescope_id)\n",
-    "            hillas_c = hillas_parameters(camera[clean], image[clean])\n",
-    "            leakage_c = leakage(camera, image, clean)\n",
-    "            timing_c = timing_parameters(camera[clean], image[clean], pulse_time[clean], hillas_c)\n",
-    "\n",
-    "            writer.write('events', [event_info, event.mc, hillas_c, leakage_c, timing_c])\n",
-    "    \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "df = pd.read_hdf('hillas.h5', key='dl1/events')\n",
-    "df.set_index(['obs_id', 'event_id', 'telescope_id'], inplace=True)\n",
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.scatter(np.log10(df.energy), np.log10(df.intensity))\n",
-    "plt.xlabel('log10(E / TeV)')\n",
-    "plt.ylabel('log10(intensity)')\n",
-    "None"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Isn't python slow?\n",
-    "\n",
-    "* Many of you might have heard: \"Python is slow\".\n",
-    "* That's trueish.\n",
-    "* All python objects are classes living on the heap, event integers.\n",
-    "* Looping over lots of \"primitives\" is quite slow compared to other languages.\n",
-    "\n",
-    "⇒ Vectorize as much as possible using numpy  \n",
-    "⇒ Use existing interfaces to fast C / C++ / Fortran code  \n",
-    "⇒ Optimize using cython or numba  \n",
-    "\n",
-    "**But: \"Premature Optimization is the root of all evil\" — Donald Knuth**\n",
-    "\n",
-    "So profile to find exactly what is slow.\n",
-    "\n",
-    "### Why use python then?\n",
-    "\n",
-    "* Python works very well as *glue* for libraries of all kinds of languages\n",
-    "* Python has a rich ecosystem for data science, physics, algorithms, astronomy\n",
-    "\n",
-    "### Example: Number of Islands\n",
-    "\n",
-    "Find all groups of pixels, that survived the cleaning"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ctapipe.image import toymodel\n",
-    "from ctapipe.instrument import CameraGeometry\n",
-    "\n",
-    "\n",
-    "camera = CameraGeometry.from_name('LSTCam')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's create a toy images with several islands;"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "np.random.seed(42)\n",
-    "\n",
-    "image = np.zeros(camera.n_pixels)\n",
-    "\n",
-    "\n",
-    "for i in range(9):\n",
-    "    \n",
-    "    model = toymodel.Gaussian(\n",
-    "        x=np.random.uniform(-0.8, 0.8) * u.m,\n",
-    "        y=np.random.uniform(-0.8, 0.8) * u.m,\n",
-    "        width=np.random.uniform(0.05, 0.075) * u.m,\n",
-    "        length=np.random.uniform(0.1, 0.15) * u.m,\n",
-    "        psi=np.random.uniform(0, 2 * np.pi) * u.rad,\n",
-    "    )\n",
-    "\n",
-    "    new_image, sig, bg = model.generate_image(\n",
-    "        camera, \n",
-    "        intensity=np.random.uniform(1000, 3000),\n",
-    "        nsb_level_pe=5\n",
-    "    )\n",
-    "    image += new_image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clean = tailcuts_clean(camera, image, picture_thresh=10, boundary_thresh=5, min_number_picture_neighbors=2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "disp = CameraDisplay(camera)\n",
-    "disp.image = image\n",
-    "disp.highlight_pixels(clean, color='xkcd:red', linewidth=1.5)\n",
-    "disp.add_colorbar()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def num_islands_python(camera, clean):\n",
-    "    ''' A breadth first search to find connected islands of neighboring pixels in the cleaning set'''\n",
-    "    \n",
-    "    # the camera geometry has a [n_pixel, n_pixel] boolean array\n",
-    "    # that is True where two pixels are neighbors\n",
-    "    neighbors = camera.neighbor_matrix\n",
-    "    \n",
-    "    island_ids = np.zeros(camera.n_pixels)\n",
-    "    current_island = 0\n",
-    "    \n",
-    "    # a set to remember which pixels we already visited\n",
-    "    visited = set()\n",
-    "\n",
-    "    # go only through the pixels, that survived cleaning\n",
-    "    for pix_id in np.where(clean)[0]:\n",
-    "        if pix_id not in visited:\n",
-    "            # remember that we already checked this pixel\n",
-    "            visited.add(pix_id)\n",
-    "            \n",
-    "            # if we land in the outer loop again, we found a new island\n",
-    "            current_island += 1\n",
-    "            island_ids[pix_id] = current_island\n",
-    "            \n",
-    "            # now check all neighbors of the current pixel recursively\n",
-    "            to_check = set(np.where(neighbors[pix_id] & clean)[0])\n",
-    "            while to_check:\n",
-    "                pix_id = to_check.pop()\n",
-    "                \n",
-    "                if pix_id not in visited:    \n",
-    "                    visited.add(pix_id)\n",
-    "                    island_ids[pix_id] = current_island\n",
-    "                    \n",
-    "                    to_check.update(np.where(neighbors[pix_id] & clean)[0])\n",
-    "    \n",
-    "    n_islands = current_island\n",
-    "    return n_islands, island_ids"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n_islands, island_ids = num_islands_python(camera, clean)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from matplotlib.colors import ListedColormap\n",
-    "\n",
-    "cmap = plt.get_cmap('Paired')\n",
-    "cmap = ListedColormap(cmap.colors[:n_islands])\n",
-    "cmap.set_under('k')\n",
-    "\n",
-    "disp = CameraDisplay(camera)\n",
-    "disp.image = island_ids\n",
-    "disp.cmap = cmap\n",
-    "disp.set_limits_minmax(0.5, n_islands + 0.5)\n",
-    "disp.add_colorbar()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%timeit num_islands_python(camera, clean)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from scipy.sparse.csgraph import connected_components\n",
-    "\n",
-    "def num_islands_scipy(camera, clean):\n",
-    "    neighbors = camera.neighbor_matrix_sparse\n",
-    "    \n",
-    "    clean_neighbors = neighbors[clean][:, clean]\n",
-    "    num_islands, labels = connected_components(clean_neighbors, directed=False)\n",
-    "    \n",
-    "    island_ids = np.zeros(camera.n_pixels)\n",
-    "    island_ids[clean] = labels + 1\n",
-    "    \n",
-    "    return num_islands, island_ids"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "n_islands_s, island_ids_s = num_islands_scipy(camera, clean)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "disp = CameraDisplay(camera)\n",
-    "disp.image = island_ids_s\n",
-    "disp.cmap = cmap\n",
-    "disp.set_limits_minmax(0.5, n_islands_s + 0.5)\n",
-    "disp.add_colorbar()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%timeit num_islands_scipy(camera, clean)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**A lot less code, and a factor 3 speed improvement**"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/examples/stereo_reconstruction.py
+++ b/examples/stereo_reconstruction.py
@@ -65,7 +65,7 @@ for event in event_source:
         n_islands, island_ids = number_of_islands(camera, clean)
 
         timing_c = timing_parameters(
-            camera[clean], image[clean], peakpos[clean], hillas_c
+            camera[clean], image[clean], peakpos[clean], hillas_c, clean,
         )
 
         # store parameters for stereo reconstruction


### PR DESCRIPTION
It appears that implicitly masking pixels for image > 0 rather than explicitly asking for a cleaning mask tends to make the user (at least me) use the function in a bad way.
Explicitly requiring a cleaning mask should make the user more aware of the need to clean the image before using the function `timing_parameters`.