### PR TITLE
Miscelleanous performance improvements

### DIFF
--- a/ctapipe/image/concentration.py
+++ b/ctapipe/image/concentration.py
@@ -30,7 +30,7 @@ def concentration(geom, image, hillas_parameters):
     cog_pixels = np.argsort(delta_x ** 2 + delta_y ** 2)
     conc_cog = np.sum(image[cog_pixels[:3]]) / h.intensity
 
-    if hillas_parameters.width != 0:
+    if hillas_parameters.width.value != 0:
         # get all pixels inside the hillas ellipse
         longi, trans = camera_to_shower_coordinates(
             pix_x, pix_y, x, y, h.psi.to_value(u.rad)

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -38,6 +38,7 @@ from .hillas import hillas_parameters, camera_to_shower_coordinates
     ],
     "(s),(),(),(),()->(),()",
     nopython=True,
+    cache=True,
 )
 def extract_around_peak(
     waveforms, peak_index, width, shift, sampling_rate_ghz, sum_, peak_time
@@ -887,11 +888,7 @@ class TwoPassWindowSum(ImageExtractor):
 
         # get projected distances along main image axis
         long, _ = camera_to_shower_coordinates(
-            camera_geometry.pix_x,
-            camera_geometry.pix_y,
-            hillas.x,
-            hillas.y,
-            hillas.psi,
+            camera_geometry.pix_x, camera_geometry.pix_y, hillas.x, hillas.y, hillas.psi
         )
 
         # get the predicted times as a linear relation
@@ -1022,7 +1019,7 @@ class TwoPassWindowSum(ImageExtractor):
             )
 
         charge2, pulse_time2 = self._apply_second_pass(
-            waveforms, telid, selected_gain_channel, charge1, pulse_time1, correction1,
+            waveforms, telid, selected_gain_channel, charge1, pulse_time1, correction1
         )
         # FIXME: properly make sure that output is 32Bit instead of downcasting here
         return charge2.astype("float32"), pulse_time2.astype("float32")

--- a/ctapipe/image/hillas.py
+++ b/ctapipe/image/hillas.py
@@ -14,10 +14,7 @@ from ..containers import HillasParametersContainer
 HILLAS_ATOL = np.finfo(np.float64).eps
 
 
-__all__ = [
-    "hillas_parameters",
-    "HillasParameterizationError",
-]
+__all__ = ["hillas_parameters", "HillasParameterizationError"]
 
 
 def camera_to_shower_coordinates(x, y, cog_x, cog_y, psi):
@@ -170,11 +167,11 @@ def hillas_parameters(geom, image):
         x=u.Quantity(cog_x, unit),
         y=u.Quantity(cog_y, unit),
         r=u.Quantity(cog_r, unit),
-        phi=Angle(cog_phi, unit=u.rad),
+        phi=u.Quantity(cog_phi, unit=u.rad),
         intensity=size,
         length=u.Quantity(length, unit),
         width=u.Quantity(width, unit),
-        psi=Angle(psi, unit=u.rad),
+        psi=u.Quantity(psi, unit=u.rad),
         skewness=skewness_long,
         kurtosis=kurtosis_long,
     )

--- a/ctapipe/image/hillas.py
+++ b/ctapipe/image/hillas.py
@@ -6,7 +6,6 @@ Hillas-style moment-based shower image parametrization.
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import Angle
 from astropy.units import Quantity
 from ..containers import HillasParametersContainer
 

--- a/ctapipe/image/morphology.py
+++ b/ctapipe/image/morphology.py
@@ -3,7 +3,7 @@ from numba import njit
 from ..containers import MorphologyContainer
 
 
-@njit
+@njit(cache=True)
 def _num_islands_sparse_indices(indices, indptr, mask):
 
     # non-signal pixel get label == 0, we marke the cleaning

--- a/ctapipe/image/morphology.py
+++ b/ctapipe/image/morphology.py
@@ -8,14 +8,20 @@ def _num_islands_sparse_indices(indices, indptr, mask):
 
     labels = np.zeros(len(mask), dtype=np.int16)
     cleaning_pixels = np.where(mask)[0]
