### PR TITLE
Add support to read multiple containers from one table at once

### DIFF
--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -446,8 +446,10 @@ class HDF5TableReader(TableReader):
             of containers.
         """
 
+        return_iterable = True
         if isinstance(containers, Container):
             containers = (containers, )
+            return_iterable = False
 
         if prefixes is False:
             prefixes = ["" for container in containers]
@@ -480,10 +482,10 @@ class HDF5TableReader(TableReader):
                     container[fieldname] = self._apply_col_transform(
                         table_name, colname, row[colname]
                     )
-            if len(containers) == 1:
-                yield containers[0]
-            else:
+            if return_iterable:
                 yield containers
+            else:
+                yield containers[0]
             row_count += 1
 
 

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -402,7 +402,9 @@ class HDF5TableReader(TableReader):
                 else:
                     colname_without_prefix = colname
                 if colname_without_prefix in container.fields:
-                    self._cols_to_read[table_name][container.container_prefix].append(colname)
+                    self._cols_to_read[table_name][container.container_prefix].append(
+                        colname
+                    )
                 else:
                     self.log.warning(
                         f"Table {table_name} has column {colname_without_prefix} that is not in "
@@ -426,7 +428,7 @@ class HDF5TableReader(TableReader):
             for key in tab.attrs._f_list():
                 container.meta[key] = tab.attrs[key]
 
-    def read(self, table_name, containers, prefix=False):
+    def read(self, table_name, containers, prefixes=False):
         """
         Returns a generator that reads the next row from the table into the
         given container. The generator returns the same container. Note that
@@ -451,14 +453,12 @@ class HDF5TableReader(TableReader):
         if isinstance(containers, Container):
             containers = (containers, )
 
-        if prefix is False:
+        if prefixes is False:
             prefixes = ["" for container in containers]
-        elif prefix is True:
+        elif prefixes is True:
             prefixes = [container.prefix for container in containers]
-        elif isinstance(prefix, str):
-            prefixes = [prefix for container in containers]
-        else:
-            prefixes = prefix
+        elif isinstance(prefixes, str):
+            prefixes = [prefixes for container in containers]
         assert len(prefixes) == len(containers)
 
         if table_name not in self._tables:

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -361,10 +361,10 @@ class HDF5TableReader(TableReader):
 
         self._h5file.close()
 
-    def _setup_table(self, table_name, container, prefix):
+    def _setup_table(self, table_name, containers, prefixes):
         tab = self._h5file.get_node(table_name)
         self._tables[table_name] = tab
-        self._map_table_to_container(table_name, container, prefix)
+        self._map_table_to_containers(table_name, containers, prefixes)
         self._map_transforms_from_table_header(table_name)
         return tab
 
@@ -390,41 +390,43 @@ class HDF5TableReader(TableReader):
 
                 self.add_column_transform(table_name, colname, transform_int_to_enum)
 
-    def _map_table_to_container(self, table_name, container, prefix=None):
-        """ identifies which columns in the table to read into the container,
+    def _map_table_to_containers(self, table_name, containers, prefixes):
+        """ identifies which columns in the table to read into the containers,
         by comparing their names including an optional prefix."""
         tab = self._tables[table_name]
-        for colname in tab.colnames:
-            if prefix and colname.startswith(prefix):
-                colname_without_prefix = colname[len(prefix) + 1:]
-            else:
-                colname_without_prefix = colname
-            if colname_without_prefix in container.fields:
-                self._cols_to_read[table_name].append(colname)
-            else:
-                self.log.warning(
-                    f"Table {table_name} has column {colname_without_prefix} that is not in "
-                    f"container {container.__class__.__name__}. It will be skipped."
-                )
+        for container, prefix in zip(containers, prefixes):
+            self._cols_to_read[table_name][container.container_prefix] = []
+            for colname in tab.colnames:
+                if prefix and colname.startswith(prefix):
+                    colname_without_prefix = colname[len(prefix) + 1:]
+                else:
+                    colname_without_prefix = colname
+                if colname_without_prefix in container.fields:
+                    self._cols_to_read[table_name][container.container_prefix].append(colname)
+                else:
+                    self.log.warning(
+                        f"Table {table_name} has column {colname_without_prefix} that is not in "
+                        f"container {container.__class__.__name__}. It will be skipped."
+                    )
 
-        # also check that the container doesn't have fields that are not
-        # in the table:
-        for colname in container.fields:
-            if prefix:
-                colname_with_prefix = f"{prefix}_{colname}"
-            else:
-                colname_with_prefix = colname
-            if colname_with_prefix not in self._cols_to_read[table_name]:
-                self.log.warning(
-                    f"Table {table_name} is missing column {colname_with_prefix}"
-                    f"that is in container {container.__class__.__name__}. It will be skipped."
-                )
+            # also check that the container doesn't have fields that are not
+            # in the table:
+            for colname in container.fields:
+                if prefix:
+                    colname_with_prefix = f"{prefix}_{colname}"
+                else:
+                    colname_with_prefix = colname
+                if colname_with_prefix not in self._cols_to_read[table_name]:
+                    self.log.warning(
+                        f"Table {table_name} is missing column {colname_with_prefix}"
+                        f"that is in container {container.__class__.__name__}. It will be skipped."
+                    )
 
-        # copy all user-defined attributes back to Container.mets
-        for key in tab.attrs._f_list():
-            container.meta[key] = tab.attrs[key]
+            # copy all user-defined attributes back to Container.mets
+            for key in tab.attrs._f_list():
+                container.meta[key] = tab.attrs[key]
 
-    def read(self, table_name: str, container: Container, prefix=False):
+    def read(self, table_name, containers, prefix=False):
         """
         Returns a generator that reads the next row from the table into the
         given container. The generator returns the same container. Note that
