### PR TITLE
WIP make muon displayer configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 =======
-ctapipe |teststatus| |codacy| |coverage| |conda| 
+ctapipe |teststatus| |codacy| |coverage| |conda| |doiv07|
 =======
 
 .. |teststatus| image:: https://travis-ci.org/cta-observatory/ctapipe.svg?branch=master
@@ -11,10 +11,11 @@ ctapipe |teststatus| |codacy| |coverage| |conda|
 .. |conda| image:: https://anaconda.org/cta-observatory/ctapipe/badges/installer/conda.svg
 .. |coverage| image:: https://codecov.io/gh/cta-observatory/ctapipe/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/cta-observatory/ctapipe
+.. |doiv07| image:: https://zenodo.org/badge/37927055.svg
+  :target: https://zenodo.org/badge/latestdoi/37927055
 
 Low-level data processing pipeline software for
 `CTA <www.cta-observatory.org>`_ (the Cherenkov Telescope Array)
-
 
 This is code is a prototype data processing framework and is under rapid
 development. It is not recommended for production use unless you are an
@@ -22,6 +23,12 @@ expert or developer!
 
 * Code: https://github.com/cta-observatory/ctapipe
 * Docs: https://cta-observatory.github.io/ctapipe/
+
+Citing this software
+--------------------
+If you use this software for a publication, please cite using the following DOIs: 
+
+- v0.7.0 : |doiv07|
 
 
 Installation for Users

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -38,3 +38,22 @@ def example_event(_global_example_event):
 
     """
     return deepcopy(_global_example_event)
+
+
+
+@pytest.fixture(scope='function')
+def calibrated_event(example_event):
+    """
+    Use this fixture anywhere you need a test event read from a MC file. For
+    example:
+
+    .. code-block::
+        def test_my_thing(calibrated_event):
+            assert len(calibrated_event.r0.tels_with_data)>0
+
+    """
+    from ctapipe.calib import CameraCalibrator
+    calib = CameraCalibrator()
+    calib(example_event)
+
+    return deepcopy(example_event)

--- a/ctapipe/image/muon/features.py
+++ b/ctapipe/image/muon/features.py
@@ -150,7 +150,7 @@ def ring_containment(
     ring_y = cring_y + ring_radius * np.sin(angle_ring)
     d_squared = ring_x**2 + ring_y**2
 
-    ringcontainment = np.mean(d < cam_rad**2)
+    ringcontainment = np.mean(d_squared < cam_rad**2)
     return ringcontainment
 
 

--- a/ctapipe/image/muon/features.py
+++ b/ctapipe/image/muon/features.py
@@ -1,6 +1,5 @@
 import numpy as np
 import logging
-import math as mt
 
 log = logging.getLogger(__name__)
 
@@ -146,7 +145,7 @@ def ring_containment(
     ringcontainment: float
         the ratio of ring inside the camera
     """
-    angle_ring = np.linspace(0, 2 * mt.pi, 360)
+    angle_ring = np.linspace(0, 2 * np.pi, 360)
     ring_x = cring_x + ring_radius * np.cos(angle_ring)
     ring_y = cring_y + ring_radius * np.sin(angle_ring)
     d = np.sqrt(np.power(ring_x, 2) + np.power(ring_y, 2))

