### PR TITLE
Make data volume reducer configurable for CameraCalibrator

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -6,7 +6,7 @@ calibration and image extraction, as well as supporting algorithms.
 import warnings
 import numpy as np
 from ctapipe.core import Component
-from ctapipe.image.extractor import NeighborPeakWindowSum
+from ctapipe.image.extractor import ImageExtractor, NeighborPeakWindowSum
 from ctapipe.image.reducer import DataVolumeReducer
 from ctapipe.core.traits import create_class_enum_trait
 
@@ -21,6 +21,10 @@ class CameraCalibrator(Component):
 
     data_volume_reducer_type = create_class_enum_trait(
         DataVolumeReducer, default_value="NullDataVolumeReducer"
+    ).tag(config=True)
+
+    image_extractor_type = create_class_enum_trait(
+        ImageExtractor, default_value="NeighborPeakWindowSum"
     ).tag(config=True)
 
     def __init__(
@@ -58,9 +62,9 @@ class CameraCalibrator(Component):
         self._r1_empty_warn = False
         self._dl0_empty_warn = False
 
-        if image_extractor is None:
-            image_extractor = NeighborPeakWindowSum(parent=self, subarray=subarray)
-        self.image_extractor = image_extractor
+        self.image_extractor = ImageExtractor.from_name(
+            self.image_extractor_type, subarray=self.subarray, parent=self
+        )
 
         self.data_volume_reducer = DataVolumeReducer.from_name(
             self.data_volume_reducer_type,

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -5,10 +5,14 @@ import numpy as np
 import pytest
 from scipy.stats import norm
 from traitlets.config.configurable import Config
-from astropy import units as u
 
 from ctapipe.calib.camera.calibrator import CameraCalibrator
-from ctapipe.image.extractor import LocalPeakWindowSum, FullWaveformSum
+from ctapipe.image.extractor import (
+    NeighborPeakWindowSum,
+    LocalPeakWindowSum,
+    FullWaveformSum,
+)
+from ctapipe.image.reducer import NullDataVolumeReducer, TailCutsDataVolumeReducer
 from ctapipe.instrument import CameraGeometry
 from ctapipe.containers import DataContainer
 
@@ -34,23 +38,31 @@ def test_manual_extractor(example_subarray):
 
 
 def test_config(example_subarray):
-    window_shift = 3
-    window_width = 9
+    calibrator = CameraCalibrator(subarray=example_subarray)
+
+    # test defaults
+    assert isinstance(calibrator.image_extractor, NeighborPeakWindowSum)
+    assert isinstance(calibrator.data_volume_reducer, NullDataVolumeReducer)
+
     config = Config(
         {
-            "LocalPeakWindowSum": {
-                "window_shift": window_shift,
-                "window_width": window_width,
+            "CameraCalibrator": {
+                "image_extractor_type": "LocalPeakWindowSum",
+                "LocalPeakWindowSum": {"window_width": 15},
+                "data_volume_reducer_type": "TailCutsDataVolumeReducer",
+                "TailCutsDataVolumeReducer": {
+                    "TailcutsImageCleaner": {"picture_threshold_pe": 20.0}
+                },
             }
         }
     )
-    calibrator = CameraCalibrator(
-        subarray=example_subarray,
-        image_extractor=LocalPeakWindowSum(subarray=example_subarray, config=config),
-        config=config,
-    )
-    assert calibrator.image_extractor.window_shift.tel[None] == window_shift
-    assert calibrator.image_extractor.window_width.tel[None] == window_width
+
+    calibrator = CameraCalibrator(example_subarray, config=config)
+    assert isinstance(calibrator.image_extractor, LocalPeakWindowSum)
+    assert calibrator.image_extractor.window_width.tel[None] == 15
+
+    assert isinstance(calibrator.data_volume_reducer, TailCutsDataVolumeReducer)
+    assert calibrator.data_volume_reducer.cleaner.picture_threshold_pe.tel[None] == 20
 
 
 def test_check_r1_empty(example_event, example_subarray):

--- a/ctapipe/image/reducer.py
+++ b/ctapipe/image/reducer.py
@@ -84,43 +84,6 @@ class DataVolumeReducer(TelescopeComponent):
             Mask of selected pixels.
         """
 
-    @classmethod
-    def from_name(
-        cls, name, subarray, image_extractor=None, config=None, parent=None, **kwargs
-    ):
-        """
-        Obtain an instance of a subclass via its name
-
-        Parameters
-        ----------
-        name : str
-            Name of the subclass to obtain
-        config : traitlets.loader.Config
-            Configuration specified by config file or cmdline arguments.
-            Used to set traitlet values.
-            This argument is typically only specified when using this method
-            from within a Tool.
-        parent : ctapipe.core.Tool
-            Tool executable that is calling this component.
-            Passes the correct logger and configuration to the component.
-            This argument is typically only specified when using this method
-            from within a Tool (config need not be passed if parent is used).
-        kwargs
-
-        Returns
-        -------
-        instace
-            Instance of subclass to this class
-        """
-        requested_subclass = cls.non_abstract_subclasses()[name]
-        return requested_subclass(
-            subarray=subarray,
-            image_extractor=image_extractor,
-            config=config,
-            parent=parent,
-            **kwargs,
-        )
-
 
 class NullDataVolumeReducer(DataVolumeReducer):
     """
@@ -151,20 +114,31 @@ class TailCutsDataVolumeReducer(DataVolumeReducer):
         If set to 'False', the iteration steps in 2) are skipped and
         normal TailcutCleaning is used.
     """
+
     image_extractor_type = Unicode(
-        default_value="NeighborPeakWindowSum", help="Name of the image_extractor"
-        "to be used.",
+        default_value="NeighborPeakWindowSum",
+        help="Name of the image_extractor" "to be used.",
     ).tag(config=True)
+
     n_end_dilates = IntTelescopeParameter(
         default_value=1, help="Number of how many times to dilate at the end."
     ).tag(config=True)
+
     do_boundary_dilation = BoolTelescopeParameter(
         default_value=True,
         help="If set to 'False', the iteration steps in 2) are skipped and"
         "normal TailcutCleaning is used.",
     ).tag(config=True)
 
-    def __init__(self, subarray, config=None, parent=None, **kwargs):
+    def __init__(
+        self,
+        subarray,
+        config=None,
+        parent=None,
+        cleaner=None,
+        image_extractor=None,
+        **kwargs,
+    ):
         """
         Parameters
         ----------
@@ -178,13 +152,17 @@ class TailCutsDataVolumeReducer(DataVolumeReducer):
         """
         super().__init__(config=config, parent=parent, subarray=subarray, **kwargs)
 
-        self.cleaner = TailcutsImageCleaner(parent=self, subarray=self.subarray)
+        if cleaner is None:
+            self.cleaner = TailcutsImageCleaner(parent=self, subarray=self.subarray)
+        else:
+            self.cleaner = cleaner
 
-        self.image_extractor = ImageExtractor.from_name(
-            self.image_extractor_type,
-            subarray=self.subarray,
-            parent=self
-        )
+        if image_extractor is None:
+            self.image_extractor = ImageExtractor.from_name(
+                self.image_extractor_type, subarray=self.subarray, parent=self
+            )
+        else:
+            self.image_extractor = image_extractor
 
     def select_pixels(self, waveforms, telid=None, selected_gain_channel=None):
         camera_geom = self.subarray.tel[telid].camera.geometry

--- a/ctapipe/image/reducer.py
+++ b/ctapipe/image/reducer.py
@@ -9,11 +9,7 @@ from ctapipe.core.traits import IntTelescopeParameter, BoolTelescopeParameter, U
 from ctapipe.image.extractor import ImageExtractor
 from ctapipe.image.cleaning import dilate
 
-__all__ = [
-    "DataVolumeReducer",
-    "NullDataVolumeReducer",
-    "TailCutsDataVolumeReducer",
-]
+__all__ = ["DataVolumeReducer", "NullDataVolumeReducer", "TailCutsDataVolumeReducer"]
 
 
 class DataVolumeReducer(TelescopeComponent):
@@ -87,6 +83,43 @@ class DataVolumeReducer(TelescopeComponent):
         mask: array
             Mask of selected pixels.
         """
+
+    @classmethod
+    def from_name(
+        cls, name, subarray, image_extractor=None, config=None, parent=None, **kwargs
+    ):
+        """
+        Obtain an instance of a subclass via its name
+
+        Parameters
+        ----------
+        name : str
+            Name of the subclass to obtain
+        config : traitlets.loader.Config
+            Configuration specified by config file or cmdline arguments.
+            Used to set traitlet values.
+            This argument is typically only specified when using this method
+            from within a Tool.
+        parent : ctapipe.core.Tool
+            Tool executable that is calling this component.
+            Passes the correct logger and configuration to the component.
+            This argument is typically only specified when using this method
+            from within a Tool (config need not be passed if parent is used).
+        kwargs
+
+        Returns
+        -------
+        instace
+            Instance of subclass to this class
+        """
+        requested_subclass = cls.non_abstract_subclasses()[name]
+        return requested_subclass(
+            subarray=subarray,
+            image_extractor=image_extractor,
+            config=config,
+            parent=parent,
+            **kwargs,
+        )
 
 
 class NullDataVolumeReducer(DataVolumeReducer):

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -143,15 +143,10 @@ class DisplayDL1Calib(Tool):
         help="Telescope to view. Set to None to display all telescopes.",
     ).tag(config=True)
 
-    extractor_product = traits.create_class_enum_trait(
-        ImageExtractor, default_value="NeighborPeakWindowSum"
-    )
-
     aliases = Dict(
         dict(
             input="EventSource.input_url",
             max_events="EventSource.max_events",
-            extractor="DisplayDL1Calib.extractor_product",
             T="DisplayDL1Calib.telescope",
             O="ImagePlotter.output_path",
         )

--- a/ctapipe/tools/display_integrator.py
+++ b/ctapipe/tools/display_integrator.py
@@ -214,7 +214,7 @@ class DisplayIntegrator(Tool):
 
     event_index = Int(0, help="Event index to view.").tag(config=True)
     use_event_id = Bool(
-        False, help="event_index will obtain an event using event_id instead of index.",
+        False, help="event_index will obtain an event using event_id instead of index."
     ).tag(config=True)
     telescope = Int(
         None,
@@ -224,15 +224,10 @@ class DisplayIntegrator(Tool):
     ).tag(config=True)
     channel = Enum([0, 1], 0, help="Channel to view").tag(config=True)
 
-    extractor_product = traits.create_class_enum_trait(
-        ImageExtractor, default_value="NeighborPeakWindowSum"
-    )
-
     aliases = Dict(
         dict(
             f="EventSource.input_url",
             max_events="EventSource.max_events",
-            extractor="DisplayIntegrator.extractor_product",
             E="DisplayIntegrator.event_index",
             T="DisplayIntegrator.telescope",
             C="DisplayIntegrator.channel",
@@ -253,7 +248,6 @@ class DisplayIntegrator(Tool):
         # make sure gzip files are seekable
         self.config.SimTelEventSource.back_seekable = True
         self.eventseeker = None
-        self.extractor = None
         self.calibrator = None
 
     def setup(self):
@@ -262,15 +256,8 @@ class DisplayIntegrator(Tool):
         event_source = self.add_component(EventSource.from_config(parent=self))
         self.subarray = event_source.subarray
         self.eventseeker = self.add_component(EventSeeker(event_source, parent=self))
-        self.extractor = self.add_component(
-            ImageExtractor.from_name(
-                self.extractor_product, parent=self, subarray=self.subarray
-            )
-        )
         self.calibrate = self.add_component(
-            CameraCalibrator(
-                parent=self, image_extractor=self.extractor, subarray=self.subarray
-            )
+            CameraCalibrator(parent=self, subarray=self.subarray)
         )
 
     def start(self):
@@ -294,7 +281,7 @@ class DisplayIntegrator(Tool):
             )
             exit()
 
-        extractor_name = self.extractor.__class__.__name__
+        extractor_name = self.calibrate.image_extractor.__class__.__name__
 
         plot(self.subarray, event, telid, self.channel, extractor_name)
 

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -36,16 +36,12 @@ class ChargeResolutionGenerator(Tool):
         directory_ok=False,
         help="Path to store the output HDF5 file",
     ).tag(config=True)
-    extractor_product = traits.create_class_enum_trait(
-        ImageExtractor, default_value="NeighborPeakWindowSum"
-    )
 
     aliases = Dict(
         dict(
             f="SimTelEventSource.input_url",
             max_events="SimTelEventSource.max_events",
             T="SimTelEventSource.allowed_tels",
-            extractor="ChargeResolutionGenerator.extractor_product",
             O="ChargeResolutionGenerator.output_path",
         )
     )
@@ -65,7 +61,7 @@ class ChargeResolutionGenerator(Tool):
 
         extractor = self.add_component(
             ImageExtractor.from_name(
-                self.extractor_product, parent=self, subarray=self.eventsource.subarray,
+                self.extractor_product, parent=self, subarray=self.eventsource.subarray
             )
         )
 

--- a/ctapipe/tools/muon_reconstruction.py
+++ b/ctapipe/tools/muon_reconstruction.py
@@ -11,7 +11,6 @@ from ctapipe.io import EventSource
 from ctapipe.io import HDF5TableWriter
 from ctapipe.image.cleaning import TailcutsImageCleaner
 from ctapipe.coordinates import TelescopeFrame, CameraFrame
-from ctapipe.image import ImageExtractor
 from ctapipe.containers import MuonParametersContainer
 from ctapipe.instrument import CameraGeometry
 
@@ -42,7 +41,7 @@ class MuonAnalysis(Tool):
     )
 
     completeness_threshold = traits.FloatTelescopeParameter(
-        default_value=30.0, help="Threshold for calculating the ``ring_completeness``",
+        default_value=30.0, help="Threshold for calculating the ``ring_completeness``"
     ).tag(config=True)
 
     ratio_width = traits.FloatTelescopeParameter(
@@ -66,11 +65,7 @@ class MuonAnalysis(Tool):
     ).tag(config=True)
 
     pedestal = traits.FloatTelescopeParameter(
-        help="Pedestal noise rms", default_value=1.1,
-    ).tag(config=True)
-
-    extractor_name = traits.create_class_enum_trait(
-        ImageExtractor, default_value="GlobalPeakWindowSum",
+        help="Pedestal noise rms", default_value=1.1
     ).tag(config=True)
 
     classes = [
@@ -79,7 +74,7 @@ class MuonAnalysis(Tool):
         EventSource,
         MuonRingFitter,
         MuonIntensityFitter,
-    ] + traits.classes_with_traits(ImageExtractor)
+    ]
 
     aliases = {
         "i": "EventSource.input_url",
@@ -104,27 +99,18 @@ class MuonAnalysis(Tool):
             )
 
         self.source = self.add_component(EventSource.from_config(parent=self))