+    n_cleaning_pixels = len(cleaning_pixels)
     current_island = 0
 
-    to_check = set()
-    for idx in cleaning_pixels:
+    visited = np.zeros(len(mask), dtype=np.bool_)
+    to_check = []
+
+    for i in range(n_cleaning_pixels):
+        idx = cleaning_pixels[i]
 
         # we already visited this pixel
-        if labels[idx] != 0:
+        if visited[idx]:
             continue
+
+        visited[idx] = True
 
         # start a new island
         current_island += 1
@@ -23,17 +29,22 @@ def _num_islands_sparse_indices(indices, indptr, mask):
 
         # check neighbors recursively
         neighbors = indices[indptr[idx] : indptr[idx + 1]]
-        for i in range(len(neighbors)):
-            to_check.add(neighbors[i])
+        for n in range(len(neighbors)):
+            to_check.append(neighbors[n])
 
-        while to_check:
+        while len(to_check) > 0:
             idx = to_check.pop()
-            if mask[idx] and labels[idx] == 0:
+            visited[idx] = True
+
+            if mask[idx]:
                 labels[idx] = current_island
 
                 neighbors = indices[indptr[idx] : indptr[idx + 1]]
-                for i in range(len(neighbors)):
-                    to_check.add(neighbors[i])
+
+                for n in range(len(neighbors)):
+                    if not visited[neighbors[n]]:
+                        to_check.append(neighbors[n])
+
     return current_island, labels
 
 

--- a/ctapipe/image/statistics.py
+++ b/ctapipe/image/statistics.py
@@ -4,7 +4,7 @@ from numba import njit
 from ..containers import StatisticsContainer
 
 
-@njit()
+@njit(cache=True)
 def skewness(data, mean=None, std=None):
     """Calculate skewnewss (normalized third central moment)
     with allowing precomputed mean and std.
@@ -37,7 +37,7 @@ def skewness(data, mean=None, std=None):
     return np.mean(((data - mean) / std) ** 3)
 
 
-@njit()
+@njit(cache=True)
 def kurtosis(data, mean=None, std=None, fisher=True):
     """Calculate kurtosis (normalized fourth central moment)
     with allowing precomputed mean and std.

--- a/ctapipe/image/tests/test_geometry_converter.py
+++ b/ctapipe/image/tests/test_geometry_converter.py
@@ -32,12 +32,12 @@ def create_mock_image(geom):
     )
 
     _, image, _ = model.generate_image(
-        geom, intensity=0.5 * geom.n_pixels, nsb_level_pe=3,
+        geom, intensity=0.5 * geom.n_pixels, nsb_level_pe=3
     )
     return image
 
 
-@pytest.mark.parametrize("rot", [3,])
+@pytest.mark.parametrize("rot", [3])
 @pytest.mark.parametrize("camera_name", camera_names)
 def test_convert_geometry(camera_name, rot):
 
@@ -77,11 +77,11 @@ def test_convert_geometry(camera_name, rot):
     #     plt.tight_layout()
     #     plt.pause(.1)
 
-    assert np.abs(hillas_1.phi - hillas_0.phi).deg < 1.0
+    assert np.abs(hillas_1.phi - hillas_0.phi).to_value(u.deg) < 1.0
     # TODO: test other parameters
 
 
