### PR TITLE
Move container definition into image module

### DIFF
--- a/ctapipe/image/__init__.py
+++ b/ctapipe/image/__init__.py
@@ -6,4 +6,5 @@ from .reducer import *
 from .muon import *
 from .geometry_converter import *
 from .leakage import *
-from .concentration import concentration
+from .concentration import concentration, ConcentrationContainer
+from .containers import ImageParametersContainer, MorphologyContainer

--- a/ctapipe/image/concentration.py
+++ b/ctapipe/image/concentration.py
@@ -1,6 +1,22 @@
 import numpy as np
-from ..io.containers import ConcentrationContainer
+from numpy import nan
+
 from .hillas import camera_to_shower_coordinates
+from ..core import Container, Field
+
+
+class ConcentrationContainer(Container):
+    """
+    Concentrations are ratios between light amount
+    in certain areas of the image and the full image.
+    """
+
+    container_prefix = "concentration"
+    cog = Field(
+        nan, "Percentage of photo-electrons in the three pixels closest to the cog"
+    )
+    core = Field(nan, "Percentage of photo-electrons inside the hillas ellipse")
+    pixel = Field(nan, "Percentage of photo-electrons in the brightest pixel")
 
 
 def concentration(geom, image, hillas_parameters):

--- a/ctapipe/image/containers.py
+++ b/ctapipe/image/containers.py
@@ -1,0 +1,27 @@
+from numpy import nan
+from ..core import Container, Field
+from .hillas import HillasParametersContainer
+from .leakage import LeakageContainer
+from .timing_parameters import TimingParametersContainer
+from .concentration import ConcentrationContainer
+
+
+class MorphologyContainer(Container):
+    """ Parameters related to pixels surviving image cleaning """
+
+    num_pixels = Field(nan, "Number of usable pixels")
+    num_islands = Field(nan, "Number of distinct islands in the image")
+    num_small_islands = Field(nan, "Number of <= 2 pixel islands")
+    num_medium_islands = Field(nan, "Number of 2-50 pixel islands")
+    num_large_islands = Field(nan, "Number of > 10 pixel islands")
+
+
+class ImageParametersContainer(Container):
+    """ Collection of image parameters """
+
+    container_prefix = "params"
+    hillas = Field(HillasParametersContainer(), "Hillas Parameters")
+    timing = Field(TimingParametersContainer(), "Timing Parameters")
+    leakage = Field(LeakageContainer(), "Leakage Parameters")
+    concentration = Field(ConcentrationContainer(), "Concentration Parameters")
+    morphology = Field(MorphologyContainer(), "Morphology Parameters")

--- a/ctapipe/image/hillas.py
+++ b/ctapipe/image/hillas.py
@@ -6,9 +6,11 @@ Hillas-style moment-based shower image parametrization.
 
 import astropy.units as u
 import numpy as np
+from numpy import nan
 from astropy.coordinates import Angle
 from astropy.units import Quantity
-from ..io.containers import HillasParametersContainer
+
+from ..core import Container, Field
 
 
 HILLAS_ATOL = np.finfo(np.float64).eps
@@ -18,6 +20,24 @@ __all__ = [
     'hillas_parameters',
     'HillasParameterizationError',
 ]
+
+
+class HillasParametersContainer(Container):
+    container_prefix = "hillas"
+
+    intensity = Field(np.nan, "total intensity (size)")
+
+    x = Field(nan, "centroid x coordinate")
+    y = Field(nan, "centroid x coordinate")
+    r = Field(nan, "radial coordinate of centroid")
+    phi = Field(nan, "polar coordinate of centroid", unit=u.deg)
+
+    length = Field(nan, "standard deviation along the major-axis")
+    width = Field(nan, "standard spread along the minor-axis")
+    psi = Field(nan, "rotation angle of ellipse", unit=u.deg)
+
+    skewness = Field(nan, "measure of the asymmetry")
+    kurtosis = Field(nan, "measure of the tailedness")
 
 
 def camera_to_shower_coordinates(x, y, cog_x, cog_y, psi):

--- a/ctapipe/image/leakage.py
+++ b/ctapipe/image/leakage.py
@@ -1,12 +1,38 @@
 """
 Leakage calculation
 """
-
 import numpy as np
-from ..io.containers import LeakageContainer
+from ..core import Container, Field
+
 
 
 __all__ = ["leakage"]
