### PR TITLE
Extra TelescopeParameter use cases

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -274,3 +274,26 @@ def test_telescope_parameter_resolver():
         200.0,
         300.0,
     ]
+
+
+def test_telescope_parameter_component_arg(mock_subarray):
+    class SomeComponent(Component):
+        tel_param1 = IntTelescopeParameter(
+            default_value=[("type", "*", 10), ("type", "LST*", 100)]
+        )
+
+    comp = SomeComponent(tel_param1=[("type", "*", 2), ("type", "LST*", 4)])
+    comp.tel_param1.attach_subarray(mock_subarray)
+    assert comp.tel_param1[1] == 2
+    assert comp.tel_param1[3] == 4
+    assert comp.tel_param1[None] == 2
+
+    comp = SomeComponent(tel_param1=200)
+    comp.tel_param1.attach_subarray(mock_subarray)
+    assert comp.tel_param1[1] == 200
+    assert comp.tel_param1[3] == 200
+    assert comp.tel_param1[None] == 200
+
+    comp = SomeComponent(tel_param1=300)
+    assert comp.tel_param1[None] == 300
+

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -297,3 +297,20 @@ def test_telescope_parameter_component_arg(mock_subarray):
     comp = SomeComponent(tel_param1=300)
     assert comp.tel_param1[None] == 300
 
+
+def test_telescope_parameter_set_retain_subarray(mock_subarray):
+    class SomeComponent(Component):
+        tel_param1 = IntTelescopeParameter(
+            default_value=[("type", "*", 10), ("type", "LST*", 100)]
+        )
+
+    comp = SomeComponent()
+    comp.tel_param1.attach_subarray(mock_subarray)
+    assert comp.tel_param1[1] == 10
+    assert comp.tel_param1[3] == 100
+    assert comp.tel_param1[None] == 10
+
+    comp.tel_param1 = 5
+    assert comp.tel_param1[1] == 5
+    assert comp.tel_param1[3] == 5
+    assert comp.tel_param1[None] == 5

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -139,7 +139,7 @@ def has_traits(cls, ignore=("config", "parent")):
 
 
 class TelescopeParameterLookup:
-    def __init__(self, telecope_parameter_list=None):
+    def __init__(self, telecope_parameter_list):
         """
         Handles the lookup of corresponding configuration value from a list of
         tuples for a telid.
@@ -149,8 +149,6 @@ class TelescopeParameterLookup:
         telecope_parameter_list : list
             List of tuples in the form `[(command, argument, value), ...]`
         """
-        if telecope_parameter_list is None:
-            telecope_parameter_list = []
         self._telecope_parameter_list = telecope_parameter_list
         self._value_for_tel_id = None
         self._subarray_global_value = None

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -269,18 +269,12 @@ class TelescopeParameter(List):
         self._dtype = dtype
 
     def validate(self, obj, value):
-        # Convert normal list into TelescopeParameterLookup
-        if isinstance(value, list):
-            value = TelescopeParameterLookup(value)
-
-        # support a single value for all (convert into a default value)
+        # Support a single value for all (convert into a default value)
         if isinstance(value, self._dtype):
-            value = TelescopeParameterLookup([("type", "*", value)])
+            value = [("type", "*", value)]
 
-        # check that it is a list
-        super().validate(obj, value)
-        normalized_value = TelescopeParameterLookup()
-
+        # Check each value of list
+        normalized_value = []
         for pattern in value:
             # now check for the standard 3-tuple of (command, argument, value)
             if len(pattern) != 3:
@@ -302,6 +296,12 @@ class TelescopeParameter(List):
 
             val = self._dtype(val)
             normalized_value.append((command, arg, val))
+
+        # Convert to TelescopeParameterLookup
+        normalized_value = TelescopeParameterLookup(normalized_value)
+
+        # Validate with super method
+        super().validate(obj, normalized_value)
 
         return normalized_value
 

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -151,6 +151,7 @@ class TelescopeParameterLookup:
         """
         self._telecope_parameter_list = telecope_parameter_list
         self._value_for_tel_id = None
+        self._subarray = None
         self._subarray_global_value = None
         for param in telecope_parameter_list:
             if param[1] == "*":
@@ -167,6 +168,7 @@ class TelescopeParameterLookup:
             Description of the subarray
             (includes mapping of tel_id to tel_type)
         """
+        self._subarray = subarray
         self._value_for_tel_id = {}
         for command, arg, value in self._telecope_parameter_list:
             if command == "type":
@@ -302,6 +304,17 @@ class TelescopeParameter(List):
         super().validate(obj, normalized_value)
 
         return normalized_value
+
+    def set(self, obj, value):
+        # Retain existing subarray description
+        # when setting new value for TelescopeParameter
+        try:
+            old_value = obj._trait_values[self.name]
+        except KeyError:
+            old_value = self.default_value
+        super().set(obj, value)
+        if getattr(old_value, '_subarray', None) is not None:
+            obj._trait_values[self.name].attach_subarray(old_value._subarray)
 
 
 class FloatTelescopeParameter(TelescopeParameter):


### PR DESCRIPTION
This PR ensures TelescopeParameter:
- Can be correctly set via the args of a Component (correctly setting up TelescopeParameterLookup._subarray_global_value)
- Retains subarray description when the TelescopeParameter defaults are changed