-@pytest.mark.parametrize("rot", [3,])
+@pytest.mark.parametrize("rot", [3])
 @pytest.mark.parametrize("camera_name", camera_names)
 def test_convert_geometry_mock(camera_name, rot):
     """here we use a different key for the back conversion to trigger the mock conversion
@@ -105,7 +105,7 @@ def test_convert_geometry_mock(camera_name, rot):
         return
 
     hillas_1 = hillas_parameters(geom, image1d)
-    assert np.abs(hillas_1.phi - hillas_0.phi).deg < 1.0
+    assert np.abs(hillas_1.phi - hillas_0.phi).to_value(u.deg) < 1.0
 
 
 # def plot_cam(geom, geom2d, geom1d, image, image2d, image1d):

--- a/ctapipe/image/tests/test_morphology.py
+++ b/ctapipe/image/tests/test_morphology.py
@@ -10,23 +10,33 @@ def test_number_of_islands():
     geom = CameraGeometry.from_name("LSTCam")
 
     # create 18 triggered pixels grouped to 5 clusters
-    island_mask_true = np.zeros(geom.n_pixels)
     mask = np.zeros(geom.n_pixels).astype("bool")
     triggered_pixels = np.array(
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 37, 38, 111, 222]
     )
-    island_mask_true[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]] = 1
-    island_mask_true[14] = 2
-    island_mask_true[[37, 38]] = 3
-    island_mask_true[111] = 4
-    island_mask_true[222] = 5
-    mask[triggered_pixels] = 1
+    mask[triggered_pixels] = True
 
-    n_islands, island_mask = number_of_islands(geom, mask)
+    print(triggered_pixels)
+
+    island_labels_true = np.zeros(geom.n_pixels, dtype=np.int16)
+    island_labels_true[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]] = 1
+    island_labels_true[14] = 2
+    island_labels_true[[37, 38]] = 3
+    island_labels_true[111] = 4
+    island_labels_true[222] = 5
+
+    print(island_labels_true[mask])
+
+    n_islands, island_labels = number_of_islands(geom, mask)
     n_islands_true = 5
+    # non cleaning pixels should be zero
+    assert np.all(island_labels[~mask] == 0)
+    # all other should have some label
+    assert np.all(island_labels[mask] > 0)
+
     assert n_islands == n_islands_true
-    assert_allclose(island_mask, island_mask_true)
-    assert island_mask.dtype == np.int32
+    assert_allclose(island_labels, island_labels_true)
+    assert island_labels.dtype == np.int16
 
 
 def test_number_of_island_sizes():

--- a/ctapipe/image/tests/test_morphology.py
+++ b/ctapipe/image/tests/test_morphology.py
@@ -16,16 +16,12 @@ def test_number_of_islands():
     )
     mask[triggered_pixels] = True
 
-    print(triggered_pixels)
-
     island_labels_true = np.zeros(geom.n_pixels, dtype=np.int16)
     island_labels_true[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]] = 1
     island_labels_true[14] = 2
     island_labels_true[[37, 38]] = 3
     island_labels_true[111] = 4
     island_labels_true[222] = 5
-
-    print(island_labels_true[mask])
 
     n_islands, island_labels = number_of_islands(geom, mask)
     n_islands_true = 5

--- a/ctapipe/image/tests/test_timing_parameters.py
+++ b/ctapipe/image/tests/test_timing_parameters.py
@@ -100,3 +100,42 @@ def test_ignore_negative():
     assert_allclose(timing.slope, grad / geom.pix_x.unit, rtol=1e-2)
     assert_allclose(timing.intercept, intercept, rtol=1e-2)
     assert_allclose(timing.deviation, deviation, rtol=1e-2)
+
+
+def test_outliers():
+    from ctapipe.image import timing_parameters
+
+    """
+    Simple test that gradient fitting gives expected answers for perfect
+    gradient
+    """
+    grad = 2.0
+    intercept = 1.0
+    deviation = 0.1
+
+    geom = CameraGeometry.from_name("LSTCam")
+    hillas = HillasParametersContainer(x=0 * u.m, y=0 * u.m, psi=0 * u.deg)
+
+    random = np.random.RandomState(1)
+    x = geom.pix_x.value
+    peak_time = intercept + grad * x
+    peak_time += random.normal(0, deviation, geom.n_pixels)
+    peak_time[0] = 4
+    peak_time[10] = 20
+    peak_time[15] = 15
+
+    timing = timing_parameters(
+        geom,
+        image=np.ones(geom.n_pixels),
+        peak_time=peak_time,
+        hillas_parameters=hillas,
+        cleaning_mask=np.ones(geom.n_pixels, dtype=bool),
+    )
+
+    # Test we get the values we put in back out again
+    assert_allclose(timing.slope, grad / geom.pix_x.unit, rtol=1e-2)
+    assert_allclose(timing.intercept, intercept, rtol=1e-2)
+
+    assert np.isclose(
+        timing.deviation, np.std(peak_time - (grad * x + intercept)), rtol=0.01
+    )

--- a/ctapipe/image/timing.py
+++ b/ctapipe/image/timing.py
@@ -14,7 +14,7 @@ from ..utils.quantities import all_to_value
 __all__ = ["timing_parameters"]
 
 
-@njit
+@njit(cache=True)
 def linear_regression(x, y):
     """
     njit version of a least squares linear regression