--- a/ctapipe/image/muon/features.py
+++ b/ctapipe/image/muon/features.py
@@ -148,10 +148,9 @@ def ring_containment(
     angle_ring = np.linspace(0, 2 * np.pi, 360)
     ring_x = cring_x + ring_radius * np.cos(angle_ring)
     ring_y = cring_y + ring_radius * np.sin(angle_ring)
-    d = np.sqrt(np.power(ring_x, 2) + np.power(ring_y, 2))
+    d_squared = ring_x**2 + ring_y**2
 
-    ringcontainment = len(d[d < cam_rad]) / len(d)
-
+    ringcontainment = np.mean(d < cam_rad**2)
     return ringcontainment
 
 

--- a/ctapipe/image/muon/fitting.py
+++ b/ctapipe/image/muon/fitting.py
@@ -487,8 +487,10 @@ def taubin_circle_fit(
     x_masked = x[mask]
     y_masked = y[mask]
 
-    taubin_r_initial = x.max() / 2
-    taubin_error = taubin_r_initial * 0.1
+    R = x.max()  # x.max() just happens to be identical with R in many cases.
+
+    taubin_r_initial = R / 2
+    taubin_error = R * 0.1
     xc = 0
     yc = 0
 
@@ -501,9 +503,9 @@ def taubin_circle_fit(
         error_xc=taubin_error,
         error_yc=taubin_error,
         error_r=taubin_error,
-        limit_xc=(x.min(), x.max()),
-        limit_yc=(y.min(), y.max()),
-        limit_r=(0, 2*x.max()),
+        limit_xc=(-2*R, 2*R),
+        limit_yc=(-2*R, 2*R),
+        limit_r=(0, R),
         pedantic=False
     )
     fit.migrad()

--- a/ctapipe/image/muon/fitting.py
+++ b/ctapipe/image/muon/fitting.py
@@ -22,7 +22,7 @@ def cherenkov_integral(lambda1, lambda2):
 
 def kundu_chaudhuri_circle_fit(x, y, weights):
     """
-    Fast, analytic calculation of circle center and radius for 
+    Fast, analytic calculation of circle center and radius for
     weighted data using method given in [chaudhuri93]_
 
     Parameters
@@ -53,7 +53,7 @@ def kundu_chaudhuri_circle_fit(x, y, weights):
     center_y = (a2 * c1 - a1 * c2) / (a2 * b1 - a1 * b2)
 
     radius = np.sqrt(np.sum(
-        weights * ((center_x - x)**2 + (center_y - y)**2),
+        weights * ((center_x - x)**2 + (center_y - y)**2)
     ) / weights_sum)
 
     return radius, center_x, center_y
@@ -251,7 +251,7 @@ def radial_light_intensity(
 ):
     """
     Amount of photons per azimuthal angle phi on the muon ring as given in
-    formula (5) of [vacanti94]_ 
+    formula (5) of [vacanti94]_
 
     Parameters
     ----------
@@ -372,7 +372,7 @@ def efficiency_fit(
 
     1. fit r, x, y and width with the psf_likelihood_fit
     2. fit impact parameter with impact_parameter_chisq_fit
-    3. calculate the theoretically expected light contents for each pixel 
+    3. calculate the theoretically expected light contents for each pixel
        for the estimated parameters
     4. calculate the ratio between the observed and the expected number
        of photons.

--- a/ctapipe/image/muon/fitting.py
+++ b/ctapipe/image/muon/fitting.py
@@ -87,7 +87,8 @@ def _psf_neg_log_likelihood(params, x, y, weights):
         (np.log(sigma) + 0.5 * ((pixel_distance - radius) / sigma)**2) * weights
     )
 
-def foo(x, y):
+def strip_unit_savely(x, y):
+    '''takes quantities or simple np.array, forces into quantity and strips unit'''
     x = Quantity(x).decompose()
     y = Quantity(y).decompose()
     assert x.unit == y.unit
@@ -127,7 +128,7 @@ def psf_likelihood_fit(x, y, weights):
         standard deviation of the gaussian profile (indictor for the ring width)
     """
 
-    x, y, unit = foo(x, y)
+    x, y, unit = strip_unit_savely(x, y)
 
     start_r, start_x, start_y = kundu_chaudhuri_circle_fit(x, y, weights)
 
@@ -481,7 +482,7 @@ def taubin_circle_fit(
     mask: array-like boolean
         true for pixels surviving the cleaning
     """
-    x, y, orinal_unit = foo(x, y)
+    x, y, orinal_unit = strip_unit_savely(x, y)
 
     x_masked = x[mask]
     y_masked = y[mask]

--- a/ctapipe/image/muon/fitting.py
+++ b/ctapipe/image/muon/fitting.py
@@ -518,6 +518,12 @@ def taubin_circle_fit(
 
 
 def make_taubin_loss_function(x, y):
+    '''closure around taubin_loss_function to make
+    surviving pixel positions availaboe inside.
+
+    x, y: positions of pixels surviving the cleaning
+        should not be quantities
+    '''
 
     def taubin_loss_function(xc, yc, r):
         """taubin fit formula

--- a/ctapipe/image/muon/muon_diagnostic_plots.py
+++ b/ctapipe/image/muon/muon_diagnostic_plots.py
@@ -89,185 +89,186 @@ def plot_muon_efficiency(outputpath):
         plt.show()
 
 
+def threshold(geom):
+    '''derive cleaning threshold from camera geometry'''
+    tailcuts = (5., 7.)
+    # Try a higher threshold for
+    if geom.cam_id == 'FlashCam':
+        tailcuts = (10., 12.)
+
+    # this dict can be directly unpacked into the
+    # tailcuts_clean() call
+    return dict(
+        picture_thresh=tailcuts[0],
+        boundary_thresh=tailcuts[1]
+    )
+
 def plot_muon_event(event, muonparams):
-    if muonparams['MuonRingParams'] is not None:
+    """ Plot the muon event and overlay muon parameters"""
+    if not muonparams['MuonRingParams']:
+        return
 
-        # Plot the muon event and overlay muon parameters
-        fig = plt.figure(figsize=(16, 7))
+    fig = plt.figure(figsize=(16, 7))
 
-        colorbar = None
-        colorbar2 = None
+    colorbar = None
+    colorbar2 = None
 
-        subarray = event.inst.subarray
+    subarray = event.inst.subarray
 
-        # for tel_id in event.dl0.tels_with_data:
-        for tel_id in muonparams['TelIds']:
-            idx = muonparams['TelIds'].index(tel_id)
+    # for tel_id in event.dl0.tels_with_data:
+    for tel_id in muonparams['TelIds']:
+        idx = muonparams['TelIds'].index(tel_id)
 
-            if not muonparams['MuonRingParams'][idx]:
+        if not muonparams['MuonRingParams'][idx]:
+            continue
+
+        npads = 2
+        # Only create two pads if there is timing information extracted
+        # from the calibration
+        ax1 = fig.add_subplot(1, npads, 1)
+        plotter = CameraPlotter(event)
+        image = event.dl1.tel[tel_id].image
+        geom = event.inst.subarray.tel[tel_id].camera
+        clean_mask = tailcuts_clean(geom, image, **threshold(geom))
+        signals = image * clean_mask
+
+        rotr_angle = geom.pix_rotation
+
+        # Convert to camera frame (centre & radius)
+        altaz = AltAz(alt=event.mc.alt, az=event.mc.az)
+
+        ring_nominal = SkyCoord(
+            delta_az=muonparams['MuonRingParams'][idx].ring_center_x,
+            delta_alt=muonparams['MuonRingParams'][idx].ring_center_y,
+            frame=NominalFrame(origin=altaz)
+        )
+
+        flen = subarray.tel[tel_id].optics.equivalent_focal_length
+        ring_camcoord = ring_nominal.transform_to(CameraFrame(
+            pointing_direction=altaz,
+            focal_length=flen,
+            rotation=rotr_angle))
+
+        centroid = (ring_camcoord.x.value, ring_camcoord.y.value)
+
+        radius = muonparams['MuonRingParams'][idx].ring_radius
+        ringrad_camcoord = 2 * radius.to(u.rad) * flen  # But not FC?
+
+        px = subarray.tel[tel_id].camera.pix_x
+        py = subarray.tel[tel_id].camera.pix_y
+        camera_coord = SkyCoord(
+            x=px,
+            y=py,
+            frame=CameraFrame(
+                focal_length=flen,
+                rotation=geom.pix_rotation,
+            )
+        )
+
+        nom_coord = camera_coord.transform_to(
+            NominalFrame(origin=altaz)
+        )
+
+        px = nom_coord.delta_az.to(u.deg)
+        py = nom_coord.delta_alt.to(u.deg)
+        dist = np.sqrt(np.power(px - muonparams['MuonRingParams'][idx].ring_center_x,
+                                2) + np.power(py - muonparams['MuonRingParams'][idx].
+                                              ring_center_y, 2))
+        ring_dist = np.abs(dist - muonparams['MuonRingParams'][idx].ring_radius)
+        pix_rmask = ring_dist < muonparams['MuonRingParams'][idx].ring_radius * 0.4
+
+        if muonparams['MuonIntensityParams'][idx] is not None:
+            signals *= muonparams['MuonIntensityParams'][idx].mask
+        elif muonparams['MuonIntensityParams'][idx] is None:
+            signals *= pix_rmask
+
+        camera1 = plotter.draw_camera(tel_id, signals, ax1)
+
+        cmaxmin = (max(signals) - min(signals))
+        cmin = min(signals)
+        if not cmin:
+            cmin = 1.
+        if not cmaxmin:
+            cmaxmin = 1.
+
+        cmap_charge = colors.LinearSegmentedColormap.from_list(
+            'cmap_c', [(0 / cmaxmin, 'darkblue'),
+                       (np.abs(cmin) / cmaxmin, 'black'),
+                       (2.0 * np.abs(cmin) / cmaxmin, 'blue'),
+                       (2.5 * np.abs(cmin) / cmaxmin, 'green'),
+                       (1, 'yellow')]
+        )
+        camera1.pixels.set_cmap(cmap_charge)
+        if not colorbar:
+            camera1.add_colorbar(ax=ax1, label=" [photo-electrons]")
+            colorbar = camera1.colorbar
+        else:
+            camera1.colorbar = colorbar
+        camera1.update(True)
+
+        camera1.add_ellipse(centroid, ringrad_camcoord.value,
+                            ringrad_camcoord.value, 0., 0., color="red")
+
+        if muonparams['MuonIntensityParams'][idx] is not None:
+
+            ringwidthfrac = muonparams['MuonIntensityParams'][idx].ring_width / \
+                muonparams['MuonRingParams'][idx].ring_radius
+            ringrad_inner = ringrad_camcoord * (1. - ringwidthfrac)
+            ringrad_outer = ringrad_camcoord * (1. + ringwidthfrac)
+            camera1.add_ellipse(centroid, ringrad_inner.value,
+                                ringrad_inner.value, 0., 0.,
+                                color="magenta")
+            camera1.add_ellipse(centroid, ringrad_outer.value,
+                                ringrad_outer.value, 0., 0.,
+                                color="magenta")
+            npads = 2
+            ax2 = fig.add_subplot(1, npads, npads)
+            pred = muonparams['MuonIntensityParams'][idx].prediction
+
+            if len(pred) != np.sum(
+                    muonparams['MuonIntensityParams'][idx].mask):
+                logger.warning("Lengths do not match...len(pred)=%s len("
+                               "mask)=", len(pred),
+                               np.sum(muonparams['MuonIntensityParams'][idx].mask))
+
+            # Numpy broadcasting - fill in the shape
+            plotpred = np.zeros(image.shape)
+            truelocs = np.where(muonparams['MuonIntensityParams'][idx].mask == True)
+            plotpred[truelocs] = pred
+
+            camera2 = plotter.draw_camera(tel_id, plotpred, ax2)
+
+            if np.isnan(max(plotpred)) or np.isnan(min(plotpred)):
+                logger.debug("nan prediction, skipping...")
                 continue
 
-            # otherwise...
-            npads = 2
-            # Only create two pads if there is timing information extracted
-            # from the calibration
-            ax1 = fig.add_subplot(1, npads, 1)
-            plotter = CameraPlotter(event)
-            image = event.dl1.tel[tel_id].image
-            geom = event.inst.subarray.tel[tel_id].camera
+            c2maxmin = (max(plotpred) - min(plotpred))
+            if not c2maxmin:
+                c2maxmin = 1.
 
-            tailcuts = (5., 7.)
-            # Try a higher threshold for
-            if geom.cam_id == 'FlashCam':
-                tailcuts = (10., 12.)
-
-            clean_mask = tailcuts_clean(geom, image,
-                                        picture_thresh=tailcuts[0],
-                                        boundary_thresh=tailcuts[1])
-
-            signals = image * clean_mask
-
-            rotr_angle = geom.pix_rotation
-# The following two lines have been commented out to avoid a rotation error.
-#            if geom.cam_id == 'LSTCam' or geom.cam_id == 'NectarCam':
-
-#                rotr_angle = 0. * u.deg
-
-            # Convert to camera frame (centre & radius)
-            altaz = AltAz(alt=event.mc.alt, az=event.mc.az)
-
-            ring_nominal = SkyCoord(
-                delta_az=muonparams['MuonRingParams'][idx].ring_center_x,
-                delta_alt=muonparams['MuonRingParams'][idx].ring_center_y,
-                frame=NominalFrame(origin=altaz)
+            c2map_charge = colors.LinearSegmentedColormap.from_list(
+                'c2map_c', [(0 / c2maxmin, 'darkblue'),
+                            (np.abs(min(plotpred)) / c2maxmin, 'black'),
+                            (
+                            2.0 * np.abs(min(plotpred)) / c2maxmin, 'blue'),
+                            (2.5 * np.abs(min(plotpred)) / c2maxmin,
+                             'green'),
+                            (1, 'yellow')]
             )
-
-            flen = subarray.tel[tel_id].optics.equivalent_focal_length
-            ring_camcoord = ring_nominal.transform_to(CameraFrame(
-                pointing_direction=altaz,
-                focal_length=flen,
-                rotation=rotr_angle))
-
-            centroid = (ring_camcoord.x.value, ring_camcoord.y.value)
-
-            radius = muonparams['MuonRingParams'][idx].ring_radius
-            ringrad_camcoord = 2 * radius.to(u.rad) * flen  # But not FC?
-
-            px = subarray.tel[tel_id].camera.pix_x
-            py = subarray.tel[tel_id].camera.pix_y
-            camera_coord = SkyCoord(
-                x=px,
-                y=py,
-                frame=CameraFrame(
-                    focal_length=flen,
-                    rotation=geom.pix_rotation,
-                )
-            )
-
-            nom_coord = camera_coord.transform_to(
-                NominalFrame(origin=altaz)
-            )
-
-            px = nom_coord.delta_az.to(u.deg)
-            py = nom_coord.delta_alt.to(u.deg)
-            dist = np.sqrt(np.power(px - muonparams['MuonRingParams'][idx].ring_center_x,
-                                    2) + np.power(py - muonparams['MuonRingParams'][idx].
-                                                  ring_center_y, 2))
-            ring_dist = np.abs(dist - muonparams['MuonRingParams'][idx].ring_radius)
-            pix_rmask = ring_dist < muonparams['MuonRingParams'][idx].ring_radius * 0.4
-
-            if muonparams['MuonIntensityParams'][idx] is not None:
-                signals *= muonparams['MuonIntensityParams'][idx].mask
-            elif muonparams['MuonIntensityParams'][idx] is None:
-                signals *= pix_rmask
-
-            camera1 = plotter.draw_camera(tel_id, signals, ax1)
-
-            cmaxmin = (max(signals) - min(signals))
-            cmin = min(signals)
-            if not cmin:
-                cmin = 1.
-            if not cmaxmin:
-                cmaxmin = 1.
-
-            cmap_charge = colors.LinearSegmentedColormap.from_list(
-                'cmap_c', [(0 / cmaxmin, 'darkblue'),
-                           (np.abs(cmin) / cmaxmin, 'black'),
-                           (2.0 * np.abs(cmin) / cmaxmin, 'blue'),
-                           (2.5 * np.abs(cmin) / cmaxmin, 'green'),
-                           (1, 'yellow')]
-            )
-            camera1.pixels.set_cmap(cmap_charge)
-            if not colorbar:
-                camera1.add_colorbar(ax=ax1, label=" [photo-electrons]")
-                colorbar = camera1.colorbar
+            camera2.pixels.set_cmap(c2map_charge)
+            if not colorbar2:
+                camera2.add_colorbar(ax=ax2, label=" [photo-electrons]")
+                colorbar2 = camera2.colorbar
             else:
-                camera1.colorbar = colorbar
-            camera1.update(True)
+                camera2.colorbar = colorbar2
+            camera2.update(True)
+            plt.pause(1.)  # make shorter
 
-            camera1.add_ellipse(centroid, ringrad_camcoord.value,
-                                ringrad_camcoord.value, 0., 0., color="red")
-
-            if muonparams['MuonIntensityParams'][idx] is not None:
-
-                ringwidthfrac = muonparams['MuonIntensityParams'][idx].ring_width / \
-                    muonparams['MuonRingParams'][idx].ring_radius
-                ringrad_inner = ringrad_camcoord * (1. - ringwidthfrac)
-                ringrad_outer = ringrad_camcoord * (1. + ringwidthfrac)
-                camera1.add_ellipse(centroid, ringrad_inner.value,
-                                    ringrad_inner.value, 0., 0.,
-                                    color="magenta")
-                camera1.add_ellipse(centroid, ringrad_outer.value,
-                                    ringrad_outer.value, 0., 0.,
-                                    color="magenta")
-                npads = 2
-                ax2 = fig.add_subplot(1, npads, npads)
-                pred = muonparams['MuonIntensityParams'][idx].prediction
-
-                if len(pred) != np.sum(
-                        muonparams['MuonIntensityParams'][idx].mask):
-                    logger.warning("Lengths do not match...len(pred)=%s len("
-                                   "mask)=", len(pred),
-                                   np.sum(muonparams['MuonIntensityParams'][idx].mask))
-
-                # Numpy broadcasting - fill in the shape
-                plotpred = np.zeros(image.shape)
-                truelocs = np.where(muonparams['MuonIntensityParams'][idx].mask == True)
-                plotpred[truelocs] = pred
-
-                camera2 = plotter.draw_camera(tel_id, plotpred, ax2)
-
-                if np.isnan(max(plotpred)) or np.isnan(min(plotpred)):
-                    logger.debug("nan prediction, skipping...")
-                    continue
-
-                c2maxmin = (max(plotpred) - min(plotpred))
-                if not c2maxmin:
-                    c2maxmin = 1.
-
-                c2map_charge = colors.LinearSegmentedColormap.from_list(
-                    'c2map_c', [(0 / c2maxmin, 'darkblue'),
-                                (np.abs(min(plotpred)) / c2maxmin, 'black'),
-                                (
-                                2.0 * np.abs(min(plotpred)) / c2maxmin, 'blue'),
-                                (2.5 * np.abs(min(plotpred)) / c2maxmin,
-                                 'green'),
-                                (1, 'yellow')]
-                )
-                camera2.pixels.set_cmap(c2map_charge)
-                if not colorbar2:
-                    camera2.add_colorbar(ax=ax2, label=" [photo-electrons]")
-                    colorbar2 = camera2.colorbar
-                else:
-                    camera2.colorbar = colorbar2
-                camera2.update(True)
-                plt.pause(1.)  # make shorter
-
-            # plt.pause(0.1)
-            # if pp is not None:
-            #    pp.savefig(fig)
-            # fig.savefig(str(args.output_path) + "_" +
-            #            str(event.dl0.event_id) + '.png')
+        # plt.pause(0.1)
+        # if pp is not None:
+        #    pp.savefig(fig)
+        # fig.savefig(str(args.output_path) + "_" +
+        #            str(event.dl0.event_id) + '.png')
 
 
-            plt.close()
+        plt.close()

--- a/ctapipe/image/muon/muon_integrator.py
+++ b/ctapipe/image/muon/muon_integrator.py
@@ -432,11 +432,12 @@ class MuonLineIntegrate:
         fit_params = minuit.values
 
         fitoutput.impact_parameter = fit_params['impact_parameter'] * u.m
-        # fitoutput.phi = fit_params['phi']*u.rad
-        fitoutput.impact_parameter_pos_x = fit_params['impact_parameter'] * np.cos(
-            fit_params['phi'] * u.rad) * u.m
-        fitoutput.impact_parameter_pos_y = fit_params['impact_parameter'] * np.sin(
-            fit_params['phi'] * u.rad) * u.m
+        fitoutput.impact_parameter_pos_x = (
+            fit_params['impact_parameter'] * np.cos(fit_params['phi']) * u.m
+        )
+        fitoutput.impact_parameter_pos_y = (
+            fit_params['impact_parameter'] * np.sin(fit_params['phi']) * u.m
+        )
         fitoutput.ring_width = fit_params['ring_width'] * self.unit
         fitoutput.optical_efficiency_muon = fit_params['optical_efficiency_muon']
 

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -249,9 +249,8 @@ def analyze_muon_event(event):
                 ]
 
                 if all(conditions):
-                    muonintensityparam = muonintensityoutput
                     idx = tellist.index(telid)
-                    muonintensitylist[idx] = muonintensityparam
+                    muonintensitylist[idx] = muonintensityoutput
                     logger.debug("Muon found in tel %d,  tels in event=%d",
                                  telid, len(event.dl0.tels_with_data))
                 else:

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -263,12 +263,11 @@ def analyze_muon_event(event):
             ring_fit.ring_center_x,
             ring_fit.ring_center_y
         )
-        if not is_ring_good(image * mask, ring_fit, muon_cut):
-            output.append({
-                'MuonRingParams': ring_fit,
-                'mirror_radius': mirror_radius,
-            })
-        else:
+        result = {
+            'MuonRingParams': ring_fit,
+            'mirror_radius': mirror_radius,
+        }
+        if is_ring_good(image * mask, ring_fit, muon_cut):
 
             muonintensityoutput = calc_muon_intensity_parameters(
                 x, y, image, mask, ring_fit
@@ -291,11 +290,11 @@ def analyze_muon_event(event):
                 > muon_cut['RingWidth'][0]
             ]
 
-            output.append({
-                'MuonRingParams': ring_fit,
+            result.update({
                 'MuonIntensityParams': muonintensityoutput,
                 'muon_found': all(conditions),
-                'mirror_radius': mirror_radius,
             })
+
+        output.append(result)
 
     return output

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -205,9 +205,6 @@ def analyze_muon_event(event):
                 image[mask]
             )
 
-            muonintensityoutput.tel_id = telid
-            muonintensityoutput.obs_id = event.dl0.obs_id
-            muonintensityoutput.event_id = event.dl0.event_id
             muonintensityoutput.mask = mask
 
             idx_ring = np.nonzero(pix_im)
@@ -249,10 +246,14 @@ def analyze_muon_event(event):
                 > muon_cut['RingWidth'][0]
             ]
 
-
+        # this is just copying information from event to these
+        # containers. would be nice if not needed at all. copying is lame
         ring_fit.tel_id = telid
         ring_fit.obs_id = event.dl0.obs_id
         ring_fit.event_id = event.dl0.event_id
+        muonintensityoutput.tel_id = telid
+        muonintensityoutput.obs_id = event.dl0.obs_id
+        muonintensityoutput.event_id = event.dl0.event_id
 
         output.append({
             'MuonRingParams': ring_fit,

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -196,59 +196,58 @@ def analyze_muon_event(event):
                 secondary_radius=muon_cut['SecRad'],
             )
 
-            if image.shape[0] == muon_cut['total_pix']:
-                muonintensityoutput = ctel.fit_muon(
-                    ring_fit.ring_center_x,
-                    ring_fit.ring_center_y,
-                    ring_fit.ring_radius,
-                    x[mask],
-                    y[mask],
-                    image[mask]
-                )
+            muonintensityoutput = ctel.fit_muon(
+                ring_fit.ring_center_x,
+                ring_fit.ring_center_y,
+                ring_fit.ring_radius,
+                x[mask],
+                y[mask],
+                image[mask]
+            )
 
-                muonintensityoutput.tel_id = telid
-                muonintensityoutput.obs_id = event.dl0.obs_id
-                muonintensityoutput.event_id = event.dl0.event_id
-                muonintensityoutput.mask = mask
+            muonintensityoutput.tel_id = telid
+            muonintensityoutput.obs_id = event.dl0.obs_id
+            muonintensityoutput.event_id = event.dl0.event_id
+            muonintensityoutput.mask = mask
 
-                idx_ring = np.nonzero(pix_im)
-                muonintensityoutput.ring_completeness = ring_completeness(
-                    x[idx_ring],
-                    y[idx_ring],
-                    pix_im[idx_ring],
-                    ring_fit.ring_radius,
-                    ring_fit.ring_center_x,
-                    ring_fit.ring_center_y,
-                    threshold=30,
-                    bins=30)
-                muonintensityoutput.ring_size = np.sum(pix_im)
+            idx_ring = np.nonzero(pix_im)
+            muonintensityoutput.ring_completeness = ring_completeness(
+                x[idx_ring],
+                y[idx_ring],
+                pix_im[idx_ring],
+                ring_fit.ring_radius,
+                ring_fit.ring_center_x,
+                ring_fit.ring_center_y,
+                threshold=30,
+                bins=30)
+            muonintensityoutput.ring_size = np.sum(pix_im)
 
-                dist_ringwidth_mask = ring_dist < muonintensityoutput.ring_width
-                pix_ringwidth_im = image * dist_ringwidth_mask
-                idx_ringwidth = np.nonzero(pix_ringwidth_im)
+            dist_ringwidth_mask = ring_dist < muonintensityoutput.ring_width
+            pix_ringwidth_im = image * dist_ringwidth_mask
+            idx_ringwidth = np.nonzero(pix_ringwidth_im)
 
-                muonintensityoutput.ring_pix_completeness = (
-                    npix_above_threshold(pix_ringwidth_im[idx_ringwidth], tailcuts['picture_thresh'])
-                    / len(pix_im[idx_ringwidth])
-                )
+            muonintensityoutput.ring_pix_completeness = (
+                npix_above_threshold(pix_ringwidth_im[idx_ringwidth], tailcuts['picture_thresh'])
+                / len(pix_im[idx_ringwidth])
+            )
 
-                logger.debug("Tel %d Impact parameter = %s mirror_radius=%s "
-                             "ring_width=%s", telid,
-                             muonintensityoutput.impact_parameter, mirror_radius,
-                             muonintensityoutput.ring_width)
-                conditions = [
-                    muonintensityoutput.impact_parameter <
-                    muon_cut['Impact'][1] * mirror_radius,
+            logger.debug("Tel %d Impact parameter = %s mirror_radius=%s "
+                         "ring_width=%s", telid,
+                         muonintensityoutput.impact_parameter, mirror_radius,
+                         muonintensityoutput.ring_width)
+            conditions = [
+                muonintensityoutput.impact_parameter <
+                muon_cut['Impact'][1] * mirror_radius,
 
-                    muonintensityoutput.impact_parameter
-                    > muon_cut['Impact'][0] * mirror_radius,
+                muonintensityoutput.impact_parameter
+                > muon_cut['Impact'][0] * mirror_radius,
 
-                    muonintensityoutput.ring_width
-                    < muon_cut['RingWidth'][1],
+                muonintensityoutput.ring_width
+                < muon_cut['RingWidth'][1],
 
-                    muonintensityoutput.ring_width
-                    > muon_cut['RingWidth'][0]
-                ]
+                muonintensityoutput.ring_width
+                > muon_cut['RingWidth'][0]
+            ]
 
 
         ring_fit.tel_id = telid

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -124,7 +124,7 @@ def analyze_muon_event(event):
         else:
             img = image
 
-        muonring = MuonRingFitter(fit_method="chaudhuri_kundu")
+        muon_ring_fit = MuonRingFitter(fit_method="chaudhuri_kundu")
 
         logger.debug("img: %s mask: %s, x=%s y= %s", np.sum(image),
                      np.sum(clean_mask), x, y)
@@ -132,13 +132,13 @@ def analyze_muon_event(event):
         if not sum(img):  # Nothing left after tail cuts
             continue
 
-        muonringparam = muonring(x, y, image, clean_mask)
+        muonringparam = muon_ring_fit(x, y, image, clean_mask)
 
         dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2)
                        + np.power(y - muonringparam.ring_center_y, 2))
         ring_dist = np.abs(dist - muonringparam.ring_radius)
 
-        muonringparam = muonring(
+        muonringparam = muon_ring_fit(
             x, y, img, (ring_dist < muonringparam.ring_radius * 0.4)
         )
 
@@ -146,7 +146,7 @@ def analyze_muon_event(event):
                        np.power(y - muonringparam.ring_center_y, 2))
         ring_dist = np.abs(dist - muonringparam.ring_radius)
 
-        muonringparam = muonring(
+        muonringparam = muon_ring_fit(
             x, y, img, (ring_dist < muonringparam.ring_radius * 0.4)
         )
 

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -124,7 +124,7 @@ def analyze_muon_event(event):
         else:
             img = image
 
-        muonring = MuonRingFitter(teldes = None, fit_method="chaudhuri_kundu")
+        muonring = MuonRingFitter(fit_method="chaudhuri_kundu")
 
         logger.debug("img: %s mask: %s, x=%s y= %s", np.sum(image),
                      np.sum(clean_mask), x, y)
@@ -132,22 +132,22 @@ def analyze_muon_event(event):
         if not sum(img):  # Nothing left after tail cuts
             continue
 
-        muonringparam = muonring.fit(x, y, image * clean_mask)
+        muonringparam = muonring(x, y, image, clean_mask)
 
-        dist = np.sqrt(np.power(x - muonringparam. ring_center_x, 2)
+        dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2)
                        + np.power(y - muonringparam.ring_center_y, 2))
         ring_dist = np.abs(dist - muonringparam.ring_radius)
 
-        muonringparam = muonring.fit(
-            x, y, img * (ring_dist < muonringparam.ring_radius * 0.4)
+        muonringparam = muonring(
+            x, y, img, (ring_dist < muonringparam.ring_radius * 0.4)
         )
 
         dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2) +
                        np.power(y - muonringparam.ring_center_y, 2))
         ring_dist = np.abs(dist - muonringparam.ring_radius)
 
-        muonringparam = muonring.fit(
-            x, y, img * (ring_dist < muonringparam.ring_radius * 0.4)
+        muonringparam = muonring(
+            x, y, img, (ring_dist < muonringparam.ring_radius * 0.4)
         )
 
         muonringparam.tel_id = telid

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -150,7 +150,26 @@ def do_multi_ring_fit(x, y, image, clean_mask):
 
     return ring_fit, mask
 
-def calc_muon_intensity_parameters(x, y, image, mask, ring_fit):
+def calc_muon_intensity_parameters(x, y, image, mask, ring_fit, ctel):
+    '''
+    Parameters
+    ----------
+
+    x: ndarray in degrees
+        x-position of the pixels in the camera
+    y: ndarray in degrees
+        y-position of the pixels in the camera
+    image: ndarray 1D
+        charge of the pixels in the camera
+    mask: ndarray boolean, shape like image
+        true if pixel is likely to be on muon ring
+
+    ring_fit: MuonParameterContainer
+        result of previous ring fit
+
+    ctel: MuonLineIntegrate
+        to be used in here.
+    '''
 
     muonintensityoutput = ctel.fit_muon(
         ring_fit.ring_center_x,
@@ -276,31 +295,3 @@ def analyze_muon_event(event):
         })
 
     return muon_event_param
-
-
-@deprecated('0.6')
-def analyze_muon_source(source):
-    """
-    Generator for analyzing all the muon events
-
-    Parameters
-    ----------
-    source : ctapipe.io.EventSource
-        input event source
-
-    Returns
-    -------
-    analyzed_muon : container
-    A ctapipe event container (MuonParameter) with muon information
-
-    """
-    log.info(f"[FUNCTION] {__name__}")
-
-    if geom_dict is None:
-        geom_dict = {}
-    numev = 0
-    for event in source:  # Put a limit on number of events
-        numev += 1
-        analyzed_muon = analyze_muon_event(event)
-
-        yield analyzed_muon

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -93,6 +93,20 @@ def generate_muon_cuts_by_telescope_name():
 
     return muon_cuts_by_name
 
+def is_something_good(pix_im, ring_fit, muon_cut):
+    '''this is testing something on the image and the fit,
+    but I do not really get it.
+    '''
+    return (
+        npix_above_threshold(
+            pix_im, muon_cut['tail_cuts']['picture_thresh']
+        ) > 0.1 * muon_cut['min_pix']
+        and npix_composing_ring(pix_im) > muon_cut['min_pix']
+        and nom_dist < muon_cut['CamRad']
+        and ring_fit.ring_radius < 1.5 * u.deg
+        and ring_fit.ring_radius > 1. * u.deg
+    )
+
 
 def analyze_muon_event(event):
     """
@@ -160,21 +174,13 @@ def analyze_muon_event(event):
             (ring_fit.ring_center_y)**2
         )
 
-        minpix = muon_cut['min_pix']
-
         mirror_radius = np.sqrt(teldes.optics.mirror_area.to("m2") / np.pi)
 
         # Camera containment radius -  better than nothing - guess pixel
         # diameter of 0.11, all cameras are perfectly circular   cam_rad =
         # np.sqrt(numpix*0.11/(2.*np.pi))
 
-        if (
-            npix_above_threshold(pix_im, tailcuts['picture_thresh']) > 0.1 * minpix
-            and npix_composing_ring(pix_im) > minpix
-            and nom_dist < muon_cut['CamRad']
-            and ring_fit.ring_radius < 1.5 * u.deg
-            and ring_fit.ring_radius > 1. * u.deg
-        ):
+        if is_something_good(pix_im, ring_fit, muon_cut)
             ring_fit.ring_containment = ring_containment(
                 ring_fit.ring_radius,
                 muon_cut['CamRad'],

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -233,13 +233,13 @@ def analyze_muon_event(event):
 
         ring_fit, mask = do_multi_ring_fit(x, y, image, clean_mask)
 
+        ring_fit.ring_containment = ring_containment(
+            ring_fit.ring_radius,
+            muon_cut['CamRad'],
+            ring_fit.ring_center_x,
+            ring_fit.ring_center_y
+        )
         if is_ring_good(image * mask, ring_fit, muon_cut)
-            ring_fit.ring_containment = ring_containment(
-                ring_fit.ring_radius,
-                muon_cut['CamRad'],
-                ring_fit.ring_center_x,
-                ring_fit.ring_center_y
-            )
 
             muonintensityoutput = calc_muon_intensity_parameters(
                 x, y, image, mask, ring_fit

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -60,17 +60,24 @@ def analyze_muon_event(event):
     cleaning = True
 
 
-{'picture_thresh': 5, 'boundary_thresh': 7}
+
     muon_cuts = {'Name': names, 'tail_cuts': tail_cuts, 'Impact': impact,
                  'RingWidth': ringwidth, 'total_pix': total_pix,
                  'min_pix': min_pix, 'CamRad': cam_rad, 'SecRad': sec_rad,
                  'SCT': sct, 'AngPixW': ang_pixel_width, 'HoleRad': hole_rad}
 
     muon_cuts_list_of_dicts = [
-        {k:v for k,v in zip(keys, x)}
-        for x in zip(*muon_cuts.values())
+        {k:v for k,v in zip(keys, values)}
+        for values in zip(*muon_cuts.values())
     ]
     muon_cuts_by_name = {mc['Name']:mc for mc in muon_cuts_list_of_dicts}
+
+    # replace tail_cuts tuples with more descriptive dicts.
+    for muon_cut in muon_cuts_by_name.values():
+        muon_cut['tail_cuts'] = {
+            'picture_thresh': muon_cut['tail_cuts'][0],
+            'boundary_thresh': muon_cut['tail_cuts'][1],
+        }
 
     logger.debug(muon_cuts)
 

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -45,21 +45,8 @@ def calc_dist_and_ring_dist(x, y, ring_fit, parameter=0.4):
 
     return dist, ring_dist, dist_mask
 
-def analyze_muon_event(event):
-    """
-    Generic muon event analyzer.
 
-    Parameters
-    ----------
-    event : ctapipe dl1 event container
-
-
-    Returns
-    -------
-    ring_fit, muonintensityparam : MuonRingParameter
-    and MuonIntensityParameter container event
-
-    """
+def generate_muon_cuts_by_telescope_name():
     names = ['LST_LST_LSTCam', 'MST_MST_NectarCam', 'MST_MST_FlashCam', 'MST_SCT_SCTCam',
              'SST_1M_DigiCam', 'SST_GCT_CHEC', 'SST_ASTRI_ASTRICam', 'SST_ASTRI_CHEC']
     tail_cuts = [(5, 7), (5, 7), (10, 12), (5, 7),
@@ -103,6 +90,26 @@ def analyze_muon_event(event):
             'picture_thresh': muon_cut['tail_cuts'][0],
             'boundary_thresh': muon_cut['tail_cuts'][1],
         }
+
+    return muon_cuts_by_name
+
+
+def analyze_muon_event(event):
+    """
+    Generic muon event analyzer.
+
+    Parameters
+    ----------
+    event : ctapipe dl1 event container
+
+
+    Returns
+    -------
+    ring_fit, muonintensityparam : MuonRingParameter
+    and MuonIntensityParameter container event
+
+    """
+    muon_cuts_by_name = generate_muon_cuts_by_telescope_name()
 
     logger.debug(muon_cuts)
 

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -130,16 +130,20 @@ def analyze_muon_event(event):
 
         muonringparam = muon_ring_fit(x, y, image, clean_mask)
 
-        dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2)
-                       + np.power(y - muonringparam.ring_center_y, 2))
+        dist = np.sqrt(
+            np.power(x - muonringparam.ring_center_x, 2) +
+            np.power(y - muonringparam.ring_center_y, 2)
+        )
         ring_dist = np.abs(dist - muonringparam.ring_radius)
 
         muonringparam = muon_ring_fit(
             x, y, img, (ring_dist < muonringparam.ring_radius * 0.4)
         )
 
-        dist = np.sqrt(np.power(x - muonringparam.ring_center_x, 2) +
-                       np.power(y - muonringparam.ring_center_y, 2))
+        dist = np.sqrt(
+            np.power(x - muonringparam.ring_center_x, 2) +
+            np.power(y - muonringparam.ring_center_y, 2)
+        )
         ring_dist = np.abs(dist - muonringparam.ring_radius)
 
         muonringparam = muon_ring_fit(
@@ -149,11 +153,15 @@ def analyze_muon_event(event):
         muonringparam.tel_id = telid
         muonringparam.obs_id = event.dl0.obs_id
         muonringparam.event_id = event.dl0.event_id
-        dist_mask = np.abs(dist - muonringparam.
-                           ring_radius) < muonringparam.ring_radius * 0.4
+        dist_mask = (
+            np.abs(dist - muonringparam.ring_radius)
+            < muonringparam.ring_radius * 0.4
+        )
         pix_im = image * dist_mask
-        nom_dist = np.sqrt(np.power(muonringparam.ring_center_x,
-                                    2) + np.power(muonringparam.ring_center_y, 2))
+        nom_dist = np.sqrt(
+            np.power(muonringparam.ring_center_x, 2) +
+            np.power(muonringparam.ring_center_y, 2)
+        )
 
         minpix = muon_cut['min_pix']
 

--- a/ctapipe/image/muon/muon_reco_functions.py
+++ b/ctapipe/image/muon/muon_reco_functions.py
@@ -14,7 +14,7 @@ from ctapipe.image.muon.features import ring_completeness
 from ctapipe.image.muon.features import npix_above_threshold
 from ctapipe.image.muon.features import npix_composing_ring
 from ctapipe.image.muon.muon_integrator import MuonLineIntegrate
-from ctapipe.image.muon.muon_ring_finder import ChaudhuriKunduRingFitter
+from ctapipe.image.muon.muon_ring_finder import MuonRingFitter
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ def analyze_muon_event(event):
         else:
             img = image
 
-        muonring = ChaudhuriKunduRingFitter(None)
+        muonring = MuonRingFitter(teldes = None, fit_method="chaudhuri_kundu")
 
         logger.debug("img: %s mask: %s, x=%s y= %s", np.sum(image),
                      np.sum(clean_mask), x, y)

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -2,16 +2,10 @@ import numpy as np
 import astropy.units as u
 from ctapipe.core import Component
 from ctapipe.io.containers import MuonRingParameter
-from .fitting import kundu_chaudhuri_circle_fit
+from .fitting import kundu_chaudhuri_circle_fit, taubin_circle_fit
 import traitlets as traits
-from iminuit import Minuit
 
-__all__ = ['MuonRingFitter', 'muon_ring_fit']
-
-def muon_ring_fit(fit_method, *args, **kwargs):
-    fitter = MuonRingFitter(fit_method)
-    fit_result = fitter(*args, **kwargs)
-    return fit_result
+__all__ = ['MuonRingFitter']
 
 class MuonRingFitter(Component):
     """Different ring fit algorithms for muon rings
@@ -24,129 +18,31 @@ class MuonRingFitter(Component):
     def __init__(self, config=None, parent=None, **kwargs):
         super().__init__(config, parent, **kwargs)
 
-        self.fit_map = {
-            'taubin': taubin_fit,
-            'chaudhuri_kundu': chaudhuri_kundu_fit
-        }
 
     def __call__(self, geom, img, mask):
         """allows any fit to be called in form of
             MuonRingFitter(fit_method = "name of the fit")
         """
-        output = self.fit_map[self.fit_method](geom, img, mask)
+        x = geom.pix_x
+        y = geom.pix_y
+
+        if self.fit_method == 'taubin':
+            radius, center_x, center_y = taubin_circle_fit(x, y, mask)
+        else:
+            radius, center_x, center_y = kundu_chaudhuri_circle_fit(x, y, img * mask)
+
+        output = fill_output_container(radius, center_x, center_y)
+        output.ring_fit_method = self.fit_method
 
         return output
 
 
-def chaudhuri_kundu_fit(geom, weight, mask, times=None):
-    """Fast and reliable analytical circle fitting method previously used
-    in the H.E.S.S.  experiment for muon identification
-
-    Implementation based on [chaudhuri93]_
-    """
-    x = geom.pix_x
-    y = geom.pix_y
-    original_unit = x.unit
-
-    x = x.to_value(original_unit)
-    y = y.to_value(original_unit)
-    weight = weight * mask
-
-    radius, center_x, center_y = kundu_chaudhuri_circle_fit(x, y, weight)
-
+def fill_output_container(radius, center_x, center_y):
     output = MuonRingParameter()
-    output.ring_center_x = center_x  * original_unit
-    output.ring_center_y = center_y  * original_unit
-    output.ring_radius = radius  * original_unit
-    output.ring_phi = np.arctan(center_y / center_x)
+    output.ring_center_x = center_x
+    output.ring_center_y = center_y
+    output.ring_radius = radius
+    output.ring_phi = np.arctan2(center_y, center_x)
     output.ring_inclination = np.sqrt(center_x ** 2. + center_y ** 2.)
-    output.ring_fit_method = "ChaudhuriKundu"
 
     return output
-
-
-def taubin_fit(geom, weight, mask, times=None):
-    """
-    Parameters
-    ----------
-    x: array in u.m
-        X position of pixel surviving the cleaning
-
-    y: array in u.m
-        Y position of pixel surviving the cleaning
-
-    Returns : MuonRingParameter
-    -------
-    """
-
-    """ initialization for taubin_fit with the
-    initial default values, errors, and limits
-    """
-    x = geom.pix_x
-    y = geom.pix_y
-    orinal_unit = x.unit
-
-    x_min_in_m = x.min().to_value(orinal_unit)
-    x_max_in_m = x.max().to_value(orinal_unit)
-    y_min_in_m = y.min().to_value(orinal_unit)
-    y_max_in_m = y.max().to_value(orinal_unit)
-
-    x = x[mask]
-    y = y[mask]
-
-    taubin_r_initial = x_max_in_m / 2
-    taubin_error = taubin_r_initial * 0.1
-    xc = 0
-    yc = 0
-
-    # minimization method
-    fit = Minuit(
-        make_taubin_loss_function(
-            x.to_value(orinal_unit),
-            y.to_value(orinal_unit)
-        ),
-        xc=xc,
-        yc=yc,
-        r=taubin_r_initial,
-        error_xc=taubin_error,
-        error_yc=taubin_error,
-        error_r=taubin_error,
-        limit_xc=(x_min_in_m, x_max_in_m),
-        limit_yc=(y_min_in_m, y_max_in_m),
-        pedantic=False
-    )
-    fit.migrad()
-
-    output = MuonRingParameter()
-    output.ring_center_x = fit.values['xc'] * orinal_unit
-    output.ring_center_y = fit.values['yc'] * orinal_unit
-    output.ring_radius = fit.values['r'] * orinal_unit
-    output.ring_fit_method = "Taubin"
-
-    return output
-
-
-def make_taubin_loss_function(x, y):
-
-    def taubin_loss_function(xc, yc, r):
-        """taubin fit formula
-        reference : Barcelona_Muons_TPA_final.pdf (slide 6)
-        """
-        upper_term = (
-            (
-                (x - xc) ** 2 +
-                (y - yc) ** 2
-                - r ** 2
-            ) ** 2
-        ).sum()
-
-        lower_term = (
-            (
-                (x - xc) ** 2 +
-                (y - yc) ** 2
-            )
-        ).sum()
-
-        return np.abs(upper_term) / np.abs(lower_term)
-
-    return taubin_loss_function

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -89,7 +89,6 @@ class MuonRingFitter(Component):
         r: radius of fitted ring
        """
         init_params, init_errs, init_limits = self.initialization()
-        print("initparams", init_params, init_errs, init_limits)
         # minimization method
         m = Minuit(self.fitFormula,
                    **init_params,

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -15,171 +15,169 @@ class MuonRingFitter(Component):
         default_value='chaudhuri_kundu'
     ).tag(config=True)
 
-    def __init__(self, teldes, config=None, parent=None, **kwargs):
+    def __init__(self, geom=None, config=None, parent=None, **kwargs):
         """
-        teldes: telescope description
-                in form of event.inst.subarray.tel[telid]
+        geom: CameraGeometry
+            in form of event.inst.subarray.tel[telid].camera
         """
         super().__init__(config, parent, **kwargs)
-        self.teldes = teldes
 
-    def fitFormula(self, xc, yc, r):
-        """taubin fit formula
-        reference : Barcelona_Muons_TPA_final.pdf (slide 6)
-        """
-        upper_term = (
-            (
-                    (np.array(self.x) - xc) ** 2 +
-                    (np.array(self.y) - yc) ** 2
-                    - r ** 2
-            ) ** 2
-        ).sum()
-
-        lower_term = (
-            (
-                    (np.array(self.x) - xc) ** 2 +
-                    (np.array(self.y) - yc) ** 2
-            )
-        ).sum()
-
-        return np.abs(upper_term) / np.abs(lower_term)
-
-    def initialization(self):
-        """ initialization for taubin_fit with the
-        initial default values, errors, and limits
-        """
-        focal_length = self.teldes.optics.equivalent_focal_length.to_value(u.m)
-        taubin_r_initial = 0.5 / focal_length
-        taubin_error = 0.1 / focal_length
-        taubin_limit = (-(1 / focal_length), 1 / focal_length)
-        xc = 0
-        yc = 0
-        init_params = {
-            'xc': xc,
-            'yc': yc,
-            'r': taubin_r_initial,
+        self.fit_map = {
+            'taubin': self.taubin_fit,
+            'chaudhuri_kundu': chaudhuri_kundu_fit
         }
 
-        init_errs = {
-            'error_xc': taubin_error,
-            'error_yc': taubin_error,
-            'error_r': taubin_error,
-        }
-
-        init_limits = {
-            'limit_xc': taubin_limit,
-            'limit_yc': taubin_limit,
-        }
-        return init_params, init_errs, init_limits
+        self.geom = geom
 
     def taubin_fit(self, x, y, weight=None, times=None):
         """
         Parameters
         ----------
-        px: array
-            X position of pixel
+        x: array in u.m
+            X position of pixel surviving the cleaning
 
-        py: array
-            Y position of pixel
+        y: array in u.m
+            Y position of pixel surviving the cleaning
 
-        Returns
+        Returns : MuonRingParameter
         -------
-        xc: x coordinate of fitted ring center
-        yc: y coordinate of fitted ring center
-        r: radius of fitted ring
-       """
-        init_params, init_errs, init_limits = self.initialization()
+        """
+
+        """ initialization for taubin_fit with the
+        initial default values, errors, and limits
+        """
+        x_min_in_m = self.geom.pix_x.min().to_value(u.m)
+        x_max_in_m = self.geom.pix_x.max().to_value(u.m)
+        y_min_in_m = self.geom.pix_y.min().to_value(u.m)
+        y_max_in_m = self.geom.pix_y.max().to_value(u.m)
+
+        taubin_r_initial = x_max_in_m / 2
+        taubin_error = taubin_r_initial * 0.1
+        xc = 0
+        yc = 0
+
         # minimization method
-        m = Minuit(self.fitFormula,
-                   **init_params,
-                   **init_errs,
-                   **init_limits,
-                   pedantic=False)
-        m.migrad()
-        # calculate xc, yc, r
-        fitparams = m.values
-        xc_fit = fitparams['xc']
-        yc_fit = fitparams['yc']
-        r_fit = fitparams['r']
+        fit = Minuit(
+            make_taubin_loss_function(x, y),
+            xc=xc,
+            yc=yc,
+            r=taubin_r_initial,
+            error_xc=taubin_error,
+            error_yc=taubin_error,
+            error_r=taubin_error,
+            limit_xc=(x_min_in_m, x_max_in_m),
+            limit_yc=(y_min_in_m, y_max_in_m),
+            pedantic=False
+        )
+        fit.migrad()
 
         output = MuonRingParameter()
-        output.ring_center_x = xc_fit
-        output.ring_center_y = yc_fit
-        output.ring_radius = r_fit
+        output.ring_center_x = fit.values['xc'] * u.m
+        output.ring_center_y = fit.values['yc'] * u.m
+        output.ring_radius = fit.values['r'] * u.m
         output.ring_fit_method = "Taubin"
 
         return output
 
-    def chaudhuri_kundu_fit(self, x, y, weight, times=None):
-        """Fast and reliable analytical circle fitting method previously used
-        in the H.E.S.S.  experiment for muon identification
 
-        Implementation based on [chaudhuri93]_
-
-        Parameters
-        ----------
-        x: ndarray
-            X position of pixel
-        y: ndarray
-            Y position of pixel
-        weight: ndarray
-            weighting of pixel in fit
-
-        Returns
-        -------
-        X position, Y position, radius, orientation and inclination of circle
-        """
-        # First calculate the weighted average positions of the pixels
-        sum_weight = np.sum(weight)
-        av_weighted_pos_x = np.sum(x * weight) / sum_weight
-        av_weighted_pos_y = np.sum(y * weight) / sum_weight
-
-        # The following notation is a bit ugly but directly references the paper notation
-        factor = x ** 2 + y ** 2
-
-        a = np.sum(weight * (x - av_weighted_pos_x) * x)
-        a_prime = np.sum(weight * (y - av_weighted_pos_y) * x)
-
-        b = np.sum(weight * (x - av_weighted_pos_x) * y)
-        b_prime = np.sum(weight * (y - av_weighted_pos_y) * y)
-
-        c = np.sum(weight * (x - av_weighted_pos_x) * factor) * 0.5
-        c_prime = np.sum(weight * (y - av_weighted_pos_y) * factor) * 0.5
-
-        nom_0 = ((a * b_prime) - (a_prime * b))
-        nom_1 = ((a_prime * b) - (a * b_prime))
-
-        # Calculate circle centre and radius
-        centre_x = ((b_prime * c) - (b * c_prime)) / nom_0
-        centre_y = ((a_prime * c) - (a * c_prime)) / nom_1
-
-        radius = np.sqrt(
-            # np.sum(weight * ((x - centre_x*u.deg)**2 +
-            # (y - centre_y*u.deg)**2)) / # centre * u.deg ???
-            np.sum(weight * ((x - centre_x) ** 2 + (y - centre_y) ** 2)) /
-            sum_weight
-        )
-
-        output = MuonRingParameter()
-        output.ring_center_x = centre_x  # *u.deg
-        output.ring_center_y = centre_y  # *u.deg
-        output.ring_radius = radius  # *u.deg
-        output.ring_phi = np.arctan(centre_y / centre_x)
-        output.ring_inclination = np.sqrt(centre_x ** 2. + centre_y ** 2.)
-        # output.meta.ring_fit_method = "ChaudhuriKundu"
-        output.ring_fit_method = "ChaudhuriKundu"
-
-        return output
 
     def fit(self, x, y, img):
         """allows any fit to be called in form of
             MuonRingFitter(fit_method = "name of the fit")
         """
-        self.x = x
-        self.y = y
-        fit_map = {'taubin': self.taubin_fit,
-                   'chaudhuri_kundu': self.chaudhuri_kundu_fit
-                   }
-        output = fit_map[self.fit_method](x, y, img)
+        output = self.fit_map[self.fit_method](x, y, img)
 
         return output
+
+
+
+def chaudhuri_kundu_fit(x, y, weight, times=None):
+    """Fast and reliable analytical circle fitting method previously used
+    in the H.E.S.S.  experiment for muon identification
+
+    Implementation based on [chaudhuri93]_
+
+    Parameters
+    ----------
+    x: ndarray
+        X position of pixel
+    y: ndarray
+        Y position of pixel
+    weight: ndarray
+        weighting of pixel in fit
+
+    Returns
+    -------
+    X position, Y position, radius, orientation and inclination of circle
+    """
+    # First calculate the weighted average positions of the pixels
+    x = x.to_value(u.m)
+    y = y.to_value(u.m)
+
+    sum_weight = np.sum(weight)
+    av_weighted_pos_x = np.sum(x * weight) / sum_weight
+    av_weighted_pos_y = np.sum(y * weight) / sum_weight
+
+    # The following notation is a bit ugly but directly references the paper notation
+    factor = x ** 2 + y ** 2
+
+    a = np.sum(weight * (x - av_weighted_pos_x) * x)
+    a_prime = np.sum(weight * (y - av_weighted_pos_y) * x)
+
+    b = np.sum(weight * (x - av_weighted_pos_x) * y)
+    b_prime = np.sum(weight * (y - av_weighted_pos_y) * y)
+
+    c = np.sum(weight * (x - av_weighted_pos_x) * factor) * 0.5
+    c_prime = np.sum(weight * (y - av_weighted_pos_y) * factor) * 0.5
+
+    nom_0 = ((a * b_prime) - (a_prime * b))
+    nom_1 = ((a_prime * b) - (a * b_prime))
+
+    # Calculate circle centre and radius
+    centre_x = ((b_prime * c) - (b * c_prime)) / nom_0
+    centre_y = ((a_prime * c) - (a * c_prime)) / nom_1
+
+    radius = np.sqrt(
+        # np.sum(weight * ((x - centre_x*u.deg)**2 +
+        # (y - centre_y*u.deg)**2)) / # centre * u.deg ???
+        np.sum(weight * ((x - centre_x) ** 2 + (y - centre_y) ** 2)) /
+        sum_weight
+    )
+
+    output = MuonRingParameter()
+    output.ring_center_x = centre_x  * u.m
+    output.ring_center_y = centre_y  * u.m
+    output.ring_radius = radius  * u.m
+    output.ring_phi = np.arctan(centre_y / centre_x)
+    output.ring_inclination = np.sqrt(centre_x ** 2. + centre_y ** 2.)
+    output.ring_fit_method = "ChaudhuriKundu"
+
+    return output
+
+
+def make_taubin_loss_function(x, y):
+    x_in_m = x.to_value(u.m)
+    y_in_m = y.to_value(u.m)
+
+    def taubin_loss_function(self, xc, yc, r):
+        """taubin fit formula
+        reference : Barcelona_Muons_TPA_final.pdf (slide 6)
+        """
+        upper_term = (
+            (
+                (x_in_m - xc) ** 2 +
+                (y_in_m - yc) ** 2
+                - r ** 2
+            ) ** 2
+        ).sum()
+
+        lower_term = (
+            (
+                (x_in_m - xc) ** 2 +
+                (y_in_m - yc) ** 2
+            )
+        ).sum()
+
+        return np.abs(upper_term) / np.abs(lower_term)
+
+    return taubin_loss_function

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -103,9 +103,9 @@ class MuonRingFitter(Component):
         r_fit = fitparams['r']
 
         output = MuonRingParameter()
-        output.ring_center_x = xc_fit * u.rad
-        output.ring_center_y = yc_fit * u.rad
-        output.ring_radius = r_fit * u.rad
+        output.ring_center_x = xc_fit
+        output.ring_center_y = yc_fit
+        output.ring_radius = r_fit
         output.ring_fit_method = "Taubin"
 
         return output

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -1,16 +1,126 @@
 import numpy as np
 import astropy.units as u
-from ctapipe.image.muon.ring_fitter import RingFitter
+from ctapipe.core import Component
 from ctapipe.io.containers import MuonRingParameter
+import traitlets as traits
 from iminuit import Minuit
 
-__all__ = ['ChaudhuriKunduRingFitter']
+__all__ = ['MuonRingFitter']
 
 
-class ChaudhuriKunduRingFitter(RingFitter):
+class MuonRingFitter(Component):
+    """Different ring fit algorithms for muon rings
+    """
+    fit_method = traits.CaselessStrEnum(
+        ['taubin', 'chaudhuri_kundu'],
+        default_value='chaudhuri_kundu'
+    ).tag(config=True)
 
-    @u.quantity_input
-    def fit(self, x: u.deg, y: u.deg, weight, times=None):
+    tel_type = traits.CaselessStrEnum(
+        ['LST_LST_LSTCam', 'MST_MST_NectarCam', 'MST_MST_FlashCam', 'MST_SCT_SCTCam',
+         'SST_1M_DigiCam', 'SST_GCT_CHEC', 'SST_ASTRI_ASTRICam', 'SST_ASTRI_CHEC'],
+        default_value='LST_LST_LSTCam'
+    ).tag(config=True)
+
+    def __init__(self, config=None, parent=None, **kwargs):
+        super().__init__(config, parent, **kwargs)
+
+    def fitFormula(self, xc, yc, r):
+        '''taubin fit formula
+        reference : Barcelona_Muons_TPA_final.pdf (slide 6)
+        '''
+        upper_term = sum(
+            (
+                    (np.array(self.x) - xc) ** 2 +
+                    (np.array(self.y) - yc) ** 2
+                    - r ** 2
+            ) ** 2
+        )
+        lower_term = sum(
+            (
+                    (np.array(self.x) - xc) ** 2 +
+                    (np.array(self.y) - yc) ** 2
+            )
+        )
+
+        return np.abs(upper_term) / np.abs(lower_term)
+
+    def initialization(self):
+        """ initialization for taubin_fit with the
+        initial default values, errors, and limits
+        """
+        names = ['LST_LST_LSTCam', 'MST_MST_NectarCam', 'MST_MST_FlashCam', 'MST_SCT_SCTCam',
+                 'SST_1M_DigiCam', 'SST_GCT_CHEC', 'SST_ASTRI_ASTRICam', 'SST_ASTRI_CHEC']
+        taubin_r_initial = [0.02, 0.03, 0.03, 0.03, 0.03, 0.02, 0.04, 0.02]
+        taubin_error = [0.003, 0.005, 0.005, 0.005, 0.006, 0.004, 0.007, 0.004]
+        taubin_limit = [(-0.0365, 0.0365), (-0.0640, 0.0640), (-0.0625, 0.0625), (-0.0646, 0.0646),
+                        (-0.0719, 0.0719), (-0.0462, 0.0462), (-0.0848, 0.0848)]
+        taubin_params = {'Name': names, 'rInitial': taubin_r_initial,
+                         'error': taubin_error, 'limit': taubin_limit}
+        taubin_dictIndex = taubin_params['Name'].index(self.tel_type)
+        radius = taubin_params['rInitial'][taubin_dictIndex]
+        error = taubin_params['error'][taubin_dictIndex]
+        limit = taubin_params['limit'][taubin_dictIndex]
+        xc = 0
+        yc = 0
+        init_params = {
+            'xc': xc,
+            'yc': yc,
+            'r': radius,
+        }
+
+        init_errs = {
+            'error_xc': error,
+            'error_yc': error,
+            'error_r': error,
+        }
+
+        init_limits = {
+            'limit_xc': limit,
+            'limit_yc': limit,
+        }
+        return init_params, init_errs, init_limits
+
+    def taubin_fit(self, x, y, weight=None, times=None):
+        '''
+        Parameters
+        ----------
+        px: array
+            X position of pixel
+
+        py: array
+            Y position of pixel
+
+        Returns
+        -------
+        xc: x coordinate of fitted ring center
+        yc: y coordinate of fitted ring center
+        r: radius of fitted ring
+       '''
+        init_params, init_errs, init_limits = self.initialization()
+        print("initparams", init_params, init_errs, init_limits)
+        # minimization method
+        m = Minuit(self.fitFormula,
+                   **init_params,
+                   **init_errs,
+                   **init_limits,
+                   pedantic=False)
+        m.migrad()
+        # calculate xc, yc, r
+        fitparams = m.values
+        xc_fit = fitparams['xc']
+        yc_fit = fitparams['yc']
+        r_fit = fitparams['r']
+
+        output = MuonRingParameter()
+        output.ring_center_x = xc_fit * u.rad
+        output.ring_center_y = yc_fit * u.rad
+        output.ring_radius = r_fit * u.rad
+        output.ring_fit_method = "Taubin"
+
+        return output
+
+    def chaudhuri_kundu_fit(self, x, y, weight, times=None):
         """Fast and reliable analytical circle fitting method previously used
         in the H.E.S.S.  experiment for muon identification
 
@@ -35,7 +145,7 @@ class ChaudhuriKunduRingFitter(RingFitter):
         av_weighted_pos_y = np.sum(y * weight) / sum_weight
 
         # The following notation is a bit ugly but directly references the paper notation
-        factor = x**2 + y**2
+        factor = x ** 2 + y ** 2
 
         a = np.sum(weight * (x - av_weighted_pos_x) * x)
         a_prime = np.sum(weight * (y - av_weighted_pos_y) * x)
@@ -56,7 +166,7 @@ class ChaudhuriKunduRingFitter(RingFitter):
         radius = np.sqrt(
             # np.sum(weight * ((x - centre_x*u.deg)**2 +
             # (y - centre_y*u.deg)**2)) / # centre * u.deg ???
-            np.sum(weight * ((x - centre_x)**2 + (y - centre_y)**2)) /
+            np.sum(weight * ((x - centre_x) ** 2 + (y - centre_y) ** 2)) /
             sum_weight
         )
 
@@ -71,87 +181,15 @@ class ChaudhuriKunduRingFitter(RingFitter):
 
         return output
 
-
-class TaubinFitter():
-    """
-        Parameters
-        ----------
-        xi_list: array
-           vector of pixel x-coordinates
-        yi_list: array
-           vector of pixel y-coordinates
-
-        Returns
-        -------
-       xc: x coordinate of fitted ring center
-       yc: y coordinate of fitted ring center
-       r: radius of fitted ring
-    """
-
-    @classmethod
-    def fit(
-        self,
-        pixx,
-        pixy,
-        radius,
-        error,
-        limit,
-        xc=0,
-        yc=0,
-    ):
-        init_params = {
-            'xc': xc,
-            'yc': yc,
-            'r': radius,
-        }
-
-        init_errs = {
-            'error_xc': error,
-            'error_yc': error,
-            'error_r': error,
-        }
-
-        init_limits = {
-            'limit_xc': limit,
-            'limit_yc': limit,
-        }
-
-
-        def fitFormula(xc, yc, r):
-            # taubin fit formula
-            upper_term = sum(
-                (
-                    (np.array(pixx) - xc) ** 2 +
-                    (np.array(pixy) - yc) ** 2
-                    - r ** 2
-                ) ** 2
-            )
-            lower_term = sum(
-                (
-                    (np.array(pixx) - xc) ** 2 +
-                    (np.array(pixy) - yc) ** 2
-                )
-            )
-
-            return np.abs(upper_term) / np.abs(lower_term)
-
-        # minimization method
-        m = Minuit(fitFormula,
-                   **init_params,
-                   **init_errs,
-                   **init_limits,
-                   pedantic=False)
-        m.migrad()
-        # calculate xc, yc, r
-        fitparams = m.values
-        xc_fit = fitparams['xc']
-        yc_fit = fitparams['yc']
-        r_fit = fitparams['r']
-
-        output = MuonRingParameter()
-        output.ring_center_x = xc_fit  # *u.deg
-        output.ring_center_y = yc_fit  # *u.deg
-        output.ring_radius = r_fit  # *u.deg
-        output.ring_fit_method = "Taubin"
+    def fit(self, x, y, img):
+        """allows any fit to be called in form of
+            MuonRingFitter(fit_method = "name of the fit")
+        """
+        self.x = x
+        self.y = y
+        fit_map = {'taubin': self.taubin_fit,
+                   'chaudhuri_kundu': self.chaudhuri_kundu_fit
+                   }
+        output = fit_map[self.fit_method](x, y, img)
 
         return output

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -2,6 +2,7 @@ import numpy as np
 import astropy.units as u
 from ctapipe.core import Component
 from ctapipe.io.containers import MuonRingParameter
+from .fitting import kundu_chaudhuri_circle_fit
 import traitlets as traits
 from iminuit import Minuit
 
@@ -42,66 +43,23 @@ def chaudhuri_kundu_fit(geom, weight, mask, times=None):
     in the H.E.S.S.  experiment for muon identification
 
     Implementation based on [chaudhuri93]_
-
-    Parameters
-    ----------
-    x: ndarray
-        X position of pixel
-    y: ndarray
-        Y position of pixel
-    weight: ndarray
-        weighting of pixel in fit
-
-    Returns
-    -------
-    X position, Y position, radius, orientation and inclination of circle
     """
-    # First calculate the weighted average positions of the pixels
     x = geom.pix_x
     y = geom.pix_y
     original_unit = x.unit
 
     x = x.to_value(original_unit)
     y = y.to_value(original_unit)
-
     weight = weight * mask
 
-    sum_weight = np.sum(weight)
-    av_weighted_pos_x = np.sum(x * weight) / sum_weight
-    av_weighted_pos_y = np.sum(y * weight) / sum_weight
-
-    # The following notation is a bit ugly but directly references the paper notation
-    factor = x ** 2 + y ** 2
-
-    a = np.sum(weight * (x - av_weighted_pos_x) * x)
-    a_prime = np.sum(weight * (y - av_weighted_pos_y) * x)
-
-    b = np.sum(weight * (x - av_weighted_pos_x) * y)
-    b_prime = np.sum(weight * (y - av_weighted_pos_y) * y)
-
-    c = np.sum(weight * (x - av_weighted_pos_x) * factor) * 0.5
-    c_prime = np.sum(weight * (y - av_weighted_pos_y) * factor) * 0.5
-
-    nom_0 = ((a * b_prime) - (a_prime * b))
-    nom_1 = ((a_prime * b) - (a * b_prime))
-
-    # Calculate circle centre and radius
-    centre_x = ((b_prime * c) - (b * c_prime)) / nom_0
-    centre_y = ((a_prime * c) - (a * c_prime)) / nom_1
-
-    radius = np.sqrt(
-        # np.sum(weight * ((x - centre_x*u.deg)**2 +
-        # (y - centre_y*u.deg)**2)) / # centre * u.deg ???
-        np.sum(weight * ((x - centre_x) ** 2 + (y - centre_y) ** 2)) /
-        sum_weight
-    )
+    radius, center_x, center_y = kundu_chaudhuri_circle_fit(x, y, weight)
 
     output = MuonRingParameter()
-    output.ring_center_x = centre_x  * original_unit
-    output.ring_center_y = centre_y  * original_unit
+    output.ring_center_x = center_x  * original_unit
+    output.ring_center_y = center_y  * original_unit
     output.ring_radius = radius  * original_unit
-    output.ring_phi = np.arctan(centre_y / centre_x)
-    output.ring_inclination = np.sqrt(centre_x ** 2. + centre_y ** 2.)
+    output.ring_phi = np.arctan(center_y / center_x)
+    output.ring_inclination = np.sqrt(center_x ** 2. + center_y ** 2.)
     output.ring_fit_method = "ChaudhuriKundu"
 
     return output

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -48,7 +48,7 @@ class MuonRingFitter(Component):
         """ initialization for taubin_fit with the
         initial default values, errors, and limits
         """
-        focal_length = self.teldes.optics.equivalent_focal_length / u.m
+        focal_length = self.teldes.optics.equivalent_focal_length.to_value(u.m)
         taubin_r_initial = 0.5 / focal_length
         taubin_error = 0.1 / focal_length
         taubin_limit = (-(1 / focal_length), 1 / focal_length)

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -28,18 +28,12 @@ class MuonRingFitter(Component):
         else:
             radius, center_x, center_y = kundu_chaudhuri_circle_fit(x, y, img * mask)
 
-        output = fill_output_container(radius, center_x, center_y)
+        output = MuonRingParameter()
+        output.ring_center_x = center_x
+        output.ring_center_y = center_y
+        output.ring_radius = radius
+        output.ring_phi = np.arctan2(center_y, center_x)
+        output.ring_inclination = np.sqrt(center_x ** 2. + center_y ** 2.)
         output.ring_fit_method = self.fit_method
 
         return output
-
-
-def fill_output_container(radius, center_x, center_y):
-    output = MuonRingParameter()
-    output.ring_center_x = center_x
-    output.ring_center_y = center_y
-    output.ring_radius = radius
-    output.ring_phi = np.arctan2(center_y, center_x)
-    output.ring_inclination = np.sqrt(center_x ** 2. + center_y ** 2.)
-
-    return output

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -5,7 +5,12 @@ from ctapipe.io.containers import MuonRingParameter
 import traitlets as traits
 from iminuit import Minuit
 
-__all__ = ['MuonRingFitter']
+__all__ = ['MuonRingFitter', 'muon_ring_fit']
+
+def muon_ring_fit(fit_method, *args, **kwargs):
+    fitter = MuonRingFitter(fit_method)
+    fit_result = fitter(*args, **kwargs)
+    return fit_result
 
 class MuonRingFitter(Component):
     """Different ring fit algorithms for muon rings
@@ -15,83 +20,24 @@ class MuonRingFitter(Component):
         default_value='chaudhuri_kundu'
     ).tag(config=True)
 
-    def __init__(self, geom=None, config=None, parent=None, **kwargs):
-        """
-        geom: CameraGeometry
-            in form of event.inst.subarray.tel[telid].camera
-        """
+    def __init__(self, config=None, parent=None, **kwargs):
         super().__init__(config, parent, **kwargs)
 
         self.fit_map = {
-            'taubin': self.taubin_fit,
+            'taubin': taubin_fit,
             'chaudhuri_kundu': chaudhuri_kundu_fit
         }
 
-        self.geom = geom
-
-    def taubin_fit(self, x, y, weight=None, times=None):
-        """
-        Parameters
-        ----------
-        x: array in u.m
-            X position of pixel surviving the cleaning
-
-        y: array in u.m
-            Y position of pixel surviving the cleaning
-
-        Returns : MuonRingParameter
-        -------
-        """
-
-        """ initialization for taubin_fit with the
-        initial default values, errors, and limits
-        """
-        x_min_in_m = self.geom.pix_x.min().to_value(u.m)
-        x_max_in_m = self.geom.pix_x.max().to_value(u.m)
-        y_min_in_m = self.geom.pix_y.min().to_value(u.m)
-        y_max_in_m = self.geom.pix_y.max().to_value(u.m)
-
-        taubin_r_initial = x_max_in_m / 2
-        taubin_error = taubin_r_initial * 0.1
-        xc = 0
-        yc = 0
-
-        # minimization method
-        fit = Minuit(
-            make_taubin_loss_function(x, y),
-            xc=xc,
-            yc=yc,
-            r=taubin_r_initial,
-            error_xc=taubin_error,
-            error_yc=taubin_error,
-            error_r=taubin_error,
-            limit_xc=(x_min_in_m, x_max_in_m),
-            limit_yc=(y_min_in_m, y_max_in_m),
-            pedantic=False
-        )
-        fit.migrad()
-
-        output = MuonRingParameter()
-        output.ring_center_x = fit.values['xc'] * u.m
-        output.ring_center_y = fit.values['yc'] * u.m
-        output.ring_radius = fit.values['r'] * u.m
-        output.ring_fit_method = "Taubin"
-
-        return output
-
-
-
-    def fit(self, x, y, img):
+    def __call__(self, geom, img, mask):
         """allows any fit to be called in form of
             MuonRingFitter(fit_method = "name of the fit")
         """
-        output = self.fit_map[self.fit_method](x, y, img)
+        output = self.fit_map[self.fit_method](geom, img, mask)
 
         return output
 
 
-
-def chaudhuri_kundu_fit(x, y, weight, times=None):
+def chaudhuri_kundu_fit(geom, weight, mask, times=None):
     """Fast and reliable analytical circle fitting method previously used
     in the H.E.S.S.  experiment for muon identification
 
@@ -111,8 +57,14 @@ def chaudhuri_kundu_fit(x, y, weight, times=None):
     X position, Y position, radius, orientation and inclination of circle
     """
     # First calculate the weighted average positions of the pixels
-    x = x.to_value(u.m)
-    y = y.to_value(u.m)
+    x = geom.pix_x
+    y = geom.pix_y
+    original_unit = x.unit
+
+    x = x.to_value(original_unit)
+    y = y.to_value(original_unit)
+
+    weight = weight * mask
 
     sum_weight = np.sum(weight)
     av_weighted_pos_x = np.sum(x * weight) / sum_weight
@@ -145,9 +97,9 @@ def chaudhuri_kundu_fit(x, y, weight, times=None):
     )
 
     output = MuonRingParameter()
-    output.ring_center_x = centre_x  * u.m
-    output.ring_center_y = centre_y  * u.m
-    output.ring_radius = radius  * u.m
+    output.ring_center_x = centre_x  * original_unit
+    output.ring_center_y = centre_y  * original_unit
+    output.ring_radius = radius  * original_unit
     output.ring_phi = np.arctan(centre_y / centre_x)
     output.ring_inclination = np.sqrt(centre_x ** 2. + centre_y ** 2.)
     output.ring_fit_method = "ChaudhuriKundu"
@@ -155,26 +107,85 @@ def chaudhuri_kundu_fit(x, y, weight, times=None):
     return output
 
 
-def make_taubin_loss_function(x, y):
-    x_in_m = x.to_value(u.m)
-    y_in_m = y.to_value(u.m)
+def taubin_fit(geom, weight, mask, times=None):
+    """
+    Parameters
+    ----------
+    x: array in u.m
+        X position of pixel surviving the cleaning
 
-    def taubin_loss_function(self, xc, yc, r):
+    y: array in u.m
+        Y position of pixel surviving the cleaning
+
+    Returns : MuonRingParameter
+    -------
+    """
+
+    """ initialization for taubin_fit with the
+    initial default values, errors, and limits
+    """
+    x = geom.pix_x
+    y = geom.pix_y
+    orinal_unit = x.unit
+
+    x_min_in_m = x.min().to_value(orinal_unit)
+    x_max_in_m = x.max().to_value(orinal_unit)
+    y_min_in_m = y.min().to_value(orinal_unit)
+    y_max_in_m = y.max().to_value(orinal_unit)
+
+    x = x[mask]
+    y = y[mask]
+
+    taubin_r_initial = x_max_in_m / 2
+    taubin_error = taubin_r_initial * 0.1
+    xc = 0
+    yc = 0
+
+    # minimization method
+    fit = Minuit(
+        make_taubin_loss_function(
+            x.to_value(orinal_unit),
+            y.to_value(orinal_unit)
+        ),
+        xc=xc,
+        yc=yc,
+        r=taubin_r_initial,
+        error_xc=taubin_error,
+        error_yc=taubin_error,
+        error_r=taubin_error,
+        limit_xc=(x_min_in_m, x_max_in_m),
+        limit_yc=(y_min_in_m, y_max_in_m),
+        pedantic=False
+    )
+    fit.migrad()
+
+    output = MuonRingParameter()
+    output.ring_center_x = fit.values['xc'] * orinal_unit
+    output.ring_center_y = fit.values['yc'] * orinal_unit
+    output.ring_radius = fit.values['r'] * orinal_unit
+    output.ring_fit_method = "Taubin"
+
+    return output
+
+
+def make_taubin_loss_function(x, y):
+
+    def taubin_loss_function(xc, yc, r):
         """taubin fit formula
         reference : Barcelona_Muons_TPA_final.pdf (slide 6)
         """
         upper_term = (
             (
-                (x_in_m - xc) ** 2 +
-                (y_in_m - yc) ** 2
+                (x - xc) ** 2 +
+                (y - yc) ** 2
                 - r ** 2
             ) ** 2
         ).sum()
 
         lower_term = (
             (
-                (x_in_m - xc) ** 2 +
-                (y_in_m - yc) ** 2
+                (x - xc) ** 2 +
+                (y - yc) ** 2
             )
         ).sum()
 

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -19,13 +19,10 @@ class MuonRingFitter(Component):
         super().__init__(config, parent, **kwargs)
 
 
-    def __call__(self, geom, img, mask):
+    def __call__(self, x, y, img, mask):
         """allows any fit to be called in form of
             MuonRingFitter(fit_method = "name of the fit")
         """
-        x = geom.pix_x
-        y = geom.pix_y
-
         if self.fit_method == 'taubin':
             radius, center_x, center_y = taubin_circle_fit(x, y, mask)
         else:

--- a/ctapipe/image/muon/tests/test_muon_fitting.py
+++ b/ctapipe/image/muon/tests/test_muon_fitting.py
@@ -57,7 +57,12 @@ def test_taubin_with_units():
     center_ys = 0.6 * u.m
     ring_radius = 0.3 * u.m
     ring_width = 0.05 * u.m
-    muon_model = toymodel.RingGaussian(x=center_xs, y=center_ys, radius=ring_radius, sigma=ring_width)
+    muon_model = toymodel.RingGaussian(
+        x=center_xs,
+        y=center_ys,
+        radius=ring_radius,
+        sigma=ring_width,
+    )
 
     geom = CameraGeometry.from_name("FlashCam")
     flashcam_focal_length = u.Quantity(16, u.m)
@@ -68,8 +73,16 @@ def test_taubin_with_units():
     x = (geom.pix_x / flashcam_focal_length) * u.rad
     y = (geom.pix_y / flashcam_focal_length) * u.rad
 
-    taubinfit = TaubinFitter(pixx=x[mask], pixy=y[mask], radius=0.03, error=0.03, limit=(-0.0625, 0.0625))
-    xc_fit, yc_fit, r_fit = taubinfit.fit()
+    muon_ring_parameters = TaubinFitter.fit(
+        pixx=x[mask],
+        pixy=y[mask],
+        radius=0.03,
+        error=0.03,
+        limit=(-0.0625, 0.0625),
+    )
+    xc_fit = muon_ring_parameters.ring_center_x
+    yc_fit = muon_ring_parameters.ring_center_y
+    r_fit = muon_ring_parameters.ring_radius
 
     assert np.isclose(xc_fit * flashcam_focal_length / u.m, center_xs / u.m, 1e-1)
     assert np.isclose(xc_fit * flashcam_focal_length / u.m, center_xs / u.m, 1e-1)

--- a/ctapipe/image/muon/tests/test_muon_fitting.py
+++ b/ctapipe/image/muon/tests/test_muon_fitting.py
@@ -51,8 +51,10 @@ def test_kundu_chaudhuri_with_units():
 
 
 def test_taubin_with_units():
-    # flashCam example
-    # for this test, values are selectively chosen knowing that they converge
+    """
+    flashCam example
+    for this test, values are selectively chosen knowing that they converge
+    """
     center_xs = 0.3 * u.m
     center_ys = 0.6 * u.m
     ring_radius = 0.3 * u.m
@@ -66,7 +68,7 @@ def test_taubin_with_units():
 
     geom = CameraGeometry.from_name("FlashCam")
     flashcam_focal_length = u.Quantity(16, u.m)
-    image, sig, _ = muon_model.generate_image(
+    image, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )
     mask = tailcuts_clean(geom, image, 10, 12)

--- a/ctapipe/image/muon/tests/test_muon_fitting.py
+++ b/ctapipe/image/muon/tests/test_muon_fitting.py
@@ -1,10 +1,7 @@
 import numpy as np
 import astropy.units as u
-from ctapipe.image import toymodel,tailcuts_clean
-from ctapipe.instrument import CameraGeometry
 
 from ctapipe.image.muon import kundu_chaudhuri_circle_fit
-from ctapipe.image.muon.muon_ring_finder import TaubinFitter
 
 np.random.seed(0)
 
@@ -48,45 +45,3 @@ def test_kundu_chaudhuri_with_units():
     assert fit_x.unit == center_x.unit
     assert fit_y.unit == center_y.unit
     assert fit_radius.unit == radius.unit
-
-
-def test_taubin_with_units():
-    """
-    flashCam example
-    for this test, values are selectively chosen knowing that they converge
-    """
-    center_xs = 0.3 * u.m
-    center_ys = 0.6 * u.m
-    ring_radius = 0.3 * u.m
-    ring_width = 0.05 * u.m
-    muon_model = toymodel.RingGaussian(
-        x=center_xs,
-        y=center_ys,
-        radius=ring_radius,
-        sigma=ring_width,
-    )
-
-    geom = CameraGeometry.from_name("FlashCam")
-    flashcam_focal_length = u.Quantity(16, u.m)
-    image, _, _ = muon_model.generate_image(
-        geom, intensity=1000, nsb_level_pe=5,
-    )
-    mask = tailcuts_clean(geom, image, 10, 12)
-    x = (geom.pix_x / flashcam_focal_length) * u.rad
-    y = (geom.pix_y / flashcam_focal_length) * u.rad
-
-    muon_ring_parameters = TaubinFitter.fit(
-        pixx=x[mask],
-        pixy=y[mask],
-        radius=0.03,
-        error=0.03,
-        limit=(-0.0625, 0.0625),
-    )
-    xc_fit = muon_ring_parameters.ring_center_x
-    yc_fit = muon_ring_parameters.ring_center_y
-    r_fit = muon_ring_parameters.ring_radius
-
-    assert np.isclose(xc_fit * flashcam_focal_length / u.m, center_xs / u.m, 1e-1)
-    assert np.isclose(yc_fit * flashcam_focal_length / u.m, center_ys / u.m, 1e-1)
-    assert np.isclose(r_fit * flashcam_focal_length / u.m, ring_radius / u.m, 1e-1)
-

--- a/ctapipe/image/muon/tests/test_muon_reco.py
+++ b/ctapipe/image/muon/tests/test_muon_reco.py
@@ -1,8 +1,7 @@
-from ctapipe.calib import CameraCalibrator
-from ctapipe.image.muon import muon_reco_functions as muon
+from ctapipe.image.muon.muon_reco_functions import analyze_muon_event
 
 
-def test_basic_muon_reco(example_event):
+def test_analyze_muon_event(calibrated_event):
     """
     Really simplistic test: just run the analyze_muon_event code, to make
     sure it doesn't crash. The input event is so far not a muon, so no output
@@ -10,12 +9,6 @@ def test_basic_muon_reco(example_event):
 
     Parameters
     ----------
-    test_event - a sample event (fixture)
-
+    calibrated_event - a sample event (fixture)
     """
-
-    calib = CameraCalibrator()
-    calib(example_event)
-
-    muon_params = muon.analyze_muon_event(example_event)
-    assert muon_params is not None
+    muon_params = analyze_muon_event(calibrated_event)

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -6,7 +6,7 @@ from ctapipe.image.muon.muon_ring_finder import fill_output_container
 from ctapipe.image import tailcuts_clean, toymodel
 
 
-def test_chaudhuri_kundu_fitter():
+def test_MuonRingFitter():
     # flashCam example
     center_xs = 0.3 * u.m
     center_ys = 0.6 * u.m
@@ -27,45 +27,17 @@ def test_chaudhuri_kundu_fitter():
     )
     survivors = tailcuts_clean(geom, charge, 10, 12)
 
-    muonfit = MuonRingFitter(fit_method="chaudhuri_kundu")
-    fit_result = muonfit(geom, charge, survivors)
+    for method in ["chaudhuri_kundu", "taubin"]:
 
-    print(fit_result)
-    print(center_xs, center_ys, ring_radius)
+        muonfit = MuonRingFitter(fit_method=method)
+        fit_result = muonfit(geom, charge, survivors)
 
-    assert u.isclose(fit_result.ring_center_x, center_xs, 5e-2)
-    assert u.isclose(fit_result.ring_center_y, center_ys, 5e-2)
-    assert u.isclose(fit_result.ring_radius, ring_radius, 5e-2)
+        print(fit_result)
+        print(center_xs, center_ys, ring_radius)
 
-
-def test_taubin_fitter():
-    center_xs = 0.3 * u.m
-    center_ys = 0.6 * u.m
-    ring_radius = 0.3 * u.m
-    ring_width = 0.05 * u.m
-
-    muon_model = toymodel.RingGaussian(
-        x=center_xs,
-        y=center_ys,
-        radius=ring_radius,
-        sigma=ring_width,
-    )
-    # teldes needed for Taubin fit
-    geom = CameraGeometry.from_name("FlashCam")
-    charge, _, _ = muon_model.generate_image(
-        geom, intensity=1000, nsb_level_pe=5,
-    )
-    survivors = tailcuts_clean(geom, charge, 10, 12)
-
-    muonfit = MuonRingFitter(fit_method="taubin")
-    fit_result = muonfit(geom, charge, survivors)
-
-    print(fit_result)
-    print(center_xs, center_ys, ring_radius)
-
-    assert u.isclose(fit_result.ring_center_x, center_xs, 5e-2)
-    assert u.isclose(fit_result.ring_center_y, center_ys, 5e-2)
-    assert u.isclose(fit_result.ring_radius, ring_radius, 5e-2)
+        assert u.isclose(fit_result.ring_center_x, center_xs, 5e-2)
+        assert u.isclose(fit_result.ring_center_y, center_ys, 5e-2)
+        assert u.isclose(fit_result.ring_radius, ring_radius, 5e-2)
 
 
 def test_fill_output_container():
@@ -84,5 +56,4 @@ def test_fill_output_container():
 
 if __name__ == '__main__':
     test_fill_output_container()
-    test_chaudhuri_kundu_fitter()
-    test_taubin_fitter()
+    test_MuonRingFitter()

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -41,6 +41,7 @@ def test_MuonRingFitter():
 
 
 def test_fill_output_container():
+    '''test fill_output_container()'''
     radius = 0.3 * u.m
     center_x = 0.0 * u.m
     center_y = -0.25 * u.m

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -4,6 +4,11 @@ from ctapipe.image.muon import MuonRingFitter
 from ctapipe.image import tailcuts_clean, toymodel
 
 
+def my_tailcuts_clean(geom, charge, *args, **kwargs):
+    survivors = tailcuts_clean(geom, charge, *args, **kwargs)
+    return geom, charge, survivors
+
+
 def test_chaudhuri_kundu_fitter():
     # flashCam example
     center_xs = 0.3 * u.m
@@ -20,17 +25,13 @@ def test_chaudhuri_kundu_fitter():
 
     #testing with flashcam
     geom = CameraGeometry.from_name("FlashCam")
-    image, _, _ = muon_model.generate_image(
+    charge, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )
-    mask = tailcuts_clean(geom, image, 10, 12)
-    x = geom.pix_x
-    y = geom.pix_y
-    img = image * mask
+    cleaned_image = my_tailcuts_clean(geom, charge, 10, 12)
 
-    #call specific method with fit_method
     muonfit = MuonRingFitter(fit_method="chaudhuri_kundu")
-    fit_result = muonfit(x, y, img)
+    fit_result = muonfit(*cleaned_image)
 
     print(fit_result)
     print(center_xs, center_ys, ring_radius)
@@ -54,15 +55,14 @@ def test_taubin_fitter():
     )
     # teldes needed for Taubin fit
     geom = CameraGeometry.from_name("FlashCam")
