### PR TITLE
Make sure extractors return 32bit image / peak_time

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -131,7 +131,8 @@ class CameraCalibrator(Component):
         pedestal = event.calibration.tel[telid].dl1.pedestal_offset
         absolute = event.calibration.tel[telid].dl1.absolute_factor
         relative = event.calibration.tel[telid].dl1.relative_factor
-        charge = (charge - pedestal) * relative / absolute
+        charge -= pedestal
+        charge *= relative / absolute
 
         event.dl1.tel[telid].image = charge
         event.dl1.tel[telid].peak_time = peak_time

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -387,8 +387,8 @@ class FixedWindowSum(ImageExtractor):
             waveforms, self.window_start.tel[telid], self.window_width.tel[telid], 0,
             self.sampling_rate[telid]
         )
-        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
-        return charge * correction, peak_time
+        charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge, peak_time
 
 
 class GlobalPeakWindowSum(ImageExtractor):
@@ -444,8 +444,8 @@ class GlobalPeakWindowSum(ImageExtractor):
             self.window_shift.tel[telid],
             self.sampling_rate[telid],
         )
-        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
-        return charge * correction, peak_time
+        charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge, peak_time
 
 
 class LocalPeakWindowSum(ImageExtractor):
@@ -501,8 +501,8 @@ class LocalPeakWindowSum(ImageExtractor):
             self.window_shift.tel[telid],
             self.sampling_rate[telid],
         )
-        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
-        return charge * correction, peak_time
+        charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge, peak_time
 
 
 class NeighborPeakWindowSum(ImageExtractor):
@@ -567,8 +567,8 @@ class NeighborPeakWindowSum(ImageExtractor):
             self.window_shift.tel[telid],
             self.sampling_rate[telid],
         )
-        correction = self._calculate_correction(telid=telid)[selected_gain_channel]
-        return charge * correction, peak_time
+        charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge, peak_time
 
 
 class BaselineSubtractedNeighborPeakWindowSum(NeighborPeakWindowSum):
@@ -1015,8 +1015,9 @@ class TwoPassWindowSum(ImageExtractor):
             waveforms, telid, selected_gain_channel
         )
 
+        # FIXME: properly make sure that output is 32Bit instead of downcasting here
         if self.disable_second_pass:
-            return charge1 * correction1, pulse_time1
+            return (charge1 * correction1).astype('float32'), pulse_time1.astype('float32')
 
         charge2, pulse_time2 = self._apply_second_pass(
             waveforms,
@@ -1026,4 +1027,5 @@ class TwoPassWindowSum(ImageExtractor):
             pulse_time1,
             correction1,
         )
-        return charge2, pulse_time2
+        # FIXME: properly make sure that output is 32Bit instead of downcasting here
+        return charge2.astype('float32'), pulse_time2.astype('float32')

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -332,3 +332,17 @@ def test_extractor_tel_param(toymodel):
     assert extractor.window_width.tel[None] == n_samples
     assert extractor.window_width.tel[1] == n_samples
     assert extractor.window_width.tel[2] == n_samples // 2
+
+
+@pytest.mark.parametrize('Extractor', non_abstract_children(ImageExtractor))
+def test_dtype(Extractor, subarray):
+
+    tel_id = 1
+    n_pixels = subarray.tel[tel_id].camera.geometry.n_pixels
+    selected_gain_channel = np.zeros(n_pixels, dtype=int)
+
+    waveforms = np.ones((n_pixels, 50), dtype='float64')
+    extractor = Extractor(subarray=subarray)
+    charge, peak_time = extractor(waveforms, tel_id, selected_gain_channel)
+    assert charge.dtype == np.float32
+    assert peak_time.dtype == np.float32


### PR DESCRIPTION
Extractors with with subtraction still returned 64 bit floats. Replaced with inplace multiplication to preserve datatype (should also be faster, but not measured)