### PR TITLE
Fix calculation of pixel area guessing

### DIFF
--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -202,7 +202,7 @@ class CameraGeometry:
         Note this will not work on cameras with varying pixel sizes.
         """
 
-        dist = np.min(np.sqrt((pix_x - pix_x[0])**2 + (pix_y - pix_y[0])**2))
+        dist = np.min(np.sqrt((pix_x[1:] - pix_x[0])**2 + (pix_y[1:] - pix_y[0])**2))
 
         if pix_type.startswith('hex'):
             rad = dist / np.sqrt(3)  # radius to vertex of hexagon

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -296,3 +296,30 @@ def test_camera_coordinate_transform(camera_name):
     unit = geom.pix_x.unit
     assert np.allclose(geom.pix_x.to_value(unit), -trans_geom.pix_y.to_value(unit))
     assert np.allclose(geom.pix_y.to_value(unit), -trans_geom.pix_x.to_value(unit))
+
+
+def test_guess_area():
+    x = u.Quantity([0, 1, 2], u.cm)
+    y = u.Quantity([0, 0, 0], u.cm)
+    n_pixels = len(x)
+
+    geom = CameraGeometry(
+        'test',
+        pix_id=np.arange(n_pixels),
+        pix_area=None,
+        pix_x=x,
+        pix_y=y,
+        pix_type='rect',
+    )
+
+    assert np.all(geom.pix_area == 1 * u.cm**2)
+
+    geom = CameraGeometry(
+        'test',
+        pix_id=np.arange(n_pixels),
+        pix_area=None,
+        pix_x=x,
+        pix_y=y,
+        pix_type='hexagonal',
+    )
+    assert u.allclose(geom.pix_area, 2 * np.sqrt(3) * (0.5 * u.cm)**2)


### PR DESCRIPTION
This came up as part of #1191 and I just ran into this again, so here's the fix with an accompanying uit test

The area would always be 0, as the reference pixel was included in the distance calculation