### PR TITLE
Fix bug in ImageExtractor and WaveformModel concerning waveform sampling rate

### DIFF
--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -79,8 +79,7 @@ def test_check_r1_empty(example_event, subarray):
     with pytest.warns(UserWarning):
         calibrator(event)
     assert (event.dl0.tel[telid].waveform == 2).all()
-    sampling_rate = subarray.tel[telid].camera.readout.sampling_rate.to_value(u.GHz)
-    assert (event.dl1.tel[telid].image == 2 * 128 / sampling_rate).all()
+    assert (event.dl1.tel[telid].image == 2 * 128).all()
 
 
 def test_check_dl0_empty(example_event, subarray):

--- a/ctapipe/calib/camera/tests/test_flatfield.py
+++ b/ctapipe/calib/camera/tests/test_flatfield.py
@@ -24,7 +24,7 @@ def test_flasherflatfieldcalculator():
         }
     )
     subarray.tel[0].camera.readout.reference_pulse_shape = np.ones((1, 2))
-    subarray.tel[0].camera.readout.reference_pulse_step = u.Quantity(1, u.ns)
+    subarray.tel[0].camera.readout.reference_pulse_sample_width = u.Quantity(1, u.ns)
 
     config = Config({
         "FixedWindowSum": {

--- a/ctapipe/calib/camera/tests/test_pedestals.py
+++ b/ctapipe/calib/camera/tests/test_pedestals.py
@@ -28,7 +28,7 @@ def test_pedestal_calculator():
         },
     )
     subarray.tel[0].camera.readout.reference_pulse_shape = np.ones((1, 2))
-    subarray.tel[0].camera.readout.reference_pulse_step = u.Quantity(1, u.ns)
+    subarray.tel[0].camera.readout.reference_pulse_sample_width = u.Quantity(1, u.ns)
 
     ped_calculator = PedestalIntegrator(
         subarray=subarray,

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -129,7 +129,7 @@ def neighbor_average_waveform(waveforms, neighbors, lwt):
     """
     n_neighbors = neighbors.shape[0]
     sum_ = waveforms * lwt
-    n = np.zeros(waveforms.shape, dtype=np.int32)
+    n = np.zeros(waveforms.shape, dtype=np.int32) + lwt
     for i in prange(n_neighbors):
         pixel = neighbors[i, 0]
         neighbor = neighbors[i, 1]

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -71,7 +71,7 @@ def extract_around_peak(
         Astropy units should have to_value('GHz') applied before being passed
     sum_ : ndarray
         Return argument for ufunc (ignore)
-        Returns the sum (integration) of the waveforms in units "waveform_units * ns"
+        Returns the sum of the waveform samples
     pulse_time : ndarray
         Return argument for ufunc (ignore)
         Returns the pulse_time in units "ns"
@@ -98,7 +98,6 @@ def extract_around_peak(
     pulse_time[0] = time_num / time_den if time_den > 0 else peak_index
 
     # Convert to units of ns
-    sum_[0] /= sampling_rate_ghz
     pulse_time[0] /= sampling_rate_ghz
 
 

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -129,7 +129,7 @@ def neighbor_average_waveform(waveforms, neighbors, lwt):
     """
     n_neighbors = neighbors.shape[0]
     sum_ = waveforms * lwt
-    n = np.zeros(waveforms.shape, dtype=np.int32) + lwt
+    n = np.full(waveforms.shape, lwt, dtype=np.int32)
     for i in prange(n_neighbors):
         pixel = neighbors[i, 0]
         neighbor = neighbors[i, 1]

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -150,7 +150,7 @@ def test_extract_around_peak_charge_expected(toymodel):
 
 
 def test_neighbor_average_waveform(toymodel):
-    waveforms, subarray, telid, selected_gain_channel, true_charge, _ = toymodel
+    waveforms, subarray, telid, selected_gain_channel, _, _ = toymodel
     nei = subarray.tel[telid].camera.geometry.neighbor_matrix_where
     average_wf = neighbor_average_waveform(waveforms, nei, 0)
 

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -73,8 +73,8 @@ def toymodel(subarray):
     return waveform, subarray, telid, selected_gain_channel, charge, time
 
 
-def test_extract_around_peak(subarray, toymodel):
-    waveforms, subarray, telid, selected_gain_channel, true_charge, _ = toymodel
+def test_extract_around_peak(toymodel):
+    waveforms, _, _, _, _, _ = toymodel
     n_pixels, n_samples = waveforms.shape
     rand = np.random.RandomState(1)
     peak_index = rand.uniform(0, n_samples, n_pixels).astype(np.int)
@@ -95,8 +95,7 @@ def test_extract_around_peak(subarray, toymodel):
 
 
 def test_extract_around_peak_charge_expected(toymodel):
-    waveforms, subarray, telid, selected_gain_channel, _, _ = toymodel
-    waveforms = np.ones(waveforms.shape)
+    waveforms = np.ones((2048, 96))
     n_samples = waveforms.shape[-1]
     sampling_rate_ghz = 1
 

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -95,7 +95,7 @@ def test_extract_around_peak(subarray, toymodel):
 
 
 def test_extract_around_peak_charge_expected(toymodel):
-    waveforms, subarray, telid, selected_gain_channel, true_charge, _ = toymodel
+    waveforms, subarray, telid, selected_gain_channel, _, _ = toymodel
     waveforms = np.ones(waveforms.shape)
     n_samples = waveforms.shape[-1]
     sampling_rate_ghz = 1
@@ -272,7 +272,7 @@ def test_waveform_extractor_factory_args(subarray):
     """
     Config is supposed to be created by a `Tool`
     """
-    config = Config({"ImageExtractor": {"window_width": 20, "window_shift": 3,}})
+    config = Config({"ImageExtractor": {"window_width": 20, "window_shift": 3}})
 
     extractor = ImageExtractor.from_name(
         "LocalPeakWindowSum",

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -90,7 +90,7 @@ def test_extract_around_peak(subarray, toymodel):
 
     # Test negative amplitude
     y_offset = y - y.max() / 2
-    charge, pulse_time = extract_around_peak(y_offset[np.newaxis, :], 0, x.size, 0, 1)
+    charge, _ = extract_around_peak(y_offset[np.newaxis, :], 0, x.size, 0, 1)
     assert_allclose(charge, y_offset.sum(), rtol=1e-3)
 
 
@@ -150,7 +150,7 @@ def test_extract_around_peak_charge_expected(toymodel):
 
 
 def test_neighbor_average_waveform(toymodel):
-    waveforms, subarray, telid, selected_gain_channel, _, _ = toymodel
+    waveforms, subarray, telid, _, _, _ = toymodel
     nei = subarray.tel[telid].camera.geometry.neighbor_matrix_where
     average_wf = neighbor_average_waveform(waveforms, nei, 0)
 

--- a/ctapipe/image/tests/test_toy.py
+++ b/ctapipe/image/tests/test_toy.py
@@ -159,7 +159,7 @@ def test_waveform_model():
     ref_x_norm = np.linspace(0, ref_duration, n_ref_samples)
     ref_y_norm = norm.pdf(ref_x_norm, ref_duration / 2, pulse_sigma)
 
-    readout.reference_pulse_shape = ref_y_norm
+    readout.reference_pulse_shape = ref_y_norm[np.newaxis, :]
     readout.reference_pulse_sample_width = u.Quantity(
         ref_x_norm[1] - ref_x_norm[0], u.ns
     )

--- a/ctapipe/image/tests/test_toy.py
+++ b/ctapipe/image/tests/test_toy.py
@@ -189,9 +189,7 @@ def test_waveform_model():
 
     waveform_model = WaveformModel.from_camera_readout(readout)
     waveform = waveform_model.get_waveform(charge, time, 96)
-    np.testing.assert_allclose(
-        waveform.sum(axis=1) / readout.sampling_rate.to_value(u.GHz), charge, rtol=1e-3
-    )
+    np.testing.assert_allclose(waveform.sum(axis=1), charge, rtol=1e-3)
     np.testing.assert_allclose(
         waveform.argmax(axis=1) / readout.sampling_rate.to_value(u.GHz), time, rtol=1e-1
     )
@@ -199,11 +197,7 @@ def test_waveform_model():
     time_2 = time + 1
     time_2[charge == 0] = 0
     waveform_2 = waveform_model.get_waveform(charge, time_2, 96)
-    np.testing.assert_allclose(
-        waveform_2.sum(axis=1) / readout.sampling_rate.to_value(u.GHz),
-        charge,
-        rtol=1e-3,
-    )
+    np.testing.assert_allclose(waveform_2.sum(axis=1), charge, rtol=1e-3)
     np.testing.assert_allclose(
         waveform_2.argmax(axis=1) / readout.sampling_rate.to_value(u.GHz),
         time_2,

--- a/ctapipe/image/toymodel.py
+++ b/ctapipe/image/toymodel.py
@@ -24,7 +24,13 @@ from scipy.stats import multivariate_normal, skewnorm, norm
 from scipy.ndimage import convolve1d
 from abc import ABCMeta, abstractmethod
 
-__all__ = ["Gaussian", "SkewedGaussian", "ImageModel", "obtain_time_image"]
+__all__ = [
+    "WaveformModel",
+    "Gaussian",
+    "SkewedGaussian",
+    "ImageModel",
+    "obtain_time_image"
+]
 
 
 @u.quantity_input(
@@ -147,12 +153,14 @@ class WaveformModel:
         return sampled
 
     @classmethod
-    def from_camera_readout(cls, readout):
+    def from_camera_readout(cls, readout, gain_channel=0):
         """Create class from a `ctapipe.instrument.CameraReadout`.
 
         Parameters
         ----------
         readout : `ctapipe.instrument.CameraReadout`
+        gain_channel : int
+            The reference pulse gain channel to use
 
         Returns
         -------
@@ -160,7 +168,7 @@ class WaveformModel:
 
         """
         return cls(
-            readout.reference_pulse_shape,
+            readout.reference_pulse_shape[gain_channel],
             readout.reference_pulse_sample_width,
             (1 / readout.sampling_rate).to(u.ns),
         )


### PR DESCRIPTION
When checking the calibration for simtelarray files with different sampling rates, the result shows that the sampling rate is not currently correctly accounted for:

![image](https://user-images.githubusercontent.com/17825673/79118161-564d7900-7d8d-11ea-8059-95a90f57e312.png)

This result is what led me to create the WaveformModel in #1244, so I could properly diagnose this problem. However, in using the WaveformModel, I discovered I was not correctly integrating the charge when sampling the waveform from the convolved readout. As a result, the samples were not in p.e. as they should be.

Once this bug was fixed, and the tests for ImageExtractor were refactored to use WaveformModel (and cleaned up), I found the bug in ImageExtractor occurred in `extract_around_peak`. As the samples from simtelarray (and now WaveformModel, with this bugfix) are already in photoelectrons, they should not be divided by the sampling rate. The sampling rate is already accounted for during the waveform sampling... Instead one should just sum the waveform samples.

Once this change was made, the correct behaviour can be seen in the extracted charge for different sampling rates:

![image](https://user-images.githubusercontent.com/17825673/79118718-ecce6a00-7d8e-11ea-8a74-85243fd17cdc.png)
