### PR TITLE
Improve clarity of FixedWindowSum

### DIFF
--- a/ctapipe/calib/camera/tests/test_flatfield.py
+++ b/ctapipe/calib/camera/tests/test_flatfield.py
@@ -26,7 +26,11 @@ def test_flasherflatfieldcalculator():
     subarray.tel[0].camera.readout.reference_pulse_shape = np.ones((1, 2))
     subarray.tel[0].camera.readout.reference_pulse_sample_width = u.Quantity(1, u.ns)
 
-    config = Config({"FixedWindowSum": {"window_start": 15, "window_width": 10}})
+    config = Config({"FixedWindowSum": {
+        "peak_index": 15,
+        "window_shift": 0,
+        "window_width": 10,
+    }})
     ff_calculator = FlasherFlatFieldCalculator(
         subarray=subarray,
         charge_product="FixedWindowSum",

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -330,7 +330,7 @@ class FixedWindowSum(ImageExtractor):
         default_value=7, help="Define the width of the integration window"
     ).tag(config=True)
     window_shift = IntTelescopeParameter(
-        default_value=3,
+        default_value=0,
         help="Define the shift of the integration window from the peak_index "
         "(peak_index - shift)",
     ).tag(config=True)

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -254,7 +254,7 @@ def test_extractors(Extractor, toymodel):
 
 def test_fixed_window_sum(toymodel):
     waveforms, subarray, telid, selected_gain_channel, true_charge, true_time = toymodel
-    extractor = FixedWindowSum(subarray=subarray, window_start=47)
+    extractor = FixedWindowSum(subarray=subarray, peak_index=47)
     charge, peak_time = extractor(waveforms, telid, selected_gain_channel)
     assert_allclose(charge, true_charge, rtol=0.1)
     assert_allclose(peak_time, true_time, rtol=0.1)
@@ -320,7 +320,7 @@ def test_extractor_tel_param(toymodel):
         {
             "ImageExtractor": {
                 "window_width": [("type", "*", n_samples), ("id", "2", n_samples // 2)],
-                "window_start": 0,
+                "peak_index": 0,
             }
         }
     )
@@ -331,9 +331,9 @@ def test_extractor_tel_param(toymodel):
         "FixedWindowSum", subarray=subarray, config=config
     )
 
-    assert extractor.window_start.tel[None] == 0
-    assert extractor.window_start.tel[1] == 0
-    assert extractor.window_start.tel[2] == 0
+    assert extractor.peak_index.tel[None] == 0
+    assert extractor.peak_index.tel[1] == 0
+    assert extractor.peak_index.tel[2] == 0
     assert extractor.window_width.tel[None] == n_samples
     assert extractor.window_width.tel[1] == n_samples
     assert extractor.window_width.tel[2] == n_samples // 2


### PR DESCRIPTION
The integration_correction was not calculated correctly for FixedWindowSum, as there was no clarity of how the window start was defined w.r.t. the peak index.