-    image, _, _ = muon_model.generate_image(
+    charge, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )
-    mask = tailcuts_clean(geom, image, 10, 12)
-    x = geom.pix_x
-    y = geom.pix_y
+    cleaned_image = my_tailcuts_clean(geom, charge, 10, 12)
 
-    muonfit = MuonRingFitter(geom=geom, fit_method="taubin")
-    fit_result = muonfit(x[mask], y[mask], None)
+
+    muonfit = MuonRingFitter(fit_method="taubin")
+    fit_result = muonfit(*cleaned_image)
 
     print(fit_result)
     print(center_xs, center_ys, ring_radius)

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -41,5 +41,4 @@ def test_MuonRingFitter():
 
 
 if __name__ == '__main__':
-    test_fill_output_container()
     test_MuonRingFitter()

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -30,7 +30,7 @@ def test_MuonRingFitter():
     for method in ["chaudhuri_kundu", "taubin"]:
 
         muonfit = MuonRingFitter(fit_method=method)
-        fit_result = muonfit(geom, charge, survivors)
+        fit_result = muonfit(geom.pix_x, geom.pix_y, charge, survivors)
 
         print(fit_result)
         print(center_xs, center_ys, ring_radius)

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -1,4 +1,3 @@
-import numpy as np
 import astropy.units as u
 from ctapipe.instrument import CameraGeometry
 from ctapipe.image.muon import MuonRingFitter
