### PR TITLE
Use descriptor protocol to mark fields as deprecated

### DIFF
--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -4,7 +4,7 @@ Core functionality of ctapipe
 """
 
 from .component import Component, non_abstract_children
-from .container import Container, Field, DeprecatedField, Map
+from .container import Container, Field, Deprecated, Map
 from .provenance import Provenance, get_module_version
 from .tool import Tool, ToolConfigurationError
 
@@ -13,7 +13,7 @@ __all__ = [
     'Container',
     'Tool',
     'Field',
-    'DeprecatedField',
+    'Deprecated',
     'Map',
     'Provenance',
     'ToolConfigurationError',

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
-from ctapipe.core import Container, Field, Map, DeprecatedField
+from ctapipe.core import Container, Field, Map, Deprecated
 
 
 def test_prefix():
@@ -178,8 +178,19 @@ def test_container_brackets():
 
 def test_deprecated_field():
     class ExampleContainer(Container):
-        answer = DeprecatedField(-1, "The answer to all questions", reason="because")
+        answer = Deprecated(
+            Field(-1, "The answer to all questions"),
+            reason="because"
+        )
 
     cont = ExampleContainer()
-    cont.answer = 6
+
+    # getting deprecated value warns, but works nonetheless
+    with pytest.warns(UserWarning):
+        assert cont.answer == -1
+
+    # setting deprecated value warns, but works nonetheless
+    with pytest.warns(UserWarning):
+        cont.answer = 6
+        assert cont.answer == 6
 

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -7,7 +7,7 @@ from astropy import units as u
 from astropy.time import Time
 from numpy import nan
 
-from ..core import Container, Field, DeprecatedField, Map
+from ..core import Container, Field, Deprecated, Map
 from ..instrument import SubarrayDescription
 
 __all__ = [
@@ -183,8 +183,8 @@ class R0Container(Container):
     Storage of a Merged Raw Data Event
     """
 
-    obs_id = DeprecatedField(-1, "observation ID", reason="moved to event.index")
-    event_id = DeprecatedField(-1, "event id number", reason="moved to event.index")
+    obs_id = Deprecated(Field(-1, "observation ID"), reason="moved to event.index")
+    event_id = Deprecated(Field(-1, "event id number"), reason="moved to event.index")
     tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(R0CameraContainer), "map of tel_id to R0CameraContainer")
 
@@ -218,8 +218,8 @@ class R1Container(Container):
     Storage of a r1 calibrated Data Event
     """
 
-    obs_id = DeprecatedField(-1, "observation ID", reason="moved to event.index")
-    event_id = DeprecatedField(-1, "event id number", reason="moved to event.index")
+    obs_id = Deprecated(Field(-1, "observation ID"), reason="moved to event.index")
+    event_id = Deprecated(Field(-1, "event id number"), reason="moved to event.index")
     tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(R1CameraContainer), "map of tel_id to R1CameraContainer")
 
@@ -248,12 +248,12 @@ class DL0Container(Container):
     Storage of a data volume reduced Event
     """
 
-    obs_id = DeprecatedField(
-        -1, "observation ID", reason="moved to event.index"
-    )  # use event.index.obs_id
-    event_id = DeprecatedField(
-        -1, "event id number", reason="moved to event.index"
-    )  # use event.index.event_id
+    obs_id = Deprecated(Field(
+        -1, "observation ID",
+    ), reason="moved to event.index")
+    event_id = Deprecated(Field(
+        -1, "event id number",
+    ), reason="moved to event.index")
     tels_with_data = Field([], "list of telescopes with data")
     tel = Field(Map(DL0CameraContainer), "map of tel_id to DL0CameraContainer")
 
@@ -530,9 +530,8 @@ class DataContainer(Container):
     mcheader = Field(MCHeaderContainer(), "Monte-Carlo run header data")
     trig = Field(CentralTriggerContainer(), "central trigger information")
     count = Field(0, "number of events processed")
-    inst = DeprecatedField(
-        InstrumentContainer(),
-        "instrumental information ",
+    inst = Deprecated(
+        Field(InstrumentContainer(), "instrumental information "),
         reason="will be separated from event structure in future version",
     )
     pointing = Field(Map(TelescopePointingContainer), "Telescope pointing positions")
@@ -631,14 +630,17 @@ class MuonIntensityParameter(Container):
 
     """
 
-    obs_id = DeprecatedField(
-        0, "run identification number", reason="moved to event.index"
+    obs_id = Deprecated(
+        Field(0, "run identification number"),
+        reason="moved to event.index",
     )
-    event_id = DeprecatedField(
-        0, "event identification number", reason="moved to event.index"
+    event_id = Deprecated(
+        Field(0, "event identification number"),
+        reason="moved to event.index",
     )
-    tel_id = DeprecatedField(
-        0, "telescope identification number", reason="moved to event.index"
+    tel_id = Deprecated(
+        Field(0, "telescope identification number"),
+        reason="moved to event.index",
     )
     ring_completeness = Field(0.0, "fraction of ring present")
     ring_pix_completeness = Field(0.0, "fraction of pixels present in the ring")


### PR DESCRIPTION
Found the solution to the descriptor protocol problem watching this talk: https://www.youtube.com/watch?v=UANN2Eu6ZnM&feature=youtu.be