-        self.extractor = self.add_component(
-            ImageExtractor.from_name(
-                self.extractor_name, parent=self, subarray=self.source.subarray
-            )
-        )
         self.calib = self.add_component(
-            CameraCalibrator(
-                subarray=self.source.subarray,
-                parent=self,
-                image_extractor=self.extractor,
-            )
+            CameraCalibrator(subarray=self.source.subarray, parent=self)
         )
-        self.ring_fitter = self.add_component(MuonRingFitter(parent=self,))
+        self.ring_fitter = self.add_component(MuonRingFitter(parent=self))
         self.intensity_fitter = self.add_component(
-            MuonIntensityFitter(subarray=self.source.subarray, parent=self,)
+            MuonIntensityFitter(subarray=self.source.subarray, parent=self)
         )
         self.cleaning = self.add_component(
-            TailcutsImageCleaner(parent=self, subarray=self.source.subarray,)
+            TailcutsImageCleaner(parent=self, subarray=self.source.subarray)
         )
         self.writer = self.add_component(
-            HDF5TableWriter(self.output, "", add_prefix=True, parent=self, mode="w",)
+            HDF5TableWriter(self.output, "", add_prefix=True, parent=self, mode="w")
         )
         self.pixels_in_tel_frame = {}
         self.field_of_view = {}
