### PR TITLE
Improvement of integration_correction testing, implementation, and docstring

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -18,23 +18,26 @@ def integration_correction(
     reference_pulse_shape, reference_pulse_step, sampled_step, window_width, window_shift
 ):
     """
-    Obtain the integration correction for the window specified.
+    Obtain the correction for the integration window specified.
 
-    This correction accounts for the cherenkov signal that may be missed due
-    to a smaller integration window by looking at the reference pulse shape.
+    For any integration window applied to a noise-less unit pulse, the
+    correction (returned by this function) multiplied by the integration
+    result should equal 1.
 
-    Provides the same result as set_integration_correction from readhess.
+    This correction therefore corrects for the Cherenkov signal that may be
+    outside the integration window, and removes any dependence of the resulting
+    image on the window_width and window_shift parameters. However, the width
+    and shift of the window should still be optimised for the pulse finding and
+    to minimise the noise included in the integration.
 
     Parameters
     ----------
-    n_chan : int
-        Number of gain channels for the telescope
-    pulse_shape : ndarray
-        Numpy array containing the pulse shape for each channel.
-    refstep : int
+    reference_pulse_shape : ndarray
+        Numpy array containing the pulse shape for each gain channel
+    reference_pulse_step : float
         The step in time for each sample of the reference pulse shape
-    time_slice : int
-        The step in time for each sample of the waveforms
+    sampled_step : int
+        The step in time for each sample of the sampled waveforms
     window_width : int
         Width of the integration window.
     window_shift : int
@@ -42,9 +45,8 @@ def integration_correction(
 
     Returns
     -------
-    correction : list[2]
-        Value of the integration correction for this telescope for each
-        channel.
+    correction : ndarray
+        Value of the integration correction for each gain channel
     """
     n_channels = len(reference_pulse_shape)
     correction = np.ones(n_channels, dtype=np.float)

