### PR TITLE
Path improvements

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -66,6 +66,12 @@ def test_path_none():
         thepath = Path(exists=False)
 
     c1 = C1()
+    with pytest.raises(TraitError):
+        c1.thepath = None
+
+    class C1(Component):
+        thepath = Path(exists=False, allow_none=True)
+
     c1.thepath = None
 
 

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from traitlets import CaselessStrEnum, HasTraits, Int
+import pathlib
 
 from ctapipe.core import Component, TelescopeComponent
 from ctapipe.core.traits import (
@@ -18,6 +19,7 @@ from ctapipe.core.traits import (
     AstroTime
 )
 from ctapipe.image import ImageExtractor
+
 
 @pytest.fixture(scope="module")
 def mock_subarray():
@@ -103,6 +105,33 @@ def test_path_file_ok():
     with tempfile.NamedTemporaryFile() as f:
         with pytest.raises(TraitError):
             c.thepath = f.name
+
+
+def test_path_pathlib():
+    class C(Component):
+        thepath = Path()
+
+    c = C()
+    c.thepath = pathlib.Path()
+    assert c.thepath == pathlib.Path().absolute()
+
+
+def test_path_url():
+    class C(Component):
+        thepath = Path()
+
+    c = C()
+    # test relative
+    c.thepath = 'file://foo.hdf5'
+    assert c.thepath == (pathlib.Path() / 'foo.hdf5').absolute()
+
+    # test absolute
+    c.thepath = 'file:///foo.hdf5'
+    assert c.thepath == pathlib.Path('/foo.hdf5')
+
+    # test not other shemes raise trailet errors
+    with pytest.raises(TraitError):
+        c.thepath = 'https://example.org/test.hdf5'
 
 
 def test_enum_trait_default_is_right():

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -407,15 +407,15 @@ def test_datetimes():
 
 
 def test_time_none():
-    class SomeComponentWithTimeTrait(Component):
+    class AllowNone(Component):
         time = AstroTime(default_value=None, allow_none=True)
 
-    c = SomeComponentWithTimeTrait()
+    c = AllowNone()
     c.time = None
 
-    class SomeComponentWithTimeTrait(Component):
+    class NoNone(Component):
         time = AstroTime(default_value='2012-01-01T20:00', allow_none=False)
 
-    c = SomeComponentWithTimeTrait()
+    c = NoNone()
     with pytest.raises(TraitError):
         c.time = None

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -66,12 +66,6 @@ def test_path_none():
         thepath = Path(exists=False)
 
     c1 = C1()
-    with pytest.raises(TraitError):
-        c1.thepath = None
-
-    class C1(Component):
-        thepath = Path(exists=False, allow_none=True)
-
     c1.thepath = None
 
 

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -61,11 +61,33 @@ def test_path_exists():
         c2.thepath = f.name
 
 
+def test_path_invalid():
+    class C1(Component):
+        p = Path(exists=False)
+
+    c1 = C1()
+    with pytest.raises(TraitError):
+        c1.p = 5
+
+    with pytest.raises(TraitError):
+        c1.p = ''
+
+
+def test_bytes():
+    class C1(Component):
+        p = Path(exists=False)
+
+    c1 = C1()
+    c1.p = b'/home/foo'
+    assert c1.p == pathlib.Path('/home/foo')
+
+
 def test_path_none():
     class C1(Component):
         thepath = Path(exists=False)
 
     c1 = C1()
+    c1.thepath = 'foo'
     c1.thepath = None
 
 

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -404,3 +404,18 @@ def test_datetimes():
 
     with pytest.raises(TraitError):
         component.time = "garbage"
+
+
+def test_time_none():
+    class SomeComponentWithTimeTrait(Component):
+        time = AstroTime(default_value=None, allow_none=True)
+
+    c = SomeComponentWithTimeTrait()
+    c.time = None
+
+    class SomeComponentWithTimeTrait(Component):
+        time = AstroTime(default_value='2012-01-01T20:00', allow_none=False)
+
+    c = SomeComponentWithTimeTrait()
+    with pytest.raises(TraitError):
+        c.time = None

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -101,9 +101,9 @@ class Tool(Application):
     """
 
     config_file = Path(
-        None,
         exists=True,
         directory_ok=False,
+        allow_none=True,
         help=(
             "name of a configuration file with "
             "parameters to load in addition to "

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -103,7 +103,6 @@ class Tool(Application):
     config_file = Path(
         exists=True,
         directory_ok=False,
-        allow_none=True,
         help=(
             "name of a configuration file with "
             "parameters to load in addition to "

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -89,20 +89,26 @@ class Path(TraitType):
     """
 
     def __init__(self, *args, exists=None, directory_ok=True, file_ok=True, **kwargs):
-        super().__init__(*args, **kwargs)
+        default_value = kwargs.pop('default_value', None)
+        super().__init__(*args, default_value=default_value, **kwargs)
         self.exists = exists
         self.directory_ok = directory_ok
         self.file_ok = file_ok
 
     def validate(self, obj, value):
-
         if value is None:
-            return None
+            if self.allow_none is True:
+                return None
+            else:
+                return self.error(obj, value)
 
         if not isinstance(value, (str, bytes, pathlib.Path)):
             return self.error(obj, value)
 
         if isinstance(value, str):
+            if value == '':
+                return self.error(obj, value)
+
             try:
                 url = urlparse(value)
             except ValueError:

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -23,7 +23,6 @@ from traitlets import (
     observe,
     Set,
     CRegExp,
-    Undefined
 )
 from traitlets.config import boolean_flag as flag
 
@@ -68,14 +67,11 @@ class AstroTime(TraitType):
             the_time = Time(value)
             the_time.format = 'iso'
             return the_time
-        except ValueError as err:
-            raise TraitError(
-                f"Time values should be in a format understandable by astropy.time ("
-                f"{err})"
-            )
+        except ValueError:
+            return self.error(obj, value)
 
     def info(self):
-        info = 'an iso datestring'
+        info = 'an ISO8601 datestring or Time instance'
         if self.allow_none:
             info += 'or None'
         return info

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -96,10 +96,6 @@ class Path(TraitType):
     """
 
     def __init__(self, *args, exists=None, directory_ok=True, file_ok=True, **kwargs):
-        # this is a hack to make checking for None work at runtime
-        # by using a dynamic default instead of just None, the
-        # check is only performed at __init__ after kwargs are parsed
-        # and not during __new__ for the None default
         default_value = kwargs.pop('default_value', None)
 
         super().__init__(*args, default_value=default_value, allow_none=True, **kwargs)

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -288,6 +288,12 @@ class EventSource(Component):
         instance
             Instance of a compatible EventSource subclass
         """
+        if config is None and parent is None:
+            raise ValueError('One of config or parent must be provided')
+
+        if config is not None and parent is not None:
+            raise ValueError('Only one of config or parent must be provided')
+
         if config is None:
             config = parent.config
 

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -2,13 +2,12 @@
 Handles reading of different event/waveform containing files
 """
 from abc import abstractmethod
-from pathlib import Path
+from traitlets.config.loader import LazyConfigValue
 
 from ctapipe.core import Component, non_abstract_children, ToolConfigurationError
 from ctapipe.core import Provenance
 from ctapipe.core.plugins import detect_and_import_io_plugins
-from ctapipe.core.traits import Unicode, Int, Set, TraitError
-from traitlets.config.loader import LazyConfigValue
+from ctapipe.core.traits import Path, Int, Set, TraitError
 
 __all__ = ["EventSource", "event_source"]
 
@@ -106,9 +105,12 @@ class EventSource(Component):
         * Observation ID
     """
 
-    input_url = Unicode("", help="Path to the input file containing events.").tag(
-        config=True
-    )
+    input_url = Path(
+        directory_ok=False,
+        exists=True,
+        help="Path to the input file containing events."
+    ).tag(config=True)
+
     max_events = Int(
         None,
         allow_none=True,
@@ -144,16 +146,12 @@ class EventSource(Component):
         super().__init__(config=config, parent=parent, **kwargs)
 
         self.metadata = dict(is_simulation=False)
-        input_url: Path = Path(self.input_url).expanduser()
-
-        if not input_url.exists:
-            raise FileNotFoundError(f"file path does not exist: '{input_url}'")
-        self.log.info(f"INPUT PATH = {input_url}")
+        self.log.info(f"INPUT PATH = {self.input_url}")
 
         if self.max_events:
             self.log.info(f"Max events being read = {self.max_events}")
 
-        Provenance().add_input_file(input_url, role="DL0/Event")
+        Provenance().add_input_file(str(self.input_url), role="DL0/Event")
 
     @staticmethod
     @abstractmethod

--- a/ctapipe/io/hessioeventsource.py
+++ b/ctapipe/io/hessioeventsource.py
@@ -77,7 +77,7 @@ class HESSIOEventSource(EventSource):
 
     @property
     def subarray(self):
-        with self.pyhessio.open_hessio(self.input_url) as file:
+        with self.pyhessio.open_hessio(str(self.input_url)) as file:
             next(file.move_to_next_event())
             return self._build_subarray_info(file)
 
@@ -86,7 +86,7 @@ class HESSIOEventSource(EventSource):
         self.pyhessio.close_file()
 
     def _generator(self):
-        with self.pyhessio.open_hessio(self.input_url) as file:
+        with self.pyhessio.open_hessio(str(self.input_url)) as file:
             # the container is initialized once, and data is replaced within
             # it after each yield
             counter = 0

--- a/ctapipe/io/tests/test_event_source.py
+++ b/ctapipe/io/tests/test_event_source.py
@@ -14,7 +14,7 @@ class DummyReader(EventSource):
     """
 
     def _generator(self):
-        return range(len(self.input_url))
+        return range(5)
 
     @staticmethod
     def is_compatible(file_path):

--- a/ctapipe/io/tests/test_event_source_factory.py
+++ b/ctapipe/io/tests/test_event_source_factory.py
@@ -10,14 +10,14 @@ def test_factory():
     dataset = get_dataset_path("gamma_test_large.simtel.gz")
     reader = event_source(input_url=dataset)
     assert isinstance(reader, SimTelEventSource)
-    assert reader.input_url == dataset
+    assert str(reader.input_url) == dataset
 
 
 def test_factory_different_file():
     dataset = get_dataset_path("gamma_test_large.simtel.gz")
     reader = event_source(input_url=dataset)
     assert isinstance(reader, SimTelEventSource)
-    assert reader.input_url == dataset
+    assert str(reader.input_url) == dataset
 
 
 def test_factory_incompatible_file():
@@ -37,7 +37,7 @@ def test_from_config():
     config = Config({'EventSource': {'input_url': dataset}})
     reader = EventSource.from_config(config=config, parent=None)
     assert isinstance(reader, SimTelEventSource)
-    assert reader.input_url == dataset
+    assert str(reader.input_url) == dataset
 
 
 def test_from_config_default():
@@ -47,7 +47,7 @@ def test_from_config_default():
     config = Config()
     reader = EventSource.from_config(config=config, parent=None)
     assert isinstance(reader, SimTelEventSource)
-    assert reader.input_url == dataset
+    assert str(reader.input_url) == dataset
     EventSource.input_url.default_value = old_default
 
 
@@ -65,7 +65,7 @@ def test_event_source_config():
     config = Config({'EventSource': {'input_url': dataset1}})
     reader = event_source(dataset2, config=config)
     assert isinstance(reader, SimTelEventSource)
-    assert reader.input_url == dataset2
+    assert str(reader.input_url) == dataset2
 
 
 def test_event_source_input_url_config_override():
@@ -74,7 +74,7 @@ def test_event_source_input_url_config_override():
     config = Config({'EventSource': {'input_url': dataset1}})
     reader = event_source(input_url=dataset2, config=config)
     assert isinstance(reader, SimTelEventSource)
-    assert reader.input_url == dataset2
+    assert str(reader.input_url) == dataset2
 
 
 def test_factory_max_events():

--- a/ctapipe/plotting/charge_resolution.py
+++ b/ctapipe/plotting/charge_resolution.py
@@ -4,6 +4,7 @@ from matplotlib.ticker import FuncFormatter
 from matplotlib import pyplot as plt
 import os
 from ctapipe.core import Component, Provenance
+from ctapipe.core.traits import Path
 from traitlets import Unicode, Int
 
 
@@ -52,8 +53,8 @@ def bin_dataframe(df, n_bins):
 
 class ChargeResolutionPlotter(Component):
 
-    output_path = Unicode(
-        '', help='Output path to save the plot.'
+    output_path = Path(
+        help='Output path to save the plot.'
     ).tag(config=True)
 
     n_bins = Int(

--- a/ctapipe/plotting/charge_resolution.py
+++ b/ctapipe/plotting/charge_resolution.py
@@ -5,7 +5,7 @@ from matplotlib import pyplot as plt
 import os
 from ctapipe.core import Component, Provenance
 from ctapipe.core.traits import Path
-from traitlets import Unicode, Int
+from traitlets import Int
 
 
 def root_mean_square(array):

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -4,7 +4,7 @@ Calibrate dl0 data to dl1, and plot the photoelectron images.
 from matplotlib import colors
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
-from traitlets import Bool, Dict, Int, List, Unicode
+from traitlets import Bool, Dict, Int, List, Path
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Component, Tool
@@ -21,12 +21,13 @@ class ImagePlotter(Component):
     display = Bool(
         True, help="Display the photoelectron images on-screen as they are produced."
     ).tag(config=True)
-    output_path = Unicode(
-        None,
+    output_path = Path(
         allow_none=True,
-        help="Output path for the pdf containing all the "
-        "images. Set to None for no saved "
-        "output.",
+        directory_ok=False,
+        help=(
+            "Output path for the pdf containing all the images."
+            " Set to None for no saved output."
+        ),
     ).tag(config=True)
 
     def __init__(self, config=None, parent=None, **kwargs):

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -4,7 +4,7 @@ Calibrate dl0 data to dl1, and plot the photoelectron images.
 from matplotlib import colors
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
-from traitlets import Bool, Dict, Int, List, Path
+from traitlets import Bool, Dict, Int, List
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Component, Tool
@@ -21,8 +21,7 @@ class ImagePlotter(Component):
     display = Bool(
         True, help="Display the photoelectron images on-screen as they are produced."
     ).tag(config=True)
-    output_path = Path(
-        allow_none=True,
+    output_path = traits.Path(
         directory_ok=False,
         help=(
             "Output path for the pdf containing all the images."

--- a/ctapipe/tools/display_summed_images.py
+++ b/ctapipe/tools/display_summed_images.py
@@ -111,7 +111,7 @@ class ImageSumDisplayerTool(Tool):
             disp.image = imsum
             plt.pause(0.1)
 
-            if self.output_suffix is not "":
+            if self.output_suffix != "":
                 filename = "{:020d}{}".format(
                     event.r0.event_id, self.output_suffix
                 )

--- a/ctapipe/tools/display_summed_images.py
+++ b/ctapipe/tools/display_summed_images.py
@@ -9,18 +9,21 @@ from matplotlib import pyplot as plt
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Tool
-from ctapipe.core.traits import Unicode, Integer, Dict, List
+from ctapipe.core.traits import Unicode, Integer, Dict, List, Path
 from ctapipe.io import SimTelEventSource
 from ctapipe.visualization import CameraDisplay
+from ctapipe.utils import get_dataset_path
 
 
 class ImageSumDisplayerTool(Tool):
     description = Unicode(__doc__)
     name = "ctapipe-display-imagesum"
 
-    infile = Unicode(
+    infile = Path(
         help='input simtelarray file',
-        default="/Users/kosack/Data/CTA/Prod3/gamma.simtel.gz"
+        default_value=get_dataset_path('gamma_test_large.simtel.gz'),
+        exists=True,
+        directory_ok=False,
     ).tag(config=True)
 
     telgroup = Integer(

--- a/ctapipe/tools/dump_instrument.py
+++ b/ctapipe/tools/dump_instrument.py
@@ -8,7 +8,7 @@ automatically generated.
 from collections import defaultdict
 
 from ctapipe.core import Tool, Provenance
-from ctapipe.core.traits import (Unicode, Dict, Enum)
+from ctapipe.core.traits import Unicode, Dict, Enum, Path
 from ctapipe.io import event_source
 
 
@@ -35,7 +35,7 @@ class DumpInstrumentTool(Tool):
     description = Unicode(__doc__)
     name = 'ctapipe-dump-instrument'
 
-    infile = Unicode(help='input simtelarray file').tag(config=True)
+    infile = Path(exists=True, help='input simtelarray file').tag(config=True)
     format = Enum(['fits', 'ecsv', 'hdf5'],
                   default_value='fits',
                   help='Format of output file',

--- a/ctapipe/tools/dump_triggers.py
+++ b/ctapipe/tools/dump_triggers.py
@@ -9,7 +9,7 @@ from astropy.table import Table
 
 from ctapipe.io import event_source
 from ctapipe.core import Provenance, ToolConfigurationError
-from ctapipe.core.traits import (Unicode, Dict, Bool)
+from ctapipe.core.traits import Unicode, Dict, Bool, Path
 from ..core import Tool
 
 MAX_TELS = 1000
@@ -23,10 +23,14 @@ class DumpTriggersTool(Tool):
     # configuration parameters:
     # =============================================
 
-    infile = Unicode(help='input simtelarray file').tag(config=True)
+    infile = Path(
+        exists=True, directory_ok=False, help='input simtelarray file'
+    ).tag(config=True)
 
-    outfile = Unicode('triggers.fits',
-                      help='output filename (*.fits, *.h5)').tag(config=True)
+    outfile = Path(
+        default_value='triggers.fits', directory_ok=False,
+        help='output filename (*.fits, *.h5)',
+    ).tag(config=True)
 
     overwrite = Bool(False,
                      help="overwrite existing output file"

--- a/ctapipe/tools/dump_triggers.py
+++ b/ctapipe/tools/dump_triggers.py
@@ -118,11 +118,12 @@ class DumpTriggersTool(Tool):
         """
         # write out the final table
         try:
-            if self.outfile.endswith('fits') or self.outfile.endswith('fits.gz'):
+            if '.fits' in self.outfile.suffixes:
                 self.events.write(self.outfile, overwrite=self.overwrite)
-            elif self.outfile.endswith('h5'):
-                self.events.write(self.outfile, path='/events',
-                                  overwrite=self.overwrite)
+            elif self.outfile.suffix in ('.hdf5', '.h5', '.hdf'):
+                self.events.write(
+                    self.outfile, path='/events', overwrite=self.overwrite
+                )
             else:
                 self.events.write(self.outfile)
 

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -8,7 +8,8 @@ import os
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from traitlets import Dict, Int, List, Path
+from traitlets import Dict, Int, List
+from ctapipe.core.traits import Path
 
 from ctapipe.analysis.camera.charge_resolution import ChargeResolutionCalculator
 from ctapipe.calib import CameraCalibrator

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from traitlets import Dict, Int, List, Unicode
+from traitlets import Dict, Int, List, Path
 
 from ctapipe.analysis.camera.charge_resolution import ChargeResolutionCalculator
 from ctapipe.calib import CameraCalibrator
@@ -30,8 +30,10 @@ class ChargeResolutionGenerator(Tool):
         allow_none=True,
         help="Telescopes to include from the event file. Default = All telescopes",
     ).tag(config=True)
-    output_path = Unicode(
-        "charge_resolution.h5", help="Path to store the output HDF5 file"
+    output_path = Path(
+        default_value="charge_resolution.h5",
+        directory_ok=False,
+        help="Path to store the output HDF5 file"
     ).tag(config=True)
     extractor_product = traits.enum_trait(
         ImageExtractor, default="NeighborPeakWindowSum"

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -130,7 +130,7 @@ def test_bokeh_file_viewer():
     sys.argv = ["bokeh_file_viewer"]
     tool = BokehFileViewer(disable_server=True)
     assert run_tool(tool) == 0
-    assert tool.reader.input_url == get_dataset_path("gamma_test_large.simtel.gz")
+    assert str(tool.reader.input_url) == get_dataset_path("gamma_test_large.simtel.gz")
     assert run_tool(tool, ["--help-all"]) == 0
 
 

--- a/ctapipe/tools/utils.py
+++ b/ctapipe/tools/utils.py
@@ -2,7 +2,6 @@
 """Utils to create scripts and command-line tools"""
 import argparse
 import importlib
-import re
 from collections import OrderedDict
 
 __all__ = ['ArgparseFormatter',

--- a/examples/simple_event_writer.py
+++ b/examples/simple_event_writer.py
@@ -11,7 +11,7 @@ import numpy as np
 from tqdm import tqdm
 
 from ctapipe.core import Tool
-from ctapipe.core.traits import Unicode, List, Dict, Bool
+from ctapipe.core.traits import Path, Unicode, List, Dict, Bool
 from ctapipe.io import EventSource, HDF5TableWriter
 
 from ctapipe.calib import CameraCalibrator
@@ -23,8 +23,12 @@ class SimpleEventWriter(Tool):
     name = 'ctapipe-simple-event-writer'
     description = Unicode(__doc__)
 
-    infile = Unicode(help='input file to read', default='').tag(config=True)
-    outfile = Unicode(help='output file name', default_value='output.h5').tag(config=True)
+    infile = Path(
+        help='input file to read', directory_ok=False, exists=True,
+    ).tag(config=True)
+    outfile = Path(
+        help='output file name', directory_ok=False, default_value='output.h5'
+    ).tag(config=True)
     progress = Bool(help='display progress bar', default_value=True).tag(config=True)
 
     aliases = Dict({
@@ -40,7 +44,6 @@ class SimpleEventWriter(Tool):
 
         self.event_source = self.add_component(
             EventSource.from_config(
-                config=self.config,
                 parent=self
             )
         )

--- a/examples/tool_example.py
+++ b/examples/tool_example.py
@@ -53,7 +53,6 @@ class MyTool(Tool):
     name = Unicode("myapp")
     running = Bool(False, help="Is the app running?").tag(config=True)
     classes = List([BComponent, AComponent])
-    config_file = Unicode("", help="Load this config file").tag(config=True)
 
     aliases = Dict(
         dict(


### PR DESCRIPTION
This fixes a few issues concerning path traitlets and arguments

* traits.Path now uses pathlib.Path internally

* Path supports urls of the form `file://`, this is to make the `input_url` argument of the eventsource really an url (only file supported for now, but in the future we could think about allowing `http` to get a file directly from the web)

* Changed a lot of tool traitlets from Unicode to Path where appropriate