### PR TITLE
Add missing config, parent to hdfwriter

### DIFF
--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -96,10 +96,12 @@ class HDF5TableWriter(TableWriter):
         mode="w",
         root_uep="/",
         filters=DEFAULT_FILTERS,
+        parent=None,
+        config=None,
         **kwargs,
     ):
 
-        super().__init__(add_prefix=add_prefix)
+        super().__init__(add_prefix=add_prefix, parent=None, config=None)
         self._schemas = {}
         self._tables = {}
 

--- a/ctapipe/tools/muon_reconstruction.py
+++ b/ctapipe/tools/muon_reconstruction.py
@@ -90,7 +90,7 @@ class MuonAnalysis(Tool):
             subarray=self.source.subarray,
         ))
         self.writer = self.add_component(HDF5TableWriter(
-            self.output, "", add_prefix=True
+            self.output, "", add_prefix=True, parent=self,
         ))
         self.pixels_in_tel_frame = {}
         self.field_of_view = {}


### PR DESCRIPTION
The `HDF5TableWrite` is a component, but didn't have `config` and `parent`.

This made it impossible to set it's logging config appropriately in a tool