@@ -209,10 +195,10 @@ class MuonAnalysis(Tool):
         self.log.info(
             f"Muon fit: r={ring.radius:.2f}"
             f", width={result.width:.4f}"
-            f", efficiency={result.optical_efficiency:.2%}",
+            f", efficiency={result.optical_efficiency:.2%}"
         )
 
-        tel_event_index = TelEventIndexContainer(**event_index, tel_id=tel_id,)
+        tel_event_index = TelEventIndexContainer(**event_index, tel_id=tel_id)
 
         self.writer.write(
             "dl1/event/telescope/parameters/muons",
@@ -225,7 +211,7 @@ class MuonAnalysis(Tool):
 
         # add ring containment, not filled in fit
         containment = ring_containment(
-            ring.radius, ring.center_x, ring.center_y, fov_radius,
+            ring.radius, ring.center_x, ring.center_y, fov_radius
         )
 
         completeness = ring_completeness(
@@ -304,9 +290,7 @@ class MuonAnalysis(Tool):
         return coords.fov_lon, coords.fov_lat
 
     def finish(self):
-        Provenance().add_output_file(
-            self.output, role="muon_efficiency_parameters",
-        )
+        Provenance().add_output_file(self.output, role="muon_efficiency_parameters")
         self.writer.close()
 
 

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -157,12 +157,6 @@ class Stage1ProcessorTool(Tool):
         default_value="blosc:zstd",
     ).tag(config=True)
 
-    image_extractor_type = create_class_enum_trait(
-        base_class=ImageExtractor,
-        default_value="NeighborPeakWindowSum",
-        help="Method to use to turn a waveform into a single charge value",
-    ).tag(config=True)
-
     image_cleaner_type = create_class_enum_trait(
         base_class=ImageCleaner, default_value="TailcutsImageCleaner"
     )
@@ -185,7 +179,6 @@ class Stage1ProcessorTool(Tool):
         "output": "Stage1ProcessorTool.output_path",
         "allowed-tels": "EventSource.allowed_tels",
         "max-events": "EventSource.max_events",
-        "image-extractor-type": "Stage1ProcessorTool.image_extractor_type",
         "image-cleaner-type": "Stage1ProcessorTool.image_cleaner_type",
     }
 
