### PR TITLE
Improvements to ImageExtractor wrt integration_correction and sampling rate

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -4,75 +4,12 @@ calibration and image extraction, as well as supporting algorithms.
 """
 
 import warnings
-
 import numpy as np
-from astropy import units as u
-
 from ctapipe.core import Component
 from ctapipe.image.extractor import NeighborPeakWindowSum
 from ctapipe.image.reducer import NullDataVolumeReducer
 
 __all__ = ["CameraCalibrator"]
-
-
-def integration_correction(
-    reference_pulse_shape, reference_pulse_step, sample_width_ns,
-    window_width, window_shift
-):
-    """
-    Obtain the correction for the integration window specified.
-
-    For any integration window applied to a noise-less unit pulse, the
-    correction (returned by this function) multiplied by the integration
-    result should equal 1.
-
-    This correction therefore corrects for the Cherenkov signal that may be
-    outside the integration window, and removes any dependence of the resulting
-    image on the window_width and window_shift parameters. However, the width
-    and shift of the window should still be optimised for the pulse finding and
-    to minimise the noise included in the integration.
-
-    Parameters
-    ----------
-    reference_pulse_shape : ndarray
-        Numpy array containing the pulse shape for each gain channel
-    reference_pulse_step : float
-        The step in time for each sample of the reference pulse shape in ns
-    sample_width_ns : float
-        The width of the waveform sample time bin in ns
-    window_width : int
-        Width of the integration window (in units of n_samples)
-    window_shift : int
-        Shift to before the peak for the start of the integration window
-        (in units of n_samples)
-
-    Returns
-    -------
-    correction : ndarray
-        Value of the integration correction for each gain channel
-    """
-    n_channels = len(reference_pulse_shape)
-    correction = np.ones(n_channels, dtype=np.float)
-    for ichannel, pulse_shape in enumerate(reference_pulse_shape):
-        pulse_max_sample = pulse_shape.size * reference_pulse_step
-        pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
-        sampled_edges = np.arange(0, pulse_max_sample, sample_width_ns)
-
-        sampled_pulse, _ = np.histogram(
-            pulse_shape_x, sampled_edges, weights=pulse_shape, density=True
-        )
-        n_samples = sampled_pulse.size
-        start = sampled_pulse.argmax() - window_shift
-        start = start if start >= 0 else 0
-        end = start + window_width
-        end = end if end < n_samples else n_samples
-        if start >= end:
-            continue
-
-        integration = sampled_pulse[start:end] * sample_width_ns
-        correction[ichannel] = 1.0 / np.sum(integration)
-
-    return correction
 
 
 class CameraCalibrator(Component):
@@ -130,42 +67,6 @@ class CameraCalibrator(Component):
             image_extractor = NeighborPeakWindowSum(parent=self, subarray=subarray)
         self.image_extractor = image_extractor
 
-    def _get_correction(self, event, telid):
-        """
-        Obtain the integration correction for this telescope.
-
-        Parameters
-        ----------
-        event : container
-            A `ctapipe` event container
-        telid : int
-            The telescope id.
-            The integration correction is calculated once per telescope.
-
-        Returns
-        -------
-        ndarray
-        """
-        try:
-            selected_gain_channel = event.r1.tel[telid].selected_gain_channel
-            shift = self.image_extractor.window_shift.tel[None]
-            width = self.image_extractor.window_width.tel[None]
-            shape = self.subarray.tel[telid].camera.reference_pulse_shape
-            step_ns = self.subarray.tel[telid].camera.reference_pulse_step.to_value(u.ns)
-            sample_width_ns = (
-                    1/self.subarray.tel[telid].camera.sampling_rate
-            ).to_value(u.ns)
-            correction = integration_correction(
-                shape, step_ns, sample_width_ns, width, shift
-            )
-            pixel_correction = correction[selected_gain_channel]
-            return pixel_correction
-        except (AttributeError, KeyError):
-            # Don't apply correction when window_shift or window_width
-            # does not exist in extractor, or when container does not have
-            # a reference pulse shape
-            return np.ones(event.dl0.tel[telid].waveform.shape[0])
-
     def _check_r1_empty(self, waveforms):
         if waveforms is None:
             if not self._r1_empty_warn:
@@ -200,6 +101,7 @@ class CameraCalibrator(Component):
 
     def _calibrate_dl1(self, event, telid):
         waveforms = event.dl0.tel[telid].waveform
+        selected_gain_channel = event.r1.tel[telid].selected_gain_channel
         if self._check_dl0_empty(waveforms):
             return
         n_pixels, n_samples = waveforms.shape
@@ -213,13 +115,9 @@ class CameraCalibrator(Component):
             charge = waveforms[..., 0]
             pulse_time = np.zeros(n_pixels)
         else:
-            # TODO: apply timing correction to waveforms before charge extraction
-            charge, pulse_time = self.image_extractor(waveforms, telid=telid)
-
-            # Apply integration correction
-            # TODO: Remove integration correction
-            correction = self._get_correction(event, telid)
-            charge = charge * correction
+            charge, pulse_time = self.image_extractor(
+                waveforms, telid=telid, selected_gain_channel=selected_gain_channel
+            )
 
         # Calibrate extracted charge
         pedestal = event.calibration.tel[telid].dl1.pedestal_offset

--- a/ctapipe/calib/camera/flatfield.py
+++ b/ctapipe/calib/camera/flatfield.py
@@ -199,7 +199,9 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
         charge = 0
         peak_pos = 0
         if self.extractor:
-            charge, peak_pos = self.extractor(waveforms, self.tel_id, selected_gain_channel)
+            charge, peak_pos = self.extractor(
+                waveforms, self.tel_id, selected_gain_channel
+            )
 
         return charge, peak_pos
 

--- a/ctapipe/calib/camera/flatfield.py
+++ b/ctapipe/calib/camera/flatfield.py
@@ -193,12 +193,13 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
         """
 
         waveforms = event.r1.tel[self.tel_id].waveform
