### PR TITLE
configurable image cleaners

### DIFF
--- a/ctapipe/core/__init__.py
+++ b/ctapipe/core/__init__.py
@@ -3,20 +3,21 @@
 Core functionality of ctapipe
 """
 
-from .component import Component, non_abstract_children
+from .component import Component, TelescopeComponent, non_abstract_children
 from .container import Container, Field, DeprecatedField, Map
 from .provenance import Provenance, get_module_version
 from .tool import Tool, ToolConfigurationError
 
 __all__ = [
-    'Component',
-    'Container',
-    'Tool',
-    'Field',
-    'DeprecatedField',
-    'Map',
-    'Provenance',
-    'ToolConfigurationError',
-    'non_abstract_children',
-    'get_module_version',
+    "Component",
+    "TelescopeComponent",
+    "Container",
+    "Tool",
+    "Field",
+    "DeprecatedField",
+    "Map",
+    "Provenance",
+    "ToolConfigurationError",
+    "non_abstract_children",
+    "get_module_version",
 ]

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -366,11 +366,9 @@ def fact_image_cleaning(
 
 class ImageCleaner(TelescopeComponent):
     """
-     Abstract class for all configurable Image Cleaning algorithms.   Use
+    Abstract class for all configurable Image Cleaning algorithms.   Use
     `ImageCleaner.from_name()` to construct an instance of a particular algorithm
