### PR TITLE
Move pulse shape attributes from mc container to CameraGeometry

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -6,6 +6,7 @@ calibration and image extraction, as well as supporting algorithms.
 import warnings
 
 import numpy as np
+from astropy import units as u
 
 from ctapipe.core import Component
 from ctapipe.image.extractor import NeighborPeakWindowSum
@@ -113,6 +114,7 @@ class CameraCalibrator(Component):
         kwargs
         """
         super().__init__(config=config, parent=parent, **kwargs)
+        self.subarray = subarray
 
         self._r1_empty_warn = False
         self._dl0_empty_warn = False
@@ -145,10 +147,10 @@ class CameraCalibrator(Component):
             selected_gain_channel = event.r1.tel[telid].selected_gain_channel
             shift = self.image_extractor.window_shift.tel[None]
             width = self.image_extractor.window_width.tel[None]
-            shape = event.mc.tel[telid].reference_pulse_shape
+            shape = self.subarray.tel[telid].camera.reference_pulse_shape
             n_chan = shape.shape[0]
-            step = event.mc.tel[telid].meta["refstep"]
-            time_slice = event.mc.tel[telid].time_slice
+            step = self.subarray.tel[telid].camera.reference_pulse_step.to_value(u.ns)
+            time_slice = (1 / self.subarray.tel[telid].camera.sampling_rate).to_value(u.ns)
             correction = integration_correction(
                 n_chan, shape, step, time_slice, width, shift
             )

--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -150,7 +150,7 @@ class CameraCalibrator(Component):
             shape = self.subarray.tel[telid].camera.reference_pulse_shape
             n_chan = shape.shape[0]
             step = self.subarray.tel[telid].camera.reference_pulse_step.to_value(u.ns)
-            time_slice = (1 / self.subarray.tel[telid].camera.sampling_rate).to_value(u.ns)
+            time_slice = (1/self.subarray.tel[telid].camera.sampling_rate).to_value(u.ns)
             correction = integration_correction(
                 n_chan, shape, step, time_slice, width, shift
             )

--- a/ctapipe/image/geometry_converter_hex.py
+++ b/ctapipe/image/geometry_converter_hex.py
@@ -406,6 +406,8 @@ def convert_geometry_hex1d_to_rect2d(geom, signal, key=None, add_rot=0):
             pix_area=pix_area * u.meter ** 2,
             neighbors=geom.neighbors,
             sampling_rate=geom.sampling_rate,
+            reference_pulse_shape=geom.reference_pulse_shape,
+            reference_pulse_step=geom.reference_pulse_step,
             pix_type="rectangular",
             apply_derotation=False,
         )

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -352,14 +352,14 @@ class CameraGeometry:
             logger.warning("Sampling rate is not in file, defaulting to 1.0 GHz")
             sampling_rate = u.Quantity(1, u.GHz)
 
-        logger.warning("Reference pulse shape is not in file, defaulting to unit")
-        reference_pulse_shape = np.ones(1)
+        logger.warning("Reference pulse shape is not in file, defaulting None")
+        reference_pulse_shape = None
 
         try:
             reference_pulse_step = u.Quantity(tab.meta['REF_STEP'], u.ns)
         except KeyError:
             logger.warning("Reference pulse shape step is not in file, default: 1.0 ns")
-            reference_pulse_step = u.Quantity(1, u.ns)
+            reference_pulse_step = None
 
         return cls(
             cam_id=tab.meta.get('CAM_ID', 'Unknown'),
@@ -593,8 +593,8 @@ class CameraGeometry:
                    neighbors=None,
                    pix_type='rectangular',
                    sampling_rate=u.Quantity(1, u.GHz),
-                   reference_pulse_shape=np.ones(1),
-                   reference_pulse_step=u.Quantity(1, u.ns),
+                   reference_pulse_shape=None,
+                   reference_pulse_step=None,
                    )
 
     def get_border_pixel_mask(self, width=1):

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -352,13 +352,13 @@ class CameraGeometry:
             logger.warning("Sampling rate is not in file, defaulting to 1.0 GHz")
             sampling_rate = u.Quantity(1, u.GHz)
 
-        logger.warning("Reference pulse shape is not in file, defaulting to unit pulse shape")
+        logger.warning("Reference pulse shape is not in file, defaulting to unit")
         reference_pulse_shape = np.ones(1)
 
         try:
             reference_pulse_step = u.Quantity(tab.meta['REF_STEP'], u.ns)
         except KeyError:
-            logger.warning("Reference pulse shape step is not in file, defaulting to 1.0 ns")
+            logger.warning("Reference pulse shape step is not in file, default: 1.0 ns")
             reference_pulse_step = u.Quantity(1, u.ns)
 
         return cls(

--- a/ctapipe/instrument/camera.py
+++ b/ctapipe/instrument/camera.py
@@ -68,7 +68,8 @@ class CameraGeometry:
     _geometry_cache = {}  # dictionary CameraGeometry instances for speed
 
     def __init__(self, cam_id, pix_id, pix_x, pix_y, pix_area, pix_type,
-                 sampling_rate, pix_rotation="0d", cam_rotation="0d",
+                 sampling_rate, reference_pulse_shape, reference_pulse_step,
+                 pix_rotation="0d", cam_rotation="0d",
                  neighbors=None, apply_derotation=True, frame=None):
 
         if pix_x.ndim != 1 or pix_y.ndim != 1:
@@ -85,6 +86,8 @@ class CameraGeometry:
         self.pix_rotation = Angle(pix_rotation)
         self.cam_rotation = Angle(cam_rotation)
         self.sampling_rate = sampling_rate
+        self.reference_pulse_shape = reference_pulse_shape
+        self.reference_pulse_step = reference_pulse_step
         self._neighbors = neighbors
         self.frame = frame
 
@@ -161,6 +164,8 @@ class CameraGeometry:
             pix_area=self.pix_area,
             pix_type=self.pix_type,
             sampling_rate=self.sampling_rate,
+            reference_pulse_shape=self.reference_pulse_shape,
+            reference_pulse_step=self.reference_pulse_step,
             pix_rotation=pix_rotation,
             cam_rotation=cam_rotation,
             neighbors=None,
@@ -189,6 +194,8 @@ class CameraGeometry:
             pix_area=self.pix_area[slice_],
             pix_type=self.pix_type,
             sampling_rate=self.sampling_rate,
+            reference_pulse_shape=self.reference_pulse_shape,
+            reference_pulse_step=self.reference_pulse_step,
             pix_rotation=self.pix_rotation,
             cam_rotation=self.cam_rotation,
             neighbors=None,
@@ -304,7 +311,7 @@ class CameraGeometry:
 
     def to_table(self):
         """ convert this to an `astropy.table.Table` """
-        # currently the neighbor list is not supported, since
+        # currently the neighbor list and reference pulse shape is not supported, since
         # var-length arrays are not supported by astropy.table.Table
         return Table([self.pix_id, self.pix_x, self.pix_y, self.pix_area],
                      names=['pix_id', 'pix_x', 'pix_y', 'pix_area'],
@@ -312,7 +319,8 @@ class CameraGeometry:
                                TAB_TYPE='ctapipe.instrument.CameraGeometry',
                                TAB_VER='1.1',
                                CAM_ID=self.cam_id,
-                               SAMPFREQ=self.sampling_rate,
+                               SAMPFREQ=self.sampling_rate.to_value(u.GHz),
+                               REF_STEP=self.reference_pulse_step.to_value(u.ns),
                                PIX_ROT=self.pix_rotation.deg,
                                CAM_ROT=self.cam_rotation.deg,
                                ))
@@ -344,6 +352,15 @@ class CameraGeometry:
             logger.warning("Sampling rate is not in file, defaulting to 1.0 GHz")
             sampling_rate = u.Quantity(1, u.GHz)
 
+        logger.warning("Reference pulse shape is not in file, defaulting to unit pulse shape")
+        reference_pulse_shape = np.ones(1)
+
+        try:
+            reference_pulse_step = u.Quantity(tab.meta['REF_STEP'], u.ns)
+        except KeyError:
+            logger.warning("Reference pulse shape step is not in file, defaulting to 1.0 ns")
+            reference_pulse_step = u.Quantity(1, u.ns)
+
         return cls(
             cam_id=tab.meta.get('CAM_ID', 'Unknown'),
             pix_id=tab['pix_id'],
@@ -352,6 +369,8 @@ class CameraGeometry:
             pix_area=tab['pix_area'].quantity,
             pix_type=tab.meta['PIX_TYPE'],
             sampling_rate=sampling_rate,
+            reference_pulse_shape=reference_pulse_shape,
+            reference_pulse_step=reference_pulse_step,
             pix_rotation=Angle(tab.meta['PIX_ROT'] * u.deg),
             cam_rotation=Angle(tab.meta['CAM_ROT'] * u.deg),
         )
@@ -573,7 +592,10 @@ class CameraGeometry:
                    pix_area=(2 * rr) ** 2,
                    neighbors=None,
                    pix_type='rectangular',
-                   sampling_rate=u.Quantity(1, u.GHz))
+                   sampling_rate=u.Quantity(1, u.GHz),
+                   reference_pulse_shape=np.ones(1),
+                   reference_pulse_step=u.Quantity(1, u.ns),
+                   )
 
     def get_border_pixel_mask(self, width=1):
         '''

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -16,6 +16,8 @@ def test_construct():
                           pix_area=x * u.m**2,
                           pix_type='rectangular',
                           sampling_rate=u.Quantity(1, u.GHz),
+                          reference_pulse_shape=np.ones(1),
+                          reference_pulse_step=u.Quantity(1, u.ns),
                           pix_rotation="10d",
                           cam_rotation="12d")
 
@@ -74,6 +76,8 @@ def test_find_neighbor_pixels():
         pix_y=y.ravel(),
         pix_type='rectangular',
         sampling_rate=u.Quantity(1, u.GHz),
+        reference_pulse_shape=np.ones(1),
+        reference_pulse_step=u.Quantity(1, u.ns),
     )
 
     neigh = geom.neighbors
@@ -121,6 +125,8 @@ def test_calc_pixel_neighbors_square():
         pix_y=u.Quantity(y.ravel(), u.cm),
         pix_area=u.Quantity(np.ones(400), u.cm**2),
         sampling_rate=u.Quantity(1, u.GHz),
+        reference_pulse_shape=np.ones(1),
+        reference_pulse_step=u.Quantity(1, u.ns),
     )
 
     assert set(cam.neighbors[0]) == {1, 20}
@@ -142,6 +148,8 @@ def test_calc_pixel_neighbors_square_diagonal():
         pix_y=u.Quantity(y.ravel(), u.cm),
         pix_area=u.Quantity(np.ones(400), u.cm**2),
         sampling_rate=u.Quantity(1, u.GHz),
+        reference_pulse_shape=np.ones(1),
+        reference_pulse_step=u.Quantity(1, u.ns),
     )
 
     cam._neighbors = cam.calc_pixel_neighbors(diagonal=True)
@@ -160,6 +168,8 @@ def test_to_and_from_table():
     assert (geom.pix_area == geom2.pix_area).all()
     assert geom.pix_type == geom2.pix_type
     assert geom.sampling_rate == geom2.sampling_rate
+    assert geom.reference_pulse_shape == geom2.reference_pulse_shape
+    assert geom.reference_pulse_step == geom2.reference_pulse_step
     
 
 def test_write_read(tmpdir):
@@ -167,6 +177,12 @@ def test_write_read(tmpdir):
     filename = str(tmpdir.join('testcamera.fits.gz'))
 
     geom = CameraGeometry.from_name("LSTCam")
+
+    # Non-default to check they are correctly written and read
+    geom.sampling_rate = u.Quantity(2, u.GHz)
+    geom.reference_pulse_shape = np.arange(3).astype(np.float)
+    geom.reference_pulse_step = u.Quantity(0.5, u.ns)
+
     geom.to_table().write(filename, overwrite=True)
     geom2 = geom.from_table(filename)
 
@@ -176,6 +192,9 @@ def test_write_read(tmpdir):
     assert (geom.pix_area == geom2.pix_area).all()
     assert geom.pix_type == geom2.pix_type
     assert geom.sampling_rate == geom2.sampling_rate
+    # TODO: Reference pulse shape cannot be stored to file currently (variable length)
+    # assert np.array_equal(geom.reference_pulse_shape, geom2.reference_pulse_shape)
+    assert geom.reference_pulse_step == geom2.reference_pulse_step
 
 
 def test_precal_neighbors():
@@ -193,6 +212,8 @@ def test_precal_neighbors():
                           ],
                           pix_type='rectangular',
                           sampling_rate=u.Quantity(1, u.GHz),
+                          reference_pulse_shape=np.ones(1),
+                          reference_pulse_step=u.Quantity(1, u.ns),
                           pix_rotation="0deg",
                           cam_rotation="0deg")
 
@@ -251,6 +272,8 @@ def test_rectangle_patch_neighbors():
         pix_area=None,
         pix_type='rectangular',
         sampling_rate=u.Quantity(1, u.GHz),
+        reference_pulse_shape=np.ones(1),
+        reference_pulse_step=u.Quantity(1, u.ns),
     )
 
     assert np.all(cam.neighbor_matrix.T == cam.neighbor_matrix)

--- a/ctapipe/instrument/tests/test_camera.py
+++ b/ctapipe/instrument/tests/test_camera.py
@@ -159,6 +159,12 @@ def test_calc_pixel_neighbors_square_diagonal():
 def test_to_and_from_table():
     """ Check converting to and from an astropy Table """
     geom = CameraGeometry.from_name("LSTCam")
+
+    # Non-default to check they are correctly written and read
+    geom.sampling_rate = u.Quantity(2, u.GHz)
+    geom.reference_pulse_shape = np.arange(3).astype(np.float)
+    geom.reference_pulse_step = u.Quantity(0.5, u.ns)
+
     tab = geom.to_table()
     geom2 = geom.from_table(tab)
 
@@ -168,7 +174,8 @@ def test_to_and_from_table():
     assert (geom.pix_area == geom2.pix_area).all()
     assert geom.pix_type == geom2.pix_type
     assert geom.sampling_rate == geom2.sampling_rate
-    assert geom.reference_pulse_shape == geom2.reference_pulse_shape
+    # TODO: Reference pulse shape cannot be stored to table currently (variable length)
+    # assert np.array_equal(geom.reference_pulse_shape, geom2.reference_pulse_shape)
     assert geom.reference_pulse_step == geom2.reference_pulse_step
     
 

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -266,11 +266,6 @@ class MCCameraEventContainer(Container):
     photo_electron_image = Field(
         Map(), "reference image in pure photoelectrons, with no noise"
     )
-    # todo: move to instrument (doesn't change per event)
-    reference_pulse_shape = Field(None, "reference pulse shape for each channel")
-    # todo: move to instrument or a static MC container (don't change per
-    # event)
-    time_slice = Field(0, "width of time slice", unit=u.ns)
     dc_to_pe = Field(None, "DC/PE calibration arrays from MC file")
     pedestal = Field(None, "pedestal calibration arrays from MC file")
     azimuth_raw = Field(0, "Raw azimuth angle [radians from N->E] for the telescope")

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -263,8 +263,8 @@ class HESSIOEventSource(EventSource):
         cam_rot = file.get_camera_rotation_angle(tel_id)
         num_mirrors = file.get_mirror_number(tel_id)
         sampling_rate = u.Quantity(1 / file.get_time_slice(tel_id), u.GHz)
-        reference_pulse_shape = file.get_ref_shapes(tel_id),
-        reference_pulse_step = u.Quantity(file.get_ref_step(tel_id), u.ns),
+        reference_pulse_shape = file.get_ref_shapes(tel_id)
+        reference_pulse_step = u.Quantity(file.get_ref_step(tel_id), u.ns)
 
         camera = CameraGeometry(
             telescope.camera_name,

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -177,13 +177,10 @@ class HESSIOEventSource(EventSource):
                     mc.pedestal = pedestal
                     r0.num_trig_pix = file.get_num_trig_pixels(tel_id)
                     r0.trig_pix_id = file.get_trig_pixels(tel_id)
-                    mc.reference_pulse_shape = file.get_ref_shapes(tel_id)
 
                     # load the data per telescope/pixel
                     hessio_mc_npe = file.get_mc_number_photon_electron(tel_id)
                     mc.photo_electron_image = hessio_mc_npe
-                    mc.meta['refstep'] = file.get_ref_step(tel_id)
-                    mc.time_slice = file.get_time_slice(tel_id)
                     mc.azimuth_raw = file.get_azimuth_raw(tel_id)
                     mc.altitude_raw = file.get_altitude_raw(tel_id)
                     azimuth_cor = file.get_azimuth_cor(tel_id)
@@ -266,6 +263,8 @@ class HESSIOEventSource(EventSource):
         cam_rot = file.get_camera_rotation_angle(tel_id)
         num_mirrors = file.get_mirror_number(tel_id)
         sampling_rate = u.Quantity(1 / file.get_time_slice(tel_id), u.GHz)
+        reference_pulse_shape = file.get_ref_shapes(tel_id),
+        reference_pulse_step = u.Quantity(file.get_ref_step(tel_id), u.ns),
 
         camera = CameraGeometry(
             telescope.camera_name,
@@ -278,6 +277,8 @@ class HESSIOEventSource(EventSource):
             pix_rotation=pix_rot,
             cam_rotation=-Angle(cam_rot, u.rad),
             apply_derotation=True,
+            reference_pulse_shape=reference_pulse_shape,
+            reference_pulse_step=reference_pulse_step,
         )
 
         optics = OpticsDescription(

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -48,7 +48,7 @@ def build_camera_geometry(cam_settings, pixel_settings, telescope):
         pix_rotation=pix_rotation,
         cam_rotation=-Angle(cam_settings['cam_rot'], u.rad),
         apply_derotation=True,
-        reference_pulse_shape=pixel_settings['ref_shape'].astype('float64'),
+        reference_pulse_shape=pixel_settings['ref_shape'].astype('float64', copy=False),
         reference_pulse_step=u.Quantity(pixel_settings['ref_step'], u.ns),
     )
 

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -48,6 +48,8 @@ def build_camera_geometry(cam_settings, pixel_settings, telescope):
         pix_rotation=pix_rotation,
         cam_rotation=-Angle(cam_settings['cam_rot'], u.rad),
         apply_derotation=True,
+        reference_pulse_shape=pixel_settings['ref_shape'].astype('float64'),
+        reference_pulse_step=u.Quantity(pixel_settings['ref_step'], u.ns),
     )
 
     return camera
@@ -317,20 +319,15 @@ class SimTelEventSource(EventSource):
             tracking_positions = array_event['tracking_positions']
             for tel_id, telescope_event in telescope_events.items():
                 tel_index = self.file_.header['tel_id'].tolist().index(tel_id)
-                telescope_description = self.file_.telescope_descriptions[tel_id]
 
                 adc_samples = telescope_event.get('adc_samples')
                 if adc_samples is None:
                     adc_samples = telescope_event['adc_sums'][:, :, np.newaxis]
                 _, n_pixels, n_samples = adc_samples.shape
-                pixel_settings = telescope_description['pixel_settings']
 
                 mc = data.mc.tel[tel_id]
                 mc.dc_to_pe = array_event['laser_calibrations'][tel_id]['calib']
                 mc.pedestal = array_event['camera_monitorings'][tel_id]['pedestal']
-                mc.reference_pulse_shape = pixel_settings['ref_shape'].astype('float64')
-                mc.meta['refstep'] = float(pixel_settings['ref_step'])
-                mc.time_slice = float(pixel_settings['time_slice'])
                 mc.photo_electron_image = (
                     array_event
                     .get('photoelectrons', {})

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -64,8 +64,10 @@ def compare_sources(input_url):
 
                 assert (h.inst.subarray.tel[tel_id].camera.sampling_rate ==
                         s.inst.subarray.tel[tel_id].camera.sampling_rate)
-                assert (h.inst.subarray.tel[tel_id].camera.reference_pulse_shape ==
-                        s.inst.subarray.tel[tel_id].camera.reference_pulse_shape)
+                assert np.array_equal(
+                    h.inst.subarray.tel[tel_id].camera.reference_pulse_shape,
+                    s.inst.subarray.tel[tel_id].camera.reference_pulse_shape
+                )
                 assert (h.inst.subarray.tel[tel_id].camera.reference_pulse_step ==
                         s.inst.subarray.tel[tel_id].camera.reference_pulse_step)
 

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -71,6 +71,10 @@ def compare_sources(input_url):
 
                 assert (h.inst.subarray.tel[tel_id].camera.sampling_rate ==
                         s.inst.subarray.tel[tel_id].camera.sampling_rate)
+                assert (h.inst.subarray.tel[tel_id].camera.reference_pulse_shape ==
+                        s.inst.subarray.tel[tel_id].camera.reference_pulse_shape)
+                assert (h.inst.subarray.tel[tel_id].camera.reference_pulse_step ==
+                        s.inst.subarray.tel[tel_id].camera.reference_pulse_step)
 
 
 def test_compare_event_hessio_and_simtel():

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -45,10 +45,6 @@ def compare_sources(input_url):
 
             tels_with_data = s.r0.tels_with_data
             for tel_id in tels_with_data:
-
-                assert type(h.mc.tel[tel_id].meta['refstep']) is type(s.mc.tel[tel_id].meta['refstep'])
-                assert type(h.mc.tel[tel_id].time_slice) is type(s.mc.tel[tel_id].time_slice)
-
                 assert (h.mc.tel[tel_id].dc_to_pe == s.mc.tel[tel_id].dc_to_pe).all()
                 assert (h.mc.tel[tel_id].pedestal == s.mc.tel[tel_id].pedestal).all()
                 assert h.r0.tel[tel_id].waveform.shape == s.r0.tel[tel_id].waveform.shape

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -46,7 +46,6 @@ def compare_sources(input_url):
             tels_with_data = s.r0.tels_with_data
             for tel_id in tels_with_data:
 
-                assert h.mc.tel[tel_id].reference_pulse_shape.dtype == s.mc.tel[tel_id].reference_pulse_shape.dtype
                 assert type(h.mc.tel[tel_id].meta['refstep']) is type(s.mc.tel[tel_id].meta['refstep'])
                 assert type(h.mc.tel[tel_id].time_slice) is type(s.mc.tel[tel_id].time_slice)
 
@@ -59,11 +58,9 @@ def compare_sources(input_url):
 
                 assert h.r0.tel[tel_id].num_trig_pix == s.r0.tel[tel_id].num_trig_pix
                 assert (h.r0.tel[tel_id].trig_pix_id == s.r0.tel[tel_id].trig_pix_id).all()
-                assert (h.mc.tel[tel_id].reference_pulse_shape == s.mc.tel[tel_id].reference_pulse_shape).all()
 
                 assert (h.mc.tel[tel_id].photo_electron_image == s.mc.tel[tel_id].photo_electron_image).all()
                 assert h.mc.tel[tel_id].meta == s.mc.tel[tel_id].meta
-                assert h.mc.tel[tel_id].time_slice == s.mc.tel[tel_id].time_slice
                 assert h.mc.tel[tel_id].azimuth_raw == s.mc.tel[tel_id].azimuth_raw
                 assert h.mc.tel[tel_id].altitude_raw == s.mc.tel[tel_id].altitude_raw
                 assert h.pointing[tel_id].altitude == s.pointing[tel_id].altitude


### PR DESCRIPTION
The pulse shape is a property of the camera, and should be found in the camera description within the subarray container. This provides a common location for the pulse shape for both MC and real data, and makes the pulse shape more readily available for charge extraction algorithms.