+        selected_gain_channel = event.r1.tel[self.tel_id].selected_gain_channel
 
         # Extract charge and time
         charge = 0
         peak_pos = 0
         if self.extractor:
-            charge, peak_pos = self.extractor(waveforms, self.tel_id)
+            charge, peak_pos = self.extractor(waveforms, self.tel_id, selected_gain_channel)
 
         return charge, peak_pos
 

--- a/ctapipe/calib/camera/pedestals.py
+++ b/ctapipe/calib/camera/pedestals.py
@@ -223,12 +223,15 @@ class PedestalIntegrator(PedestalCalculator):
         """
 
         waveforms = event.r1.tel[self.tel_id].waveform
+        selected_gain_channel = event.r1.tel[self.tel_id].selected_gain_channel
 
         # Extract charge and time
         charge = 0
         peak_pos = 0
         if self.extractor:
-            charge, peak_pos = self.extractor(waveforms, self.tel_id)
+            charge, peak_pos = self.extractor(
+                waveforms, self.tel_id, selected_gain_channel
+            )
 
         return charge, peak_pos
 

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -7,10 +7,7 @@ from scipy.stats import norm
 from traitlets.config.configurable import Config
 from astropy import units as u
 
-from ctapipe.calib.camera.calibrator import (
-    CameraCalibrator,
-    integration_correction,
-)
+from ctapipe.calib.camera.calibrator import CameraCalibrator
 from ctapipe.image.extractor import LocalPeakWindowSum, FullWaveformSum
 from ctapipe.instrument import CameraGeometry
 from ctapipe.io.containers import DataContainer
@@ -19,31 +16,6 @@ from ctapipe.io.containers import DataContainer
 @pytest.fixture(scope="function")
 def subarray(example_event):
     return example_event.inst.subarray
-
-
-@pytest.fixture('module')
-def reference_pulse():
-    reference_pulse_step = 0.09
-    n_reference_pulse_samples = 1280
-    reference_pulse_shape = np.array([
-        norm.pdf(np.arange(n_reference_pulse_samples), 600, 100) * 1.7,
-        norm.pdf(np.arange(n_reference_pulse_samples), 700, 100) * 1.7,
-    ])
-    return reference_pulse_shape, reference_pulse_step
-
-
-@pytest.fixture('module')
-def sampled_reference_pulse(reference_pulse):
-    reference_pulse_shape, reference_pulse_step = reference_pulse
-    n_channels, n_reference_pulse_samples = reference_pulse_shape.shape
-    pulse_max_sample = n_reference_pulse_samples * reference_pulse_step
-    sample_width_ns = 2
-    pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
-    sampled_edges = np.arange(0, pulse_max_sample, sample_width_ns)
-    sampled_pulse = np.array([np.histogram(
-        pulse_shape_x, sampled_edges, weights=reference_pulse_shape[ichan], density=True
-    )[0] for ichan in range(n_channels)])
-    return sampled_pulse, sample_width_ns
 
 
 def test_camera_calibrator(example_event, subarray):
@@ -86,57 +58,6 @@ def test_config(subarray):
     assert calibrator.image_extractor.window_width.tel[None] == window_width
 
 
-def test_integration_correction(reference_pulse, sampled_reference_pulse):
-    reference_pulse_shape, reference_pulse_step = reference_pulse
-    sampled_pulse, sample_width_ns = sampled_reference_pulse
-    sampled_pulse_fc = sampled_pulse[0]  # Test first channel
-    full_integral = np.sum(sampled_pulse[0] * sample_width_ns)
-
-    for window_start in range(0, sampled_pulse_fc.size):
-        for window_end in range(window_start+1, sampled_pulse_fc.size):
-            window_width = window_end - window_start
-            window_shift = sampled_pulse_fc.argmax() - window_start
-            correction = integration_correction(
-                reference_pulse_shape,
-                reference_pulse_step, sample_width_ns,
-                window_width, window_shift
-            )[0]
-            window_integral = np.sum(
-                sampled_pulse_fc[window_start:window_end] * sample_width_ns
-            )
-            np.testing.assert_allclose(full_integral, window_integral * correction)
-
-
-def test_integration_correction_outofbounds(reference_pulse, sampled_reference_pulse):
-    reference_pulse_shape, reference_pulse_step = reference_pulse
-    sampled_pulse, sample_width_ns = sampled_reference_pulse
-    sampled_pulse_fc = sampled_pulse[0]  # Test first channel
-    full_integral = np.sum(sampled_pulse[0] * sample_width_ns)
-
-    for window_start in range(0, sampled_pulse_fc.size):
-        for window_end in range(sampled_pulse_fc.size, sampled_pulse_fc.size+20):
-            window_width = window_end - window_start
-            window_shift = sampled_pulse_fc.argmax() - window_start
-            correction = integration_correction(
-                reference_pulse_shape,
-                reference_pulse_step, sample_width_ns,
-                window_width, window_shift
-            )[0]
-            window_integral = np.sum(
-                sampled_pulse_fc[window_start:window_end] * sample_width_ns
-            )
-            np.testing.assert_allclose(full_integral, window_integral * correction)
-
-
-def test_integration_correction_no_ref_pulse(example_event, subarray):
-    telid = list(example_event.r0.tel)[0]
-    delattr(example_event.inst.subarray.tel[telid].camera, "reference_pulse_shape")
-    calibrator = CameraCalibrator(subarray=subarray)
-    calibrator._calibrate_dl0(example_event, telid)
-    correction = calibrator._get_correction(example_event, telid)
-    assert (correction == 1).all()
-
-
 def test_check_r1_empty(example_event, subarray):
     calibrator = CameraCalibrator(subarray=subarray)
     telid = list(example_event.r0.tel)[0]
@@ -158,10 +79,11 @@ def test_check_r1_empty(example_event, subarray):
     with pytest.warns(UserWarning):
         calibrator(event)
     assert (event.dl0.tel[telid].waveform == 2).all()
-    assert (event.dl1.tel[telid].image == 2 * 128).all()
+    sampling_rate = subarray.tel[telid].camera.sampling_rate.to_value('GHz')
+    assert (event.dl1.tel[telid].image == 2 * 128 / sampling_rate).all()
 
 
-def test_check_dl0_empty(example_event):
+def test_check_dl0_empty(example_event, subarray):
     calibrator = CameraCalibrator(subarray=subarray)
     telid = list(example_event.r0.tel)[0]
     calibrator._calibrate_dl0(example_event, telid)
@@ -182,7 +104,7 @@ def test_check_dl0_empty(example_event):
     assert (event.dl1.tel[telid].image == 2).all()
 
 
-def test_dl1_charge_calib():
+def test_dl1_charge_calib(subarray):
     camera = CameraGeometry.from_name("CHEC")
     n_pixels = camera.n_pixels
     n_samples = 96
@@ -208,7 +130,7 @@ def test_dl1_charge_calib():
     y += pedestal[:, np.newaxis]
 
     event = DataContainer()
-    telid = 0
+    telid = list(subarray.tel.keys())[0]
     event.dl0.tel[telid].waveform = y
 
     # Test default

--- a/ctapipe/calib/camera/tests/test_flatfield.py
+++ b/ctapipe/calib/camera/tests/test_flatfield.py
@@ -23,6 +23,8 @@ def test_flasherflatfieldcalculator():
             ),
         }
     )
+    subarray.tel[0].camera.reference_pulse_shape = np.ones((1, 2))
+    subarray.tel[0].camera.reference_pulse_step = u.Quantity(1, u.ns)
 
     config = Config({
         "FixedWindowSum": {

--- a/ctapipe/calib/camera/tests/test_pedestals.py
+++ b/ctapipe/calib/camera/tests/test_pedestals.py
@@ -27,6 +27,8 @@ def test_pedestal_calculator():
             ),
         },
     )
+    subarray.tel[0].camera.reference_pulse_shape = np.ones((1, 2))
+    subarray.tel[0].camera.reference_pulse_step = u.Quantity(1, u.ns)
 
     ped_calculator = PedestalIntegrator(
         subarray=subarray,

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -231,7 +231,8 @@ class ImageExtractor(Component):
     def __init__(self, subarray, config=None, parent=None, **kwargs):
         """
         Base component to handle the extraction of charge and pulse time
