### PR TITLE
Fixes for astropy 4.x

### DIFF
--- a/ctapipe/image/tests/test_geometry_converter.py
+++ b/ctapipe/image/tests/test_geometry_converter.py
@@ -1,9 +1,13 @@
 import pytest
 import numpy as np
-from ctapipe.image.geometry_converter import (convert_geometry_hex1d_to_rect2d,
-                                              convert_geometry_rect2d_back_to_hexe1d,
-                                              astri_to_2d_array, array_2d_to_astri,
-                                              chec_to_2d_array, array_2d_to_chec)
+from ctapipe.image.geometry_converter import (
+    convert_geometry_hex1d_to_rect2d,
+    convert_geometry_rect2d_back_to_hexe1d,
+    astri_to_2d_array,
+    array_2d_to_astri,
+    chec_to_2d_array,
+    array_2d_to_chec,
+)
 from ctapipe.image.hillas import hillas_parameters
 from ctapipe.instrument import CameraGeometry
 from ctapipe.image.toymodel import Gaussian
@@ -14,28 +18,26 @@ cam_ids = CameraGeometry.get_known_camera_names()
 
 
 def create_mock_image(geom):
-    '''
+    """
     creates a mock image, which parameters are adapted to the camera size
-    '''
+    """
 
-    camera_r = np.max(np.sqrt(geom.pix_x**2 + geom.pix_y**2))
+    camera_r = np.max(np.sqrt(geom.pix_x ** 2 + geom.pix_y ** 2))
     model = Gaussian(
         x=0.3 * camera_r,
         y=0 * u.m,
         width=0.03 * camera_r,
         length=0.10 * camera_r,
-        psi="25d"
+        psi="25d",
     )
 
     _, image, _ = model.generate_image(
-        geom,
-        intensity=0.5 * geom.n_pixels,
-        nsb_level_pe=3,
+        geom, intensity=0.5 * geom.n_pixels, nsb_level_pe=3,
     )
     return image
 
 
-@pytest.mark.parametrize("rot", [3, ])
+@pytest.mark.parametrize("rot", [3,])
 @pytest.mark.parametrize("cam_id", cam_ids)
 def test_convert_geometry(cam_id, rot):
 
@@ -43,16 +45,16 @@ def test_convert_geometry(cam_id, rot):
     image = create_mock_image(geom)
     hillas_0 = hillas_parameters(geom, image)
 
-    if geom.pix_type == 'hexagonal':
+    if geom.pix_type == "hexagonal":
         convert_geometry_1d_to_2d = convert_geometry_hex1d_to_rect2d
         convert_geometry_back = convert_geometry_rect2d_back_to_hexe1d
 
-        geom2d, image2d = convert_geometry_1d_to_2d(geom, image,
-                                                    geom.cam_id + str(rot),
-                                                    add_rot=rot)
-        geom1d, image1d = convert_geometry_back(geom2d, image2d,
-                                                geom.cam_id + str(rot),
-                                                add_rot=rot)
+        geom2d, image2d = convert_geometry_1d_to_2d(
+            geom, image, geom.cam_id + str(rot), add_rot=rot
+        )
+        geom1d, image1d = convert_geometry_back(
+            geom2d, image2d, geom.cam_id + str(rot), add_rot=rot
+        )
 
     else:
         if geom.cam_id == "ASTRICam":
@@ -79,7 +81,7 @@ def test_convert_geometry(cam_id, rot):
     # TODO: test other parameters
 
 
-@pytest.mark.parametrize("rot", [3, ])
+@pytest.mark.parametrize("rot", [3,])
 @pytest.mark.parametrize("cam_id", cam_ids)
 def test_convert_geometry_mock(cam_id, rot):
     """here we use a different key for the back conversion to trigger the mock conversion
@@ -89,16 +91,14 @@ def test_convert_geometry_mock(cam_id, rot):
     image = create_mock_image(geom)
     hillas_0 = hillas_parameters(geom, image)
 
-    if geom.pix_type == 'hexagonal':
+    if geom.pix_type == "hexagonal":
         convert_geometry_1d_to_2d = convert_geometry_hex1d_to_rect2d
         convert_geometry_back = convert_geometry_rect2d_back_to_hexe1d
 
-        geom2d, image2d = convert_geometry_1d_to_2d(geom, image, key=None,
-                                                    add_rot=rot)
-        geom1d, image1d = convert_geometry_back(geom2d, image2d,
-                                                "_".join([geom.cam_id,
-                                                          str(rot), "mock"]),
-                                                add_rot=rot)
+        geom2d, image2d = convert_geometry_1d_to_2d(geom, image, key=None, add_rot=rot)
+        geom1d, image1d = convert_geometry_back(
+            geom2d, image2d, "_".join([geom.cam_id, str(rot), "mock"]), add_rot=rot
+        )
     else:
         # originally rectangular geometries don't need a buffer and therefore no mock
         # conversion

