### PR TITLE
use float32 for images, and validate

### DIFF
--- a/ctapipe/calib/camera/flatfield.py
+++ b/ctapipe/calib/camera/flatfield.py
@@ -343,14 +343,15 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
                                              pixel_median > self.time_cut_outliers[1])
 
         return {
-            'sample_time': (trigger_time - time_start) / 2 * u.s,
-            'sample_time_range': [time_start, trigger_time] * u.s,
+            # FIXME Why divided by two here?
+            'sample_time': u.Quantity((trigger_time - time_start) / 2, u.s),
+            'sample_time_min': u.Quantity(time_start, u.s),
+            'sample_time_max': u.Quantity(trigger_time, u.s),
             'time_mean': np.ma.getdata(pixel_mean),
             'time_median': np.ma.getdata(pixel_median),
             'time_std': np.ma.getdata(pixel_std),
             'relative_time_median': np.ma.getdata(relative_median),
             'time_median_outliers': np.ma.getdata(time_median_outliers),
-
         }
 
     def calculate_relative_gain_results(

--- a/ctapipe/calib/camera/pedestals.py
+++ b/ctapipe/calib/camera/pedestals.py
@@ -339,14 +339,17 @@ def calculate_time_results(
 ):
     """Calculate and return the sample time"""
     return {
-        'sample_time': (trigger_time - time_start) / 2 * u.s,
-        'sample_time_range': [time_start, trigger_time] * u.s,
+        # FIXME Why divided by two here?
+        'sample_time': u.Quantity((trigger_time - time_start) / 2, u.s),
+        'sample_time_min': u.Quantity(time_start, u.s),
+        'sample_time_max': u.Quantity(trigger_time, u.s),
     }
 
 
-def calculate_pedestal_results(self,
-                               trace_integral,
-                               masked_pixels_of_sample,
+def calculate_pedestal_results(
+    self,
+    trace_integral,
+    masked_pixels_of_sample,
 ):
     """Calculate and return the sample statistics"""
     masked_trace_integral = np.ma.array(

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -109,10 +109,10 @@ def test_dl1_charge_calib(example_subarray):
 
     # Randomize times and create pulses
     time_offset = random.uniform(mid - 10, mid + 10, n_pixels)[:, np.newaxis]
-    y = norm.pdf(x, time_offset, pulse_sigma)
+    y = norm.pdf(x, time_offset, pulse_sigma).astype('float32')
 
     # Define absolute calibration coefficients
-    absolute = random.uniform(100, 1000, n_pixels)
+    absolute = random.uniform(100, 1000, n_pixels).astype('float32')
     y *= absolute[:, np.newaxis]
 
     # Define relative coefficients

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -133,7 +133,7 @@ def test_dl1_charge_calib(example_subarray):
         image_extractor=FullWaveformSum(subarray=example_subarray)
     )
     calibrator(event)
-    np.testing.assert_allclose(event.dl1.tel[telid].image, y.sum(1))
+    np.testing.assert_allclose(event.dl1.tel[telid].image, y.sum(1), rtol=1e-4)
 
     event.calibration.tel[telid].dl1.time_shift = time_offset
     event.calibration.tel[telid].dl1.pedestal_offset = pedestal * n_samples
@@ -146,6 +146,6 @@ def test_dl1_charge_calib(example_subarray):
         image_extractor=FullWaveformSum(subarray=example_subarray)
     )
     calibrator(event)
-    np.testing.assert_allclose(event.dl1.tel[telid].image, 1)
+    np.testing.assert_allclose(event.dl1.tel[telid].image, 1, rtol=1e-5)
 
     # TODO: Test with timing corrections

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -407,15 +407,15 @@ class MCEventContainer(Container):
 
     container_prefix = "true"
 
-    energy = Field(0.0, "Monte-Carlo Energy", unit=u.TeV)
-    alt = Field(0.0, "Monte-carlo altitude", unit=u.deg)
-    az = Field(0.0, "Monte-Carlo azimuth", unit=u.deg)
-    core_x = Field(0.0, "MC core position", unit=u.m)
-    core_y = Field(0.0, "MC core position", unit=u.m)
-    h_first_int = Field(0.0, "Height of first interaction")
-    x_max = Field(0.0, "MC Xmax value", unit=u.g / (u.cm ** 2))
+    energy = Field(nan * u.TeV, "Monte-Carlo Energy", unit=u.TeV)
+    alt = Field(nan * u.deg, "Monte-carlo altitude", unit=u.deg)
+    az = Field(nan * u.deg, "Monte-Carlo azimuth", unit=u.deg)
+    core_x = Field(nan * u.m, "MC core position", unit=u.m)
+    core_y = Field(nan * u.m, "MC core position", unit=u.m)
+    h_first_int = Field(nan * u.m, "Height of first interaction", unit=u.m)
+    x_max = Field(nan * u.g / (u.cm**2), "MC Xmax value", unit=u.g / (u.cm ** 2))
     shower_primary_id = Field(
-        None,
+        -1,
         "MC shower primary ID 0 (gamma), 1(e-),"
         "2(mu-), 100*A+Z for nucleons and nuclei,"
         "negative for antimatter.",

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -503,15 +503,15 @@ class ReconstructedShowerContainer(Container):
     Standard output of algorithms reconstructing shower geometry
     """
 
-    alt = Field(0.0 * u.deg, "reconstructed altitude", unit=u.deg)
-    alt_uncert = Field(0.0 * u.deg, "reconstructed altitude uncertainty", unit=u.deg)
-    az = Field(0.0 * u.deg, "reconstructed azimuth", unit=u.deg)
-    az_uncert = Field(0.0 * u.deg, "reconstructed azimuth uncertainty", unit=u.deg)
-    core_x = Field(0.0 * u.m, "reconstructed x coordinate of the core position", unit=u.m)
-    core_y = Field(0.0 * u.m, "reconstructed y coordinate of the core position", unit=u.m)
-    core_uncert = Field(0.0 * u.m, "uncertainty of the reconstructed core position", unit=u.m)
-    h_max = Field(0.0 * u.m, "reconstructed height of the shower maximum", unit=u.m)
-    h_max_uncert = Field(0.0 * u.m, "uncertainty of h_max", unit=u.m)
+    alt = Field(nan * u.deg, "reconstructed altitude", unit=u.deg)
+    alt_uncert = Field(nan * u.deg, "reconstructed altitude uncertainty", unit=u.deg)
+    az = Field(nan * u.deg, "reconstructed azimuth", unit=u.deg)
+    az_uncert = Field(nan * u.deg, "reconstructed azimuth uncertainty", unit=u.deg)
+    core_x = Field(nan * u.m, "reconstructed x coordinate of the core position", unit=u.m)
+    core_y = Field(nan * u.m, "reconstructed y coordinate of the core position", unit=u.m)
+    core_uncert = Field(nan * u.m, "uncertainty of the reconstructed core position", unit=u.m)
+    h_max = Field(nan * u.m, "reconstructed height of the shower maximum", unit=u.m)
+    h_max_uncert = Field(nan * u.m, "uncertainty of h_max", unit=u.m)
     is_valid = Field(
         False,
         (
@@ -523,9 +523,9 @@ class ReconstructedShowerContainer(Container):
         [], ("list of the telescope ids used in the" " reconstruction of the shower")
     )
     average_intensity = Field(
-        0.0, "average intensity of the intensities used for reconstruction"
+        nan, "average intensity of the intensities used for reconstruction"
     )
-    goodness_of_fit = Field(0.0, "measure of algorithm success (if fit)")
+    goodness_of_fit = Field(nan, "measure of algorithm success (if fit)")
 
 
 class ReconstructedEnergyContainer(Container):

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -53,7 +53,7 @@ __all__ = [
 
 
 # see https://github.com/astropy/astropy/issues/6509
-NAN_TIME = Time(np.ma.masked_array(nan, mask=True), format='mjd')
+NAN_TIME = Time(np.ma.masked_array(nan, mask=True), format="mjd")
 
 
 class EventType(enum.Enum):
@@ -165,8 +165,10 @@ class TimingParametersContainer(Container):
     """
 
     container_prefix = "timing"
-    slope = Field(nan / u.m, "Slope of arrival times along main shower axis", unit=1/u.m)
-    slope_err = Field(nan / u.m, "Uncertainty `slope`", unit=1/u.m)
+    slope = Field(
+        nan / u.m, "Slope of arrival times along main shower axis", unit=1 / u.m
+    )
+    slope_err = Field(nan / u.m, "Uncertainty `slope`", unit=1 / u.m)
     intercept = Field(nan, "intercept of arrival times along main shower axis")
     intercept_err = Field(nan, "Uncertainty `intercept`")
     deviation = Field(
@@ -206,17 +208,23 @@ class DL1CameraContainer(Container):
     image = Field(
         None,
         "Numpy array of camera image, after waveform extraction." "Shape: (n_pixel)",
+        dtype=np.float32,
+        ndim=1,
     )
     peak_time = Field(
         None,
         "Numpy array containing position of the peak of the pulse as determined by "
         "the extractor. Shape: (n_pixel)",
+        dtype=np.float32,
+        ndim=1,
     )
 
     image_mask = Field(
         None,
         "Boolean numpy array where True means the pixel has passed cleaning. Shape: ("
         "n_pixel)",
+        dtype=np.bool,
+        ndim=1,
     )
 
     parameters = Field(ImageParametersContainer(), "Parameters derived from images")
@@ -230,6 +238,8 @@ class MCDL1CameraContainer(DL1CameraContainer):
         None,
         "Numpy array of camera image in PE as simulated before noise has been added. "
         "Shape: (n_pixel)",
+        dtype=np.float32,
+        ndim=1,
     )
 
     true_parameters = Field(
@@ -478,14 +488,14 @@ class MCHeaderContainer(Container):
 
 
 class TelescopeTriggerContainer(Container):
-    time = Field(NAN_TIME, 'Telescope trigger time')
+    time = Field(NAN_TIME, "Telescope trigger time")
 
 
 class TriggerContainer(Container):
     time = Field(NAN_TIME, "central average time stamp")
     tels_with_trigger = Field([], "list of telescope ids with data")
     event_type = Field(EventType.SUBARRAY, "Event type")
-    tel = Field(Map(TelescopeTriggerContainer), 'telescope-wise trigger information')
+    tel = Field(Map(TelescopeTriggerContainer), "telescope-wise trigger information")
 
 
 class ReconstructedShowerContainer(Container):
@@ -661,7 +671,8 @@ class DataContainer(Container):
 
 
 class MuonRingContainer(Container):
-    '''Container for the result of a ring fit, center_x, center_y'''
+    """Container for the result of a ring fit, center_x, center_y"""
+
     center_x = Field(nan * u.deg, "center (x) of the fitted muon ring", unit=u.deg)
     center_y = Field(nan * u.deg, "center (y) of the fitted muon ring", unit=u.deg)
     radius = Field(nan * u.deg, "radius of the fitted muon ring", unit=u.deg)
@@ -687,11 +698,11 @@ class MuonParametersContainer(Container):
         nan,
         "Complenetess of the muon ring"
         ", estimated by dividing the ring into segments"
-        " and counting segments above a threshold"
+        " and counting segments above a threshold",
     )
-    intensity_ratio = Field(nan, 'Intensity ratio of pixels in the ring to all pixels')
+    intensity_ratio = Field(nan, "Intensity ratio of pixels in the ring to all pixels")
     mean_squared_error = Field(
-        nan, 'MSE of the deviation of all pixels after cleaning from the ring fit'
+        nan, "MSE of the deviation of all pixels after cleaning from the ring fit"
     )
 
 

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -442,15 +442,15 @@ class MCHeaderContainer(Container):
     corsika_version = Field(nan, "CORSIKA version * 1000")
     simtel_version = Field(nan, "sim_telarray version * 1000")
     energy_range_min = Field(
-        nan, "Lower limit of energy range " "of primary particle", unit=u.TeV
+        nan * u.TeV, "Lower limit of energy range " "of primary particle", unit=u.TeV
     )
     energy_range_max = Field(
-        nan, "Upper limit of energy range " "of primary particle", unit=u.TeV
+        nan * u.TeV, "Upper limit of energy range " "of primary particle", unit=u.TeV
     )
-    prod_site_B_total = Field(nan, "total geomagnetic field", unit=u.uT)
-    prod_site_B_declination = Field(nan, "magnetic declination", unit=u.rad)
-    prod_site_B_inclination = Field(nan, "magnetic inclination", unit=u.rad)
-    prod_site_alt = Field(nan, "height of observation level", unit=u.m)
+    prod_site_B_total = Field(nan * u.uT, "total geomagnetic field", unit=u.uT)
+    prod_site_B_declination = Field(nan * u.rad, "magnetic declination", unit=u.rad)
+    prod_site_B_inclination = Field(nan * u.rad, "magnetic inclination", unit=u.rad)
+    prod_site_alt = Field(nan * u.m, "height of observation level", unit=u.m)
     prod_site_array = Field("None", "site array")
     prod_site_coord = Field("None", "site (long., lat.) coordinates")
     prod_site_subarray = Field("None", "site subarray")
@@ -465,24 +465,24 @@ class MCHeaderContainer(Container):
     detector_prog_id = Field(nan, "simtelarray=1")
     num_showers = Field(nan, "Number of showers simulated")
     shower_reuse = Field(nan, "Numbers of uses of each shower")
-    max_alt = Field(nan, "Maximimum shower altitude", unit=u.rad)
-    min_alt = Field(nan, "Minimum shower altitude", unit=u.rad)
-    max_az = Field(nan, "Maximum shower azimuth", unit=u.rad)
-    min_az = Field(nan, "Minimum shower azimuth", unit=u.rad)
-    diffuse = Field(nan, "Diffuse Mode On/Off")
-    max_viewcone_radius = Field(nan, "Maximum viewcone radius", unit=u.deg)
-    min_viewcone_radius = Field(nan, "Minimum viewcone radius", unit=u.deg)
-    max_scatter_range = Field(nan, "Maximum scatter range", unit=u.m)
-    min_scatter_range = Field(nan, "Minimum scatter range", unit=u.m)
+    max_alt = Field(nan * u.rad, "Maximimum shower altitude", unit=u.rad)
+    min_alt = Field(nan * u.rad, "Minimum shower altitude", unit=u.rad)
+    max_az = Field(nan * u.rad, "Maximum shower azimuth", unit=u.rad)
+    min_az = Field(nan * u.rad, "Minimum shower azimuth", unit=u.rad)
+    diffuse = Field(False, "Diffuse Mode On/Off")
+    max_viewcone_radius = Field(nan * u.deg, "Maximum viewcone radius", unit=u.deg)
+    min_viewcone_radius = Field(nan * u.deg, "Minimum viewcone radius", unit=u.deg)
+    max_scatter_range = Field(nan * u.m, "Maximum scatter range", unit=u.m)
+    min_scatter_range = Field(nan * u.m, "Minimum scatter range", unit=u.m)
     core_pos_mode = Field(nan, "Core Position Mode (fixed/circular/...)")
-    injection_height = Field(nan, "Height of particle injection", unit=u.m)
-    atmosphere = Field(nan, "Atmospheric model number")
+    injection_height = Field(nan * u.m, "Height of particle injection", unit=u.m)
+    atmosphere = Field(nan * u.m, "Atmospheric model number")
     corsika_iact_options = Field(nan, "Detector MC information")
     corsika_low_E_model = Field(nan, "Detector MC information")
     corsika_high_E_model = Field(nan, "Detector MC information")
     corsika_bunchsize = Field(nan, "Number of photons per bunch")
-    corsika_wlen_min = Field(nan, "Minimum wavelength of cherenkov light", unit=u.nm)
-    corsika_wlen_max = Field(nan, "Maximum wavelength of cherenkov light", unit=u.nm)
+    corsika_wlen_min = Field(nan * u.m, "Minimum wavelength of cherenkov light", unit=u.nm)
+    corsika_wlen_max = Field(nan * u.m, "Maximum wavelength of cherenkov light", unit=u.nm)
     corsika_low_E_detail = Field(nan, "Detector MC information")
     corsika_high_E_detail = Field(nan, "Detector MC information")
 
@@ -503,15 +503,15 @@ class ReconstructedShowerContainer(Container):
     Standard output of algorithms reconstructing shower geometry
     """
 
-    alt = Field(0.0, "reconstructed altitude", unit=u.deg)
-    alt_uncert = Field(0.0, "reconstructed altitude uncertainty", unit=u.deg)
-    az = Field(0.0, "reconstructed azimuth", unit=u.deg)
-    az_uncert = Field(0.0, "reconstructed azimuth uncertainty", unit=u.deg)
-    core_x = Field(0.0, "reconstructed x coordinate of the core position", unit=u.m)
-    core_y = Field(0.0, "reconstructed y coordinate of the core position", unit=u.m)
-    core_uncert = Field(0.0, "uncertainty of the reconstructed core position", unit=u.m)
-    h_max = Field(0.0, "reconstructed height of the shower maximum")
-    h_max_uncert = Field(0.0, "uncertainty of h_max")
+    alt = Field(0.0 * u.deg, "reconstructed altitude", unit=u.deg)
+    alt_uncert = Field(0.0 * u.deg, "reconstructed altitude uncertainty", unit=u.deg)
+    az = Field(0.0 * u.deg, "reconstructed azimuth", unit=u.deg)
+    az_uncert = Field(0.0 * u.deg, "reconstructed azimuth uncertainty", unit=u.deg)
+    core_x = Field(0.0 * u.m, "reconstructed x coordinate of the core position", unit=u.m)
+    core_y = Field(0.0 * u.m, "reconstructed y coordinate of the core position", unit=u.m)
+    core_uncert = Field(0.0 * u.m, "uncertainty of the reconstructed core position", unit=u.m)
+    h_max = Field(0.0 * u.m, "reconstructed height of the shower maximum", unit=u.m)
+    h_max_uncert = Field(0.0 * u.m, "uncertainty of h_max", unit=u.m)
     is_valid = Field(
         False,
         (
@@ -533,8 +533,8 @@ class ReconstructedEnergyContainer(Container):
     Standard output of algorithms estimating energy
     """
 
-    energy = Field(-1.0, "reconstructed energy", unit=u.TeV)
-    energy_uncert = Field(-1.0, "reconstructed energy uncertainty", unit=u.TeV)
+    energy = Field(nan * u.TeV, "reconstructed energy", unit=u.TeV)
+    energy_uncert = Field(nan * u.TeV, "reconstructed energy uncertainty", unit=u.TeV)
     is_valid = Field(
         False,
         (
@@ -712,9 +712,12 @@ class FlatFieldContainer(Container):
     [n_events] flat-field events
     """
 
-    sample_time = Field(0, "Time associated to the flat-field event set ", unit=u.s)
-    sample_time_range = Field(
-        [], "Range of time of the flat-field events [t_min, t_max]", unit=u.s
+    sample_time = Field(0 * u.s, "Time associated to the flat-field event set ", unit=u.s)
+    sample_time_min = Field(
+        nan * u.s, "Minimum time of the flat-field events", unit=u.s
+    )
+    sample_time_max = Field(
+        nan * u.s, "Maximum time of the flat-field events", unit=u.s
     )
     n_events = Field(0, "Number of events used for statistics")
 
@@ -764,10 +767,13 @@ class PedestalContainer(Container):
     [n_pedestal] pedestal events
     """
 
-    n_events = Field(0, "Number of events used for statistics")
-    sample_time = Field(0, "Time associated to the pedestal event set", unit=u.s)
-    sample_time_range = Field(
-        [], "Range of time of the pedestal events [t_min, t_max]", unit=u.s
+    n_events = Field(-1, "Number of events used for statistics")
+    sample_time = Field(nan * u.s, "Time associated to the pedestal event set", unit=u.s)
+    sample_time_min = Field(
+        nan * u.s, "Time of first pedestal event", unit=u.s
+    )
+    sample_time_max = Field(
+        nan * u.s, "Time of last pedestal event", unit=u.s
     )
     charge_mean = Field(None, "np array of pedestal average (n_chan, n_pix)")
     charge_median = Field(None, "np array of the pedestal  median (n_chan, n_pix)")
@@ -813,10 +819,15 @@ class WaveformCalibrationContainer(Container):
     Container for the pixel calibration coefficients
     """
 
-    time = Field(0, "Time associated to the calibration event", unit=u.s)
-    time_range = Field(
-        [],
-        "Range of time of validity for the calibration event [t_min, t_max]",
+    time = Field(nan * u.s, "Time associated to the calibration event", unit=u.s)
+    time_min = Field(
+        nan * u.s,
+        "Earliest time of validity for the calibration event",
+        unit=u.s,
+    )
+    time_max = Field(
+        nan * u.s,
+        "Latest time of validity for the calibration event",
         unit=u.s,
     )
 

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -88,7 +88,7 @@ class Field:
             if not isinstance(value, Quantity):
                 raise FieldValidationError(
                     f"{errorstr} Should have units of {self.unit}"
-                )
+                ) from None
             try:
                 value.to(self.unit)
             except UnitConversionError as err:

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -42,7 +42,7 @@ def test_path_exists():
         thepath = Path(exists=False)
 
     c1 = C1()
-    c1.thepath = "test"
+    c1.thepath = "non-existent-path-that-should-never-exist-not-even-by-accident"
 
     with tempfile.NamedTemporaryFile() as f:
         with pytest.raises(TraitError):

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -40,7 +40,7 @@ from .hillas import hillas_parameters, camera_to_shower_coordinates
     nopython=True,
 )
 def extract_around_peak(
-        waveforms, peak_index, width, shift, sampling_rate_ghz, sum_, peak_time
+    waveforms, peak_index, width, shift, sampling_rate_ghz, sum_, peak_time
 ):
     """
     This function performs the following operations:
@@ -91,12 +91,6 @@ def extract_around_peak(
     n_samples = waveforms.size
     start = peak_index - shift
     end = start + width
-
-    # whole range invalid
-    if end <= 0:
-        peak_time[0] = peak_index / sampling_rate_ghz
-        sum_[0] = 0
-        return
 
     # reduce to valid range
     start = max(0, start)

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -33,8 +33,8 @@ from .hillas import hillas_parameters, camera_to_shower_coordinates
 
 @guvectorize(
     [
-        (float64[:], int64, int64, int64, float64, float64[:], float64[:]),
-        (float32[:], int64, int64, int64, float64, float64[:], float64[:]),
+        (float64[:], int64, int64, int64, float64, float32[:], float32[:]),
+        (float32[:], int64, int64, int64, float64, float32[:], float32[:]),
     ],
     "(s),(),(),(),()->(),()",
     nopython=True,

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -99,6 +99,7 @@ def test_extract_around_peak(toymodel):
     y_offset = y - y.max() / 2
     charge, _ = extract_around_peak(y_offset[np.newaxis, :], 0, x.size, 0, 1)
     assert_allclose(charge, y_offset.sum(), rtol=1e-3)
+    assert charge.dtype == np.float32
 
 
 def test_extract_around_peak_charge_expected(toymodel):

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -148,6 +148,9 @@ class HDF5TableWriter(TableWriter):
         # create pytables schema description for the given container
         pos = 0
         for container in containers:
+
+            container.validate()  # ensure the data are complete
+
             for col_name, value in container.items(add_prefix=self.add_prefix):
 
                 typename = ""

--- a/ctapipe/reco/HillasReconstructor.py
+++ b/ctapipe/reco/HillasReconstructor.py
@@ -172,7 +172,6 @@ class HillasReconstructor(Reconstructor):
         core_pos = self.estimate_core_position(hillas_dict, array_pointing)
 
         # container class for reconstructed showers
-        result = ReconstructedShowerContainer()
         _, lat, lon = cartesian_to_spherical(*direction)
 
         # estimate max height of shower
@@ -180,22 +179,18 @@ class HillasReconstructor(Reconstructor):
 
         # astropy's coordinates system rotates counter-clockwise.
         # Apparently we assume it to be clockwise.
-        result.alt, result.az = lat, -lon
-        result.core_x = core_pos[0]
-        result.core_y = core_pos[1]
-        result.core_uncert = np.nan
-
-        result.tel_ids = [h for h in hillas_dict.keys()]
-        result.average_intensity = np.mean([h.intensity for h in hillas_dict.values()])
-        result.is_valid = True
-
-        result.alt_uncert = err_est_dir
-        result.az_uncert = np.nan
-
-        result.h_max = h_max
-        result.h_max_uncert = np.nan
-
-        result.goodness_of_fit = np.nan
+        # that's why lon get's a sign
+        result = ReconstructedShowerContainer(
+            alt=lat,
+            az=-lon,
+            core_x=core_pos[0],
+            core_y=core_pos[1],
+            tel_ids=[h for h in hillas_dict.keys()],
+            average_intensity=np.mean([h.intensity for h in hillas_dict.values()]),
+            is_valid=True,
+            alt_uncert=err_est_dir,
+            h_max=h_max
+        )
 
         return result
 

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -170,20 +170,12 @@ class HillasIntersection(Reconstructor):
         )
         # nom = sky_pos.transform_to(nom_frame)
         sky_pos = nom.transform_to(array_pointing.frame)
-
-        result = ReconstructedShowerContainer()
-        result.alt = sky_pos.altaz.alt.to(u.rad)
-        result.az = sky_pos.altaz.az.to(u.rad)
-
         tilt = SkyCoord(
             x=core_x * u.m,
             y=core_y * u.m,
             frame=tilted_frame,
         )
         grd = project_to_ground(tilt)
-        result.core_x = grd.x
-        result.core_y = grd.y
-
         x_max = self.reconstruct_xmax(
             nom.fov_lon,
             nom.fov_lat,
@@ -193,18 +185,23 @@ class HillasIntersection(Reconstructor):
             90 * u.deg - array_pointing.alt,
         )
 
-        result.core_uncert = np.sqrt(core_err_x**2 + core_err_y**2) * u.m
-
-        result.tel_ids = [h for h in hillas_dict_mod.keys()]
-        result.average_intensity = np.mean([h.intensity for h in hillas_dict_mod.values()])
-        result.is_valid = True
-
         src_error = np.sqrt(err_x**2 + err_y**2)
-        result.alt_uncert = src_error.to(u.rad)
-        result.az_uncert = src_error.to(u.rad)
-        result.h_max = x_max
-        result.h_max_uncert = np.nan
-        result.goodness_of_fit = np.nan
+
+        result = ReconstructedShowerContainer(
+            alt=sky_pos.altaz.alt.to(u.rad),
+            az=sky_pos.altaz.az.to(u.rad),
+            core_x=grd.x,
+            core_y=grd.y,
+            core_uncert=u.Quantity(np.sqrt(core_err_x**2 + core_err_y**2), u.m),
+            tel_ids=[h for h in hillas_dict_mod.keys()],
+            average_intensity=np.mean([h.intensity for h in hillas_dict_mod.values()]),
+            is_valid=True,
+            alt_uncert=src_error.to(u.rad),
+            az_uncert=src_error.to(u.rad),
+            h_max=x_max,
+            h_max_uncert=u.Quantity(np.nan * x_max.unit),
+            goodness_of_fit=np.nan,
+        )
 
         return result
 


### PR DESCRIPTION
- Changes Containers for images to specify
they should be float32
- call validate() when making schema in HDF5TableWriter


So far doesn't change the computation of the images. Need to ensure ImageExtractor creates float32s. 