### PR TITLE
Move gain selection from CameraCalibrator to EventSource

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -1,6 +1,5 @@
 import numpy as np
 from ctapipe.core import Component
-from ctapipe.calib.camera.gainselection import ManualGainSelector
 from ctapipe.image.reducer import NullDataVolumeReducer
 from ctapipe.image.extractor import NeighborPeakWindowSum
 import warnings
@@ -74,7 +73,6 @@ class CameraCalibrator(Component):
     the DL1 data level in the event container.
     """
     def __init__(self, config=None, parent=None,
-                 gain_selector=None,
                  data_volume_reducer=None,
                  image_extractor=None,
                  **kwargs):
@@ -89,9 +87,6 @@ class CameraCalibrator(Component):
             Tool executable that is calling this component.
             Passes the correct logger to the component.
             Set to None if no Tool to pass.
-        gain_selector : ctapipe.calib.camera.gainselection.GainSelector
-            The GainSelector to use. If None, then ManualGainSelector will be
-            used, which by default selects the high/first gain channel.
         data_volume_reducer : ctapipe.image.reducer.DataVolumeReducer
             The DataVolumeReducer to use. If None, then
             NullDataVolumeReducer will be used by default, and waveforms
@@ -105,10 +100,6 @@ class CameraCalibrator(Component):
 
         self._r1_empty_warn = False
         self._dl0_empty_warn = False
-
-        if gain_selector is None:
-            gain_selector = ManualGainSelector(parent=self)
-        self.gain_selector = gain_selector
 
         if data_volume_reducer is None:
             data_volume_reducer = NullDataVolumeReducer(parent=self)
@@ -177,26 +168,7 @@ class CameraCalibrator(Component):
         if self._check_r1_empty(waveforms):
             return
 
-        # Perform gain selection. This is typically not the responsibility of
-        # ctapipe; DL0 (and R1) waveforms are aleady gain selected and
-        # therefore single channel. However, the waveforms read from
-        # simtelarray do not have the gain selection applied, and so must be
-        # done as part of the calibration step to ensure the correct
-        # waveform dimensions.
-        waveforms_gs, selected_gain_channel = self.gain_selector(waveforms)
-        if selected_gain_channel is not None:
-            event.r1.tel[telid].selected_gain_channel = selected_gain_channel
-        else:
-            # If pixel_channel is None, then waveforms has already been
-            # pre-gainselected, and presumably the selected_gain_channel
-            # container is filled by the EventSource
-            if event.r1.tel[telid].selected_gain_channel is None:
-                raise ValueError(
-                    "EventSource is loading pre-gainselected waveforms "
-                    "without filling the selected_gain_channel container"
-                )
-
-        reduced_waveforms = self.data_volume_reducer(waveforms_gs)
+        reduced_waveforms = self.data_volume_reducer(waveforms)
         event.dl0.tel[telid].waveform = reduced_waveforms
 
     def _calibrate_dl1(self, event, telid):

--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -24,8 +24,7 @@ class GainChannel(IntEnum):
 
 class GainSelector(Component):
     """
-    Base class for algorithms that reduce a 2-gain-channel waveform to a
-    single waveform.
+    Base class for algorithms that decide on the gain channel to use
     """
 
     def __call__(self, waveforms):
@@ -40,24 +39,19 @@ class GainSelector(Component):
 
         Returns
         -------
-        reduced_waveforms : ndarray
-            Waveform with a single channel
-            Shape: (n_pix, n_samples)
+        selected_gain_channel : ndarray
+            Gain channel to use for each pixel
+            Shape: n_pix
+            Dtype: int8
         """
-        if waveforms.ndim == 2:  # Return if already gain selected
-            selected_gain_channel = None  # Provided by EventSource
-            return waveforms, selected_gain_channel
+        if waveforms.ndim == 2:  # Return None if already gain selected
+            return None
         elif waveforms.ndim == 3:
             n_channels, n_pixels, _ = waveforms.shape
-            if n_channels == 1:  # Reduce if already single channel
-                selected_gain_channel = np.zeros(n_pixels, dtype=int)
-                return waveforms[0], selected_gain_channel
+            if n_channels == 1:  # Must be first channel if only one channel
+                return np.zeros(n_pixels, dtype=np.int8)
             else:
