### PR TITLE
Return global value from TelescopeParameterLookup when passed None

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -136,9 +136,12 @@ def test_telescope_parameter_lookup():
     with pytest.raises(ValueError):
         telparam_list[1]
 
+    assert telparam_list[None] == 10
+
     telparam_list.attach_subarray(subarray)
     assert telparam_list[1] == 10
     assert telparam_list[3] == 100
+    assert telparam_list[None] == 10
 
     with pytest.raises(KeyError):
         telparam_list[200]
@@ -146,6 +149,12 @@ def test_telescope_parameter_lookup():
     with pytest.raises(ValueError):
         bad_config = TelescopeParameterLookup([("unknown", "a", 15.0)])
         bad_config.attach_subarray(subarray)
+
+    telparam_list2 = TelescopeParameterLookup(
+        [("type", "LST*", 100)]
+    )
+    with pytest.raises(KeyError):
+        telparam_list2[None]
 
 
 def test_telescope_parameter_patterns():

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -199,7 +199,7 @@ class TelescopeParameterLookup:
             if self._subarray_global_value is not None:
                 return self._subarray_global_value
             else:
-                raise KeyError("No global value set for TelescopeParamter")
+                raise KeyError("No subarray global value set for TelescopeParameter")
         if self._value_for_tel_id is None:
             raise ValueError(
                 "TelescopeParameterLookup: No subarray attached, call "

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -153,10 +153,10 @@ class TelescopeParameterLookup:
             telecope_parameter_list = []
         self._telecope_parameter_list = telecope_parameter_list
         self._value_for_tel_id = None
-        self._global_value = None
+        self._subarray_global_value = None
         for param in telecope_parameter_list:
             if param[1] == "*":
-                self._global_value = param[2]
+                self._subarray_global_value = param[2]
 
     def attach_subarray(self, subarray):
         """
@@ -196,8 +196,8 @@ class TelescopeParameterLookup:
         Returns the resolved parameter for the given telescope id
         """
         if tel_id is None:
-            if self._global_value is not None:
-                return self._global_value
+            if self._subarray_global_value is not None:
+                return self._subarray_global_value
             else:
                 raise KeyError("No global value set for TelescopeParamter")
         if self._value_for_tel_id is None:


### PR DESCRIPTION
If a global value is set in the TelescopeParameter defaults (e.g. `default_value=[("type", "*", value)]`, this PR adds the ability to retrieve that value from the TelescopeParameter in the absence of any subarray information. This then allows, for example, an IntTelescopeParameter to behave as a normal Int traitlet if there is no subarray information available.