### PR TITLE
add helper function, might be nice for parametrized tests

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -145,14 +145,22 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         instace
             Instance of subclass to this class
         """
+        requested_subclass = cls.non_abstract_subclasses()[name]
+        return requested_subclass(config=config, parent=parent, **kwargs)
+
+    @classmethod
+    def non_abstract_subclasses(cls):
+        """
+        get dict{name: cls} of non abstract subclasses,
+        subclasses can possibly be definded in plugins
+        """
         detect_and_import_io_plugins()
         subclasses = {
             base.__name__: base
             for base in non_abstract_children(cls)
         }
-        requested_subclass = subclasses[name]
+        return subclasses
 
-        return requested_subclass(config=config, parent=parent, **kwargs)
 
     def get_current_config(self):
         """ return the current configuration as a dict (e.g. the values

--- a/ctapipe/core/tests/test_component.py
+++ b/ctapipe/core/tests/test_component.py
@@ -292,6 +292,15 @@ def test_help_changed_default():
     assert "Default: 199.0" in help_msg
     ExampleComponent.param.default_value = old_default
 
+def test_non_abstract_subclasses():
+    """non_abstract_subclasses() is a helper function:
+    it might just be nice, in case a person wants to see the subclasses
+    in a python session.
+
+    Can also be helpful in parametrized tests, to make sure all
+    sublcasses are being tested.
+    """
+    assert "ExampleSubclass1" in ExampleComponent.non_abstract_subclasses()
 
 def test_from_name():
     """ Make sure one can construct a Component subclass by name"""


### PR DESCRIPTION
just a tiny helper function breakout with a test.

I thought it might be nice to have parametrized tests (which I just learned about :-) to include any new subclass automatically.

so go from something like this:
https://github.com/cta-observatory/ctapipe/blob/384b64147e2d9a95c118bb450091ae6e72a28a3f/ctapipe/image/tests/test_image_cleaner_component.py#L9-L11

to this:
```python
@pytest.mark.parametrize(
    "method", ImageCleaner.non_abstract_subclasses().keys()
)
```

In addition, I thought it might be nice to allow people to learn about the available subclasses in a python session. Unless there is already a way, which I forgot about ... 