@@ -46,7 +46,7 @@ def linear_regression(x, y):
     return params[0], params[1], cov
 
 
-@njit
+@njit(cache=True)
 def sigma_clipping_linreg(x, y, kappa=3, n_iter=3):
     """
     Linear regression with sigma clipping.
@@ -129,7 +129,9 @@ def timing_parameters(geom, image, peak_time, hillas_parameters, cleaning_mask=N
         pix_x, pix_y, x, y, hillas_parameters.psi.to_value(u.rad)
     )
 
-    slope, intercept, cov = sigma_clipping_linreg(x=longi, y=peak_time)
+    slope, intercept, cov = sigma_clipping_linreg(
+        x=longi, y=peak_time.astype("float64")
+    )
     slope_err, intercept_err = np.sqrt(np.diag(cov))
 
     predicted_time = slope * longi + intercept

--- a/ctapipe/image/timing.py
+++ b/ctapipe/image/timing.py
@@ -43,11 +43,11 @@ def linear_regression(x, y):
 
     cov = np.linalg.inv(X.T @ X)
     params = cov @ X.T @ y
-    return params[0], params[1], cov
+    return params[0][0], params[1][0], cov
 
 
 @njit(cache=True)
-def sigma_clipping_linreg(x, y, kappa=3, n_iter=3):
+def sigma_clipping_linreg(x, y, kappa=2.5, n_iter=3):
     """
     Linear regression with sigma clipping.
     Iteratively perform a linear regression, excluding points
@@ -76,12 +76,13 @@ def sigma_clipping_linreg(x, y, kappa=3, n_iter=3):
     """
 
     a, b, cov = linear_regression(x, y)
+    mask = np.ones(len(x), dtype=np.bool_)
 
     for i in range(n_iter):
         delta = y - (a * x + b)
         sigma = np.std(delta)
+        mask &= np.abs(delta) < (kappa * sigma)
 
-        mask = delta < (kappa * sigma)
         a, b, cov = linear_regression(x[mask], y[mask])
 
     return a, b, cov

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -415,7 +415,7 @@ class CameraDisplay:
             centroid=(cen_x, cen_y),
             length=length * 2,
             width=width * 2,
-            angle=hillas_parameters.psi.rad,
+            angle=hillas_parameters.psi.to_value(u.rad),
             **kwargs,
         )
 


### PR DESCRIPTION
## Quantity vs. Angle

```
In [4]: %timeit Angle(5, u.rad)                                                                                                               
10.1 µs ± 63.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [5]: %timeit u.Quantity(5, u.rad)                                                                                                          
3.46 µs ± 28.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

## Reimplement number_of_islands

From
```
318 µs ± 11.7 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
To
```
13.8 µs ± 15.4 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

## Timing parameters using sigma clipping instead of siegelslopes:

1855 pixels:

From
```
153 ms ± 382 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
To
```
311 µs ± 88.9 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

100 Pixels:
From 
```
4.35 ms ± 5.39 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
To
```
229 µs ± 102 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


## Overall

On the LST Muon Mono run:

From
```
10000/10000 [02:29<00:00, 66.99ev/s]
```
To
```
10000/10000 [01:28<00:00, 113.16ev/s]
```