### PR TITLE
Use pointing container in examples and docs

### DIFF
--- a/docs/tutorials/coordinates_example.ipynb
+++ b/docs/tutorials/coordinates_example.ipynb
@@ -230,8 +230,8 @@
    "outputs": [],
    "source": [
     "telescope_pointing = SkyCoord(\n",
-    "    alt=event.mc.tel[tel_id].altitude_raw * u.rad, \n",
-    "    az=event.mc.tel[tel_id].azimuth_raw * u.rad, \n",
+    "    alt=event.pointing[tel_id].altitude, \n",
+    "    az=event.pointing[tel_id].azimuth, \n",
     "    frame=altaz,\n",
     ")\n",
     "\n",
@@ -646,7 +646,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
+++ b/docs/tutorials/lst_analysis_bootcamp_2018.ipynb
@@ -736,8 +736,8 @@
     "                time_gradients[telescope_id] = 1.0\n",
     "\n",
     "            telescope_pointings[telescope_id] = SkyCoord(\n",
-    "                alt=event.mc.tel[telescope_id].altitude_raw * u.rad,\n",
-    "                az=event.mc.tel[telescope_id].azimuth_raw * u.rad,\n",
+    "                alt=event.pointing[telescope_id].altitude,\n",
+    "                az=event.pointing[telescope_id].azimuth,\n",
     "                frame=horizon_frame\n",
     "            )  \n",
     "            \n",
@@ -1232,7 +1232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/theta_square.ipynb
+++ b/docs/tutorials/theta_square.ipynb
@@ -109,8 +109,8 @@
     "\n",
     "        # telescope pointing direction\n",
     "        telescope_pointings[tel_id] = SkyCoord(\n",
-    "            alt=event.mc.tel[tel_id].altitude_raw * u.rad,\n",
-    "            az=event.mc.tel[tel_id].azimuth_raw * u.rad,\n",
+    "            alt=event.pointing[tel_id].altitude,\n",
+    "            az=event.pointing[tel_id].azimuth,\n",
     "            frame=horizon_frame\n",
     "        )  \n",
     "\n",
@@ -239,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.7"
   },
   "toc": {
    "nav_menu": {

--- a/examples/plot_showers_in_nominal.py
+++ b/examples/plot_showers_in_nominal.py
@@ -40,13 +40,10 @@ with event_source(input_url=input_url) as source:
             focal_length = event.inst.subarray.tels[tel_id].optics.equivalent_focal_length
             image = dl1.image
 
-            # telescope mc info
-            mc_tel = event.mc.tel[tel_id]
-
             telescope_pointing = SkyCoord(
-                alt=mc_tel['altitude_raw'],
-                az=mc_tel['azimuth_raw'],
-                unit='rad', frame=AltAz(),
+                alt=event.pointing[tel_id].altitude,
+                az=event.pointing[tel_id].azimuth,
+                frame=AltAz(),
             )
             camera_frame = CameraFrame(
                 telescope_pointing=telescope_pointing, focal_length=focal_length

--- a/examples/plot_theta_square.py
+++ b/examples/plot_theta_square.py
@@ -49,8 +49,8 @@ for event in source:
 
         # telescope pointing direction as dictionary of SkyCoord
         telescope_pointings[tel_id] = SkyCoord(
-            alt=event.mc.tel[tel_id].altitude_raw * u.rad,
-            az=event.mc.tel[tel_id].azimuth_raw * u.rad,
+            alt=event.pointing[tel_id].altitude,
+            az=event.pointing[tel_id].azimuth,
             frame=horizon_frame
         )
 


### PR DESCRIPTION
Some examples were still using the values from `event.mc` and not `event.pointing`.

Also, interestingly, `event.pointing` is missing the `.tel`. Should we add that to make it consistent?