-        from an image cube (waveforms), taking into account the sampling rate of the waveform.
+        from an image cube (waveforms), taking into account the sampling rate
+        of the waveform.
 
         Assuming a waveform with sample units X and containing a noise-less unit
         pulse, the aim of the ImageExtractor is to return 1 X*ns.

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -13,10 +13,12 @@ __all__ = [
     "extract_around_peak",
     "neighbor_average_waveform",
     "subtract_baseline",
+    "integration_correction"
 ]
 
 
 from abc import abstractmethod
+from functools import lru_cache
 import numpy as np
 from traitlets import Int
 from ctapipe.core.traits import IntTelescopeParameter
@@ -26,13 +28,15 @@ from numba import njit, prange, guvectorize, float64, float32, int64
 
 @guvectorize(
     [
-        (float64[:], int64, int64, int64, float64[:], float64[:]),
-        (float32[:], int64, int64, int64, float64[:], float64[:]),
+        (float64[:], int64, int64, int64, float64, float64[:], float64[:]),
+        (float32[:], int64, int64, int64, float64, float64[:], float64[:]),
     ],
-    "(s),(),(),()->(),()",
+    "(s),(),(),(),()->(),()",
     nopython=True,
 )
-def extract_around_peak(waveforms, peak_index, width, shift, sum_, pulse_time):
+def extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz, sum_, pulse_time
+):
     """
     This function performs the following operations:
 
@@ -62,12 +66,15 @@ def extract_around_peak(waveforms, peak_index, width, shift, sum_, pulse_time):
         Window size of integration window for each pixel.
     shift : ndarray or int
         Window size of integration window for each pixel.
+    sampling_rate_ghz : float
+        Sampling rate of the camera, in units of GHz
+        Astropy units should have to_value('GHz') applied before being passed
     sum_ : ndarray
         Return argument for ufunc (ignore)
-        Returns the sum
+        Returns the sum (integration) of the waveforms in units "waveform_units * ns"
     pulse_time : ndarray
         Return argument for ufunc (ignore)
-        Returns the pulse_time
+        Returns the pulse_time in units "ns"
 
     Returns
     -------
@@ -88,9 +95,11 @@ def extract_around_peak(waveforms, peak_index, width, shift, sum_, pulse_time):
             if waveforms[isample] > 0:
                 time_num += waveforms[isample] * isample
                 time_den += waveforms[isample]
-
-    # TODO: Return pulse time in units of ns instead of isample
     pulse_time[0] = time_num / time_den if time_den > 0 else peak_index
+
+    # Convert to units of ns
+    sum_[0] /= sampling_rate_ghz
+    pulse_time[0] /= sampling_rate_ghz
 
 
 @njit(parallel=True)
@@ -158,11 +167,74 @@ def subtract_baseline(waveforms, baseline_start, baseline_end):
     return baseline_corrected
 
 
+def integration_correction(
+    reference_pulse_shape, reference_pulse_step, sample_width_ns,
+    window_width, window_shift
+):
+    """
+    Obtain the correction for the integration window specified.
+
+    For any integration window applied to a noise-less unit pulse, the
+    correction (returned by this function) multiplied by the integration
+    result should equal 1.
+
+    This correction therefore corrects for the Cherenkov signal that may be
+    outside the integration window, and removes any dependence of the resulting
+    image on the window_width and window_shift parameters. However, the width
+    and shift of the window should still be optimised for the pulse finding and
+    to minimise the noise included in the integration.
+
+    Parameters
+    ----------
+    reference_pulse_shape : ndarray
+        Numpy array containing the pulse shape for each gain channel
+    reference_pulse_step : float
+        The step in time for each sample of the reference pulse shape in ns
+    sample_width_ns : float
+        The width of the waveform sample time bin in ns
+    window_width : int
+        Width of the integration window (in units of n_samples)
+    window_shift : int
+        Shift to before the peak for the start of the integration window
+        (in units of n_samples)
+
+    Returns
+    -------
+    correction : ndarray
+        Value of the integration correction for each gain channel
+    """
+    n_channels = len(reference_pulse_shape)
+    correction = np.ones(n_channels, dtype=np.float)
+    for ichannel, pulse_shape in enumerate(reference_pulse_shape):
+        pulse_max_sample = pulse_shape.size * reference_pulse_step
+        pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
+        sampled_edges = np.arange(0, pulse_max_sample, sample_width_ns)
+
+        sampled_pulse, _ = np.histogram(
+            pulse_shape_x, sampled_edges, weights=pulse_shape, density=True
+        )
+        n_samples = sampled_pulse.size
+        start = sampled_pulse.argmax() - window_shift
+        start = start if start >= 0 else 0
+        end = start + window_width
+        end = end if end < n_samples else n_samples
+        if start >= end:
+            continue
+
+        integration = sampled_pulse[start:end] * sample_width_ns
+        correction[ichannel] = 1.0 / np.sum(integration)
+
+    return correction
+
+
 class ImageExtractor(Component):
     def __init__(self, subarray, config=None, parent=None, **kwargs):
         """
         Base component to handle the extraction of charge and pulse time
