### PR TITLE
Scalar default values in TelescopeParameter

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -184,6 +184,33 @@ def test_telescope_parameter_patterns():
         comp.tel_param_int = [(12, "", 5)]  # command not string
 
 
+def test_telescope_parameter_scalar_default():
+    subarray = MagicMock()
+    subarray.tel_ids = [1, 2, 3, 4]
+    subarray.get_tel_ids_for_type = (
+        lambda x: [3, 4] if x == "LST_LST_LSTCam" else [1, 2]
+    )
+    subarray.telescope_types = [
+        "LST_LST_LSTCam",
+        "MST_MST_NectarCam",
+        "MST_MST_FlashCam",
+    ]
+
+    class SomeComponent(Component):
+        tel_param_int = IntTelescopeParameter(default_value=1)
+
+    comp = SomeComponent()
+    comp.tel_param_int.attach_subarray(subarray)
+    assert comp.tel_param_int[1] == 1
+
+    class SomeComponent(Component):
+        tel_param_int = FloatTelescopeParameter(default_value=1.5)
+
+    comp = SomeComponent()
+    comp.tel_param_int.attach_subarray(subarray)
+    assert comp.tel_param_int[1] == 1.5
+
+
 def test_telescope_parameter_resolver():
     """ check that you can resolve the rules specified in a
     TelescopeParameter trait"""
@@ -223,8 +250,6 @@ def test_telescope_parameter_resolver():
         "MST_MST_NectarCam",
         "MST_MST_FlashCam",
     ]
-
-    print(type(comp.tel_param1))
 
     comp.tel_param1.attach_subarray(subarray)
     comp.tel_param2.attach_subarray(subarray)

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -196,19 +196,19 @@ def test_telescope_parameter_scalar_default():
         "MST_MST_FlashCam",
     ]
 
-    class SomeComponent(Component):
-        tel_param_int = IntTelescopeParameter(default_value=1)
+    class SomeComponentInt(Component):
+        tel_param = IntTelescopeParameter(default_value=1)
 
-    comp = SomeComponent()
-    comp.tel_param_int.attach_subarray(subarray)
-    assert comp.tel_param_int[1] == 1
+    comp_int = SomeComponentInt()
+    comp_int.tel_param.attach_subarray(subarray)
+    assert comp_int.tel_param[1] == 1
 
-    class SomeComponent(Component):
-        tel_param_int = FloatTelescopeParameter(default_value=1.5)
+    class SomeComponentFloat(Component):
+        tel_param = FloatTelescopeParameter(default_value=1.5)
 
-    comp = SomeComponent()
-    comp.tel_param_int.attach_subarray(subarray)
-    assert comp.tel_param_int[1] == 1.5
+    comp_float = SomeComponentFloat()
+    comp_float.tel_param.attach_subarray(subarray)
+    assert comp_float.tel_param[1] == 1.5
 
 
 def test_telescope_parameter_resolver():

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -252,11 +252,11 @@ class TelescopeParameter(List):
     klass = TelescopeParameterLookup
 
     def __init__(self, dtype=float, default_value=None, **kwargs):
+        if not isinstance(dtype, type):
+            raise ValueError("dtype should be a type")
         if isinstance(default_value, dtype):
             default_value = [("type", "*", default_value)]
         super().__init__(default_value=default_value, **kwargs)
-        if not isinstance(dtype, type):
-            raise ValueError("dtype should be a type")
         self._dtype = dtype
 
     def validate(self, obj, value):

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -251,8 +251,10 @@ class TelescopeParameter(List):
     """
     klass = TelescopeParameterLookup
 
-    def __init__(self, dtype=float, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, dtype=float, default_value=None, **kwargs):
+        if isinstance(default_value, dtype):
+            default_value = [("type", "*", default_value)]
+        super().__init__(default_value=default_value, **kwargs)
         if not isinstance(dtype, type):
             raise ValueError("dtype should be a type")
         self._dtype = dtype


### PR DESCRIPTION
Adds the ability to set the default value of a TelescopeParameter with a scalar (`default_value=value`), instead of having to express the full `default_value=[(“type”, “*”, value)]`