### PR TITLE
Improve extract_pulse_time_around_peak to ignore negative samples

### DIFF
--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -218,7 +218,7 @@ def extract_pulse_time_around_peak(waveforms, peak_index, width, shift, ret):
     num = 0
     den = 0
     for isample in prange(start, end):
-        if 0 <= isample < n_samples:
+        if (0 <= isample < n_samples) & (waveforms[isample] > 0):
             num += waveforms[isample] * isample
             den += waveforms[isample]
 

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -103,7 +103,7 @@ def test_neighbor_average_waveform(camera_waveforms):
     assert_allclose(average_wf[0, 48], 98.565743, rtol=1e-3)
 
 
-def test_extract_pulse_time_around_peak(camera_waveforms):
+def test_extract_pulse_time_around_peak():
     x = np.arange(100)
     y = norm.pdf(x, 41.2, 6)
     pulse_time = extract_pulse_time_around_peak(
@@ -112,12 +112,11 @@ def test_extract_pulse_time_around_peak(camera_waveforms):
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
 
-def test_extract_pulse_time_around_peak_with_negative(camera_waveforms):
-    y = np.array([3.97, 0.22,  1.47, 3.09, -3.9, -4.78])
-    pulse_time = extract_pulse_time_around_peak(
-        y[np.newaxis, :], 0, 6, 0
-    )
-    assert (pulse_time > 0) & (pulse_time < y.size)
+def test_extract_pulse_time_around_peak_within_range(example_event):
+    telid = list(example_event.r0.tel)[0]
+    waveforms = example_event.r1.tel[telid].waveform
+    pulse_time = extract_pulse_time_around_peak(waveforms, 20, 6, 0)
+    assert (pulse_time > 0).all() & (pulse_time < waveforms.shape[1]).all()
 
 
 def test_baseline_subtractor(camera_waveforms):

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -112,11 +112,13 @@ def test_extract_pulse_time_around_peak():
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
 
-def test_extract_pulse_time_around_peak_within_range(example_event):
-    telid = list(example_event.r0.tel)[0]
-    waveforms = example_event.r1.tel[telid].waveform
-    pulse_time = extract_pulse_time_around_peak(waveforms, 20, 6, 0)
-    assert (pulse_time > 0).all() & (pulse_time < waveforms.shape[1]).all()
+def test_extract_pulse_time_around_peak_negatives():
+    x = np.arange(100)
+    y = -1.2 * x + 20
+    pulse_time = extract_pulse_time_around_peak(
+        y[np.newaxis, :], 12, 10, 0
+    )
+    assert (pulse_time > 0).all() & (pulse_time < x.size).all()
 
 
 def test_baseline_subtractor(camera_waveforms):

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -112,8 +112,10 @@ def test_extract_pulse_time_around_peak():
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
 
-def test_extract_pulse_time_around_peak_negatives():
+def test_extract_pulse_time_around_peak_within_range():
     x = np.arange(100)
+    # Generic waveform that goes from positive to negative in window
+    # Can cause extreme values with incorrect handling of weighted average
     y = -1.2 * x + 20
     pulse_time = extract_pulse_time_around_peak(
         y[np.newaxis, :], 12, 10, 0

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -112,6 +112,14 @@ def test_extract_pulse_time_around_peak(camera_waveforms):
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
 
+def test_extract_pulse_time_around_peak_with_negative(camera_waveforms):
+    y = np.array([3.97, 0.22,  1.47, 3.09, -3.9, -4.78])
+    pulse_time = extract_pulse_time_around_peak(
+        y[np.newaxis, :], 0, 6, 0
+    )
+    assert (pulse_time > 0) & (pulse_time < y.size)
+
+
 def test_baseline_subtractor(camera_waveforms):
     waveforms, _ = camera_waveforms
     n_pixels, _ = waveforms.shape


### PR DESCRIPTION
Created to address #1127 