-        from an image cube (waveforms).
+        from an image cube (waveforms), taking into account the sampling rate of the waveform.
+
+        Assuming a waveform with sample units X and containing a noise-less unit
+        pulse, the aim of the ImageExtractor is to return 1 X*ns.
 
         Parameters
         ----------
@@ -189,8 +261,34 @@ class ImageExtractor(Component):
             except (AttributeError, TypeError):
                 pass
 
+        self.sampling_rate = {
+            telid: telescope.camera.sampling_rate.to_value('GHz')
+            for telid, telescope in subarray.tel.items()
+        }
+
     @abstractmethod
-    def __call__(self, waveforms, telid=None):
+    def _calculate_correction(self, telid):
+        """
+        Calculate the correction for the extracted change such that the value
+        returned would equal 1 for a noise-less unit pulse.
+
+        Decorate this method with @lru_cache to ensure it is only calculated
+        once per telescope
+
+        Parameters
+        ----------
+        telid : int
+
+        Returns
+        -------
+        correction : ndarray
+        The correction to apply to an extracted charge using this ImageExtractor
+        Has size n_channels, as a different correction value might be required
+        for different gain channels
+        """
+
+    @abstractmethod
+    def __call__(self, waveforms, telid, selected_gain_channel):
         """
         Call the relevant functions to fully extract the charge and time
         for the particular extractor.
@@ -202,15 +300,19 @@ class ImageExtractor(Component):
             (n_pix, n_samples).
         telid : int
             The telescope id. Used to obtain to correct traitlet configuration
-            If None, the subarray global default value is used
+            and instrument properties
+        selected_gain_channel : ndarray
+            The channel selected in the gain selection, per pixel. Required in
+            some cases to calculate the correct correction for the charge
+            extraction.
 
         Returns
         -------
         charge : ndarray
-            Extracted charge.
+            Charge extracted from the waveform in "waveform_units * ns"
             Shape: (n_pix)
         pulse_time : ndarray
-            Floating point pulse time in each pixel.
+            Floating point pulse time in each pixel in units "ns"
             Shape: (n_pix)
         """
 
