### PR TITLE
Add guessing MAGIC telescope

### DIFF
--- a/ctapipe/instrument/guess.py
+++ b/ctapipe/instrument/guess.py
@@ -24,6 +24,8 @@ TELESCOPE_NAMES = {
     GuessingKey(1855, 28.0): GuessingResult("LST", "LST", "LSTCam", 1),
     GuessingKey(11328, 5.59): GuessingResult("MST", "SCT", "SCTCam", 1),
     # Non-CTA Telescopes
+    GuessingKey(1039, 16.97): GuessingResult("LST", "MAGIC", "MAGICCam", 1),
+    GuessingKey(1039, 0.0): GuessingResult('LST', 'MAGIC', 'MAGICCamMars', 1),
     GuessingKey(960, 15.0): GuessingResult("MST", "HESS-I", "HESS-I", 1),
     GuessingKey(2048, 36.0): GuessingResult("LST", "HESS-II", "HESS-II", 1),
     GuessingKey(1440, 4.998): GuessingResult("SST", "FACT", "FACT", 1),

--- a/ctapipe/instrument/guess.py
+++ b/ctapipe/instrument/guess.py
@@ -25,7 +25,6 @@ TELESCOPE_NAMES = {
     GuessingKey(11328, 5.59): GuessingResult("MST", "SCT", "SCTCam", 1),
     # Non-CTA Telescopes
     GuessingKey(1039, 16.97): GuessingResult("LST", "MAGIC", "MAGICCam", 1),
-    GuessingKey(1039, 0.0): GuessingResult('LST', 'MAGIC', 'MAGICCamMars', 1),
     GuessingKey(960, 15.0): GuessingResult("MST", "HESS-I", "HESS-I", 1),
     GuessingKey(2048, 36.0): GuessingResult("LST", "HESS-II", "HESS-II", 1),
     GuessingKey(1440, 4.998): GuessingResult("SST", "FACT", "FACT", 1),


### PR DESCRIPTION
Fix to read MAGICCam from MC files. For the issue look at cta-observatory/protopipe#36. Solution to this is adding the missing MAGIC infos in `guess.py`.