@@ -436,45 +438,54 @@ class HDF5TableReader(TableReader):
             name of table to read from
         container : ctapipe.core.Container
             Container instance to fill
-        prefix: bool or str
+        prefix: bool, str or list
             Prefix that was added while writing the file.
             If True, the container prefix is taken into consideration, when
             comparing column names and container fields.
             If False, no prefix is used.
-            If a string is provided, it is used as prefix. This is äquivalent
-            to creating a container, changing its prefix and
-            using this container with prefix=True.
+            If a string is provided, it is used as prefix for all containers.
+            If a list is provided, the length needs to match th number
+            of containers.
         """
 
-        if prefix is True:
-            prefix = container.prefix
-        elif prefix is False:
-            prefix = None
+        if isinstance(containers, Container):
+            containers = (containers, )
+
+        if prefix is False:
+            prefixes = ["" for container in containers]
+        elif prefix is True:
+            prefixes = [container.prefix for container in containers]
+        elif isinstance(prefix, str):
+            prefixes = [prefix for container in containers]
+        else:
+            prefixes = prefix
+        assert len(prefixes) == len(containers)
 
         if table_name not in self._tables:
-            tab = self._setup_table(table_name, container, prefix)
+            tab = self._setup_table(table_name, containers, prefixes)
         else:
             tab = self._tables[table_name]
 
         row_count = 0
 
         while 1:
-
             try:
                 row = tab[row_count]
             except IndexError:
                 return  # stop generator when done
-
-            for colname in self._cols_to_read[table_name]:
-                if prefix and colname.startswith(prefix):
-                    colname_without_prefix = colname[len(prefix) + 1:]
-                else:
-                    colname_without_prefix = colname
-                container[colname_without_prefix] = self._apply_col_transform(
-                    table_name, colname, row[colname]
-                )
-
-            yield container
+            for container, prefix in zip(containers, prefixes):
+                for colname in self._cols_to_read[table_name][container.container_prefix]:
+                    if prefix and colname.startswith(prefix):
+                        colname_without_prefix = colname[len(prefix) + 1:]
+                    else:
+                        colname_without_prefix = colname
+                    container[colname_without_prefix] = self._apply_col_transform(
+                        table_name, colname, row[colname]
+                    )
+            if len(containers) == 1:
+                yield containers[0]
+            else:
+                yield containers
             row_count += 1
 
 

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -330,10 +330,6 @@ class HDF5TableReader(TableReader):
 
     Todo:
     - add ability to synchronize reading of multiple tables on a key
-
-    - add ability (also with TableWriter) to read a row into n containers at
-        once, assuming no naming conflicts (so we can add e.g. event_id)
-
     """
 
     def __init__(self, filename, **kwargs):

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -129,7 +129,7 @@ class TableReader(Component, metaclass=ABCMeta):
 
     def __init__(self):
         super().__init__()
-        self._cols_to_read = defaultdict(list)
+        self._cols_to_read = defaultdict(dict)
         self._transforms = defaultdict(dict)
 
     def __enter__(self):

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -2,7 +2,7 @@ import re
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
-from ctapipe.core import Component, Container
+from ctapipe.core import Component
 
 __all__ = ["TableReader", "TableWriter"]
 
@@ -84,8 +84,8 @@ class TableWriter(Component, metaclass=ABCMeta):
         ----------
         table_name: str
             name of table to write to
-        container: `ctapipe.core.Container`
-            container to write
+        containers: ctapipe.core.Container or iterable thereof
+            container instance(s) to write
         **kwargs:
             may be passed to a lower level implementation to set options
         """
@@ -168,7 +168,7 @@ class TableReader(Component, metaclass=ABCMeta):
         return value
 
     @abstractmethod
-    def read(self, table_name: str, container: Container, prefix=False):
+    def read(self, table_name, prefixes, containers, **kwargs):
         """
         Returns a generator that reads the next row from the table into the
         given container.  The generator returns the same container. Note that