--- a/ctapipe/visualization/mpl_array.py
+++ b/ctapipe/visualization/mpl_array.py
@@ -149,7 +149,7 @@ class ArrayDisplay:
         if self._quiver is None:
             coords = self.tel_coords
             self._quiver = self.axes.quiver(
-                coords.x, coords.y,
+                coords.x.value, coords.y.value,
                 u, v,
                 color=c,
                 scale_units='xy',

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -1,10 +1,13 @@
+"""
+Tests for array display
+"""
+
 # skip these tests if matplotlib can't be imported
 import pytest
 
 plt = pytest.importorskip("matplotlib.pyplot")
 
-from ctapipe.instrument import (CameraGeometry, SubarrayDescription,
-                                TelescopeDescription)
+from ctapipe.instrument import CameraGeometry, SubarrayDescription, TelescopeDescription
 from ctapipe.io.containers import HillasParametersContainer
 from numpy import ones
 from astropy import units as u
@@ -19,14 +22,14 @@ def test_camera_display_single():
     image = ones(len(geom.pix_x), dtype=float)
     disp.image = image
     disp.add_colorbar()
-    disp.cmap = 'nipy_spectral'
+    disp.cmap = "nipy_spectral"
     disp.set_limits_minmax(0, 10)
     disp.set_limits_percent(95)
     disp.enable_pixel_picker()
     disp.highlight_pixels([1, 2, 3, 4, 5])
-    disp.norm = 'log'
-    disp.norm = 'symlog'
-    disp.cmap = 'rainbow'
+    disp.norm = "log"
+    disp.norm = "symlog"
+    disp.cmap = "rainbow"
 
     with pytest.raises(ValueError):
         disp.image = ones(10)
@@ -54,6 +57,7 @@ def test_camera_display_multiple():
 
 
 def test_array_display():
+    """ check that we can do basic array display functionality """
     from ctapipe.visualization.mpl_array import ArrayDisplay
     from ctapipe.image.timing_parameters import timing_parameters
 
@@ -65,9 +69,7 @@ def test_array_display():
         tel_pos[ii + 1] = pos
 
     sub = SubarrayDescription(
-        name="TestSubarray",
-        tel_positions=tel_pos,
-        tel_descriptions=tels
+        name="TestSubarray", tel_positions=tel_pos, tel_descriptions=tels
     )
 
     ad = ArrayDisplay(sub)
@@ -97,16 +99,18 @@ def test_array_display():
         image=ones(geom.n_pixels),
         pulse_time=intercept + grad * geom.pix_x.value,
         hillas_parameters=hillas,
-        cleaning_mask=ones(geom.n_pixels, dtype=bool)
+        cleaning_mask=ones(geom.n_pixels, dtype=bool),
     )
     gradient_dict = {
         1: timing_rot20.slope.value,
         2: timing_rot20.slope.value,
     }
-    ad.set_vector_hillas(hillas_dict=hillas_dict,
-                         length=500,
-                         time_gradient=gradient_dict,
-                         angle_offset=0 * u.deg)
+    ad.set_vector_hillas(
+        hillas_dict=hillas_dict,
+        length=500,
+        time_gradient=gradient_dict,
+        angle_offset=0 * u.deg,
+    )
 
     ad.set_line_hillas(hillas_dict, range=300)
     ad.add_labels()

--- a/examples/array_display.py
+++ b/examples/array_display.py
@@ -8,14 +8,13 @@ from ctapipe.io import event_source
 from ctapipe.utils import datasets
 from ctapipe.visualization import ArrayDisplay
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     plt.figure(figsize=(9.5, 8.5))
 
     # load up a single event, so we can get the subarray info:
     source = event_source(
-        datasets.get_dataset_path("gamma_test_large.simtel.gz"),
-        max_events=1,
+        datasets.get_dataset_path("gamma_test_large.simtel.gz"), max_events=1,
     )
 
     event = next(iter(source))


### PR DESCRIPTION
The master build is currently broken since the update to astropy-4

in astropy 4, and the latest NumPy, numpy functions *retain* units correctly
whereas before they were stripped off. Functions that relied on them disappearing
then break.

In `geometry_converter_hex`: 
* fixed instances of unit problems
* Also first fixed, and then, removed the `@jit` (originally it did not ever compile in no_python mode), however now when compiled with `@njit`, it seems it introduces some rounding error that breaks the hex converter (probably means the algorithm is unstable, but that's for another day!)