--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -15,7 +15,7 @@ __all__ = ["CameraCalibrator"]
 
 
 def integration_correction(
-    reference_pulse_shape, reference_pulse_step, sampled_step, window_width, window_shift
+    reference_pulse_shape, reference_pulse_step, sample_width, window_width, window_shift
 ):
     """
     Obtain the correction for the integration window specified.
@@ -35,13 +35,14 @@ def integration_correction(
     reference_pulse_shape : ndarray
         Numpy array containing the pulse shape for each gain channel
     reference_pulse_step : float
-        The step in time for each sample of the reference pulse shape
-    sampled_step : int
-        The step in time for each sample of the sampled waveforms
+        The step in time for each sample of the reference pulse shape in ns
+    sample_width : float
+        The width of the waveform sample time bin in ns
     window_width : int
-        Width of the integration window.
+        Width of the integration window (in units of n_samples)
     window_shift : int
-        Shift to before the peak for the start of the integration window.
+        Shift to before the peak for the start of the integration window
+        (in units of n_samples)
 
     Returns
     -------
@@ -53,7 +54,7 @@ def integration_correction(
     for ichannel, pulse_shape in enumerate(reference_pulse_shape):
         pulse_max_sample = pulse_shape.size * reference_pulse_step
         pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
-        sampled_edges = np.arange(0, pulse_max_sample, sampled_step)
+        sampled_edges = np.arange(0, pulse_max_sample, sample_width)
 
         sampled_pulse, _ = np.histogram(
             pulse_shape_x, sampled_edges, weights=pulse_shape, density=True
@@ -66,7 +67,7 @@ def integration_correction(
         if start >= end:
             continue
 
-        integration = sampled_pulse[start:end] * sampled_step
+        integration = sampled_pulse[start:end] * sample_width
         correction[ichannel] = 1.0 / np.sum(integration)
 
     return correction

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -86,7 +86,7 @@ def test_integration_correction(reference_pulse, sampled_reference_pulse):
             window_width = window_end - window_start
             window_shift = sampled_pulse_fc.argmax() - window_start
             correction = integration_correction(
-                len(reference_pulse_shape), reference_pulse_shape,
+                reference_pulse_shape,
                 reference_pulse_step, sampled_step,
                 window_width, window_shift
             )[0]
@@ -103,11 +103,11 @@ def test_integration_correction_outofbounds(reference_pulse, sampled_reference_p
     full_integral = np.sum(sampled_pulse[0] * sampled_step)
 
     for window_start in range(0, sampled_pulse_fc.size):
-        for window_end in range(sampled_pulse_fc.size-1, sampled_pulse_fc.size*2):
+        for window_end in range(sampled_pulse_fc.size, sampled_pulse_fc.size+20):
             window_width = window_end - window_start
             window_shift = sampled_pulse_fc.argmax() - window_start
             correction = integration_correction(
-                len(reference_pulse_shape), reference_pulse_shape,
+                reference_pulse_shape,
                 reference_pulse_step, sampled_step,
                 window_width, window_shift
             )[0]

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -36,13 +36,13 @@ def sampled_reference_pulse(reference_pulse):
     reference_pulse_shape, reference_pulse_step = reference_pulse
     n_channels, n_reference_pulse_samples = reference_pulse_shape.shape
     pulse_max_sample = n_reference_pulse_samples * reference_pulse_step
-    sampled_step = 2
+    sample_width = 2
     pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
-    sampled_edges = np.arange(0, pulse_max_sample, sampled_step)
+    sampled_edges = np.arange(0, pulse_max_sample, sample_width)
     sampled_pulse = np.array([np.histogram(
         pulse_shape_x, sampled_edges, weights=reference_pulse_shape[ichan], density=True
     )[0] for ichan in range(n_channels)])
-    return sampled_pulse, sampled_step
+    return sampled_pulse, sample_width
 
 
 def test_camera_calibrator(example_event, subarray):
@@ -87,9 +87,9 @@ def test_config(subarray):
 
 def test_integration_correction(reference_pulse, sampled_reference_pulse):
     reference_pulse_shape, reference_pulse_step = reference_pulse
-    sampled_pulse, sampled_step = sampled_reference_pulse
+    sampled_pulse, sample_width = sampled_reference_pulse
     sampled_pulse_fc = sampled_pulse[0]  # Test first channel
-    full_integral = np.sum(sampled_pulse[0] * sampled_step)
+    full_integral = np.sum(sampled_pulse[0] * sample_width)
 
     for window_start in range(0, sampled_pulse_fc.size):
         for window_end in range(window_start+1, sampled_pulse_fc.size):
@@ -97,20 +97,20 @@ def test_integration_correction(reference_pulse, sampled_reference_pulse):
             window_shift = sampled_pulse_fc.argmax() - window_start
             correction = integration_correction(
                 reference_pulse_shape,
-                reference_pulse_step, sampled_step,
+                reference_pulse_step, sample_width,
                 window_width, window_shift
             )[0]
             window_integral = np.sum(
-                sampled_pulse_fc[window_start:window_end] * sampled_step
+                sampled_pulse_fc[window_start:window_end] * sample_width
             )
             np.testing.assert_allclose(full_integral, window_integral * correction)
 
 
 def test_integration_correction_outofbounds(reference_pulse, sampled_reference_pulse):
     reference_pulse_shape, reference_pulse_step = reference_pulse
-    sampled_pulse, sampled_step = sampled_reference_pulse
+    sampled_pulse, sample_width = sampled_reference_pulse
     sampled_pulse_fc = sampled_pulse[0]  # Test first channel
-    full_integral = np.sum(sampled_pulse[0] * sampled_step)
+    full_integral = np.sum(sampled_pulse[0] * sample_width)
 
     for window_start in range(0, sampled_pulse_fc.size):
         for window_end in range(sampled_pulse_fc.size, sampled_pulse_fc.size+20):
@@ -118,11 +118,11 @@ def test_integration_correction_outofbounds(reference_pulse, sampled_reference_p
             window_shift = sampled_pulse_fc.argmax() - window_start
             correction = integration_correction(
                 reference_pulse_shape,
-                reference_pulse_step, sampled_step,
+                reference_pulse_step, sample_width,
                 window_width, window_shift
             )[0]
             window_integral = np.sum(
-                sampled_pulse_fc[window_start:window_end] * sampled_step
+                sampled_pulse_fc[window_start:window_end] * sample_width
             )
             np.testing.assert_allclose(full_integral, window_integral * correction)
 

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -36,13 +36,13 @@ def sampled_reference_pulse(reference_pulse):
     reference_pulse_shape, reference_pulse_step = reference_pulse
     n_channels, n_reference_pulse_samples = reference_pulse_shape.shape
     pulse_max_sample = n_reference_pulse_samples * reference_pulse_step
-    sample_width = 2
+    sample_width_ns = 2
     pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
-    sampled_edges = np.arange(0, pulse_max_sample, sample_width)
+    sampled_edges = np.arange(0, pulse_max_sample, sample_width_ns)
     sampled_pulse = np.array([np.histogram(
         pulse_shape_x, sampled_edges, weights=reference_pulse_shape[ichan], density=True
     )[0] for ichan in range(n_channels)])
-    return sampled_pulse, sample_width
+    return sampled_pulse, sample_width_ns
 
 
 def test_camera_calibrator(example_event, subarray):
@@ -87,9 +87,9 @@ def test_config(subarray):
 
 def test_integration_correction(reference_pulse, sampled_reference_pulse):
     reference_pulse_shape, reference_pulse_step = reference_pulse
-    sampled_pulse, sample_width = sampled_reference_pulse
+    sampled_pulse, sample_width_ns = sampled_reference_pulse
     sampled_pulse_fc = sampled_pulse[0]  # Test first channel
-    full_integral = np.sum(sampled_pulse[0] * sample_width)
+    full_integral = np.sum(sampled_pulse[0] * sample_width_ns)
 
     for window_start in range(0, sampled_pulse_fc.size):
         for window_end in range(window_start+1, sampled_pulse_fc.size):
@@ -97,20 +97,20 @@ def test_integration_correction(reference_pulse, sampled_reference_pulse):
             window_shift = sampled_pulse_fc.argmax() - window_start
             correction = integration_correction(
                 reference_pulse_shape,
-                reference_pulse_step, sample_width,
+                reference_pulse_step, sample_width_ns,
                 window_width, window_shift
             )[0]
             window_integral = np.sum(
-                sampled_pulse_fc[window_start:window_end] * sample_width
+                sampled_pulse_fc[window_start:window_end] * sample_width_ns
             )
             np.testing.assert_allclose(full_integral, window_integral * correction)
 
 
 def test_integration_correction_outofbounds(reference_pulse, sampled_reference_pulse):
     reference_pulse_shape, reference_pulse_step = reference_pulse
-    sampled_pulse, sample_width = sampled_reference_pulse
+    sampled_pulse, sample_width_ns = sampled_reference_pulse
     sampled_pulse_fc = sampled_pulse[0]  # Test first channel
-    full_integral = np.sum(sampled_pulse[0] * sample_width)
+    full_integral = np.sum(sampled_pulse[0] * sample_width_ns)
 
     for window_start in range(0, sampled_pulse_fc.size):
         for window_end in range(sampled_pulse_fc.size, sampled_pulse_fc.size+20):
@@ -118,11 +118,11 @@ def test_integration_correction_outofbounds(reference_pulse, sampled_reference_p
             window_shift = sampled_pulse_fc.argmax() - window_start
             correction = integration_correction(
                 reference_pulse_shape,
-                reference_pulse_step, sample_width,
+                reference_pulse_step, sample_width_ns,
                 window_width, window_shift
             )[0]
             window_integral = np.sum(
-                sampled_pulse_fc[window_start:window_end] * sample_width
+                sampled_pulse_fc[window_start:window_end] * sample_width_ns
             )
             np.testing.assert_allclose(full_integral, window_integral * correction)
 


### PR DESCRIPTION
The integration_correction function corrects an integration of a pulse for the part of the pulse that is outside the integration window. If a noise-less unit pulse is being integrated, then the `integration * correction` should always equal 1, irregardless of the integration window width and shift.

This PR improves the integration_correction method:
- Tests now check that the values returned are correct as per the intention of the method
- Integration windows that extend beyond the reference pulse are now correctly corrected
- The implementation is cleaned up a bit, and the variable names are more clear
- The docstring is improved to more accurately describe the purpose of the method