@@ -17,7 +16,6 @@ def test_chaudhuri_kundu_fitter():
     )
     #testing with flashcam
     geom = CameraGeometry.from_name("FlashCam")
-    focal_length = u.Quantity(16, u.m)
     image, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -1,6 +1,6 @@
 import numpy as np
 import astropy.units as u
-from ctapipe.instrument import CameraGeometry, TelescopeDescription
+from ctapipe.instrument import CameraGeometry
 from ctapipe.image.muon import MuonRingFitter
 from ctapipe.image.muon.muon_ring_finder import fill_output_container
 from ctapipe.image import tailcuts_clean, toymodel

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -2,7 +2,6 @@ import numpy as np
 import astropy.units as u
 from ctapipe.instrument import CameraGeometry
 from ctapipe.image.muon import MuonRingFitter
-from ctapipe.image.muon.muon_ring_finder import fill_output_container
 from ctapipe.image import tailcuts_clean, toymodel
 
 

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -40,21 +40,6 @@ def test_MuonRingFitter():
         assert u.isclose(fit_result.ring_radius, ring_radius, 5e-2)
 
 
-def test_fill_output_container():
-    '''test fill_output_container()'''
-    radius = 0.3 * u.m
-    center_x = 0.0 * u.m
-    center_y = -0.25 * u.m
-
-    output = fill_output_container(radius, center_x, center_y)
-
-    assert output.ring_center_x == center_x
-    assert output.ring_center_y == center_y
-    assert output.ring_radius == radius
-    assert output.ring_phi == np.arctan2(center_y, center_x)
-    assert output.ring_inclination == np.sqrt(center_x ** 2. + center_y ** 2.)
-
-
 if __name__ == '__main__':
     test_fill_output_container()
     test_MuonRingFitter()

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -15,15 +15,15 @@ def test_chaudhuri_kundu_fitter():
         radius=ring_radius,
         sigma=ring_width,
     )