-
-     All subclasses should define __call__(tel__id, image, arrival_times)
-     """
+    """
 
     @abstractmethod
     def __call__(
@@ -432,6 +430,9 @@ class TailcutsImageCleaner(ImageCleaner):
 
 
 class MARSImageCleaner(TailcutsImageCleaner):
+    """
+    1st-pass MARS-like Image cleaner (See `ctapipe.image.mars_cleaning_1st_pass`)
+    """
     def __call__(
         self, tel_id: int, image: np.ndarray, arrival_times=None
     ) -> np.ndarray:

--- a/ctapipe/image/cleaning.py
+++ b/ctapipe/image/cleaning.py
@@ -374,7 +374,24 @@ class ImageCleaner(TelescopeComponent):
     def __call__(
         self, tel_id: int, image: np.ndarray, arrival_times: np.ndarray = None
     ) -> np.ndarray:
-        """ return a cleaned image """
+        """
+        Identify pixels with signal, and reject those with pure noise.
+
+        Parameters
+        ----------
+        tel_id: int
+            which telescope id in the subarray is being used (determines
+            which cut is used)
+        image : np.ndarray
+            image pixel data corresponding to the camera geometry
+        arrival_times: np.ndarray
+            image of arrival time (not used in this method)
+
+        Returns
+        -------
+        np.ndarray
+            boolean mask of pixels passing cleaning
+        """
         pass
 
 
@@ -399,24 +416,8 @@ class TailcutsImageCleaner(ImageCleaner):
     def __call__(
         self, tel_id: int, image: np.ndarray, arrival_times=None
     ) -> np.ndarray:
-        """ Apply image cleaning
-
-        Parameters
-        ----------
-        tel_id: int
-            which telescope id in the subarray is being used (determines
-            which cut is used)
-        image : np.ndarray
-            image pixel data corresponding to the camera geometry
-        subarray: ctapipe.image.SubarrayDescription
-            subarray definition (for mapping tel type to tel_id)
-        arrival_times: np.ndarray
-            image of arrival time (not used in this method)
-
-        Returns
-        -------
-        np.ndarray
-            boolean mask of pixels passing cleaning
+        """
+        Apply standard picture-boundary cleaning. See `ImageCleaner.__call__()`
         """
 
         return tailcuts_clean(
@@ -436,22 +437,8 @@ class MARSImageCleaner(TailcutsImageCleaner):
     def __call__(
         self, tel_id: int, image: np.ndarray, arrival_times=None
     ) -> np.ndarray:
-        """ Apply image cleaning
-
-        Parameters
-        ----------
-        tel_id: int
-            which telescope id in the subarray is being used (determines
-            which cut is used)
-        image : np.ndarray
-            image pixel data corresponding to the camera geometry
-        arrival_times: np.ndarray
-            image of arrival time (not used in this method)
-
-        Returns
-        -------
-        np.ndarray
-            boolean mask of pixels passing cleaning
+        """
+        Apply MARS-style image cleaning. See `ImageCleaner.__call__()`
         """
 
         return mars_cleaning_1st_pass(
@@ -477,6 +464,7 @@ class FACTImageCleaner(TailcutsImageCleaner):
     def __call__(
         self, tel_id: int, image: np.ndarray, arrival_times=None
     ) -> np.ndarray:
+        """ Apply FACT-style image cleaning. see ImageCleaner.__call__()"""
         return fact_image_cleaning(
             geom=self.subarray.tel[tel_id].camera,
             image=image,

--- a/ctapipe/image/tests/test_image_cleaner_component.py
+++ b/ctapipe/image/tests/test_image_cleaner_component.py
@@ -1,0 +1,29 @@
+from ctapipe.image import ImageCleaner
+from ctapipe.instrument import TelescopeDescription, SubarrayDescription
+from traitlets.config import Config
+import numpy as np
+import pytest
+
+@pytest.mark.parametrize("method", ['TailcutsImageCleaner',])
+def test_image_cleaner(method):
+    """ Test that we can construct and use a component-based ImageCleaner"""
+
+    config = Config({
+        "TailcutsImageCleaner": {"boundary_threshold": 5.0, "picture_threshold": 10.0},
+    })
+
+    tel = TelescopeDescription.from_name("MST", "NectarCam")
+    subarray = SubarrayDescription(
+        name="test", tel_positions={1: None}, tel_descriptions={1: tel}
+    )
+
+
+    clean = ImageCleaner.from_name(method, config)
+
+    image = np.zeros_like(tel.camera.pix_x.value, dtype=np.float)
+    image[10:30] = 20.0
+    image[31:40] = 8.0
+
+    mask = clean(tel_id=1, subarray=subarray, image=image)
+
+    assert np.count_nonzero(mask) == 22

--- a/ctapipe/image/tests/test_image_cleaner_component.py
+++ b/ctapipe/image/tests/test_image_cleaner_component.py
@@ -6,9 +6,7 @@ from ctapipe.image import ImageCleaner
 from ctapipe.instrument import TelescopeDescription, SubarrayDescription
 
 
-@pytest.mark.parametrize(
-    "method", ImageCleaner.non_abstract_subclasses().keys()
-)
+@pytest.mark.parametrize("method", ImageCleaner.non_abstract_subclasses().keys())
 def test_image_cleaner(method):
     """ Test that we can construct and use a component-based ImageCleaner"""
 
@@ -47,3 +45,9 @@ def test_image_cleaner(method):
     # we're not testing the algorithm here, just that it does something (for the
     # algorithm tests, see test_cleaning.py
     assert np.count_nonzero(mask) > 0
+
+
+@pytest.mark.parametrize("method", ImageCleaner.non_abstract_subclasses().keys())
+def test_image_cleaner_no_subarray(method):
+    with pytest.raises(TypeError):
+        ImageCleaner.from_name(method)

--- a/ctapipe/image/tests/test_image_cleaner_component.py
+++ b/ctapipe/image/tests/test_image_cleaner_component.py
@@ -7,7 +7,7 @@ from ctapipe.instrument import TelescopeDescription, SubarrayDescription
 
 
 @pytest.mark.parametrize(
-    "method", ["TailcutsImageCleaner", "MARSImageCleaner", "FACTImageCleaner"]
+    "method", ImageCleaner.non_abstract_subclasses().keys()
 )
 def test_image_cleaner(method):
     """ Test that we can construct and use a component-based ImageCleaner"""


### PR DESCRIPTION
This PR creates some configurable `ImageCleaners`  that are just `Component` wrappers for the existing algorithms (similar to what was in #1163 and intended to replace those.   The parameters of each can be configured differently for each telescope in the array (or by type), since they use `TelescopeParameters` traits.

 It also creates a `TelescopeComponent` base class to help with attaching a SubarrayDescription to `Components` that need them. 

The basic usage inside a Tool is:
```py3
clean = self.add_component(
    ImageCleaner.from_name(cleaning_method, subarray=subarray, parent=self)
)

...

clean_mask = clean(tel_id, image, arrival_times)
```
