### PR TITLE
ensure gain selection returns uint8, not 64-bit int

### DIFF
--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -113,4 +113,4 @@ class ThresholdGainSelector(GainSelector):
     ).tag(config=True)
 
     def select_channel(self, waveforms):
-        return (waveforms[0] > self.threshold).any(axis=1).astype(int)
+        return (waveforms[0] > self.threshold).any(axis=1).astype(np.int8)


### PR DESCRIPTION
Really small fix to return an array of uint8s instead of ints (to reduce storage space, since we clearly don't need to be able to store 2^63 channels).  