@@ -254,19 +247,8 @@ class Stage1ProcessorTool(Tool):
             )
             sys.exit(1)
 
-        self.image_extractor = self.add_component(
-            ImageExtractor.from_name(
-                self.image_extractor_type,
-                parent=self,
-                subarray=self.event_source.subarray,
-            )
-        )
         self.calibrate = self.add_component(
-            CameraCalibrator(
-                parent=self,
-                subarray=self.event_source.subarray,
-                image_extractor=self.image_extractor,
-            )
+            CameraCalibrator(parent=self, subarray=self.event_source.subarray)
         )
         self.clean = self.add_component(
             ImageCleaner.from_name(

--- a/examples/stage1_config.json
+++ b/examples/stage1_config.json
@@ -2,8 +2,10 @@
     "Stage1ProcessorTool": {
         "overwrite": false,
         "write_images": true,
-        "image_extractor_type": "NeighborPeakWindowSum",
         "image_cleaner_type": "TailcutsImageCleaner"
+    },
+    "CameraCalibrator": {
+      "image_extractor_type": "NeighborPeakWindowSum"
     },
     "TailcutsImageCleaner": {
         "picture_threshold_pe":  [


### PR DESCRIPTION
This overhauls how we treat the config of these objects. With the added traits, it should no be possible to completely configure these through the config system, so e.g. for running the dl1 tool.

It was previously impossible to set the image extractor of the camera calibrator through the config system, it had to be repeated as a traitlet for the Tool passing it down.

It was completely impossible to set the data volume reducer.

We might need to give the same treatment to other components.