### PR TITLE
Add support to read from prefixed columns

### DIFF
--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -161,7 +161,7 @@ class HDF5TableWriter(TableWriter):
                     continue
 
                 if col_name in Schema.columns:
-                    self.log.warning(f"Found duplicated column {col_name}, skipping")
+                    self.log.warning("Found duplicated column %s, skipping", col_name)
                     continue
 
                 # apply any user-defined transforms first
@@ -208,10 +208,10 @@ class HDF5TableWriter(TableWriter):
 
                 else:
                     self.log.warning(
-                        f"Column {col_name} of"
-                        f" container {container.__class__.__name__}"
-                        f" in table {table_name}"
-                        " not writable, skipping"
+                        "Column %s of container %s in table %s not writable, skipping",
+                        col_name,
+                        container.__class__.__name__,
+                        table_name
                     )
                     continue
 
@@ -280,8 +280,9 @@ class HDF5TableWriter(TableWriter):
                     row[colname] = value
                 except Exception:
                     self.log.error(
-                        f'Error writing col "{colname}" of'
-                        f' container "{container.__class__.__name__}"'
+                        'Error writing col "%s" of container "%s"',
+                        colname,
+                        container.__class__.__name__
                     )
                     raise
         row.append()

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -157,11 +157,11 @@ class HDF5TableWriter(TableWriter):
                 shape = 1
 
                 if self._is_column_excluded(table_name, col_name):
-                    self.log.debug("excluded column: %s/%s", table_name, col_name)
+                    self.log.debug(f"excluded column: {table_name}/{col_name}")
                     continue
 
                 if col_name in Schema.columns:
-                    self.log.warning("Found duplicated column %s, skipping", col_name)
+                    self.log.warning(f"Found duplicated column {col_name}, skipping")
                     continue
 
                 # apply any user-defined transforms first
@@ -208,20 +208,17 @@ class HDF5TableWriter(TableWriter):
 
                 else:
                     self.log.warning(
-                        "Column %s of container %s in table %s not writable, skipping",
-                        col_name,
-                        container.__class__.__name__,
-                        table_name
+                        f"Column {col_name} of "
+                        f"container {container.__class__.__name__} in "
+                        f"table {table_name} not writable, skipping"
                     )
                     continue
 
                 pos += 1
                 self.log.debug(
-                    "Table %s: added col: %s type: %s shape: %s",
-                    table_name,
-                    col_name,
-                    typename,
-                    shape,
+                    f"Table {table_name}: "
+                    f"added col: {col_name} type: "
+                    f"{typename} shape: {shape}"
                 )
 
         self._schemas[table_name] = Schema
@@ -254,7 +251,7 @@ class HDF5TableWriter(TableWriter):
             createparents=True,
             filters=self.filters,
         )
-        self.log.debug("CREATED TABLE: %s", table)
+        self.log.debug(f"CREATED TABLE: {table}")
         for key, val in meta.items():
             table.attrs[key] = val
 
@@ -280,9 +277,8 @@ class HDF5TableWriter(TableWriter):
                     row[colname] = value
                 except Exception:
                     self.log.error(
-                        'Error writing col "%s" of container "%s"',
-                        colname,
-                        container.__class__.__name__
+                        f"Error writing col {colname} of "
+                        f"container {container.__class__.__name__}"
                     )
                     raise
         row.append()
@@ -407,11 +403,8 @@ class HDF5TableReader(TableReader):
                 self._cols_to_read[table_name].append(colname)
             else:
                 self.log.warning(
-                    "Table '%s' has column '%s' that is not in "
-                    "container %s. It will be skipped",
-                    table_name,
-                    colname_without_prefix,
-                    container.__class__.__name__,
+                    f"Table {table_name} has column {colname_without_prefix} that is not in "
+                    f"container {container.__class__.__name__}. It will be skipped."
                 )
 
         # also check that the container doesn't have fields that are not
@@ -423,11 +416,8 @@ class HDF5TableReader(TableReader):
                 colname_with_prefix = colname
             if colname_with_prefix not in self._cols_to_read[table_name]:
                 self.log.warning(
-                    "Table '%s' is missing column '%s' that is "
-                    "in container %s. It will be skipped.",
-                    table_name,
-                    colname_with_prefix,
-                    container.__class__.__name__,
+                    f"Table {table_name} is missing column {colname_with_prefix}"
+                    f"that is in container {container.__class__.__name__}. It will be skipped."
                 )
 
         # copy all user-defined attributes back to Container.mets

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -168,7 +168,7 @@ class TableReader(Component, metaclass=ABCMeta):
         return value
 
     @abstractmethod
-    def read(self, table_name: str, container: Container):
+    def read(self, table_name: str, container: Container, prefix=False):
         """
         Returns a generator that reads the next row from the table into the
         given container.  The generator returns the same container. Note that
@@ -180,6 +180,8 @@ class TableReader(Component, metaclass=ABCMeta):
             name of table to read from
         container : ctapipe.core.Container
             Container instance to fill
+        prefix: bool or str
+            Prefix that was added while writing the file.
         """
         pass
 

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -70,6 +70,32 @@ def test_prefix(tmp_path):
     assert "hillas_x" in df.columns
     assert "leakage_pixels_width_1" in df.columns
 
+    with HDF5TableReader(tmp_file.name) as reader:
+        generator = reader.read(
+            "/blabla/events",
+            HillasParametersContainer(),
+            prefix=True
+        )
+        hillas = next(generator)
+    for value, read_value in zip(
+            hillas_parameter_container.as_dict().values(),
+            hillas.as_dict().values()
+    ):
+        np.testing.assert_equal(value, read_value)
+
+    with HDF5TableReader(tmp_file.name) as reader:
+        generator = reader.read(
+            "/blabla/events",
+            LeakageContainer(),
+            prefix=True
+        )
+        leakage = next(generator)
+    for value, read_value in zip(
+            leakage_container.as_dict().values(),
+            leakage.as_dict().values()
+    ):
+        np.testing.assert_equal(value, read_value)
+
 
 def test_units():
     class WithUnits(Container):


### PR DESCRIPTION
This fixes #1360 in order to work towards a DL1EventSource.

- The `HDF5TableReader.read()` method now has an additional, optional argument `prefix`
- Following the discussion in #1360 three use cases are supported:
    - `prefix=False`: No prefix. This is the default, because per default the writer does not add a prefix as well
    - `prefix=True`: Using the container prefix
    - `prefix="my_prefix"`: Using a custom prefix

This enables the reading of the image parameter containers, that are written by the stage1 tool, but support for reading into multiple containers at once is still missing.