### PR TITLE
Make subarray a required argument to CameraCalibrator and ImageExtractor

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -83,16 +83,20 @@ class CameraCalibrator(Component):
 
     def __init__(
         self,
+        subarray,
         config=None,
         parent=None,
         data_volume_reducer=None,
         image_extractor=None,
-        subarray=None,
         **kwargs
     ):
         """
         Parameters
         ----------
+        subarray: ctapipe.instrument.SubarrayDescription
+            Description of the subarray. Provides information about the
+            camera which are useful in calibration. Also required for
+            configuring the TelescopeParameter traitlets.
         config : traitlets.loader.Config
             Configuration specified by config file or cmdline arguments.
             Used to set traitlet values.

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -15,9 +15,14 @@ from ctapipe.instrument import CameraGeometry
 from ctapipe.io.containers import DataContainer
 
 
-def test_camera_calibrator(example_event):
+@pytest.fixture(scope="function")
+def subarray(example_event):
+    return example_event.inst.subarray
+
+
+def test_camera_calibrator(example_event, subarray):
     telid = list(example_event.r0.tel)[0]
-    calibrator = CameraCalibrator(subarray=example_event.inst.subarray)
+    calibrator = CameraCalibrator(subarray=subarray)
     calibrator(example_event)
     image = example_event.dl1.tel[telid].image
     pulse_time = example_event.dl1.tel[telid].pulse_time
@@ -27,12 +32,15 @@ def test_camera_calibrator(example_event):
     assert pulse_time.shape == (1764,)
 
 
-def test_manual_extractor():
-    calibrator = CameraCalibrator(image_extractor=LocalPeakWindowSum())
+def test_manual_extractor(subarray):
+    calibrator = CameraCalibrator(
+        subarray=subarray,
+        image_extractor=LocalPeakWindowSum(subarray=subarray)
+    )
     assert isinstance(calibrator.image_extractor, LocalPeakWindowSum)
 
 
-def test_config():
+def test_config(subarray):
     window_shift = 3
     window_width = 9
     config = Config(
@@ -44,7 +52,9 @@ def test_config():
         }
     )
     calibrator = CameraCalibrator(
-        image_extractor=LocalPeakWindowSum(config=config), config=config
+        subarray=subarray,
+        image_extractor=LocalPeakWindowSum(subarray=subarray, config=config),
+        config=config
     )
     assert calibrator.image_extractor.window_shift.tel[None] == window_shift
     assert calibrator.image_extractor.window_width.tel[None] == window_width
@@ -63,17 +73,17 @@ def test_integration_correction(example_event):
     assert correction is not None
 
 
-def test_integration_correction_no_ref_pulse(example_event):
+def test_integration_correction_no_ref_pulse(example_event, subarray):
     telid = list(example_event.r0.tel)[0]
     delattr(example_event, "mc")
-    calibrator = CameraCalibrator()
+    calibrator = CameraCalibrator(subarray=subarray)
     calibrator._calibrate_dl0(example_event, telid)
     correction = calibrator._get_correction(example_event, telid)
     assert (correction == 1).all()
 
 
-def test_check_r1_empty(example_event):
-    calibrator = CameraCalibrator()
+def test_check_r1_empty(example_event, subarray):
+    calibrator = CameraCalibrator(subarray=subarray)
     telid = list(example_event.r0.tel)[0]
     waveform = example_event.r1.tel[telid].waveform.copy()
     with pytest.warns(UserWarning):
@@ -84,7 +94,10 @@ def test_check_r1_empty(example_event):
     assert calibrator._check_r1_empty(None) is True
     assert calibrator._check_r1_empty(waveform) is False
 
-    calibrator = CameraCalibrator(image_extractor=FullWaveformSum())
+    calibrator = CameraCalibrator(
+        subarray=subarray,
+        image_extractor=FullWaveformSum(subarray=subarray)
+    )
     event = DataContainer()
     event.dl0.tel[telid].waveform = np.full((2048, 128), 2)
     with pytest.warns(UserWarning):
@@ -94,7 +107,7 @@ def test_check_r1_empty(example_event):
 
 
 def test_check_dl0_empty(example_event):
-    calibrator = CameraCalibrator()
+    calibrator = CameraCalibrator(subarray=subarray)
     telid = list(example_event.r0.tel)[0]
     calibrator._calibrate_dl0(example_event, telid)
     waveform = example_event.dl0.tel[telid].waveform.copy()
@@ -106,7 +119,7 @@ def test_check_dl0_empty(example_event):
     assert calibrator._check_dl0_empty(None) is True
     assert calibrator._check_dl0_empty(waveform) is False
 
-    calibrator = CameraCalibrator()
+    calibrator = CameraCalibrator(subarray=subarray)
     event = DataContainer()
     event.dl1.tel[telid].image = np.full(2048, 2)
     with pytest.warns(UserWarning):
@@ -144,7 +157,10 @@ def test_dl1_charge_calib():
     event.dl0.tel[telid].waveform = y
 
     # Test default
-    calibrator = CameraCalibrator(image_extractor=FullWaveformSum())
+    calibrator = CameraCalibrator(
+        subarray=subarray,
+        image_extractor=FullWaveformSum(subarray=subarray)
+    )
     calibrator(event)
     np.testing.assert_allclose(event.dl1.tel[telid].image, y.sum(1))
 
@@ -154,7 +170,10 @@ def test_dl1_charge_calib():
     event.calibration.tel[telid].dl1.relative_factor = relative
 
     # Test without need for timing corrections
-    calibrator = CameraCalibrator(image_extractor=FullWaveformSum())
+    calibrator = CameraCalibrator(
+        subarray=subarray,
+        image_extractor=FullWaveformSum(subarray=subarray)
+    )
     calibrator(event)
     np.testing.assert_allclose(event.dl1.tel[telid].image, 1)
 

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -218,13 +218,18 @@ def subtract_baseline(waveforms, baseline_start, baseline_end):
 
 
 class ImageExtractor(Component):
-    def __init__(self, config=None, parent=None, subarray=None, **kwargs):
+    def __init__(self, subarray, config=None, parent=None, **kwargs):
         """
         Base component to handle the extraction of charge and pulse time
         from an image cube (waveforms).
 
         Parameters
         ----------
