### PR TITLE
Limit matplotlib maximum version to 3.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - ipywidgets
   - joblib
   - jupyter
-  - matplotlib
+  - matplotlib<3.2  # cta-observatory/ctapipe/issues/1229
   - numba
   - numpy>=1.15.4
   - numpydoc

--- a/py3.6_env.yaml
+++ b/py3.6_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   - ipywidgets
   - joblib
   - jupyter
-  - matplotlib
+  - matplotlib<3.2  # cta-observatory/ctapipe/issues/1229
   - numba
   - numpy>=1.15.4
   - numpydoc

--- a/py3.7_env.yaml
+++ b/py3.7_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   - ipywidgets
   - joblib
   - jupyter
-  - matplotlib
+  - matplotlib<3.2  # cta-observatory/ctapipe/issues/1229
   - numba
   - numpy>=1.15.4
   - numpydoc

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'eventio~=1.0',
         'iminuit>=1.3',
         'joblib',
-        'matplotlib~=3.0',
+        'matplotlib>=3.0,<3.2',  # cta-observatory/ctapipe/issues/1229
         'numba>=0.43',
         'numpy~=1.16',
         'pandas>=0.24.0',


### PR DESCRIPTION
Temporary fix for #1229 