### PR TITLE
add __len__ to SimTelEventSource

### DIFF
--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -218,6 +218,9 @@ class SimTelEventSource(EventSource):
     def close(self):
         self.file_.close()
 
+    def __len__(self):
+        return self._mc_header.num_showers
+
     @property
     def is_simulation(self):
         return True


### PR DESCRIPTION
Add the python magic function `__len__` which is accessibly via `len()` and is e.g. used as a total indicator in `tqdm`.
For this I take the number of showers as stored in the `MCHeaderContainer`.

I mainly have the `ctapipe-stage1-process` script in mind.