### PR TITLE
Add pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+)/
+'''

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,12 @@
 # import ah_bootstrap
 from setuptools import setup, find_packages
 
-# Get the long description from the package's docstring
-import ctapipe
+import sys
+import os
+# pep 517 builds do not have cwd in PATH by default
+sys.path.insert(0, os.path.dirname(__file__))
+# Get the long and version description from the package's docstring
+import ctapipe  # noqa
 
 
 # Define entry points for command-line scripts


### PR DESCRIPTION
Reference for pyproject.toml and why we should have one:
https://www.python.org/dev/peps/pep-0518/
https://www.python.org/dev/peps/pep-0517/
https://snarky.ca/what-the-heck-is-pyproject-toml/