### PR TITLE
Calculate log likelihood analytically in muon intensity fit

### DIFF
--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -405,7 +405,13 @@ def build_negative_log_likelihood(
         # scale prediction by optical efficiency of the telescope
         prediction *= optical_efficiency_muon
 
+        # A gaussian approximation is used here, where the total
+        # standard deviation is the pedestal standard deviation (e.g. by NSB) and
+        # the single photon resolution times the image magnitude.
         sigma2 = pedestal ** 2 + prediction * (1 + spe_width ** 2)
+
+        # gaussian negative log-likelihood, analytically simplified and
+        # constant terms discarded
         neglogL = np.log(sigma2) + (image - prediction) ** 2 / sigma2
 
         return neglogL.sum()

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -412,9 +412,9 @@ def build_negative_log_likelihood(
 
         # gaussian negative log-likelihood, analytically simplified and
         # constant terms discarded
-        neglogL = np.log(sigma2) + (image - prediction) ** 2 / sigma2
+        neg_log_l = np.log(sigma2) + (image - prediction) ** 2 / sigma2
 
-        return neglogL.sum()
+        return neg_log_l.sum()
 
     return negative_log_likelihood
 


### PR DESCRIPTION
This is a large simplification of the pixel likelihood used to fit muons, as it is first simplified analytically which should enhance both speed and numerical precision.