### PR TITLE
added bad pixel info field to DL1CameraContainer

### DIFF
--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -126,6 +126,10 @@ class DL1CameraContainer(Container):
         "the extractor."
         "Shape: (n_pixel, n_samples)",
     )
+    badpixels = Field(
+        None, 
+        "Numpy (nd-)array of bools indicating (a specific type of) bad pixels"
+    )
 
 
 class DL1Container(Container):


### PR DESCRIPTION
We are using this additional field for MAGIC data processing to store (multidimensional) bad pixel information