-
+    #testing with flashcam
     geom = CameraGeometry.from_name("FlashCam")
-    flashcam_focal_length = u.Quantity(16, u.m)
+    focal_length = u.Quantity(16, u.m)
     image, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )
     mask = tailcuts_clean(geom, image, 10, 12)
-    x = (geom.pix_x / flashcam_focal_length) * u.rad
-    y = (geom.pix_y / flashcam_focal_length) * u.rad
+    x = (geom.pix_x / focal_length) * u.rad
+    y = (geom.pix_y / focal_length) * u.rad
     img = image * mask
 
     #call specific method with fit_method, teldes needed for Taubin fit
@@ -33,9 +33,9 @@ def test_chaudhuri_kundu_fitter():
     yc_fit = muon_ring_parameters.ring_center_y
     r_fit = muon_ring_parameters.ring_radius
 
-    assert np.isclose(xc_fit * flashcam_focal_length / u.m / u.rad, center_xs / u.m, 1e-1)
-    assert np.isclose(yc_fit * flashcam_focal_length / u.m / u.rad, center_ys / u.m, 1e-1)
-    assert np.isclose(r_fit * flashcam_focal_length / u.m / u.rad, ring_radius / u.m, 1e-1)
+    assert u.isclose((xc_fit * focal_length).to_value(u.m*u.rad), center_xs.to_value(u.m), 1e-1)
+    assert u.isclose((yc_fit * focal_length).to_value(u.m*u.rad), center_ys.to_value(u.m), 1e-1)
+    assert u.isclose((r_fit * focal_length).to_value(u.m*u.rad), ring_radius.to_value(u.m), 1e-1)
 
 
 if __name__ == '__main__':

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -1,113 +1,42 @@
-from ctapipe.image.muon import muon_ring_finder
 import numpy as np
 import astropy.units as u
 from ctapipe.instrument import CameraGeometry