+
+
+class LeakageContainer(Container):
+    """
+    Fraction of signal in 1 or 2-pixel width border from the edge of the
+    camera, measured in number of signal pixels or in intensity.
+    """
+
+    container_prefix = "leakage"
+
+    pixels_width_1 = Field(
+        np.nan, "fraction of pixels after cleaning that are in camera border of width=1"
+    )
+    pixels_width_2 = Field(
+        np.nan, "fraction of pixels after cleaning that are in camera border of width=2"
+    )
+    intensity_width_1 = Field(
+        np.nan,
+        "Intensity in photo-electrons after cleaning"
+        " that are in the camera border of width=1 pixel",
+    )
+    intensity_width_2 = Field(
+        np.nan,
+        "Intensity in photo-electrons after cleaning"
+        " that are in the camera border of width=2 pixels",
+    )
 
 
 def leakage(geom, image, cleaning_mask):

--- a/ctapipe/image/muon/containers.py
+++ b/ctapipe/image/muon/containers.py
@@ -1,0 +1,45 @@
+import numpy as np
+from numpy import nan
+import astropy.units as u
+from ...core import Container, Field
+
+
+class MuonRingParameter(Container):
+    ring_center_x = Field(
+        nan * u.deg, "center (x) of the fitted muon ring", unit=u.deg
+    )
+    ring_center_y = Field(nan * u.deg, "center (y) of the fitted muon ring", unit=u.deg)
+    ring_radius = Field(nan * u.deg, "radius of the fitted muon ring", unit=u.deg)
+    ring_center_phi = Field(
+        nan * u.deg, "Angle of ring center within camera plane", unit=u.deg
+    )
+    ring_center_distance = Field(
+        nan * u.deg, "Distance of ring center from camera center", unit=u.deg
+    )
+    ring_chi2_fit = Field(nan, "chisquare of the muon ring fit", unit=u.deg)
+    ring_cov_matrix = Field(
+        np.full((3, 3), nan), "covariance matrix of the muon ring fit"
+    )
+    ring_containment = Field(nan, "containment of the ring inside the camera")
+
+
+class MuonIntensityParameter(Container):
+    ring_completeness = Field(nan, "fraction of ring present")
+    ring_pix_completeness = Field(nan, "fraction of pixels present in the ring")
+    ring_num_pixel = Field(-1, "number of pixels in the ring image")
+    ring_size = Field(nan, "size of the ring in pe")
+    off_ring_size = Field(nan, "image size outside of ring in pe")
+    ring_width = Field(nan, "width of the muon ring in degrees")
+    ring_time_width = Field(nan, "duration of the ring image sequence")
+    impact_parameter = Field(
+        nan, "distance of muon impact position from center of mirror"
+    )
+    impact_parameter_chi2 = Field(nan, "impact parameter chi squared")
+    intensity_cov_matrix = Field(nan, "covariance matrix of intensity")
+    impact_parameter_pos_x = Field(nan, "impact parameter x position")
+    impact_parameter_pos_y = Field(nan, "impact parameter y position")
+    cog_x = Field(nan, "Center of Gravity x")
+    cog_y = Field(nan, "Center of Gravity y")
+    prediction = Field(None, "image prediction")
+    mask = Field(None, "image pixel mask")
+    optical_efficiency_muon = Field(nan, "optical efficiency muon")

--- a/ctapipe/image/muon/muon_integrator.py
+++ b/ctapipe/image/muon/muon_integrator.py
@@ -12,8 +12,9 @@ from scipy.ndimage.filters import correlate1d
 from iminuit import Minuit
 from astropy import units as u
 from astropy.constants import alpha
-from ...io.containers import MuonIntensityParameter
 from scipy.stats import norm
+
+from .containers import MuonIntensityParameter
 
 import logging
 

--- a/ctapipe/image/muon/muon_ring_finder.py
+++ b/ctapipe/image/muon/muon_ring_finder.py
@@ -1,8 +1,9 @@
 import numpy as np
-from ctapipe.core import Component
-from ctapipe.io.containers import MuonRingParameter
-from .fitting import kundu_chaudhuri_circle_fit, taubin_circle_fit
 import traitlets as traits
+
+from ...core import Component
+from .containers import MuonRingParameter
+from .fitting import kundu_chaudhuri_circle_fit, taubin_circle_fit
 
 
 # the fit methods do not expose the same interface, so we

