### PR TITLE
Make gain_selector a trait of SimTelEventSource, fixes eventsource plugins

### DIFF
--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -164,10 +164,6 @@ class Stage1ProcessorTool(Tool):
         help="Method to use to turn a waveform into a single charge value",
     ).tag(config=True)
 
-    gain_selector_type = create_class_enum_trait(
-        base_class=GainSelector, default_value="ThresholdGainSelector"
-    ).tag(config=True)
-
     image_cleaner_type = create_class_enum_trait(
         base_class=ImageCleaner, default_value="TailcutsImageCleaner"
     )
@@ -191,7 +187,6 @@ class Stage1ProcessorTool(Tool):
         "allowed-tels": "EventSource.allowed_tels",
         "max-events": "EventSource.max_events",
         "image-extractor-type": "Stage1ProcessorTool.image_extractor_type",
-        "gain-selector-type": "Stage1ProcessorTool.gain_selector_type",
         "image-cleaner-type": "Stage1ProcessorTool.image_cleaner_type",
     }
 
@@ -250,13 +245,7 @@ class Stage1ProcessorTool(Tool):
             )
 
         # setup components:
-
-        self.gain_selector = self.add_component(
-            GainSelector.from_name(self.gain_selector_type, parent=self)
-        )
-        self.event_source = self.add_component(
-            EventSource.from_config(parent=self, gain_selector=self.gain_selector)
-        )
+        self.event_source = self.add_component(EventSource.from_config(parent=self))
         self.image_extractor = self.add_component(
             ImageExtractor.from_name(
                 self.image_extractor_type,

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -99,9 +99,6 @@ def test_stage1_datalevels():
     from ctapipe.tools.stage1 import Stage1ProcessorTool
 
     class DummyEventSource(EventSource):
-        def __init__(self, *args, gain_selector=None, **kwargs):
-            super().__init__(*args, **kwargs)
-
         @classmethod
         def is_compatible(cls, path):
             with open(path, "rb") as f:


### PR DESCRIPTION
The dl1 tool had a gain_selector member / trait that it always passed to the `EventSource`, although this is an implementation detail of the `SimTelEventSource`, not a part of the public API of `EventSource`.

This fixes it by making the `gain_selector` a trait of the `SimTelEventSource`, thus bringing the API of the SimTelEventSource back in line with the base class.