-                selected_gain_channel = self.select_channel(waveforms)
-                selected_gain_waveforms = waveforms[
-                    selected_gain_channel, np.arange(n_pixels)
-                ]
-                return selected_gain_waveforms, selected_gain_channel
+                return self.select_channel(waveforms)
         else:
             raise ValueError(
                 f"Cannot handle waveform array of shape: {waveforms.ndim}"
@@ -82,7 +76,7 @@ class GainSelector(Component):
         selected_gain_channel : ndarray
             Gain channel to use for each pixel
             Shape: n_pix
-            Dtype: int
+            Dtype: int8
         """
 
 

--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -100,7 +100,7 @@ class ThresholdGainSelector(GainSelector):
     Select gain channel according to a maximum threshold value.
     """
     threshold = traits.Float(
-        default_value=1000,
+        default_value=4000,
         help="Threshold value in waveform sample units. If a waveform "
              "contains a sample above this threshold, use the low gain "
              "channel for that pixel."

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -21,31 +21,6 @@ def test_camera_calibrator(example_event):
     assert pulse_time.shape == (1764,)
 
 
-def test_select_gain():
-    n_channels = 2
-    n_pixels = 2048
-    n_samples = 128
-    telid = 0
-
-    calibrator = CameraCalibrator()
-
-    event = DataContainer()
-    event.r1.tel[telid].waveform = np.ones((n_channels, n_pixels, n_samples))
-    calibrator._calibrate_dl0(event, telid)
-    assert event.dl0.tel[telid].waveform.shape == (n_pixels, n_samples)
-
-    event = DataContainer()
-    event.r1.tel[telid].waveform = np.ones((n_pixels, n_samples))
-    with pytest.raises(ValueError):
-        calibrator._calibrate_dl0(event, telid)
-
-    event = DataContainer()
-    event.r1.tel[telid].waveform = np.ones((n_pixels, n_samples))
-    event.r1.tel[telid].selected_gain_channel = np.zeros(n_pixels)
-    calibrator._calibrate_dl0(event, telid)
-    assert event.dl0.tel[telid].waveform.shape == (n_pixels, n_samples)
-
-
 def test_manual_extractor():
     calibrator = CameraCalibrator(image_extractor=LocalPeakWindowSum())
     assert isinstance(calibrator.image_extractor, LocalPeakWindowSum)

--- a/ctapipe/calib/camera/tests/test_gainselection.py
+++ b/ctapipe/calib/camera/tests/test_gainselection.py
@@ -14,8 +14,7 @@ def test_gain_selector():
     waveforms[1] *= 2
 
     gain_selector = DummyGainSelector()
-    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
-    np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
+    selected_gain_channel = gain_selector(waveforms)
     np.testing.assert_equal(selected_gain_channel, 0)
 
 
@@ -24,8 +23,7 @@ def test_pre_selected():
     waveforms = np.zeros(shape)
 
     gain_selector = DummyGainSelector()
-    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
-    assert waveforms.shape == waveforms_gs.shape
+    selected_gain_channel = gain_selector(waveforms)
     assert selected_gain_channel is None
 
 
@@ -34,8 +32,7 @@ def test_single_channel():
     waveforms = np.zeros(shape)
 
     gain_selector = DummyGainSelector()
-    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
-    assert waveforms_gs.shape == (2048, 128)
+    selected_gain_channel = gain_selector(waveforms)
     assert (selected_gain_channel == 0).all()
 
 
@@ -45,13 +42,11 @@ def test_manual_gain_selector():
     waveforms[1] *= 2
 
     gs_high = ManualGainSelector(channel="HIGH")
-    waveforms_gs, selected_gain_channel = gs_high(waveforms)
-    np.testing.assert_equal(waveforms[GainChannel.HIGH], waveforms_gs)
+    selected_gain_channel = gs_high(waveforms)
     np.testing.assert_equal(selected_gain_channel, 0)
 
     gs_low = ManualGainSelector(channel="LOW")
-    waveforms_gs, selected_gain_channel = gs_low(waveforms)
-    np.testing.assert_equal(waveforms[GainChannel.LOW], waveforms_gs)
+    selected_gain_channel = gs_low(waveforms)
     np.testing.assert_equal(selected_gain_channel, 1)
 
 
@@ -62,8 +57,6 @@ def test_threshold_gain_selector():
     waveforms[0, 0] = 100
 
     gain_selector = ThresholdGainSelector(threshold=50)
-    waveforms_gs, selected_gain_channel = gain_selector(waveforms)
-    assert (waveforms_gs[0] == 1).all()
-    assert (waveforms_gs[np.arange(1, 2048)] == 0).all()
+    selected_gain_channel = gain_selector(waveforms)
     assert selected_gain_channel[0] == 1
     assert (selected_gain_channel[np.arange(1, 2048)] == 0).all()

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -180,7 +180,7 @@ class R1CameraContainer(Container):
         None,
         (
             "numpy array containing a set of images, one per ADC sample"
-            "Shape: (n_channels, n_pixels, n_samples)"
+            "Shape: (n_pixels, n_samples)"
         ),
     )
     selected_gain_channel = Field(

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -40,8 +40,7 @@ class HESSIOEventSource(EventSource):
             Passes the correct logger to the component.
             Set to None if no Tool to pass.
         gain_selector : ctapipe.calib.camera.gainselection.GainSelector
-            The GainSelector to use. If None, then ManualGainSelector will be
-            used, which by default selects the high/first gain channel.
+            The GainSelector to use. If None, then ThresholdGainSelector will be used.
         kwargs
         """
         super().__init__(config=config, parent=parent, **kwargs)

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -2,6 +2,7 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.time import Time
 from ctapipe.io.eventsource import EventSource
+from ctapipe.io.simteleventsource import apply_simtel_r1_calibration
 from ctapipe.io.containers import DataContainer
 from ctapipe.instrument import (
     TelescopeDescription,
@@ -11,6 +12,7 @@ from ctapipe.instrument import (
 )
 from ctapipe.instrument.camera import UnknownPixelShapeWarning
 from ctapipe.instrument.guess import guess_telescope, UNKNOWN_TELESCOPE
+from ctapipe.calib.camera.gainselection import ThresholdGainSelector
 import numpy as np
 import warnings
 
@@ -18,15 +20,30 @@ __all__ = ['HESSIOEventSource']
 
 
 class HESSIOEventSource(EventSource):
-    """
-    EventSource for the hessio file format.
-
-    This class utilises `pyhessio` to read the hessio file, and stores the
-    information into the event containers.
-    """
     _count = 0
 
-    def __init__(self, config=None, parent=None, **kwargs):
+    def __init__(self, config=None, parent=None, gain_selector=None, **kwargs):
+        """
+        EventSource for the hessio file format.
+
+        This class utilises `pyhessio` to read the hessio file, and stores the
+        information into the event containers.
+
+        Parameters
+        ----------
+        config : traitlets.loader.Config
+            Configuration specified by config file or cmdline arguments.
+            Used to set traitlet values.
+            Set to None if no configuration to pass.
+        tool : ctapipe.core.Tool
+            Tool executable that is calling this component.
+            Passes the correct logger to the component.
+            Set to None if no Tool to pass.
+        gain_selector : ctapipe.calib.camera.gainselection.GainSelector
+            The GainSelector to use. If None, then ManualGainSelector will be
+            used, which by default selects the high/first gain channel.
+        kwargs
+        """
         super().__init__(config=config, parent=parent, **kwargs)
 
         try:
@@ -45,6 +62,12 @@ class HESSIOEventSource(EventSource):
         HESSIOEventSource._count += 1
 
         self.metadata['is_simulation'] = True
+
+        # Waveforms from simtelarray have both gain channels
+        # Gain selection is performed by this EventSource to produce R1 waveforms
+        if gain_selector is None:
+            gain_selector = ThresholdGainSelector(parent=self)
+        self.gain_selector = gain_selector
 
     @staticmethod
     def is_compatible(file_path):
@@ -141,9 +164,8 @@ class HESSIOEventSource(EventSource):
                     dc_to_pe = file.get_calibration(tel_id)
                     pedestal = file.get_pedestal(tel_id)
                     r0.waveform = adc_samples
-                    r1.waveform = (
-                            (adc_samples - pedestal[..., np.newaxis])
-                            * dc_to_pe[..., np.newaxis]
+                    r1.waveform, r1.selected_gain_channel = apply_simtel_r1_calibration(
+                        adc_samples, pedestal, dc_to_pe, self.gain_selector
                     )
 
                     mc.dc_to_pe = dc_to_pe

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -59,7 +59,7 @@ def apply_simtel_r1_calibration(r0_waveforms, pedestal, dc_to_pe, gain_selector)
     gain = dc_to_pe[..., np.newaxis]
     r1_waveforms = (r0_waveforms - ped) * gain
     if n_channels == 1:
-        selected_gain_channel = 0
+        selected_gain_channel = np.zeros(n_pixels)
         r1_waveforms = r1_waveforms[0]
     else:
         selected_gain_channel = gain_selector(r0_waveforms)

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -125,8 +125,7 @@ class SimTelEventSource(EventSource):
             Passes the correct logger to the component.
             Set to None if no Tool to pass.
         gain_selector : ctapipe.calib.camera.gainselection.GainSelector
-            The GainSelector to use. If None, then ManualGainSelector will be
-            used, which by default selects the high/first gain channel.
+            The GainSelector to use. If None, then ThresholdGainSelector will be used.
         kwargs
         """
         super().__init__(config=config, parent=parent, **kwargs)

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -59,7 +59,7 @@ def apply_simtel_r1_calibration(r0_waveforms, pedestal, dc_to_pe, gain_selector)
     gain = dc_to_pe[..., np.newaxis]
     r1_waveforms = (r0_waveforms - ped) * gain
     if n_channels == 1:
-        selected_gain_channel = np.zeros(n_pixels)
+        selected_gain_channel = np.zeros(n_pixels, dtype=np.int8)
         r1_waveforms = r1_waveforms[0]
     else:
         selected_gain_channel = gain_selector(r0_waveforms)

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -54,6 +54,38 @@ def build_camera_geometry(cam_settings, telescope):
 
 
 def apply_simtel_r1_calibration(r0_waveforms, pedestal, dc_to_pe, gain_selector):
+    """
+    Perform the R1 calibration for R0 simtel waveforms. This includes:
+        - Gain selection
+        - Pedestal subtraction
+        - Conversion of samples into units proportional to photoelectrons
+          (If the full signal in the waveform was integrated, then the resulting
+          value would be in photoelectrons.)
+          (Also applies flat-fielding)
+
+    Parameters
+    ----------
+    r0_waveforms : ndarray
+        Raw ADC waveforms from a simtel file. All gain channels available.
+        Shape: (n_channels, n_pixels, n_samples)
+    pedestal : ndarray
+        Pedestal stored in the simtel file for each gain channel
+        Shape: (n_channels, n_pixels)
+    dc_to_pe : ndarray
+        Conversion factor between R0 waveform samples and ~p.e., stored in the
+        simtel file for each gain channel
+        Shape: (n_channels, n_pixels)
+    gain_selector : ctapipe.calib.camera.gainselection.GainSelector
+
+    Returns
+    -------
+    r1_waveforms : ndarray
+        Calibrated waveforms
+        Shape: (n_pixels, n_samples)
+    selected_gain_channel : ndarray
+        The gain channel selected for each pixel
+        Shape: (n_pixels)
+    """
     n_channels, n_pixels, n_samples = r0_waveforms.shape
     ped = pedestal[..., np.newaxis] / n_samples
     gain = dc_to_pe[..., np.newaxis]

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -2,8 +2,9 @@ import numpy as np
 import pytest
 import copy
 from ctapipe.utils import get_dataset_path
-from ctapipe.io.simteleventsource import SimTelEventSource
+from ctapipe.io.simteleventsource import SimTelEventSource, apply_simtel_r1_calibration
 from ctapipe.io.hessioeventsource import HESSIOEventSource
+from ctapipe.calib.camera.gainselection import ThresholdGainSelector
 from itertools import zip_longest
 
 gamma_test_large_path = get_dataset_path("gamma_test_large.simtel.gz")
@@ -53,6 +54,7 @@ def compare_sources(input_url):
                 assert h.r0.tel[tel_id].waveform.shape == s.r0.tel[tel_id].waveform.shape
                 assert h.r1.tel[tel_id].waveform.shape == s.r1.tel[tel_id].waveform.shape
                 assert np.allclose(h.r0.tel[tel_id].waveform, s.r0.tel[tel_id].waveform)
+                assert np.allclose(h.r1.tel[tel_id].waveform, s.r1.tel[tel_id].waveform)
 
                 assert h.r0.tel[tel_id].num_trig_pix == s.r0.tel[tel_id].num_trig_pix
                 assert (h.r0.tel[tel_id].trig_pix_id == s.r0.tel[tel_id].trig_pix_id).all()
@@ -211,3 +213,36 @@ def test_instrument():
     event = next(iter(source))
     subarray = event.inst.subarray
     assert subarray.tel[1].optics.num_mirrors == 1
+
+
+def test_apply_simtel_r1_calibration():
+    n_channels = 2
+    n_pixels = 2048
+    n_samples = 128
+
+
+    r0_waveforms = np.zeros((n_channels, n_pixels, n_samples))
+    r0_waveforms[0, 0, :] = 100
+    r0_waveforms[1, :, :] = 1
+
+    pedestal = np.zeros((n_channels, n_pixels))
+    pedestal[0] = 90 * n_samples
+    pedestal[1] = 0.9 * n_samples
+
+    dc_to_pe = np.zeros((n_channels, n_pixels))
+    dc_to_pe[0] = 0.01
+    dc_to_pe[1] = 0.1
+
+    gain_selector = ThresholdGainSelector(threshold=90)
+    r1_waveforms, selected_gain_channel = apply_simtel_r1_calibration(
+        r0_waveforms, pedestal, dc_to_pe, gain_selector
+    )
+
+    assert selected_gain_channel[0] == 1
+    assert (selected_gain_channel[np.arange(1, 2048)] == 0).all()
+    assert r1_waveforms.ndim == 2
+    assert r1_waveforms.shape == (n_pixels, n_samples)
+
+    ped = pedestal / n_samples
+    assert r1_waveforms[0, 0] == (r0_waveforms[1, 0, 0] - ped[1, 0]) * dc_to_pe[1, 0]
+    assert r1_waveforms[1, 0] == (r0_waveforms[0, 1, 0] - ped[0, 1]) * dc_to_pe[0, 1]

--- a/ctapipe/plotting/bokeh_event_viewer.py
+++ b/ctapipe/plotting/bokeh_event_viewer.py
@@ -27,7 +27,7 @@ class BokehEventViewerCamera(CameraDisplay):
 
         self._view_options = {
             'r0': lambda e, t, c, time: e.r0.tel[t].waveform[c, :, time],
-            'r1': lambda e, t, c, time: e.r1.tel[t].waveform[c, :, time],
+            'r1': lambda e, t, c, time: e.r1.tel[t].waveform[:, time],
             'dl0': lambda e, t, c, time: e.dl0.tel[t].waveform[:, time],
             'dl1': lambda e, t, c, time: e.dl1.tel[t].image[:],
             'pulse_time': lambda e, t, c, time: e.dl1.tel[t].pulse_time[:],
@@ -176,7 +176,7 @@ class BokehEventViewerWaveform(WaveformDisplay):
 
         self._view_options = {
             'r0': lambda e, t, c, p: e.r0.tel[t].waveform[c, p],
-            'r1': lambda e, t, c, p: e.r1.tel[t].waveform[c, p],
+            'r1': lambda e, t, c, p: e.r1.tel[t].waveform[p],
             'dl0': lambda e, t, c, p: e.dl0.tel[t].waveform[p],
         }
 

--- a/ctapipe/plotting/tests/test_bokeh_event_viewer.py
+++ b/ctapipe/plotting/tests/test_bokeh_event_viewer.py
@@ -141,7 +141,7 @@ def test_view_camera(example_event):
 
     cam = viewer.cameras[0]
     cam.view = 'r1'
-    assert (cam.image == example_event.r1.tel[t].waveform[0, :, 0]).all()
+    assert (cam.image == example_event.r1.tel[t].waveform[:, 0]).all()
 
     with pytest.raises(ValueError):
         cam.view = 'q'
@@ -159,7 +159,7 @@ def test_view_wf(example_event):
 
     wf = viewer.waveforms[0]
     wf.view = 'r1'
-    assert (wf.waveform == example_event.r1.tel[t].waveform[0, 0, :]).all()
+    assert (wf.waveform == example_event.r1.tel[t].waveform[0, :]).all()
 
     with pytest.raises(ValueError):
         wf.view = 'q'


### PR DESCRIPTION
#1166 highlighted some issues with the current order for gain selection

The first option in #1166 (perform the gain selection in the `SimtelEventSource`) made most sense to me as:
- R1 waveforms are supposed to be single channel (as the correct gain channel is decided at the camera server, before data volume reduction is performed and the resulting DL0 waveforms are stored).
- EventSources are meant to provide the single-channel DL0 (R1 for the moment, during prototyping), however the waveforms provided by the simtel `EventSources` have both gain channels.

This is accomplished by passing a GainSelector to the `SimtelEventSource` when initialising. By default, a `SimtelEventSource` will use a `ThresholdGainSelector` (which has a default threshold of 1000).

R1 waveforms are consequently now single channel (2 dimensions: n_pixels, n_samples) as is intended in the data model.

R0 waveforms are still available from the `SimtelEventSource` and contain both gain channels.