@@ -178,10 +178,10 @@ class TableReader(Component, metaclass=ABCMeta):
         ----------
         table_name: str
             name of table to read from
-        container : ctapipe.core.Container
-            Container instance to fill
-        prefix: bool or str
-            Prefix that was added while writing the file.
+        containers: ctapipe.core.Container or iterable thereof
+            Container instance(s) to fill
+        prefixes: bool, str or iterable of str
+            prefixes used during writing of the table
         """
         pass
 

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -168,7 +168,7 @@ class TableReader(Component, metaclass=ABCMeta):
         return value
 
     @abstractmethod
-    def read(self, table_name, prefixes, containers, **kwargs):
+    def read(self, table_name, containers, prefixes, **kwargs):
         """
         Returns a generator that reads the next row from the table into the
         given container.  The generator returns the same container. Note that

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -118,6 +118,30 @@ def test_read_multiple_containers():
             np.testing.assert_equal(value, read_value)
 
 
+def test_custom_prefix():
+    container = HillasParametersContainer(
+        x=1 * u.m, y=1 * u.m, length=1 * u.m, width=1 * u.m
+    )
+    container.prefix = "custom"
+    with tempfile.NamedTemporaryFile() as f:
+        with HDF5TableWriter(f.name, group_name="dl1", add_prefix=True) as writer:
+            writer.write("params", container)
+
+        with HDF5TableReader(f.name) as reader:
+            generator = reader.read(
+                "/dl1/params",
+                HillasParametersContainer(),
+                prefixes="custom"
+            )
+            read_container = next(generator)
+        assert isinstance(read_container, HillasParametersContainer)
+        for value, read_value in zip(
+            container.as_dict().values(),
+            read_container.as_dict().values()
+        ):
+            np.testing.assert_equal(value, read_value)
+
+
 def test_units():
     class WithUnits(Container):
         inverse_length = Field(5 / u.m, "foo")

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -64,7 +64,7 @@ def test_read_multiple_containers():
     with tempfile.NamedTemporaryFile() as f:
         with HDF5TableWriter(f.name, group_name="dl1", add_prefix=True) as writer:
             writer.write("params", [hillas_parameter_container, leakage_container])
-        
+
         df = pd.read_hdf(f.name, key="/dl1/params")
         assert "hillas_x" in df.columns
         assert "leakage_pixels_width_1" in df.columns
@@ -74,7 +74,7 @@ def test_read_multiple_containers():
             generator = reader.read(
                 "/dl1/params",
                 HillasParametersContainer(),
-                prefix=True
+                prefixes=True
             )
             hillas = next(generator)
         for value, read_value in zip(
@@ -87,7 +87,7 @@ def test_read_multiple_containers():
             generator = reader.read(
                 "/dl1/params",
                 LeakageContainer(),
-                prefix=True
+                prefixes=True
             )
             leakage = next(generator)
         for value, read_value in zip(
@@ -101,7 +101,7 @@ def test_read_multiple_containers():
             generator = reader.read(
                 "/dl1/params",
                 [HillasParametersContainer(), LeakageContainer()],
-                prefix=True,
+                prefixes=True,
             )
             hillas_, leakage_ = next(generator)
 
@@ -110,7 +110,7 @@ def test_read_multiple_containers():
             leakage_.as_dict().values()
         ):
             np.testing.assert_equal(value, read_value)
-    
+
         for value, read_value in zip(
             hillas_parameter_container.as_dict().values(),
             hillas_.as_dict().values()

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -329,14 +329,16 @@ def test_read_container(temp_h5_file):
     with HDF5TableReader(temp_h5_file) as reader:
 
         # get the generators for each table
-        mctab = reader.read("/R0/MC", mc)
+        # test supplying a single container as well as an
+        # iterable with one entry only
+        mctab = reader.read("/R0/MC", (mc,))
         r0tab1 = reader.read("/R0/tel_001", r0tel1)
         r0tab2 = reader.read("/R0/tel_002", r0tel2)
 
         # read all 3 tables in sync
         for ii in range(3):
 
-            m = next(mctab)
+            m = next(mctab)[0]
             r0_1 = next(r0tab1)
             r0_2 = next(r0tab2)
 


### PR DESCRIPTION
This allows to provide a list of containers to the `HDF5TableReader.read()` function to directly read a table into multiple containers without having to set up a new reader for each container.
The main reason for this are the dl1 parameters tables in the dl1 files. 

This makes use of the fact, that a container has two prefixes: `container.prefix` and `container.container_prefix` to avoid the case of an empty `container.prefix`. This might affect the edge case where multiple containers of the same kind (e.g for different cleaning levels) are written into one table. I am not sure if that is something we ever want to do though. 

Related discussion: #1367
