### PR TITLE
Rename muon containers to make naming more consistent

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -660,7 +660,7 @@ class DataContainer(Container):
     )
 
 
-class MuonRingParameter(Container):
+class MuonRingContainer(Container):
     '''Container for the result of a ring fit, center_x, center_y'''
     center_x = Field(nan * u.deg, "center (x) of the fitted muon ring", unit=u.deg)
     center_y = Field(nan * u.deg, "center (y) of the fitted muon ring", unit=u.deg)
@@ -673,7 +673,7 @@ class MuonRingParameter(Container):
     )
 
 
-class MuonIntensityParameter(Container):
+class MuonEfficiencyContainer(Container):
     width = Field(nan, "width of the muon ring in degrees")
     impact = Field(nan, "distance of muon impact position from center of mirror")
     impact_x = Field(nan, "impact parameter x position")
@@ -681,7 +681,7 @@ class MuonIntensityParameter(Container):
     optical_efficiency = Field(nan, "optical efficiency muon")
 
 
-class MuonImageParameters(Container):
+class MuonParametersContainer(Container):
     containment = Field(nan, "containment of the ring inside the camera")
     completeness = Field(
         nan,

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -16,7 +16,7 @@ from scipy.stats import norm
 from astropy.coordinates import SkyCoord
 from functools import lru_cache
 
-from ...containers import MuonIntensityParameter
+from ...containers import MuonEfficiencyContainer
 from ...coordinates import CameraFrame, TelescopeFrame
 from ...core import TelescopeComponent
 from ...core.traits import FloatTelescopeParameter, IntTelescopeParameter
@@ -481,7 +481,7 @@ class MuonIntensityFitter(TelescopeComponent):
 
         Returns
         -------
-        MuonIntensityParameters
+        MuonEfficiencyContainer
         """
         telescope = self.subarray.tel[tel_id]
         if telescope.optics.num_mirrors != 1:
@@ -539,7 +539,7 @@ class MuonIntensityFitter(TelescopeComponent):
         # Get fitted values
         result = minuit.values
 
-        return MuonIntensityParameter(
+        return MuonEfficiencyContainer(
             impact=result['impact_parameter'] * u.m,
             impact_x=result['impact_parameter'] * np.cos(result['phi']) * u.m,
             impact_y=result['impact_parameter'] * np.sin(result['phi']) * u.m,

--- a/ctapipe/image/muon/ring_fitter.py
+++ b/ctapipe/image/muon/ring_fitter.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ctapipe.core import Component
-from ctapipe.containers import MuonRingParameter
+from ctapipe.containers import MuonRingContainer
 from .fitting import kundu_chaudhuri_circle_fit, taubin_circle_fit
 import traitlets as traits
 
@@ -41,7 +41,7 @@ class MuonRingFitter(Component):
         fit_function = FIT_METHOD_BY_NAME[self.fit_method]
         radius, center_x, center_y = fit_function(x, y, img, mask)
 
-        return MuonRingParameter(
+        return MuonRingContainer(
             center_x=center_x,
             center_y=center_y,
             radius=radius,

--- a/ctapipe/tools/muon_reconstruction.py
+++ b/ctapipe/tools/muon_reconstruction.py
@@ -12,7 +12,7 @@ from ctapipe.io import HDF5TableWriter
 from ctapipe.image.cleaning import TailcutsImageCleaner
 from ctapipe.coordinates import TelescopeFrame, CameraFrame
 from ctapipe.image import ImageExtractor
-from ctapipe.containers import MuonImageParameters
+from ctapipe.containers import MuonParametersContainer
 from ctapipe.instrument import CameraGeometry
 
 from ctapipe.image.muon import (
@@ -251,7 +251,7 @@ class MuonAnalysis(Tool):
             ring.radius, ring.center_x, ring.center_y
         )
 
-        return MuonImageParameters(
+        return MuonParametersContainer(
             containment=containment,
             completeness=completeness,
             intensity_ratio=intensity_ratio,

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -35,7 +35,7 @@ def test_muon_reconstruction(tmpdir):
         t = tables.open_file(f.name)
         table = t.root.dl1.event.telescope.parameters.muons[:]
         assert len(table) > 20
-        assert np.count_nonzero(np.isnan(table['muonringparameter_radius'])) == 0
+        assert np.count_nonzero(np.isnan(table['muonring_radius'])) == 0
 
     assert run_tool(MuonAnalysis(), ["--help-all"]) == 0
 


### PR DESCRIPTION
The muon containers were named pretty inconsistently to the other containers