### PR TITLE
Fixes for CameraCalibrator and extract_around_peak

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -219,6 +219,7 @@ class CameraCalibrator(Component):
             A `ctapipe` event container
         """
         # TODO: How to handle different calibrations depending on telid?
-        for telid in event.r1.tel.keys():
+        tel = event.r1.tel or event.dl0.tel or event.dl1.tel
+        for telid in tel.keys():
             self._calibrate_dl0(event, telid)
             self._calibrate_dl1(event, telid)

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -120,7 +120,7 @@ def test_dl1_charge_calib():
 
     event = DataContainer()
     telid = 0
-    event.r1.tel[telid].waveform = y[np.newaxis, ...]
+    event.dl0.tel[telid].waveform = y
 
     # Test default
     calibrator = CameraCalibrator(image_extractor=FullWaveformSum())

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -73,10 +73,18 @@ def test_check_r1_empty(example_event):
     with pytest.warns(UserWarning):
         example_event.r1.tel[telid].waveform = None
         calibrator._calibrate_dl0(example_event, telid)
-        assert example_event.dl0.tel[telid].waveform == None
+        assert example_event.dl0.tel[telid].waveform is None
 
     assert calibrator._check_r1_empty(None) is True
     assert calibrator._check_r1_empty(waveform) is False
+
+    calibrator = CameraCalibrator(image_extractor=FullWaveformSum())
+    event = DataContainer()
+    event.dl0.tel[telid].waveform = np.full((2048, 128), 2)
+    with pytest.warns(UserWarning):
+        calibrator(event)
+    assert (event.dl0.tel[telid].waveform == 2).all()
+    assert (event.dl1.tel[telid].image == 2*128).all()
 
 
 def test_check_dl0_empty(example_event):
@@ -87,10 +95,17 @@ def test_check_dl0_empty(example_event):
     with pytest.warns(UserWarning):
         example_event.dl0.tel[telid].waveform = None
         calibrator._calibrate_dl1(example_event, telid)
-        assert example_event.dl1.tel[telid].image == None
+        assert example_event.dl1.tel[telid].image is None
 
     assert calibrator._check_dl0_empty(None) is True
     assert calibrator._check_dl0_empty(waveform) is False
+
+    calibrator = CameraCalibrator()
+    event = DataContainer()
+    event.dl1.tel[telid].image = np.full(2048, 2)
+    with pytest.warns(UserWarning):
+        calibrator(event)
+    assert (event.dl1.tel[telid].image == 2).all()
 
 
 def test_dl1_charge_calib():

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -82,10 +82,11 @@ def extract_around_peak(waveforms, peak_index, width, shift, sum, pulse_time):
     time_num = 0
     time_den = 0
     for isample in prange(start, end):
-        if (0 <= isample < n_samples) & (waveforms[isample] > 0):
+        if 0 <= isample < n_samples:
             sum[0] += waveforms[isample]
-            time_num += waveforms[isample] * isample
-            time_den += waveforms[isample]
+            if waveforms[isample] > 0:
+                time_num += waveforms[isample] * isample
+                time_den += waveforms[isample]
 
     # TODO: Return pulse time in units of ns instead of isample
     pulse_time[0] = time_num / time_den if time_den > 0 else peak_index

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -56,6 +56,11 @@ def test_extract_around_peak(camera_waveforms):
     assert_allclose(charge[0], 1.0, rtol=1e-3)
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
+    # Test negative amplitude
+    y_offset = y - y.max() / 2
+    charge, pulse_time = extract_around_peak(y_offset[np.newaxis, :], 0, x.size, 0)
+    assert_allclose(charge, y_offset.sum(), rtol=1e-3)
+
 
 def test_extract_around_peak_charge_expected(camera_waveforms):
     waveforms, _ = camera_waveforms


### PR DESCRIPTION
Tests appear to be failing in the master as one of the test R1 waveforms was not corrected following merging #1167, and the automated tests for open PRs did not catch it.

When fixing this test I discovered two bugs:
- Missing DLs are not correctly handled (as the telescope keys for R1 may be unfilled)
- The changes to extract_around_peak in #1146 meant that negative samples were incorrectly excluded from the charge sum.

This PR fixes these problems.