### PR TITLE
Make sure event source provides R1 or DL0, fix datalevels of SimTelEventSource

### DIFF
--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -224,7 +224,7 @@ class SimTelEventSource(EventSource):
 
     @property
     def datalevels(self):
-        return (DataLevel.R0, DataLevel.R1, DataLevel.DL0)
+        return (DataLevel.R0, DataLevel.R1)
 
     @property
     def obs_id(self):
@@ -388,7 +388,7 @@ class SimTelEventSource(EventSource):
                 )
 
                 self._fill_event_pointing(
-                    data.pointing.tel[tel_id], mc, tracking_positions[tel_id],
+                    data.pointing.tel[tel_id], mc, tracking_positions[tel_id]
                 )
 
                 r0 = data.r0.tel[tel_id]
@@ -468,8 +468,8 @@ class SimTelEventSource(EventSource):
             energy_range_min=mc_run_head["E_range"][0] * u.TeV,
             energy_range_max=mc_run_head["E_range"][1] * u.TeV,
             prod_site_B_total=mc_run_head["B_total"] * u.uT,
-            prod_site_B_declination=Angle(mc_run_head["B_declination"], u.rad,),
-            prod_site_B_inclination=Angle(mc_run_head["B_inclination"], u.rad,),
+            prod_site_B_declination=Angle(mc_run_head["B_declination"], u.rad),
+            prod_site_B_inclination=Angle(mc_run_head["B_inclination"], u.rad),
             prod_site_alt=mc_run_head["obsheight"] * u.m,
             spectral_index=mc_run_head["spectral_index"],
             shower_prog_start=mc_run_head["shower_prog_start"],

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -119,7 +119,7 @@ def test_properties():
 
     assert source.is_simulation
     assert source.mc_header.corsika_version == 6990
-    assert source.datalevels == (DataLevel.R0, DataLevel.R1, DataLevel.DL0)
+    assert source.datalevels == (DataLevel.R0, DataLevel.R1)
     assert source.obs_id == 7514
 
 
@@ -207,7 +207,7 @@ def test_calibration_events():
         EventType.SUBARRAY,
     ]
     with SimTelEventSource(
-        input_url=calib_events_path, skip_calibration_events=False,
+        input_url=calib_events_path, skip_calibration_events=False
     ) as reader:
 
         for event, expected_type in zip_longest(reader, expected_types):

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -705,7 +705,7 @@ class Stage1ProcessorTool(Tool):
                 writer.exclude(
                     f"/simulation/event/telescope/parameters/{table_name}", r"timing_.*"
                 )
-                writer.exclude(f"/simulation/event/subarray/shower", "true_tel")
+                writer.exclude("/simulation/event/subarray/shower", "true_tel")
 
     def start(self):
 

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from tqdm.autonotebook import tqdm
 from collections import defaultdict
 
-from ctapipe.io import metadata as meta
+from ..io import metadata as meta, DataLevel
 from ..calib.camera import CameraCalibrator, GainSelector
 from ..containers import (
     ImageParametersContainer,
@@ -250,13 +250,20 @@ class Stage1ProcessorTool(Tool):
             )
 
         # setup components:
-
         self.gain_selector = self.add_component(
             GainSelector.from_name(self.gain_selector_type, parent=self)
         )
         self.event_source = self.add_component(
             EventSource.from_config(parent=self, gain_selector=self.gain_selector)
         )
