### PR TITLE
Add resolving to the TelescopeParameter

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -11,10 +11,10 @@ from ctapipe.core.traits import (
     classes_with_traits,
     enum_trait,
     has_traits,
+    TelescopeParameterList,
     TelescopeParameter,
     FloatTelescopeParameter,
     IntTelescopeParameter,
-    TelescopeParameterResolver,
 )
 from ctapipe.image import ImageExtractor
 
@@ -117,6 +117,37 @@ def test_has_traits():
     assert has_traits(WithATrait)
 
 
+def test_telescope_parameter_list():
+    subarray = MagicMock()
+    subarray.tel_ids = [1, 2, 3, 4]
+    subarray.get_tel_ids_for_type = (
+        lambda x: [3, 4] if x == "LST_LST_LSTCam" else [1, 2]
+    )
+    subarray.telescope_types = [
+        "LST_LST_LSTCam",
+        "MST_MST_NectarCam",
+        "MST_MST_FlashCam",
+    ]
+
+    telparam_list = TelescopeParameterList(
+        [("type", "*", 10), ("type", "LST*", 100)]
+    )
+
+    with pytest.raises(ValueError):
+        telparam_list.resolve(1)
+
+    telparam_list.attach_subarray(subarray)
+    assert telparam_list.resolve(1) == 10
+    assert telparam_list.resolve(3) == 100
+
+    with pytest.raises(KeyError):
+        telparam_list.resolve(200)
+
+    with pytest.raises(ValueError):
+        bad_config = TelescopeParameterList([("unknown", "a", 15.0)])
+        bad_config.attach_subarray(subarray)
+
+
 def test_telescope_parameter_patterns():
     """ Test validation of TelescopeParameters"""
 
@@ -193,31 +224,26 @@ def test_telescope_parameter_resolver():
         "MST_MST_FlashCam",
     ]
 
-    resolver1 = TelescopeParameterResolver(subarray=subarray, tel_param=comp.tel_param1)
-    resolver2 = TelescopeParameterResolver(subarray=subarray, tel_param=comp.tel_param2)
-    resolver3 = TelescopeParameterResolver(subarray=subarray, tel_param=comp.tel_param3)
+    print(type(comp.tel_param1))
 
-    assert resolver1.value_for_tel_id(1) == 10
-    assert resolver1.value_for_tel_id(3) == 100
+    comp.tel_param1.attach_subarray(subarray)
+    comp.tel_param2.attach_subarray(subarray)
+    comp.tel_param3.attach_subarray(subarray)
 
-    assert list(map(resolver2.value_for_tel_id, [1, 2, 3, 4])) == [
+    assert comp.tel_param1.resolve(1) == 10
+    assert comp.tel_param1.resolve(3) == 100
+
+    assert list(map(comp.tel_param2.resolve, [1, 2, 3, 4])) == [
         10.0,
         10.0,
         200.0,
         100.0,
     ]
 
-    assert list(map(resolver3.value_for_tel_id, [1, 2, 3, 4, 100])) == [
+    assert list(map(comp.tel_param3.resolve, [1, 2, 3, 4, 100])) == [
         200.0,
         200.0,
         200.0,
         200.0,
         300.0,
     ]
-
-    with pytest.raises(KeyError):
-        resolver1.value_for_tel_id(200)
-
-    with pytest.raises(ValueError):
-        bad_config = [("unknown", "a", 15.0)]
-        TelescopeParameterResolver(subarray=subarray, tel_param=bad_config)

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -134,14 +134,14 @@ def test_telescope_parameter_list():
     )
 
     with pytest.raises(ValueError):
-        telparam_list.resolve(1)
+        telparam_list[1]
 
     telparam_list.attach_subarray(subarray)
-    assert telparam_list.resolve(1) == 10
-    assert telparam_list.resolve(3) == 100
+    assert telparam_list[1] == 10
+    assert telparam_list[3] == 100
 
     with pytest.raises(KeyError):
-        telparam_list.resolve(200)
+        telparam_list[200]
 
     with pytest.raises(ValueError):
         bad_config = TelescopeParameterList([("unknown", "a", 15.0)])
@@ -162,7 +162,7 @@ def test_telescope_parameter_patterns():
 
     # single value allowed (converted to ("default","",val) )
     comp.tel_param = 4.5
-    assert comp.tel_param[0][2] == 4.5
+    assert list(comp.tel_param)[0][2] == 4.5
 
     comp.tel_param = [("type", "*", 1.0), ("type", "*LSTCam", 16.0), ("id", 16, 10.0)]
 
@@ -230,17 +230,17 @@ def test_telescope_parameter_resolver():
     comp.tel_param2.attach_subarray(subarray)
     comp.tel_param3.attach_subarray(subarray)
 
-    assert comp.tel_param1.resolve(1) == 10
-    assert comp.tel_param1.resolve(3) == 100
+    assert comp.tel_param1[1] == 10
+    assert comp.tel_param1[3] == 100
 
-    assert list(map(comp.tel_param2.resolve, [1, 2, 3, 4])) == [
+    assert list(map(comp.tel_param2.__getitem__, [1, 2, 3, 4])) == [
         10.0,
         10.0,
         200.0,
         100.0,
     ]
 
-    assert list(map(comp.tel_param3.resolve, [1, 2, 3, 4, 100])) == [
+    assert list(map(comp.tel_param3.__getitem__, [1, 2, 3, 4, 100])) == [
         200.0,
         200.0,
         200.0,

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -158,7 +158,8 @@ class TelescopeParameterList(list):
         for command, arg, value in self:
             if command == "type":
                 matched_tel_types = [
-                    str(t) for t in subarray.telescope_types if fnmatch(str(t), argument)
+                    str(t) for t in subarray.telescope_types
+                    if fnmatch(str(t), arg)
                 ]
                 logger.debug(f"argument '{arg}' matched: {matched_tel_types}")
                 if len(matched_tel_types) == 0:

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -176,7 +176,7 @@ class TelescopeParameterList(list):
             else:
                 raise ValueError(f"Unrecognized command: {command}")
 
-    def resolve(self, tel_id: int):
+    def __getitem__(self, tel_id: int):
         """
         Returns the resolved parameter for the given telescope id
         """


### PR DESCRIPTION
This PR attaches the resolving of a `TelescopeParameter` to the parameter itself, removing the need for `TelescopeParameterResolver`.

This is achieved by making TelescopeParameter a traitlet which returns a `TelescopeParameterList` instead of a `list`. 

`TelescopeParameterList` is a subclass of `list` with methods `attach_subarray` and `resolve`, the same functionality that was previously found in `TelescopeParameterResolver`.

This is how a TelescopeParameter was utilised before:
```python
class SomeComponent(Component):
   tel_param1 = IntTelescopeParameter(
      default_value=[("type", "*", 10), ("type", "LST*", 100)]
   )

def __init__(self, subarray):
   self._tel_param1_resolver = TelescopeParameterResolver(subarray, self.tel_param1)

def __call__(self, telid):
   param1 = self._tel_param1_resolver.value_for_tel_id(telid)
```

With this PR, a Component can utilise a `TelescopeParameter` as below:
```python
class SomeComponent(Component):
   tel_param1 = IntTelescopeParameter(
      default_value=[("type", "*", 10), ("type", "LST*", 100)]
   )

def __init__(self, subarray):
   self.tel_param1.attach_subarray(subarray)

def __call__(self, telid):
   param1 = self.tel_param1.resolve(telid)
```

In the future, when the database is defined, it may be possible to have the `TelescopeParameterList` to retrieve the `SubarrayDescription` itself, removing the need to attach it manually.