### PR TITLE
Source visualisation in camera

### DIFF
--- a/ctapipe/coordinates/transforms.py
+++ b/ctapipe/coordinates/transforms.py
@@ -1,0 +1,36 @@
+from astropy.coordinates import SkyCoord, AltAz
+from ..coordinates import CameraFrame
+import astropy.units as u
+
+
+
+def event_pos_in_camera(event, tel_id, horizon_frame=AltAz()):
+    """
+    Return the position of the source in the camera frame
+
+    Parameters
+    ----------
+    event: `ctapipe.io.containers.DataContainer`
+    tel_id: int - id of the telescope
+    horizon_frame: `astropy.coordinates.builtin_frames.altaz.AltAz`
+
+    Returns
+    -------
+    (x, y) (float, float): position in the camera
+    """
+
+    focal = event.inst.subarray.tel[tel_id].optics.equivalent_focal_length
+
+    telescope_pointing = SkyCoord(alt=event.mc.tel[tel_id].altitude_raw * u.rad,
+                                  az=event.mc.tel[tel_id].azimuth_raw * u.rad,
+                                  frame=horizon_frame)
+
+    event_direction = SkyCoord(alt=event.mc.alt,
+                               az=event.mc.az,
+                               frame=horizon_frame)
+
+    camera_frame = CameraFrame(focal_length=focal,
+                               telescope_pointing=telescope_pointing)
+
+    camera_pos = event_direction.transform_to(camera_frame)
+    return camera_pos.x, camera_pos.y

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -122,6 +122,7 @@ class CameraDisplay:
         pix_y = self.geom.pix_y.value[self.geom.mask]
         pix_area = self.geom.pix_area.value[self.geom.mask]
 
+
         for x, y, area in zip(pix_x, pix_y, pix_area):
             if self.geom.pix_type.startswith("hex"):
                 r = sqrt(area * 2 / 3 / sqrt(3)) + 2 * PIXEL_EPSILON
@@ -418,6 +419,34 @@ class CameraDisplay:
             )
 
             self._axes_overlays.append(text)
+
+
+    def overlay_point_source(self, x, y, **kwargs):
+        """
+        Overlay the source in the camera frame
+
+        Parameters
+        ----------
+        x: x source position in the camera frame
+        y: y source position in the camera frame
+        kwargs: args for `matplotlib.pyplot.scatter`
+        """
+
+        w = self.axes.figure.get_figwidth()
+        if 'marker' not in kwargs:
+            kwargs['marker'] = '*'
+        if 's' not in kwargs:
+            kwargs['s'] = 20 * w
+        if 'linewidth' not in kwargs:
+            kwargs['linewidth'] = 0.2 * w
+        if 'color' not in kwargs:
+            kwargs['color'] = 'red'
+
+        src_point = self.axes.scatter(x, y, **kwargs)
+        self._axes_overlays.append(src_point)
+
+        return src_point
+
 
     def clear_overlays(self):
         """ Remove added overlays from the axes """


### PR DESCRIPTION
Add function to overlay a point source in the camera 
```
display = CameraDisplay(geom, image)
fig = display.axes.get_figure()

event_pos = event_pos_in_camera(event, tel_id)
display.overlay_point_source(event_pos[0], event_pos[1])
```

![image](https://user-images.githubusercontent.com/4263646/67037226-6d344b00-f11d-11e9-99cd-9ea6285f4e39.png)