--- a/ctapipe/image/tests/test_hillas.py
+++ b/ctapipe/image/tests/test_hillas.py
@@ -1,7 +1,7 @@
 from ctapipe.instrument import CameraGeometry
 from ctapipe.image import tailcuts_clean, toymodel
 from ctapipe.image.hillas import hillas_parameters, HillasParameterizationError
-from ctapipe.io.containers import HillasParametersContainer
+from ctapipe.image.containers import HillasParametersContainer
 from astropy.coordinates import Angle
 from astropy import units as u
 import numpy as np

--- a/ctapipe/image/tests/test_timing_parameters.py
+++ b/ctapipe/image/tests/test_timing_parameters.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
 from ctapipe.instrument.camera import CameraGeometry
-from ctapipe.io.containers import HillasParametersContainer
+from ctapipe.image.containers import HillasParametersContainer
 
 
 def test_psi_0():

--- a/ctapipe/image/timing_parameters.py
+++ b/ctapipe/image/timing_parameters.py
@@ -3,14 +3,32 @@ Image timing-based shower image parametrization.
 """
 
 import numpy as np
+from numpy import nan
 from numpy.polynomial.polynomial import polyval
-from ctapipe.io.containers import TimingParametersContainer
 from .hillas import camera_to_shower_coordinates
+from ..core import Container, Field
 
 
 __all__ = [
     'timing_parameters'
 ]
+
+
+class TimingParametersContainer(Container):
+    """
+    Slope and Intercept of a linear regression of the arrival times
+    along the shower main axis
+    """
+    container_prefix = "timing"
+    slope = Field(nan, "Slope of arrival times along main shower axis")
+    slope_err = Field(nan, "Uncertainty `slope`")
+    intercept = Field(nan, "intercept of arrival times along main shower axis")
+    intercept_err = Field(nan, "Uncertainty `intercept`")
+    deviation = Field(
+        nan,
+        "Root-mean-square deviation of the pulse times "
+        "with respect to the predicted time",
+    )
 
 
 def timing_parameters(geom, image, pulse_time, hillas_parameters, cleaning_mask=None):

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -1,8 +1,6 @@
 """
 Container structures for data that should be read or written to disk
 """
-
-import numpy as np
 from astropy import units as u
 from astropy.time import Time
 from numpy import nan
@@ -11,6 +9,10 @@ from ..core import Container, Field, DeprecatedField, Map
 from ..instrument import SubarrayDescription
 from ..image.hillas import HillasParametersContainer
 from ..image.timing_parameters import TimingParametersContainer
+from ..image.concentration import ConcentrationContainer
+from ..image.leakage import LeakageContainer
+from ..image.muon.containers import MuonIntensityParameter, MuonRingParameter
+
 
 
 __all__ = [
@@ -54,6 +56,8 @@ __all__ = [
     "TelEventIndexContainer",
     "ImageParametersContainer",
     "SimulatedShowerDistribution",
+    "MuonIntensityParameter",
+    "MuonRingParameter",
 ]
 
 
@@ -544,103 +548,6 @@ class SST1MDataContainer(DataContainer):
     sst1m = Field(SST1MContainer(), "optional SST1M Specific Information")
 
 
-class MuonRingParameter(Container):
-    ring_center_x = Field(
-        nan * u.deg, "center (x) of the fitted muon ring", unit=u.deg
-    )
-    ring_center_y = Field(nan * u.deg, "center (y) of the fitted muon ring", unit=u.deg)
-    ring_radius = Field(nan * u.deg, "radius of the fitted muon ring", unit=u.deg)
-    ring_center_phi = Field(
-        nan * u.deg, "Angle of ring center within camera plane", unit=u.deg
-    )
-    ring_center_distance = Field(
-        nan * u.deg, "Distance of ring center from camera center", unit=u.deg
-    )
-    ring_chi2_fit = Field(nan, "chisquare of the muon ring fit", unit=u.deg)
-    ring_cov_matrix = Field(
-        np.full((3, 3), nan), "covariance matrix of the muon ring fit"
-    )
-    ring_containment = Field(nan, "containment of the ring inside the camera")
-
-
-class MuonIntensityParameter(Container):
-    ring_completeness = Field(nan, "fraction of ring present")
-    ring_pix_completeness = Field(nan, "fraction of pixels present in the ring")
-    ring_num_pixel = Field(-1, "number of pixels in the ring image")
-    ring_size = Field(nan, "size of the ring in pe")
-    off_ring_size = Field(nan, "image size outside of ring in pe")
-    ring_width = Field(nan, "width of the muon ring in degrees")
-    ring_time_width = Field(nan, "duration of the ring image sequence")
-    impact_parameter = Field(
-        nan, "distance of muon impact position from center of mirror"
-    )
-    impact_parameter_chi2 = Field(nan, "impact parameter chi squared")
-    intensity_cov_matrix = Field(nan, "covariance matrix of intensity")
-    impact_parameter_pos_x = Field(nan, "impact parameter x position")
-    impact_parameter_pos_y = Field(nan, "impact parameter y position")
-    cog_x = Field(nan, "Center of Gravity x")
-    cog_y = Field(nan, "Center of Gravity y")
-    prediction = Field(None, "image prediction")
-    mask = Field(None, "image pixel mask")
-    optical_efficiency_muon = Field(nan, "optical efficiency muon")
-
-
-class LeakageContainer(Container):
-    """
-    Fraction of signal in 1 or 2-pixel width border from the edge of the
-    camera, measured in number of signal pixels or in intensity.
-    """
-
-    container_prefix = "leakage"
-
-    pixels_width_1 = Field(
-        nan, "fraction of pixels after cleaning that are in camera border of width=1"
-    )
-    pixels_width_2 = Field(
-        nan, "fraction of pixels after cleaning that are in camera border of width=2"
-    )
-    intensity_width_1 = Field(
-        nan,
-        "Intensity in photo-electrons after cleaning"
-        " that are in the camera border of width=1 pixel",
-    )
-    intensity_width_2 = Field(
-        nan,
-        "Intensity in photo-electrons after cleaning"
-        " that are in the camera border of width=2 pixels",
-    )
-
-
-class ConcentrationContainer(Container):
-    """
-    Concentrations are ratios between light amount
-    in certain areas of the image and the full image.
-    """
-
-    container_prefix = "concentration"
-    cog = Field(
-        nan, "Percentage of photo-electrons in the three pixels closest to the cog"
-    )
-    core = Field(nan, "Percentage of photo-electrons inside the hillas ellipse")
-    pixel = Field(nan, "Percentage of photo-electrons in the brightest pixel")
-
-
-class TimingParametersContainer(Container):
-    """
-    Slope and Intercept of a linear regression of the arrival times
-    along the shower main axis
-    """
-
-    container_prefix = "timing"
-    slope = Field(nan, "Slope of arrival times along main shower axis")
-    slope_err = Field(nan, "Uncertainty `slope`")
-    intercept = Field(nan, "intercept of arrival times along main shower axis")
-    intercept_err = Field(nan, "Uncertainty `intercept`")
-    deviation = Field(
-        nan,
-        "Root-mean-square deviation of the pulse times "
-        "with respect to the predicted time",
-    )
 
 
 class MorphologyContainer(Container):

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -7,12 +7,6 @@ from numpy import nan
 
 from ..core import Container, Field, DeprecatedField, Map
 from ..instrument import SubarrayDescription
-from ..image.hillas import HillasParametersContainer
-from ..image.timing_parameters import TimingParametersContainer
-from ..image.concentration import ConcentrationContainer
-from ..image.leakage import LeakageContainer
-from ..image.muon.containers import MuonIntensityParameter, MuonRingParameter
-
 
 
 __all__ = [
@@ -40,11 +34,6 @@ __all__ = [
     "ParticleClassificationContainer",
     "DataContainer",
     "SST1MDataContainer",
-    "HillasParametersContainer",
-    "LeakageContainer",
-    "ConcentrationContainer",
-    "MorphologyContainer",
-    "TimingParametersContainer",
     "FlatFieldContainer",
     "PedestalContainer",
     "PixelStatusContainer",
@@ -54,10 +43,7 @@ __all__ = [
     "EventAndMonDataContainer",
     "EventIndexContainer",
     "TelEventIndexContainer",
-    "ImageParametersContainer",
     "SimulatedShowerDistribution",
-    "MuonIntensityParameter",
-    "MuonRingParameter",
 ]
 
 
@@ -547,28 +533,6 @@ class DataContainer(Container):
 class SST1MDataContainer(DataContainer):
     sst1m = Field(SST1MContainer(), "optional SST1M Specific Information")
 
-
-
-
-class MorphologyContainer(Container):
-    """ Parameters related to pixels surviving image cleaning """
-
-    num_pixels = Field(nan, "Number of usable pixels")
-    num_islands = Field(nan, "Number of distinct islands in the image")
-    num_small_islands = Field(nan, "Number of <= 2 pixel islands")
-    num_medium_islands = Field(nan, "Number of 2-50 pixel islands")
-    num_large_islands = Field(nan, "Number of > 10 pixel islands")
-
-
-class ImageParametersContainer(Container):
-    """ Collection of image parameters """
-
-    container_prefix = "params"
-    hillas = Field(HillasParametersContainer(), "Hillas Parameters")
-    timing = Field(TimingParametersContainer(), "Timing Parameters")
-    leakage = Field(LeakageContainer(), "Leakage Parameters")
-    concentration = Field(ConcentrationContainer(), "Concentration Parameters")
-    morphology = Field(MorphologyContainer(), "Morphology Parameters")
 
 
 class FlatFieldContainer(Container):

--- a/ctapipe/io/containers.py
+++ b/ctapipe/io/containers.py
@@ -9,6 +9,9 @@ from numpy import nan
 
 from ..core import Container, Field, DeprecatedField, Map
 from ..instrument import SubarrayDescription
+from ..image.hillas import HillasParametersContainer
+from ..image.timing_parameters import TimingParametersContainer
+
 
 __all__ = [
     "InstrumentContainer",
@@ -580,24 +583,6 @@ class MuonIntensityParameter(Container):
     prediction = Field(None, "image prediction")
     mask = Field(None, "image pixel mask")
     optical_efficiency_muon = Field(nan, "optical efficiency muon")
-
-
-class HillasParametersContainer(Container):
-    container_prefix = "hillas"
-
-    intensity = Field(nan, "total intensity (size)")
-
-    x = Field(nan, "centroid x coordinate")
-    y = Field(nan, "centroid x coordinate")
-    r = Field(nan, "radial coordinate of centroid")
-    phi = Field(nan, "polar coordinate of centroid", unit=u.deg)
-
-    length = Field(nan, "standard deviation along the major-axis")
-    width = Field(nan, "standard spread along the minor-axis")
-    psi = Field(nan, "rotation angle of ellipse", unit=u.deg)
-
-    skewness = Field(nan, "measure of the asymmetry")
-    kurtosis = Field(nan, "measure of the tailedness")
 
 
 class LeakageContainer(Container):

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -11,6 +11,8 @@ from ctapipe.core.container import Container, Field
 from ctapipe.io.containers import (
     R0CameraContainer,
     MCEventContainer,
+)
+from ctapipe.image.containers import (
     HillasParametersContainer,
     LeakageContainer,
 )

--- a/ctapipe/reco/tests/test_ImPACT.py
+++ b/ctapipe/reco/tests/test_ImPACT.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from ctapipe.io.containers import (ReconstructedShowerContainer,
                                    ReconstructedEnergyContainer)
 from ctapipe.reco.ImPACT import ImPACTReconstructor
-from ctapipe.io.containers import HillasParametersContainer
+from ctapipe.image.containers import HillasParametersContainer
 from astropy.coordinates import Angle, AltAz, SkyCoord
 
 

--- a/ctapipe/reco/tests/test_hillas_intersection.py
+++ b/ctapipe/reco/tests/test_hillas_intersection.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 import numpy as np
 from astropy.coordinates import SkyCoord
 from ctapipe.coordinates import NominalFrame, AltAz, CameraFrame
-from ctapipe.io.containers import HillasParametersContainer
+from ctapipe.image.containers import HillasParametersContainer
 
 from ctapipe.io import event_source
 

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -8,7 +8,7 @@ import pytest
 plt = pytest.importorskip("matplotlib.pyplot")
 
 from ctapipe.instrument import CameraGeometry, SubarrayDescription, TelescopeDescription
-from ctapipe.io.containers import HillasParametersContainer
+from ctapipe.image.containers import HillasParametersContainer
 from numpy import ones
 from astropy import units as u
 


### PR DESCRIPTION
This solves the circular import Problem @HealthyPear is facing in #1215 .

As image imported these containers from io, it imported the whole simetelevent source which imports the calibration stack which imports something from image.