@@ -220,8 +322,16 @@ class FullWaveformSum(ImageExtractor):
     Extractor that sums the entire waveform.
     """
 
-    def __call__(self, waveforms, telid=None):
-        charge, pulse_time = extract_around_peak(waveforms, 0, waveforms.shape[-1], 0)
+    def _calculate_correction(self, telid):
+        """
+        No correction is required, as the full pulse has been integrated.
+        """
+        return 1
+
+    def __call__(self, waveforms, telid, selected_gain_channel):
+        charge, pulse_time = extract_around_peak(
+            waveforms, 0, waveforms.shape[-1], 0, self.sampling_rate[telid]
+        )
         return charge, pulse_time
 
 
@@ -237,11 +347,27 @@ class FixedWindowSum(ImageExtractor):
         default_value=7, help="Define the width of the integration window"
     ).tag(config=True)
 
-    def __call__(self, waveforms, telid=None):
-        charge, pulse_time = extract_around_peak(
-            waveforms, self.window_start.tel[telid], self.window_width.tel[telid], 0
+    @lru_cache(maxsize=128)
+    def _calculate_correction(self, telid):
+        """
+        Assuming the pulse is centered in the manually defined integration
+        window, the integration_correction with a shift=0 is correct
+        """
+        return integration_correction(
+            self.subarray.tel[telid].camera.reference_pulse_shape,
+            self.subarray.tel[telid].camera.reference_pulse_step.to_value('ns'),
+            (1/self.subarray.tel[telid].camera.sampling_rate).to_value('ns'),
+            self.window_width.tel[telid],
+            0,
         )
-        return charge, pulse_time
+
+    def __call__(self, waveforms, telid, selected_gain_channel):
+        charge, pulse_time = extract_around_peak(
+            waveforms, self.window_start.tel[telid], self.window_width.tel[telid], 0,
+            self.sampling_rate[telid]
+        )
+        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge * correction, pulse_time
 
 
 class GlobalPeakWindowSum(ImageExtractor):
@@ -259,15 +385,27 @@ class GlobalPeakWindowSum(ImageExtractor):
         "(peak_index - shift)",
     ).tag(config=True)
 
-    def __call__(self, waveforms, telid=None):
+    @lru_cache(maxsize=128)
+    def _calculate_correction(self, telid):
+        return integration_correction(
+            self.subarray.tel[telid].camera.reference_pulse_shape,
+            self.subarray.tel[telid].camera.reference_pulse_step.to_value('ns'),
+            (1/self.subarray.tel[telid].camera.sampling_rate).to_value('ns'),
+            self.window_width.tel[telid],
+            self.window_shift.tel[telid],
+        )
+
+    def __call__(self, waveforms, telid, selected_gain_channel):
         peak_index = waveforms.mean(axis=-2).argmax(axis=-1)
         charge, pulse_time = extract_around_peak(
             waveforms,
             peak_index,
             self.window_width.tel[telid],
             self.window_shift.tel[telid],
+            self.sampling_rate[telid]
         )
-        return charge, pulse_time
+        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge * correction, pulse_time
 
 
 class LocalPeakWindowSum(ImageExtractor):
@@ -285,15 +423,27 @@ class LocalPeakWindowSum(ImageExtractor):
         "from the peak_index (peak_index - shift)",
     ).tag(config=True)
 
-    def __call__(self, waveforms, telid=None):
+    @lru_cache(maxsize=128)
+    def _calculate_correction(self, telid):
+        return integration_correction(
+            self.subarray.tel[telid].camera.reference_pulse_shape,
+            self.subarray.tel[telid].camera.reference_pulse_step.to_value('ns'),
+            (1/self.subarray.tel[telid].camera.sampling_rate).to_value('ns'),
+            self.window_width.tel[telid],
+            self.window_shift.tel[telid],
+        )
+
+    def __call__(self, waveforms, telid, selected_gain_channel):
         peak_index = waveforms.argmax(axis=-1).astype(np.int)
         charge, pulse_time = extract_around_peak(
             waveforms,
             peak_index,
             self.window_width.tel[telid],
             self.window_shift.tel[telid],
+            self.sampling_rate[telid]
         )
-        return charge, pulse_time
+        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge * correction, pulse_time
 
 
 class NeighborPeakWindowSum(ImageExtractor):
@@ -316,7 +466,17 @@ class NeighborPeakWindowSum(ImageExtractor):
         "1: local pixel counts as much as any neighbor)",
     ).tag(config=True)
 
-    def __call__(self, waveforms, telid=None):
+    @lru_cache(maxsize=128)
+    def _calculate_correction(self, telid):
+        return integration_correction(
+            self.subarray.tel[telid].camera.reference_pulse_shape,
+            self.subarray.tel[telid].camera.reference_pulse_step.to_value('ns'),
+            (1/self.subarray.tel[telid].camera.sampling_rate).to_value('ns'),
+            self.window_width.tel[telid],
+            self.window_shift.tel[telid],
+        )
+
+    def __call__(self, waveforms, telid, selected_gain_channel):
         neighbors = self.subarray.tel[telid].camera.neighbor_matrix_where
         average_wfs = neighbor_average_waveform(
             waveforms, neighbors, self.lwt.tel[telid]
@@ -327,8 +487,10 @@ class NeighborPeakWindowSum(ImageExtractor):
             peak_index,
             self.window_width.tel[telid],
             self.window_shift.tel[telid],
+            self.sampling_rate[telid]
         )
-        return charge, pulse_time
+        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge * correction, pulse_time
 
 
 class BaselineSubtractedNeighborPeakWindowSum(NeighborPeakWindowSum):
@@ -342,8 +504,8 @@ class BaselineSubtractedNeighborPeakWindowSum(NeighborPeakWindowSum):
     )
     baseline_end = Int(10, help="End sample for baseline estimation").tag(config=True)
 
-    def __call__(self, waveforms, telid=None):
+    def __call__(self, waveforms, telid, selected_gain_channel):
         baseline_corrected = subtract_baseline(
             waveforms, self.baseline_start, self.baseline_end
         )
-        return super().__call__(baseline_corrected, telid)
+        return super().__call__(baseline_corrected, telid, selected_gain_channel)

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -282,7 +282,9 @@ def test_neighbor_peak_window_sum_lwt(camera_waveforms):
 def test_waveform_extractor_factory(camera_waveforms):
     waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = ImageExtractor.from_name("LocalPeakWindowSum", subarray=subarray)
-    extractor(waveforms, telid, selected_gain_channel)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge, true_charge, rtol=0.1)
+    assert_allclose(pulse_time, waveforms.shape[1]//2, rtol=0.1)
 
 
 def test_waveform_extractor_factory_args(camera_waveforms):

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -9,6 +9,7 @@ from ctapipe.image.extractor import (
     extract_around_peak,
     neighbor_average_waveform,
     subtract_baseline,
+    integration_correction,
     ImageExtractor,
     FullWaveformSum,
     FixedWindowSum,
@@ -22,6 +23,7 @@ from ctapipe.instrument import SubarrayDescription, TelescopeDescription
 
 @pytest.fixture(scope="module")
 def camera_waveforms():
+    telid = 1
     subarray = SubarrayDescription(
         "test array",
         tel_positions={1: np.zeros(3) * u.m, 2: np.ones(3) * u.m},
@@ -44,88 +46,144 @@ def camera_waveforms():
     x = np.arange(n_samples)
 
     # Randomize times
-    t_pulse = random.uniform(mid - 10, mid + 10, n_pixels)[:, np.newaxis]
+    t_pulse = random.uniform(mid - 2, mid + 2, n_pixels)[:, np.newaxis]
 
     # Create pulses
     y = norm.pdf(x, t_pulse, pulse_sigma)
 
-    # Randomize amplitudes
-    y *= random.uniform(100, 1000, n_pixels)[:, np.newaxis]
+    # Create reference pulse
+    x_ref = np.arange(n_samples*2)
+    reference_pulse = norm.pdf(x_ref, n_samples, pulse_sigma*2)
+    subarray.tel[telid].camera.reference_pulse_shape = [reference_pulse]
+    subarray.tel[telid].camera.reference_pulse_step = u.Quantity(0.5, u.ns)
 
-    return y, subarray
+    # Randomize amplitudes
+    charge = random.uniform(100, 1000, n_pixels)
+    y *= charge[:, np.newaxis]
+
+    selected_gain_channel = np.zeros(n_pixels, dtype=np.int)
+
+    return y, subarray, telid, selected_gain_channel, charge
+
+
+@pytest.fixture('module')
+def reference_pulse():
+    reference_pulse_step = 0.09
+    n_reference_pulse_samples = 1280
+    reference_pulse_shape = np.array([
+        norm.pdf(np.arange(n_reference_pulse_samples), 600, 100) * 1.7,
+        norm.pdf(np.arange(n_reference_pulse_samples), 700, 100) * 1.7,
+    ])
+    return reference_pulse_shape, reference_pulse_step
+
+
+@pytest.fixture('module')
+def sampled_reference_pulse(reference_pulse):
+    reference_pulse_shape, reference_pulse_step = reference_pulse
+    n_channels, n_reference_pulse_samples = reference_pulse_shape.shape
+    pulse_max_sample = n_reference_pulse_samples * reference_pulse_step
+    sample_width_ns = 2
+    pulse_shape_x = np.arange(0, pulse_max_sample, reference_pulse_step)
+    sampled_edges = np.arange(0, pulse_max_sample, sample_width_ns)
+    sampled_pulse = np.array([np.histogram(
+        pulse_shape_x, sampled_edges, weights=reference_pulse_shape[ichan], density=True
+    )[0] for ichan in range(n_channels)])
+    return sampled_pulse, sample_width_ns
 
 
 def test_extract_around_peak(camera_waveforms):
-    waveforms, _ = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     n_pixels, n_samples = waveforms.shape
     rand = np.random.RandomState(1)
     peak_index = rand.uniform(0, n_samples, n_pixels).astype(np.int)
-    charge, pulse_time = extract_around_peak(waveforms, peak_index, 7, 3)
-    assert_allclose(charge[0], 146.022991, rtol=1e-3)
-    assert_allclose(pulse_time[0], 40.659884, rtol=1e-3)
+    charge, pulse_time = extract_around_peak(waveforms, peak_index, 7, 3, 1)
+    assert_allclose(charge[0], 115.838406, rtol=1e-3)
+    assert_allclose(pulse_time[0], 40.789745, rtol=1e-3)
 
     x = np.arange(100)
     y = norm.pdf(x, 41.2, 6)
-    charge, pulse_time = extract_around_peak(y[np.newaxis, :], 0, x.size, 0)
+    charge, pulse_time = extract_around_peak(y[np.newaxis, :], 0, x.size, 0, 1)
     assert_allclose(charge[0], 1.0, rtol=1e-3)
     assert_allclose(pulse_time[0], 41.2, rtol=1e-3)
 
     # Test negative amplitude
     y_offset = y - y.max() / 2
-    charge, pulse_time = extract_around_peak(y_offset[np.newaxis, :], 0, x.size, 0)
+    charge, pulse_time = extract_around_peak(y_offset[np.newaxis, :], 0, x.size, 0, 1)
     assert_allclose(charge, y_offset.sum(), rtol=1e-3)
 
 
 def test_extract_around_peak_charge_expected(camera_waveforms):
-    waveforms, _ = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     waveforms = np.ones(waveforms.shape)
     n_samples = waveforms.shape[-1]
+    sampling_rate_ghz = 1
 
     peak_index = 0
     width = 10
     shift = 0
-    charge, _ = extract_around_peak(waveforms, peak_index, width, shift)
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz
+    )
     assert_equal(charge, 10)
 
     peak_index = 0
     width = 10
     shift = 10
-    charge, _ = extract_around_peak(waveforms, peak_index, width, shift)
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz
+    )
     assert_equal(charge, 0)
 
     peak_index = 0
     width = 20
     shift = 10
-    charge, _ = extract_around_peak(waveforms, peak_index, width, shift)
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz
+    )
     assert_equal(charge, 10)
 
     peak_index = n_samples
     width = 10
     shift = 0
-    charge, _ = extract_around_peak(waveforms, peak_index, width, shift)
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz
+    )
     assert_equal(charge, 0)
 
     peak_index = n_samples
     width = 20
     shift = 10
-    charge, _ = extract_around_peak(waveforms, peak_index, width, shift)
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz
+    )
     assert_equal(charge, 10)
 
     peak_index = 0
     width = n_samples * 3
     shift = n_samples
-    charge, _ = extract_around_peak(waveforms, peak_index, width, shift)
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz
+    )
     assert_equal(charge, n_samples)
+
+    # Test sampling rate
+    peak_index = n_samples
+    width = 20
+    shift = 10
+    charge, _ = extract_around_peak(
+        waveforms, peak_index, width, shift, sampling_rate_ghz * 2
+    )
+    assert_equal(charge, 5)
 
 
 def test_neighbor_average_waveform(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     nei = subarray.tel[1].camera.neighbor_matrix_where
     average_wf = neighbor_average_waveform(waveforms, nei, 0)
-    assert_allclose(average_wf[0, 48], 28.690154, rtol=1e-3)
+    assert_allclose(average_wf[0, 48], 50.069126, rtol=1e-3)
 
     average_wf = neighbor_average_waveform(waveforms, nei, 4)
-    assert_allclose(average_wf[0, 48], 98.565743, rtol=1e-3)
+    assert_allclose(average_wf[0, 48], 122.558372, rtol=1e-3)
 
 
 def test_extract_pulse_time_within_range():
@@ -133,12 +191,12 @@ def test_extract_pulse_time_within_range():
     # Generic waveform that goes from positive to negative in window
     # Can cause extreme values with incorrect handling of weighted average
     y = -1.2 * x + 20
-    _, pulse_time = extract_around_peak(y[np.newaxis, :], 12, 10, 0)
+    _, pulse_time = extract_around_peak(y[np.newaxis, :], 12, 10, 0, 1)
     assert (pulse_time >= 0).all() & (pulse_time < x.size).all()
 
 
 def test_baseline_subtractor(camera_waveforms):
-    waveforms, _ = camera_waveforms
+    waveforms, _, _, _, _ = camera_waveforms
     n_pixels, _ = waveforms.shape
     rand = np.random.RandomState(1)
     offset = np.arange(n_pixels)[:, np.newaxis]
@@ -148,70 +206,112 @@ def test_baseline_subtractor(camera_waveforms):
     assert_allclose(baseline_subtracted.mean(), 0, atol=1e-3)
 
 
+def test_integration_correction(reference_pulse, sampled_reference_pulse):
+    reference_pulse_shape, reference_pulse_step = reference_pulse
+    sampled_pulse, sample_width_ns = sampled_reference_pulse
+    sampled_pulse_fc = sampled_pulse[0]  # Test first channel
+    full_integral = np.sum(sampled_pulse[0] * sample_width_ns)
+
+    for window_start in range(0, sampled_pulse_fc.size):
+        for window_end in range(window_start+1, sampled_pulse_fc.size):
+            window_width = window_end - window_start
+            window_shift = sampled_pulse_fc.argmax() - window_start
+            correction = integration_correction(
+                reference_pulse_shape,
+                reference_pulse_step, sample_width_ns,
+                window_width, window_shift
+            )[0]
+            window_integral = np.sum(
+                sampled_pulse_fc[window_start:window_end] * sample_width_ns
+            )
+            np.testing.assert_allclose(full_integral, window_integral * correction)
+
+
+def test_integration_correction_outofbounds(reference_pulse, sampled_reference_pulse):
+    reference_pulse_shape, reference_pulse_step = reference_pulse
+    sampled_pulse, sample_width_ns = sampled_reference_pulse
+    sampled_pulse_fc = sampled_pulse[0]  # Test first channel
+    full_integral = np.sum(sampled_pulse[0] * sample_width_ns)
+
+    for window_start in range(0, sampled_pulse_fc.size):
+        for window_end in range(sampled_pulse_fc.size, sampled_pulse_fc.size+20):
+            window_width = window_end - window_start
+            window_shift = sampled_pulse_fc.argmax() - window_start
+            correction = integration_correction(
+                reference_pulse_shape,
+                reference_pulse_step, sample_width_ns,
+                window_width, window_shift
+            )[0]
+            window_integral = np.sum(
+                sampled_pulse_fc[window_start:window_end] * sample_width_ns
+            )
+            np.testing.assert_allclose(full_integral, window_integral * correction)
+
+
 def test_full_waveform_sum(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = FullWaveformSum(subarray=subarray)
-    charge, pulse_time = extractor(waveforms)
-    assert_allclose(charge[0], 545.945, rtol=1e-3)
-    assert_allclose(pulse_time[0], 46.34044, rtol=1e-3)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 46.34044, rtol=0.1)
 
 
 def test_fixed_window_sum(camera_waveforms):
-    waveforms, subarray = camera_waveforms
-    extractor = FixedWindowSum(subarray=subarray, window_start=45)
-    charge, pulse_time = extractor(waveforms)
-    assert_allclose(charge[0], 232.559, rtol=1e-3)
-    assert_allclose(pulse_time[0], 47.823488, rtol=1e-3)
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
+    extractor = FixedWindowSum(subarray=subarray, window_start=47)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 47.823488, rtol=0.1)
 
 
 def test_global_peak_window_sum(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = GlobalPeakWindowSum(subarray=subarray)
-    charge, pulse_time = extractor(waveforms)
-    assert_allclose(charge[0], 232.559, rtol=1e-3)
-    assert_allclose(pulse_time[0], 47.823488, rtol=1e-3)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 47.823488, rtol=0.1)
 
 
 def test_local_peak_window_sum(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = LocalPeakWindowSum(subarray=subarray)
-    charge, pulse_time = extractor(waveforms)
-    assert_allclose(charge[0], 240.3, rtol=1e-3)
-    assert_allclose(pulse_time[0], 46.036266, rtol=1e-3)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 46.036266, rtol=0.1)
 
 
 def test_neighbor_peak_window_sum(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = NeighborPeakWindowSum(subarray=subarray)
-    charge, pulse_time = extractor(waveforms, telid=1)
-    assert_allclose(charge[0], 94.671, rtol=1e-3)
-    assert_allclose(pulse_time[0], 54.116092, rtol=1e-3)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 54.116092, rtol=0.1)
 
     extractor.lwt = 4
-    charge, pulse_time = extractor(waveforms, telid=1)
-    assert_allclose(charge[0], 220.418657, rtol=1e-3)
-    assert_allclose(pulse_time[0], 48.717848, rtol=1e-3)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 48.717848, rtol=0.1)
 
 
 def test_baseline_subtracted_neighbor_peak_window_sum(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = BaselineSubtractedNeighborPeakWindowSum(subarray=subarray)
-    charge, pulse_time = extractor(waveforms, telid=1)
-    assert_allclose(charge[0], 94.671, rtol=1e-3)
-    assert_allclose(pulse_time[0], 54.116092, rtol=1e-3)
+    charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge[0], true_charge[0], rtol=0.1)
+    assert_allclose(pulse_time[0], 54.116092, rtol=0.1)
 
 
 def test_waveform_extractor_factory(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, telid, selected_gain_channel, true_charge = camera_waveforms
     extractor = ImageExtractor.from_name("LocalPeakWindowSum", subarray=subarray)
-    extractor(waveforms)
+    extractor(waveforms, telid, selected_gain_channel)
 
 
 def test_waveform_extractor_factory_args(camera_waveforms):
     """
     Config is supposed to be created by a `Tool`
     """
-    _, subarray = camera_waveforms
+    _, subarray, _, _, _ = camera_waveforms
     config = Config({"ImageExtractor": {"window_width": 20, "window_shift": 3,}})
 
     extractor = ImageExtractor.from_name(
@@ -230,7 +330,7 @@ def test_waveform_extractor_factory_args(camera_waveforms):
 
 
 def test_extractor_tel_param(camera_waveforms):
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, _, _, _ = camera_waveforms
     _, n_samples = waveforms.shape
 
     config = Config(
@@ -242,7 +342,7 @@ def test_extractor_tel_param(camera_waveforms):
         }
     )
 
-    waveforms, subarray = camera_waveforms
+    waveforms, subarray, _, _, _ = camera_waveforms
     n_pixels, n_samples = waveforms.shape
     extractor = ImageExtractor.from_name(
         "FixedWindowSum",

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -83,19 +83,20 @@ class ImagePlotter(Component):
             self.c_intensity = CameraDisplay(geom, ax=self.ax_intensity)
             self.c_pulse_time = CameraDisplay(geom, ax=self.ax_pulse_time)
 
-            tmaxmin = event.dl0.tel[telid].waveform.shape[1]
-            t_chargemax = pulse_time[image.argmax()]
-            cmap_time = colors.LinearSegmentedColormap.from_list(
-                "cmap_t",
-                [
-                    (0 / tmaxmin, "darkgreen"),
-                    (0.6 * t_chargemax / tmaxmin, "green"),
-                    (t_chargemax / tmaxmin, "yellow"),
-                    (1.4 * t_chargemax / tmaxmin, "blue"),
-                    (1, "darkblue"),
-                ],
-            )
-            self.c_pulse_time.pixels.set_cmap(cmap_time)
+            if (pulse_time != 0.).all():
+                tmaxmin = event.dl0.tel[telid].waveform.shape[1]
+                t_chargemax = pulse_time[image.argmax()]
+                cmap_time = colors.LinearSegmentedColormap.from_list(
+                    "cmap_t",
+                    [
+                        (0 / tmaxmin, "darkgreen"),
+                        (0.6 * t_chargemax / tmaxmin, "green"),
+                        (t_chargemax / tmaxmin, "yellow"),
+                        (1.4 * t_chargemax / tmaxmin, "blue"),
+                        (1, "darkblue"),
+                    ],
+                )
+                self.c_pulse_time.pixels.set_cmap(cmap_time)
 
             if not self.cb_intensity:
                 self.c_intensity.add_colorbar(


### PR DESCRIPTION
The integration_correction is a powerful tool. It removes the dependance of the resulting extracted charge on the size of the integration window used. This means that any other calibration is integration window independent!

However, there are two problems in the way we currently use it:
1. As it is currently attached to the CameraCalibrator, it is the same method applied for any ImageExtractor. For the currently defined extractors this has been somewhat alright, as they are all integration-window based. But for more advanced extractors (e.g. digital filter), this will not be the correct correction to apply
2. We allow it to be skipped if there is no reference_pulse_shape defined. This means that real camera data might not benefit from this function if the developer has not specified a reference pulse shape, and then their calibration is integration window dependant (which may be accidentally overlooked)

I have addressed both of these points in this PR, by:
- Adding a `_calculate_correction` method to the ImageExtractors, so one can define the appropriate way to calculate the correction for each particular extractor. For a noise-less unit pulse the resulting charge from an ImageExtractor should always equal 1, ensuring the correct units for the resulting charge - this is the goal of the correction factor.
- Removing the ability to skip over the correction if there is no reference pulse defined.
- Moving integration_correction method to extractor.py, as this is a more appropriate place for it now.

Also included in this PR is the correct application of the sampling rate to the extracted charge and pulse time. So they are now in units of "waveform unit * nanosecond" and "nanosecond" respectively. 

These changes have allowed me to update the tests for ImageExtractor so that they no longer expect an otherwise meaningless value for the charge, but instead the charge should equal the total charge (i.e. the true charge) specified in generating the waveform.

There is no change to the API of the calibration in this PR.