### PR TITLE
improve TwoPassWindowSum extractor

### DIFF
--- a/ctapipe/image/concentration.py
+++ b/ctapipe/image/concentration.py
@@ -30,7 +30,7 @@ def concentration(geom, image, hillas_parameters):
     cog_pixels = np.argsort(delta_x ** 2 + delta_y ** 2)
     conc_cog = np.sum(image[cog_pixels[:3]]) / h.intensity
 
-    if hillas_parameters.width != 0:
+    if hillas_parameters.width.value != 0:
         # get all pixels inside the hillas ellipse
         longi, trans = camera_to_shower_coordinates(
             pix_x, pix_y, x, y, h.psi.to_value(u.rad)

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -895,8 +895,8 @@ class TwoPassWindowSum(ImageExtractor):
         # window along each waveform
 
         # Now the definition of peak_index is really the peak.
-        # We have to add 2 samples each side, so the shist will always
-        # be (-)2, while width will alwapys end 4 samples to the right.
+        # We have to add 2 samples each side, so the shift will always
+        # be (-)2, while width will always end 4 samples to the right.
         # This "always" refers to a 5-samples window of course
         window_width_default = 4
         window_shift_default = 2

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -731,7 +731,7 @@ class TwoPassWindowSum(ImageExtractor):
         # Since we have to add 1 sample on each side, window_shift will always
         # be (-)1, while window_width will always be window1_width + 1
         # so we the final 5-samples window will be 1+3+1
-        window_width = width + 1
+        window_width = width + 2
         window_shift = 1
 
         # the 'peak_index' argument of 'extract_around_peak' has a different
@@ -898,7 +898,7 @@ class TwoPassWindowSum(ImageExtractor):
         # We have to add 2 samples each side, so the shift will always
         # be (-)2, while width will always end 4 samples to the right.
         # This "always" refers to a 5-samples window of course
-        window_width_default = 4
+        window_width_default = 5
         window_shift_default = 2
 
         # now let's deal with some edge cases: the predicted peak falls before
@@ -908,12 +908,12 @@ class TwoPassWindowSum(ImageExtractor):
 
         # BUT, if the resulting 5-samples window falls outside of the readout
         # window then we take the first (or last) 5 samples
-        window_width_before = 4
+        window_width_before = 5
         window_shift_before = 0
 
         # in the case where the window is after, shift backward
-        window_width_after = 4
-        window_shift_after = 4
+        window_width_after = 5
+        window_shift_after = 5
 
         # and put them together:
         window_widths = np.full(nonCore_waveforms.shape[0], window_width_default)

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -682,7 +682,7 @@ class TwoPassWindowSum(ImageExtractor):
             shift,
         )
 
-    def _apply_first_pass(self, waveforms, telid, selected_gain_channel):
+    def _apply_first_pass(self, waveforms, telid):
         """
         Execute step 1.
 
@@ -692,9 +692,6 @@ class TwoPassWindowSum(ImageExtractor):
             DL0-level waveforms of one event.
         telid : int
             Index of the telescope.
-        selected_gain_channel: array of size (N_channels, N_pixels)
-            Array containing the index of the selected gain channel for each
-            pixel (0 for low gain, 1 for high gain).
 
         Returns
         -------
@@ -1009,9 +1006,7 @@ class TwoPassWindowSum(ImageExtractor):
             Shape: (n_pix)
         """
 