-from ctapipe.image import tailcuts_clean
-from ctapipe.image.toymodel import RingGaussian
+from ctapipe.image.muon import MuonRingFitter
+from ctapipe.image import tailcuts_clean, toymodel
 
-
-def test_ChaudhuriKunduRingFitter_old():
-
-    fitter = muon_ring_finder.ChaudhuriKunduRingFitter()
-
-    points = np.linspace(-100, 100, 200)
-
-    x, y = np.meshgrid(points, points) * u.deg
-    weight = np.zeros(x.shape)
-
-    c_x = 50 * u.deg
-    c_y = 20 * u.deg
-
-    r = np.sqrt((x - c_x)**2 + (y - c_y)**2)
-
-    min_r = 10 * u.deg
-    max_r = 20 * u.deg
-
-    weight[(r > min_r) & (r < max_r)] = 1
-    output = fitter.fit(x, y, weight)
-
-    lim_p = 0.05 * u.deg
-    lim_r = 1 * u.deg
-    rad_a = 0.5 * (max_r + min_r)
-
-    assert abs(output.ring_center_x - c_x) < lim_p
-    assert abs(output.ring_center_y - c_y) < lim_p
-    assert abs(output.ring_radius - rad_a) < lim_r
-
-
-def test_ChaudhuriKunduRingFitterHline():
-
-    fitter = muon_ring_finder.ChaudhuriKunduRingFitter()
-
-    x = np.linspace(20, 30, 10) * u.deg   # Make linear array in x
-    y = np.full_like(x, 15)               # Fill y array of same size with y
-    weight = np.ones(x.shape)           # Fill intensity array with value
-
-    output = fitter.fit(x, y, weight)
-
-    # TODO in muon_ring_fitter decide what to do if unreconstructable
-    # ... add Status Flag?
-    assert output.ring_radius is not np.NaN
-    assert output.ring_phi is not np.NaN
-    assert output.ring_inclination is not np.NaN
-
-
-def test_ChaudhuriKunduRingFitter():
-
-    geom = CameraGeometry.from_name('LSTCam')
-    focal_length = u.Quantity(28, u.m)
-
-    ring_radius = u.Quantity(0.4, u.m)  # make sure this is in camera coordinates
-    ring_width = u.Quantity(0.03, u.m)
-    center_x = u.Quantity(-0.2, u.m)
-    center_y = u.Quantity(-0.3, u.m)
-
-    muon_model = RingGaussian(
-        x=center_x, y=center_y,
-        sigma=ring_width, radius=ring_radius,
+def test_chaudhuri_kundu_fitter():
+    center_xs = 0.3 * u.m
+    center_ys = 0.6 * u.m
+    ring_radius = 0.3 * u.m
+    ring_width = 0.05 * u.m
+    muon_model = toymodel.RingGaussian(
+        x=center_xs,
+        y=center_ys,
+        radius=ring_radius,
+        sigma=ring_width,
     )
 
+    geom = CameraGeometry.from_name("FlashCam")
+    flashcam_focal_length = u.Quantity(16, u.m)
     image, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )
