### PR TITLE
TelescopeParameter Trait

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -21,6 +21,7 @@ from ctapipe.image import ImageExtractor
 
 def test_path_exists():
     """ require existence of path """
+
     class C1(Component):
         thepath = Path(exists=False)
 
@@ -45,6 +46,7 @@ def test_path_exists():
 
 def test_path_directory_ok():
     """ test path is a directory """
+
     class C(Component):
         thepath = Path(exists=True, directory_ok=False)
 
@@ -63,6 +65,7 @@ def test_path_directory_ok():
 
 def test_path_file_ok():
     """ check that the file is there and not a directory, etc"""
+
     class C(Component):
         thepath = Path(exists=True, file_ok=False)
 
@@ -116,6 +119,7 @@ def test_has_traits():
 
 def test_telescope_parameter_patterns():
     """ Test validation of TelescopeParameters"""
+
     class SomeComponent(Component):
         tel_param = TelescopeParameter()
         tel_param_int = IntTelescopeParameter()
@@ -143,10 +147,17 @@ def test_telescope_parameter_patterns():
 
     comp.tel_param_int = [("type", "LST_LST_LSTCam", 1)]
 
+    with pytest.raises(TraitError):
+        comp.tel_param_int = [("*", 5)]  # wrong number of args
+
+    with pytest.raises(TraitError):
+        comp.tel_param_int = [(12, "", 5)]  # command not string
+
 
 def test_telescope_parameter_resolver():
     """ check that you can resolve the rules specified in a
     TelescopeParameter trait"""
