### PR TITLE
Enable access to subarray information from file before event loop

### DIFF
--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -190,6 +190,18 @@ class EventSource(Component):
         """
         return False
 
+    @property
+    @abstractmethod
+    def subarray(self):
+        """
+        Obtain the subarray from the file
+
+        Returns
+        -------
+        ctapipe.instrument.SubarrayDecription
+
+        """
+
     @abstractmethod
     def _generator(self):
         """

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -194,7 +194,7 @@ class EventSource(Component):
     @abstractmethod
     def subarray(self):
         """
-        Obtain the subarray from the file
+        Obtain the subarray from the EventSource
 
         Returns
         -------

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -51,6 +51,12 @@ class HESSIOEventSource(EventSource):
         '''This class should never be chosen in event_source()'''
         return False
 
+    @property
+    def subarray(self):
+        with self.pyhessio.open_hessio(self.input_url) as file:
+            next(file.move_to_next_event())
+            return self._build_subarray_info(file)
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         HESSIOEventSource._count -= 1
         self.pyhessio.close_file()

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -159,6 +159,10 @@ class SimTelEventSource(EventSource):
     def is_compatible(file_path):
         return is_eventio(Path(file_path).expanduser())
 
+    @property
+    def subarray(self):
+        return self._subarray_info
+
     def _generator(self):
         if self.file_.tell() > self.start_pos:
             self.file_._next_header_pos = 0

--- a/ctapipe/io/tests/test_event_source.py
+++ b/ctapipe/io/tests/test_event_source.py
@@ -20,6 +20,10 @@ class DummyReader(EventSource):
     def is_compatible(file_path):
         return False
 
+    @property
+    def subarray(self):
+        return None
+
 
 def test_can_be_implemented():
     dataset = get_dataset_path("gamma_test_large.simtel.gz")

--- a/ctapipe/io/tests/test_hessio_event_source.py
+++ b/ctapipe/io/tests/test_hessio_event_source.py
@@ -2,6 +2,7 @@ import copy
 import pytest
 from ctapipe.utils import get_dataset_path
 from ctapipe.io.hessioeventsource import HESSIOEventSource
+from copy import deepcopy
 
 dataset = get_dataset_path("gamma_test_large.simtel.gz")
 
@@ -51,3 +52,14 @@ def test_that_event_is_not_modified_after_loop():
         #      assert last_event == event
         # So for the moment we just compare event ids
         assert event.r0.event_id == last_event.r0.event_id
+
+
+def test_subarray_property():
+    dataset = get_dataset_path("gamma_test_large.simtel.gz")
+    source = HESSIOEventSource(input_url=dataset)
+    subarray = deepcopy(source.subarray)
+    event = next(iter(source))
+    subarray_event = event.inst.subarray
+    assert subarray.tel.keys() == subarray_event.tel.keys()
+    assert (subarray.tel[1].camera.pix_x ==
+            subarray_event.tel[1].camera.pix_x).all()

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -5,6 +5,7 @@ from ctapipe.utils import get_dataset_path
 from ctapipe.io.simteleventsource import SimTelEventSource
 from ctapipe.io.hessioeventsource import HESSIOEventSource
 from itertools import zip_longest
+from copy import deepcopy
 
 gamma_test_large_path = get_dataset_path("gamma_test_large.simtel.gz")
 gamma_test_path = get_dataset_path("gamma_test.simtel.gz")
@@ -209,3 +210,13 @@ def test_instrument():
     event = next(iter(source))
     subarray = event.inst.subarray
     assert subarray.tel[1].optics.num_mirrors == 1
+
+
+def test_subarray_property():
+    source = SimTelEventSource(input_url=gamma_test_large_path)
+    subarray = deepcopy(source.subarray)
+    event = next(iter(source))
+    subarray_event = event.inst.subarray
+    assert subarray.tel.keys() == subarray_event.tel.keys()
+    assert (subarray.tel[1].camera.pix_x ==
+            subarray_event.tel[1].camera.pix_x).all()


### PR DESCRIPTION
In #1155 I encountered another situation where it would be useful to have the subarray information available immediately after initialising the eventsource (before starting the event loop).

This appears to be a fairly straightforward change, which could help keep a lot of other code tidy.

This idea was originally suggested in #722