+
+        if DataLevel.DL0 not in self.event_source.datalevels:
+            self.log.critical(
+                f"{self.name} needs the EventSource to provide DL0 data"
+                f", {self.event_source} does noet"
+            )
+            sys.exit(1)
+
         self.image_extractor = self.add_component(
             ImageExtractor.from_name(
                 self.image_extractor_type,
@@ -542,7 +549,6 @@ class Stage1ProcessorTool(Tool):
         add entries to the event/telescope tables for each telescope in a single
         event
         """
-
         # write the telescope tables
         for tel_id, dl1_camera in event.dl1.tel.items():
             dl1_camera.prefix = ""  # don't want a prefix for this container

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -257,10 +257,11 @@ class Stage1ProcessorTool(Tool):
             EventSource.from_config(parent=self, gain_selector=self.gain_selector)
         )
 
-        if DataLevel.DL0 not in self.event_source.datalevels:
+        datalevels = self.event_source.datalevels
+        if DataLevel.R1 not in datalevels and DataLevel.DL0 not in datalevels:
             self.log.critical(
-                f"{self.name} needs the EventSource to provide DL0 data"
-                f", {self.event_source} does noet"
+                f"{self.name} needs the EventSource to provide either R1 or DL0 data"
+                f", {self.event_source} provides only {datalevels}"
             )
             sys.exit(1)
 

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -14,6 +14,7 @@ import tables
 
 from ctapipe.utils import get_dataset_path
 from ctapipe.core import run_tool
+from ctapipe.io import DataLevel
 import numpy as np
 
 
@@ -92,6 +93,67 @@ def test_stage_1():
             assert "peak_time" in dl1_image.dtype.names
 
 
+def test_stage1_datalevels():
+    """test the dl1 tool on a file not providing r1 or dl0"""
+    from ctapipe.io import EventSource
+    from ctapipe.tools.stage1 import Stage1ProcessorTool
+
+    class DummyEventSource(EventSource):
+        def __init__(self, *args, gain_selector=None, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        @classmethod
+        def is_compatible(cls, path):
+            with open(path, "rb") as f:
+                dummy = f.read(5)
+                return dummy == b"dummy"
+
+        @property
+        def datalevels(self):
+            return (DataLevel.R0,)
+
+        @property
+        def is_simulation(self):
+            return True
+
+        @property
+        def obs_id(self):
+            return 1
+
+        @property
+        def subarray(self):
+            return None
+
+        def _generator(self):
+            return None
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".dummy") as f:
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".h5") as out:
+            f.write(b"dummy")
+            f.flush()
+
+            tool = Stage1ProcessorTool()
+            assert (
+                run_tool(
+                    tool,
+                    argv=[
+                        "--config=./examples/stage1_config.json",
+                        f"--input={f.name}",
+                        f"--output={out.name}",
+                        "--write-images",
+                        "--overwrite",
+                    ],
+                )
+                == 1
+            )
+            # make sure the dummy event source was really used
+            assert isinstance(tool.event_source, DummyEventSource)
+
+            # we need to "touch" the output file again, otherwise tempfile will
+            # complain it no longer exists as the tool removed it
+            open(out.name, mode="a").close()
+
+
 def test_muon_reconstruction(tmpdir):
     from ctapipe.tools.muon_reconstruction import MuonAnalysis
 
@@ -99,7 +161,7 @@ def test_muon_reconstruction(tmpdir):
         assert (
             run_tool(
                 MuonAnalysis(),
-                argv=[f"--input={LST_MUONS}", f"--output={f.name}", "--overwrite",],
+                argv=[f"--input={LST_MUONS}", f"--output={f.name}", "--overwrite"],
             )
             == 0
         )
@@ -203,7 +265,7 @@ def test_dump_instrument(tmpdir):
     sys.argv = ["dump_instrument"]
     tmpdir.chdir()
 
-    tool = DumpInstrumentTool(infile=GAMMA_TEST_LARGE,)
+    tool = DumpInstrumentTool(infile=GAMMA_TEST_LARGE)
 
     assert run_tool(tool) == 0
     assert tmpdir.join("FlashCam.camgeom.fits.gz").exists()

--- a/docs/ctapipe_api/instrument/camerageometry_example.py
+++ b/docs/ctapipe_api/instrument/camerageometry_example.py
@@ -5,7 +5,7 @@ geom = CameraGeometry.from_name("LSTCam")
 
 plt.figure(figsize=(8, 3))
 plt.subplot(1, 2, 1)
-plt.imshow(geom.neighbor_matrix, origin="bottom")
+plt.imshow(geom.neighbor_matrix, origin="lower")
 plt.title("Pixel Neighbor Matrix")
 
 plt.subplot(1, 2, 2)


### PR DESCRIPTION
This adds a check to the stage1 process that the selected event source does provide DL0 data, which is the needed starting point for this tool.

In the future, as soon as a DL1_IMAGES event source is ready, this could also be accepted, but would need code to skip the calibration and image extraction part to only calculate parameters.