### PR TITLE
Use count_nonzero instead of sum for bool arrays

### DIFF
--- a/ctapipe/image/leakage.py
+++ b/ctapipe/image/leakage.py
@@ -34,8 +34,8 @@ def leakage(geom, image, cleaning_mask):
     mask1 = border1 & cleaning_mask
     mask2 = border2 & cleaning_mask
 
-    leakage_pixel1 = np.sum(mask1)
-    leakage_pixel2 = np.sum(mask2)
+    leakage_pixel1 = np.count_nonzero(mask1)
+    leakage_pixel2 = np.count_nonzero(mask2)
 
     leakage_intensity1 = np.sum(image[mask1])
     leakage_intensity2 = np.sum(image[mask2])

--- a/ctapipe/image/tests/test_cleaning.py
+++ b/ctapipe/image/tests/test_cleaning.py
@@ -9,7 +9,7 @@ def test_tailcuts_clean_simple():
     image = np.zeros_like(geom.pix_id, dtype=np.float)
 
     num_pix = 40
-    some_neighs = geom.neighbors[num_pix][0:3]  # pick 4 neighbors
+    some_neighs = geom.neighbors[num_pix][0:3]  # pick 3 neighbors
     image[num_pix] = 5.0  # set a single image pixel
     image[some_neighs] = 3.0  # make some boundaries that are neighbors
     image[10] = 3.0  # a boundary that is not a neighbor
@@ -17,12 +17,9 @@ def test_tailcuts_clean_simple():
     mask = cleaning.tailcuts_clean(geom, image, picture_thresh=4.5,
                                    boundary_thresh=2.5)
 
-    print((mask > 0).sum(), "clean pixels")
-    print(geom.pix_id[mask])
-
     assert 10 not in geom.pix_id[mask]
     assert set(some_neighs).union({num_pix}) == set(geom.pix_id[mask])
-    assert (mask > 0).sum() == 4
+    assert np.count_nonzero(mask) == 4
 
 
 def test_dilate():
@@ -30,19 +27,19 @@ def test_dilate():
     mask = np.zeros_like(geom.pix_id, dtype=bool)
 
     mask[100] = True  # a single pixel far from a border is true.
-    assert mask.sum() == 1
+    assert np.count_nonzero(mask) == 1
 
     # dilate a single row
     dmask = cleaning.dilate(geom, mask)
-    assert dmask.sum() == 1 + 6
+    assert np.count_nonzero(dmask) == 1 + 6
 
     # dilate a second row
     dmask = cleaning.dilate(geom, dmask)
-    assert dmask.sum() == 1 + 6 + 12
+    assert np.count_nonzero(dmask) == 1 + 6 + 12
 
     # dilate a third row
     dmask = cleaning.dilate(geom, dmask)
-    assert dmask.sum() == 1 + 6 + 12 + 18
+    assert np.count_nonzero(dmask) == 1 + 6 + 12 + 18
 
 
 def test_tailcuts_clean():


### PR DESCRIPTION
This came up on workshop I lectured at.

Kind of surprises me, but count_nonzero is much faster than sum for counting the True's in an array.

```
In [11]: mask = np.random.randint(0, 1, 2000).astype(bool)

In [12]: %timeit np.sum(mask)
7.7 µs ± 895 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [13]: %timeit np.count_nonzero(mask)
1.05 µs ± 99.3 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```