### PR TITLE
bump astropy version requirement to allow v4.0

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -27,5 +27,6 @@ if [[ "$CONDA" == "true" ]]; then
 	travis_wait 20 conda env update -n cta-dev --file py${PYTHON_VERSION}_env.yaml
 	conda activate cta-dev
 else
-	pip install -e .[all]
+	pip install -U pip
+	pip install -U -e .[all]
 fi

--- a/ctapipe/image/muon/tests/test_muon_features.py
+++ b/ctapipe/image/muon/tests/test_muon_features.py
@@ -6,6 +6,7 @@ from ctapipe.image.muon.features import ring_completeness
 from ctapipe.image.muon.features import npix_above_threshold
 from ctapipe.image.muon.features import npix_composing_ring
 
+
 def test_ring_containment():
 
     ring_radius = 1. * u.m
@@ -22,7 +23,7 @@ def test_ring_containment():
 
 def test_ring_completeness():
 
-    angle_ring = np.linspace(0, 2 * math.pi, 360.)
+    angle_ring = np.linspace(0, 2 * math.pi, 360)
     x = np.cos(angle_ring) * u.m
     y = np.sin(angle_ring) * u.m
     pe = np.random.uniform(0, 100, len(x))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     # don't need to list the sub-dependencies like numpy, since
     # astropy already depends on it)
     install_requires=[
-        'astropy~=3.0',
+        'astropy>=3,<5',
         'bokeh~=1.0',
         'eventio~=1.0',
         'iminuit>=1.3',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'joblib',
         'matplotlib~=3.0',
         'numba>=0.43',
-        'numpy~=1.11',
+        'numpy~=1.16',
         'pandas>=0.24.0',
         'psutil',
         'scikit-learn',


### PR DESCRIPTION
just changes setup.py to allow astropy 3.x or 4.x series.  Right now, if you run "python setup.py develop" after installing astropy 4.x, it gets downgraded to 3.x without this.