### PR TITLE
Fix input url handling in display_dl1

### DIFF
--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -173,15 +173,14 @@ class DisplayDL1Calib(Tool):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.config.EventSource.input_url = get_dataset_path('gamma_test_large.simtel.gz')
         self.eventsource = None
         self.calibrator = None
         self.plotter = None
 
     def setup(self):
         self.eventsource = self.add_component(
-            EventSource.from_url(
-                get_dataset_path("gamma_test_large.simtel.gz"), parent=self
-            )
+            EventSource.from_config(parent=self)
         )
 
         self.calibrator = self.add_component(CameraCalibrator(


### PR DESCRIPTION
The event source would always take the gamma simtel file and not the file given on the command line.

This allows it to get the `input_url` traitlet also from config or parent, not only from the keyword argument.