+    mask = tailcuts_clean(geom, image, 10, 12)
+    x = (geom.pix_x / flashcam_focal_length) * u.rad
+    y = (geom.pix_y / flashcam_focal_length) * u.rad
+    img = image * mask
 
-    clean_mask = tailcuts_clean(
-        geom, image, boundary_thresh=5, picture_thresh=10
-    )
+    #call specific method with fit_method, teldes needed for Taubin fit
+    muonfit = MuonRingFitter(teldes = None, fit_method="chaudhuri_kundu")
+    muon_ring_parameters = muonfit.fit(x, y, img)
+    xc_fit = muon_ring_parameters.ring_center_x
+    yc_fit = muon_ring_parameters.ring_center_y
+    r_fit = muon_ring_parameters.ring_radius
 
-    fitter = muon_ring_finder.ChaudhuriKunduRingFitter()
-
-    x = geom.pix_x / focal_length * u.rad
-    y = geom.pix_y / focal_length * u.rad
-
-    # fit 3 times, first iteration use cleaning, after that use
-    # distance to previous fit result
-    result = None
-    for _ in range(3):
-        if result is None:
-            mask = clean_mask
-        else:
-            dist = np.sqrt((x - result.ring_center_x)**2 + (y - result.ring_center_y)**2)
-            ring_dist = np.abs(dist - result.ring_radius)
-            mask = ring_dist < (result.ring_radius * 0.4)
-
-        result = fitter.fit(x[mask], y[mask], image[mask])
-
-    assert np.isclose(
-        result.ring_radius.to_value(u.rad), ring_radius / focal_length,
-        rtol=0.05,
-    )
-    assert np.isclose(
-        result.ring_center_x.to_value(u.rad), center_x / focal_length,
-        rtol=0.05
-    )
-    assert np.isclose(
-        result.ring_center_y.to_value(u.rad), center_y / focal_length,
-        rtol=0.05,
-    )
+    assert np.isclose(xc_fit * flashcam_focal_length / u.m / u.rad, center_xs / u.m, 1e-1)
+    assert np.isclose(yc_fit * flashcam_focal_length / u.m / u.rad, center_ys / u.m, 1e-1)
+    assert np.isclose(r_fit * flashcam_focal_length / u.m / u.rad, ring_radius / u.m, 1e-1)
 
 
 if __name__ == '__main__':
