### PR TITLE
add vitables to user environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ dependencies:
   - sphinx_rtd_theme
   - tqdm
   - traitlets
+  - vitables
   - wheel
   - xz
   - zlib


### PR DESCRIPTION
fixes #1340 , Just adds the vitables app (viewer for HDF5 files like those produced by ctapipe) to `environment.yml`

**Rationale**: we currently ask users & developers to set up their environment using environment.yml (rather than just `conda install ctapipe`), which includes packages that go beyond the required ctapipe dependencies, adding useful utilities like pandas and jupyter (also needed for documentation building).  This env will likely also be published on anaconda.org (as ctapipe-0.8-env or similar), for easy user setup.

In the future, we might want to separate the testing environment from the recommended user environment, but for now they are the same. 