+        subarray: ctapipe.instrument.SubarrayDescription
+            Description of the subarray. Provides information about the
+            camera which are useful in charge extraction, such as reference
+            pulse shape, sampling rate, neighboring pixels. Also required for
+            configuring the TelescopeParameter traitlets.
         config : traitlets.loader.Config
             Configuration specified by config file or cmdline arguments.
             Used to set traitlet values.
@@ -233,8 +238,6 @@ class ImageExtractor(Component):
             Tool executable that is calling this component.
             Passes the correct logger to the component.
             Set to None if no Tool to pass.
-        subarray: ctapipe.instrument.SubarrayDescription
-            Description of the subarray
         kwargs
         """
         super().__init__(config=config, parent=parent, **kwargs)

--- a/ctapipe/tools/bokeh/file_viewer.py
+++ b/ctapipe/tools/bokeh/file_viewer.py
@@ -89,9 +89,9 @@ class BokehFileViewer(Tool):
             subarray=self.reader.subarray,
         )
         self.calibrator = CameraCalibrator(
+            subarray=self.reader.subarray,
             parent=self,
             image_extractor=self.extractor,
-            subarray=self.reader.subarray,
         )
 
         self.viewer = BokehEventViewer(parent=self)
@@ -232,6 +232,7 @@ class BokehFileViewer(Tool):
         self.extractor = extractor
 
         self.calibrator = CameraCalibrator(
+            subarray=self.reader.subarray,
             parent=self,
             image_extractor=self.extractor,
         )

--- a/examples/load_one_event.py
+++ b/examples/load_one_event.py
@@ -10,14 +10,13 @@ from ctapipe.utils import get_dataset_path
 
 if __name__ == '__main__':
 
-    calib = CameraCalibrator()
-
     if len(sys.argv) >= 2:
         filename = sys.argv[1]
     else:
         filename = get_dataset_path("gamma_test_large.simtel.gz")
 
     with event_source(filename, max_events=1) as source:
+        calib = CameraCalibrator(subarray=source.subarray)
         for event in source:
             calib(event)
 

--- a/examples/plot_array_hillas.py
+++ b/examples/plot_array_hillas.py
@@ -31,15 +31,13 @@ if __name__ == '__main__':
     point_azimuth = {}
     point_altitude = {}
 
-    calib = CameraCalibrator()
+    subarray = source.subarray
+    calib = CameraCalibrator(subarray=subarray)
     off_angles = []
     first_event = True
     markers = None
 
     for event in source:
-
-        subarray = event.inst.subarray
-
         if first_event:
             fig, ax = plt.subplots(1, 1, figsize=(10, 8))
             array_disp = ArrayDisplay(subarray, axes=ax, tel_scale=1.0)

--- a/examples/plot_showers_in_nominal.py
+++ b/examples/plot_showers_in_nominal.py
@@ -21,7 +21,7 @@ input_url = get_dataset_path('gamma_test_large.simtel.gz')
 
 
 with event_source(input_url=input_url) as source:
-    calibrator = CameraCalibrator()
+    calibrator = CameraCalibrator(subarray=source.subarray)
 
     for event in source:
 

--- a/examples/plot_theta_square.py
+++ b/examples/plot_theta_square.py
@@ -29,7 +29,7 @@ else:
 source = event_source(filename, allowed_tels={1, 2, 3, 4})
 
 reco = HillasReconstructor()
-calib = CameraCalibrator()
+calib = CameraCalibrator(subarray=source.subarray)
 
 horizon_frame = AltAz()
 

--- a/examples/simple_event_writer.py
+++ b/examples/simple_event_writer.py
@@ -46,7 +46,7 @@ class SimpleEventWriter(Tool):
         )
 
         self.calibrator = self.add_component(
-            CameraCalibrator(parent=self)
+            CameraCalibrator(subarray=self.event_source.subarray, parent=self)
         )
 
         self.writer = self.add_component(

--- a/examples/simple_pipeline.py
+++ b/examples/simple_pipeline.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
 
     source = event_source(filename, max_events=None)
 
-    cal = CameraCalibrator()
+    cal = CameraCalibrator(subarray=source.subarray)
 
     for ii, event in enumerate(source):
 

--- a/examples/stereo_reconstruction.py
+++ b/examples/stereo_reconstruction.py
@@ -25,7 +25,7 @@ cleaning_level = {
 input_url = get_dataset_path('gamma_test_large.simtel.gz')
 event_source = event_source(input_url)
 
-calibrator = CameraCalibrator()
+calibrator = CameraCalibrator(subarray=event_source.subarray)
 horizon_frame = AltAz()
 
 reco = HillasReconstructor()


### PR DESCRIPTION
Resolves #1195 by making the subarray a required argument to `CameraCalibrator` and `ImageExtractor`. Therefore one can guarantee it is available for utilisation in whatever calibration routine that is selected.