+
     class SomeComponent(Component):
         tel_param1 = IntTelescopeParameter(
             default_value=[("*", "", 10), ("type", "LST_LST_LSTCam", 100)]
@@ -200,3 +211,7 @@ def test_telescope_parameter_resolver():
 
     with pytest.raises(KeyError):
         resolver1.value_for_tel_id(200)
+
+    with pytest.raises(ValueError):
+        bad_config = [("unknown", "a", 15.0)]
+        resolver = TelescopeParameterResolver(subarray=subarray, tel_param=bad_config)

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -1,7 +1,7 @@
 import tempfile
+from unittest.mock import MagicMock
 
 import pytest
-from unittest.mock import MagicMock
 from traitlets import CaselessStrEnum, HasTraits, Int
 
 from ctapipe.core import Component
@@ -20,6 +20,7 @@ from ctapipe.image import ImageExtractor
 
 
 def test_path_exists():
+    """ require existence of path """
     class C1(Component):
         thepath = Path(exists=False)
 
@@ -43,6 +44,7 @@ def test_path_exists():
 
 
 def test_path_directory_ok():
+    """ test path is a directory """
     class C(Component):
         thepath = Path(exists=True, directory_ok=False)
 
@@ -60,6 +62,7 @@ def test_path_directory_ok():
 
 
 def test_path_file_ok():
+    """ check that the file is there and not a directory, etc"""
     class C(Component):
         thepath = Path(exists=True, file_ok=False)
 
@@ -112,6 +115,7 @@ def test_has_traits():
 
 
 def test_telescope_parameter_patterns():
+    """ Test validation of TelescopeParameters"""
     class SomeComponent(Component):
         tel_param = TelescopeParameter()
         tel_param_int = IntTelescopeParameter()
@@ -141,6 +145,8 @@ def test_telescope_parameter_patterns():
 
 
 def test_telescope_parameter_resolver():
+    """ check that you can resolve the rules specified in a
+    TelescopeParameter trait"""
     class SomeComponent(Component):
         tel_param1 = IntTelescopeParameter(
             default_value=[("*", "", 10), ("type", "LST_LST_LSTCam", 100)]

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -120,6 +120,9 @@ def test_has_traits():
 def test_telescope_parameter_patterns():
     """ Test validation of TelescopeParameters"""
 
+    with pytest.raises(ValueError):
+        TelescopeParameter(dtype="notatype")
+
     class SomeComponent(Component):
         tel_param = TelescopeParameter()
         tel_param_int = IntTelescopeParameter()

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -214,4 +214,4 @@ def test_telescope_parameter_resolver():
 
     with pytest.raises(ValueError):
         bad_config = [("unknown", "a", 15.0)]
-        resolver = TelescopeParameterResolver(subarray=subarray, tel_param=bad_config)
+        TelescopeParameterResolver(subarray=subarray, tel_param=bad_config)

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -138,7 +138,7 @@ class TelescopeParameter(List):
     form: `[(command, argument, value), ...]`.
 
     Command can be one of:
-    - 'default' match all telescopes,  Here argument is ignored.
+    - '*' match all telescopes,  Here argument is ignored.
     - 'type': argument is then a telescope type  string (e.g.
        `('type', 'SST_ASTRI_CHEC', 4.0)`,  to apply to all telescopes of that type
     - 'id':  argument is a specific telescope ID `['id', 89, 5.0]`)
@@ -151,7 +151,7 @@ class TelescopeParameter(List):
 
     .. code-block: python
     [
-        ('default', '', 5.0),                       # default
+        ('*', '', 5.0),                       # default
         ('type', 'LST_LST_LSTCam', 5.2,
         ('type', 'MST_MST_NectarCam', 4.0,
         ('type', 'MST_MST_FlashCam', 4.5,

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -137,8 +137,8 @@ def has_traits(cls, ignore=("config", "parent")):
 
 class TelescopeParameter(List):
     """
-    Allow a parameter value to be specified as a simple float, or as a list of
-    patterns that match different telescopes.
+    Allow a parameter value to be specified as a simple value (of type *dtype*),
+    or as a list of patterns that match different telescopes.
     The patterns are given as a list of 3-tuples in in the
     form: `[(command, argument, value), ...]`.
 

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -161,13 +161,13 @@ class TelescopeParameter(List):
 
     def __init__(self, dtype=float, **kwargs):
         super().__init__(**kwargs)
-        if type(dtype) is not type:
+        if not isinstance(dtype, type):
             raise ValueError("dtype should be a type")
         self._dtype = dtype
 
     def validate(self, obj, value):
         # support a single value for all (convert into a default value)
-        if type(value) == self._dtype:
+        if isinstance(value, self._dtype):
             value = [["*", "", value]]
 
         # check that it is a list
@@ -181,14 +181,14 @@ class TelescopeParameter(List):
                     "pattern should be a tuple of (command, argument, value)"
                 )
             command, arg, val = pattern
-            if type(val) is not self._dtype:
+            if not isinstance(val, self._dtype):
                 raise TraitError(f"Value should be a {self._dtype}")
-            if type(command) is not str:
+            if not isinstance(command, str):
                 raise TraitError("command must be a string")
             if command not in ["*", "type", "id"]:
                 raise TraitError("command must be one of: '*', 'type', 'id'")
             if command == "type":
-                if type(arg) is not str:
+                if not isinstance(arg, str):
                     raise TraitError("'type' argument should be a string")
             if command == "id":
                 arg = int(arg)

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -150,13 +150,17 @@ class TelescopeParameter(List):
     --------
 
     .. code-block: python
-    [
+    tel_param = [
         ('*', '', 5.0),                       # default
-        ('type', 'LST_LST_LSTCam', 5.2,
-        ('type', 'MST_MST_NectarCam', 4.0,
-        ('type', 'MST_MST_FlashCam', 4.5,
+        ('type', 'LST_LST_LSTCam', 5.2),
+        ('type', 'MST_MST_NectarCam', 4.0),
+        ('type', 'MST_MST_FlashCam', 4.5),
         ('id', 34' 4.0),                   # override telescope 34 specifically
     ]
+
+    .. code-block: python
+    tel_param = 4.0  # sets this value for all telescopes
+
     """
 
     def __init__(self, dtype=float, **kwargs):

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -39,6 +39,10 @@ __all__ = [
     "enum_trait",
     "classes_with_traits",
     "has_traits",
+    "TelescopeParameter",
+    "FloatTelescopeParameter",
+    "IntTelescopeParameter",
+    "TelescopeParameterResolver",
 ]
 
 
@@ -124,3 +128,135 @@ def has_traits(cls, ignore=("config", "parent")):
     here.
     """
     return bool(set(cls.class_trait_names()) - set(ignore))
+
+
+class TelescopeParameter(List):
+    """
+    Allow a parameter value to be specified as a simple float, or as a list of
+    patterns that match different telescopes.
+    The patterns are given as a list of 3-tuples in in the
+    form: `[(command, argument, value), ...]`.
+
+    Command can be one of:
+    - 'default' match all telescopes,  Here argument is ignored.
+    - 'type': argument is then a telescope type  string (e.g.
+       `('type', 'SST_ASTRI_CHEC', 4.0)`,  to apply to all telescopes of that type
+    - 'id':  argument is a specific telescope ID `['id', 89, 5.0]`)
+
+    These are evaluated in-order, so you can first set a default value, and then set
+    values for specific telescopes or types to override them.
+
+    Examples
+    --------
+
+    .. code-block: python
+    [
+        ('default', '', 5.0),                       # default
+        ('type', 'LST_LST_LSTCam', 5.2,
+        ('type', 'MST_MST_NectarCam', 4.0,
+        ('type', 'MST_MST_FlashCam', 4.5,
+        ('id', 34' 4.0),                   # override telescope 34 specifically
+    ]
+    """
+
+    def __init__(self, dtype=float, **kwargs):
+        super().__init__(**kwargs)
+        if type(dtype) is not type:
+            raise ValueError("dtype should be a type")
+        self._dtype = dtype
+
+    def validate(self, obj, value):
+        # support a single value for all (convert into a default value)
+        if type(value) == self._dtype:
+            value = [["*", "", value]]
+
+        # check that it is a list
+        super().validate(obj, value)
+        normalized_value = []
+
+        for pattern in value:
+            # now check for the standard 3-tuple of )command, argument, value)
+            if len(pattern) != 3:
+                raise TraitError(
+                    "pattern should be a tuple of (command, argument, value)"
+                )
+            command, arg, val = pattern
+            if type(val) is not self._dtype:
+                raise TraitError(f"Value should be a {self._dtype}")
+            if type(command) is not str:
+                raise TraitError("command must be a string")
+            if command not in ["*", "type", "id"]:
+                raise TraitError("command must be one of: '*', 'type', 'id'")
+            if command == "type":
+                if type(arg) is not str:
+                    raise TraitError("'type' argument should be a string")
+            if command == "id":
+                arg = int(arg)
+
+            val = self._dtype(val)
+            normalized_value.append((command, arg, val))
+
+        return normalized_value
+
+
+class FloatTelescopeParameter(TelescopeParameter):
+    """ a `TelescopeParameter` with float type (see docs for `TelescopeParameter`)"""
+
+    def __init__(self, **kwargs):
+        super().__init__(dtype=float, **kwargs)
+
+
+class IntTelescopeParameter(TelescopeParameter):
+    """ a `TelescopeParameter` with int type (see docs for `TelescopeParameter`)"""
+    def __init__(self, **kwargs):
+        super().__init__(dtype=int, **kwargs)
+
+
+class TelescopeParameterResolver:
+    def __init__(
+        self,
+        subarray: "ctapipe.instrument.SubarrayDescription",
+        tel_param: "TelescopeParameter",
+    ):
+        """
+        Handles looking up a parameter by telescope_id, given a TelescopeParameter
+        trait (which maps a parameter to a set of telescopes by type, id, or other
+        selection criteria).
+
+        Parameters
+        ----------
+        name: str
+            name of the mapped parameter
+        subarray: ctapipe.instrument.SubarrayDescription
+            description of the subarray (includes mapping of tel_id to tel_type)
+        tel_param: TelescopeParameter trait
+            the parameter definitions
+        """
+
+        # build dictionary mapping tel_id to parameter:
+        self._value_for_tel_id = {}
+
+        for command, argument, value in tel_param:
+            if command == "*":
+                for tel_id in subarray.tel_ids:
+                    self._value_for_tel_id[tel_id] = value
+            elif command == "type":
+                for tel_id in subarray.get_tel_ids_for_type(argument):
+                    self._value_for_tel_id[tel_id] = value
+            elif command == "id":
+                self._value_for_tel_id[int(argument)] = value
+            else:
+                raise ValueError(f"Unrecognized command: {command}")
+
+    def value_for_tel_id(self, tel_id: int):
+        """
+        returns the resolved parameter for the given telescope id
+        """
+        try:
+            return self._value_for_tel_id[tel_id]
+        except KeyError:
+            raise KeyError(
+                f"TelescopeParameterResolver: no "
+                f"parameter value was set for telescope with tel_id="
+                f"{tel_id}. Please set it explicitly, or by telescope type or '*'."
+            )


### PR DESCRIPTION
This adds classes allow one to specify a single value for all telescopes, or specialize it by telescope type or id.  This is a needed part of #1066.  It works as follows:

```py3
    class SomeComponent(Component):
        tel_param = FloatTelescopeParameter()
        tel_param_int = IntTelescopeParameter()

    comp = SomeComponent()

    comp.tel_param = [
        ("type", "*", 1.0),
        ("type", "LST_LST_LSTCam", 16.0),
        ("type", "*NectarCam", 10.0), # wildcards allowed
        ("id", 16, 10.0),
    ]

    # single value allowed (converted to ("type","*",val) )
    comp.tel_param = 4.5


```

The rules are applied in-order (which is why they are a list, not a dict which does not maintain order in YAML for example). 

These options can also be specified in a config file, for example in JSON like this:
```json
 "TailcutsImageCleaner": {
        "boundary_threshold_pe": [
            ["type", "*", 5.0],
            ["type", "LST_LST_LSTCam", 3.0],
            ["type", "MST_MST_NectarCam", 4.0]
        ],
        "min_picture_neighbors": 2,
        "picture_threshold_pe":  [
                ["type", "*", 10.0],
                ["type", "LST_LST_LSTCam", 6.0],
                ["type", "MST_MST_NectarCam", 6.0],
                ["id", 12, 15.0]
        ]
    },
```

It also introduces another class called `TelescopeParameterResolver` which is constructed with a `TelescopeParameter` and a `SubarrayDescription`.  This class computes the mapping between the rules in the TelescopeParameter when it is constructed, and provides a `resolver.value_for_tel_id(id)` method that gives back the correct value for a given telescope ID.
This 2-step process is needed, since the subarray is not known at configuration time. 