-    test_ChaudhuriKunduRingFitter_old()
-    test_ChaudhuriKunduRingFitterHline()
-    test_ChaudhuriKunduRingFitter()
+    test_chaudhuri_kundu_fitter()

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -22,8 +22,8 @@ def test_chaudhuri_kundu_fitter():
         geom, intensity=1000, nsb_level_pe=5,
     )
     mask = tailcuts_clean(geom, image, 10, 12)
-    x = (geom.pix_x / focal_length) * u.rad
-    y = (geom.pix_y / focal_length) * u.rad
+    x = geom.pix_x
+    y = geom.pix_y
     img = image * mask
 
     #call specific method with fit_method, teldes needed for Taubin fit
@@ -33,9 +33,9 @@ def test_chaudhuri_kundu_fitter():
     yc_fit = muon_ring_parameters.ring_center_y
     r_fit = muon_ring_parameters.ring_radius
 
-    assert u.isclose((xc_fit * focal_length).to_value(u.m*u.rad), center_xs.to_value(u.m), 1e-1)
-    assert u.isclose((yc_fit * focal_length).to_value(u.m*u.rad), center_ys.to_value(u.m), 1e-1)
-    assert u.isclose((r_fit * focal_length).to_value(u.m*u.rad), ring_radius.to_value(u.m), 1e-1)
+    assert u.isclose(xc_fit, center_xs, 1e-1)
+    assert u.isclose(yc_fit, center_ys, 1e-1)
+    assert u.isclose(r_fit, ring_radius, 1e-1)
 
 
 if __name__ == '__main__':

--- a/ctapipe/image/muon/tests/test_muon_ring_finder.py
+++ b/ctapipe/image/muon/tests/test_muon_ring_finder.py
@@ -1,30 +1,32 @@
 import astropy.units as u
-from ctapipe.instrument import CameraGeometry
+from ctapipe.instrument import CameraGeometry, TelescopeDescription
 from ctapipe.image.muon import MuonRingFitter
 from ctapipe.image import tailcuts_clean, toymodel
 
 def test_chaudhuri_kundu_fitter():
-    center_xs = 0.3 * u.m
-    center_ys = 0.6 * u.m
-    ring_radius = 0.3 * u.m
-    ring_width = 0.05 * u.m
+    # flashCam example
+    center_xs = 0.3
+    center_ys = 0.6
+    ring_radius = 0.3
+    ring_width = 0.05
     muon_model = toymodel.RingGaussian(
-        x=center_xs,
-        y=center_ys,
-        radius=ring_radius,
-        sigma=ring_width,
+        x=center_xs * u.m,
+        y=center_ys * u.m,
+        radius=ring_radius * u.m,
+        sigma=ring_width * u.m,
     )
+
     #testing with flashcam
     geom = CameraGeometry.from_name("FlashCam")
     image, _, _ = muon_model.generate_image(
         geom, intensity=1000, nsb_level_pe=5,
     )
     mask = tailcuts_clean(geom, image, 10, 12)
-    x = geom.pix_x
-    y = geom.pix_y
+    x = geom.pix_x.to_value(u.m)
+    y = geom.pix_y.to_value(u.m)
     img = image * mask
 
-    #call specific method with fit_method, teldes needed for Taubin fit
+    #call specific method with fit_method
     muonfit = MuonRingFitter(teldes = None, fit_method="chaudhuri_kundu")
     muon_ring_parameters = muonfit.fit(x, y, img)
     xc_fit = muon_ring_parameters.ring_center_x
@@ -36,5 +38,40 @@ def test_chaudhuri_kundu_fitter():
     assert u.isclose(r_fit, ring_radius, 1e-1)
 
 
+def test_taubin_fitter():
+    center_xs = 0.3
+    center_ys = 0.6
+    ring_radius = 0.3
+    ring_width = 0.05
+    muon_model = toymodel.RingGaussian(
+        x=center_xs* u.m,
+        y=center_ys* u.m,
+        radius=ring_radius* u.m,
+        sigma=ring_width* u.m,
+    )
+    geom = CameraGeometry.from_name("FlashCam")
+    # teldes needed for Taubin fit
+    teldes = TelescopeDescription.from_name('MST', 'FlashCam')
+    focal_length = teldes.optics.equivalent_focal_length.to_value(u.m)
+    image, _, _ = muon_model.generate_image(
+        geom, intensity=1000, nsb_level_pe=5,
+    )
+    mask = tailcuts_clean(geom, image, 10, 12)
+    x = geom.pix_x.to_value(u.m)/focal_length
+    y = geom.pix_y.to_value(u.m)/focal_length
+    img = image * mask
+
+    muonfit = MuonRingFitter(teldes=teldes, fit_method="taubin")
+    muon_ring_parameters = muonfit.fit(x[mask], y[mask], img)
+    xc_fit = muon_ring_parameters.ring_center_x * focal_length
+    yc_fit = muon_ring_parameters.ring_center_y * focal_length
+    r_fit = muon_ring_parameters.ring_radius * focal_length
+
+
+    assert u.isclose(xc_fit, center_xs, 1e-1)
+    assert u.isclose(yc_fit, center_ys, 1e-1)
+    assert u.isclose(r_fit, ring_radius, 1e-1)
+
 if __name__ == '__main__':
-    test_chaudhuri_kundu_fitter()
+    test_chaudhuri_kundu_fitter(),
+    test_taubin_fitter()

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -74,6 +74,10 @@ class OpticsDescription:
         """Make this hashable, so it can be used as dict keys or in sets"""
         return hash(self) == hash(other)
 
+    @parameter
+    def mirror_radius(self):
+        return np.sqrt(self.mirror_area.to("m2") / np.pi)
+
     @classmethod
     def from_name(cls, name, optics_table="optics"):
         """

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -74,7 +74,7 @@ class OpticsDescription:
         """Make this hashable, so it can be used as dict keys or in sets"""
         return hash(self) == hash(other)
 
-    @parameter
+    @property
     def mirror_radius(self):
         return np.sqrt(self.mirror_area.to("m2") / np.pi)
 

--- a/ctapipe/tools/muon_reconstruction.py
+++ b/ctapipe/tools/muon_reconstruction.py
@@ -72,19 +72,17 @@ class MuonDisplayerTool(Tool):
 
 
     def start(self):
-
-        numev = 0
         self.num_muons_found = defaultdict(int)
 
-        for event in tqdm(self.source, desc='detecting muons'):
+        for event_number, event in enumerate(tqdm(
+            self.source, desc='detecting muons'
+        )):
 
             self.calib(event)
             muon_evts = analyze_muon_event(event)
 
-            if numev == 0:
+            if event_number == 0:
                 _exclude_some_columns(event.inst.subarray, self.writer)
-
-            numev += 1
 
             if not muon_evts: # No telescopes contained a good muon
                 continue
@@ -107,7 +105,7 @@ class MuonDisplayerTool(Tool):
 
             self.log.info(
                 "Event Number: %d, found %s muons",
-                numev, dict(self.num_muons_found)
+                event_number, dict(self.num_muons_found)
             )
 
     def finish(self):


### PR DESCRIPTION
**do not waste your time reviewing yet**

(aaand ... I just see I based this on #1154, which I hope will be merged after only minor changes at some point)

I just opened this PR, so you know I am working on this. Comment if you want to stop me, in case you think this goes generally in the wrong direction. 

In case you wonder, I am in contact with @AMWMitchell about this.

---

So in this PR the ultimate goal is to give a Tool-user the possibility to configure [these constants in `analyze_muon_envent()](https://github.com/cta-observatory/ctapipe/blob/2805b0baee25dc0deccf1d68187695fef946c0a9/ctapipe/image/muon/muon_reco_functions.py#L38-L61).

In order to do this, I will have to touch:
 - [MuonDisplayerTool](https://github.com/cta-observatory/ctapipe/blob/master/ctapipe/tools/muon_reconstruction.py#L39)
 - [analyze_muon_event(event)](https://github.com/cta-observatory/ctapipe/blob/master/ctapipe/image/muon/muon_reco_functions.py#L22)
 - [plot_muon_event(event, muonparams)](https://github.com/cta-observatory/ctapipe/blob/2805b0baee25dc0deccf1d68187695fef946c0a9/ctapipe/image/muon/muon_diagnostic_plots.py#L92)

At the moment, all I am doing is refactoring and tidying up, there are hardly any tests which could ensure, that I am not breaking anything in the process, the MuonDisplayerTool fails when I try to use it with plots. Therefore my first attack vector is tidying up and understanding what is going on, and then getting the Tool running again.