-        charge1, pulse_time1, correction1 = self._apply_first_pass(
-            waveforms, telid, selected_gain_channel
-        )
+        charge1, pulse_time1, correction1 = self._apply_first_pass(waveforms, telid)
 
         # FIXME: properly make sure that output is 32Bit instead of downcasting here
         if self.disable_second_pass:

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -1011,7 +1011,7 @@ class TwoPassWindowSum(ImageExtractor):
         # FIXME: properly make sure that output is 32Bit instead of downcasting here
         if self.disable_second_pass:
             return (
-                (charge1 * correction1).astype("float32"),
+                (charge1 * correction1[selected_gain_channel]).astype("float32"),
                 pulse_time1.astype("float32"),
             )
 

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -21,7 +21,7 @@ __all__ = [
 from abc import abstractmethod
 from functools import lru_cache
 import numpy as np
-from traitlets import Int
+from traitlets import Int, Bool
 from ctapipe.core.traits import IntTelescopeParameter, FloatTelescopeParameter
 from ctapipe.core import TelescopeComponent
 from numba import njit, prange, guvectorize, float64, float32, int64
@@ -641,8 +641,10 @@ class TwoPassWindowSum(ImageExtractor):
         help="Picture threshold for internal tail-cuts pass",
     ).tag(config=True)
 
-    # Boolean that is used to disable the 2np pass and return the 1st pass
-    disable_second_pass = False
+    disable_second_pass = Bool(
+        default_value=False,
+        help="only run the first pass of the extractor, for debugging purposes",
+    ).tag(config=True)
 
     @lru_cache(maxsize=4096)
     def _calculate_correction(self, telid, width, shift):

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -662,9 +662,9 @@ class TwoPassWindowSum(ImageExtractor):
         telid : int
             Index of the telescope in use.
         width : int
-            Width of the integration window (in units of n_samples)
+            Width of the integration window in samples
         shift : int
-            Values of the window shifts per pixel.
+            Window shift to the left of the pulse peak in samples
 
         Returns
         -------

--- a/ctapipe/image/tests/test_morphology.py
+++ b/ctapipe/image/tests/test_morphology.py
@@ -10,23 +10,29 @@ def test_number_of_islands():
     geom = CameraGeometry.from_name("LSTCam")
 
     # create 18 triggered pixels grouped to 5 clusters
-    island_mask_true = np.zeros(geom.n_pixels)
     mask = np.zeros(geom.n_pixels).astype("bool")
     triggered_pixels = np.array(
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 37, 38, 111, 222]
     )
-    island_mask_true[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]] = 1
-    island_mask_true[14] = 2
-    island_mask_true[[37, 38]] = 3
-    island_mask_true[111] = 4
-    island_mask_true[222] = 5
-    mask[triggered_pixels] = 1
+    mask[triggered_pixels] = True
 
-    n_islands, island_mask = number_of_islands(geom, mask)
+    island_labels_true = np.zeros(geom.n_pixels, dtype=np.int16)
+    island_labels_true[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]] = 1
+    island_labels_true[14] = 2
+    island_labels_true[[37, 38]] = 3
+    island_labels_true[111] = 4
+    island_labels_true[222] = 5
+
+    n_islands, island_labels = number_of_islands(geom, mask)
     n_islands_true = 5
+    # non cleaning pixels should be zero
+    assert np.all(island_labels[~mask] == 0)
+    # all other should have some label
+    assert np.all(island_labels[mask] > 0)
+
     assert n_islands == n_islands_true
-    assert_allclose(island_mask, island_mask_true)
-    assert island_mask.dtype == np.int32
+    assert_allclose(island_labels, island_labels_true)
+    assert island_labels.dtype == np.int16
 
 
 def test_number_of_island_sizes():


### PR DESCRIPTION
Due to the fact that each pixel might have a different value for `window_shift`, the original implementation was very slow (5-10 seconds/event), since it computed the integration correction for each event and each pixel.  However, really there is only need to compute it 3 times:  once for the usual case where the pulse is inside the readout window, and once each for the edge cases where it is before or after the window (where the window size and shift is smaller like in MARS).

This PR just minimally refactors the existing code to avoid repeated calls to `_compute_correction()` by memoization and treating the edge cases separately.    It results in a large speed increase when using the TwoPass method, though there is still work to be done (and some will be solved by merging in #1354, which improves the speed of timing_parameters, which is used internally here)

**Update**: this also fixes a bug where the integration windows were smaller than intended by 1 sample. 