### PR TITLE
Override from_name for TelescopeComponent to be able to provide subarray

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -208,3 +208,36 @@ class TelescopeComponent(Component):
                 getattr(self, trait).attach_subarray(subarray)
             except (AttributeError, TypeError):
                 pass
+
+    @classmethod
+    def from_name(cls, name, subarray, config=None, parent=None, **kwargs):
+        """
+        Obtain an instance of a subclass via its name
+
+        Parameters
+        ----------
+        name : str
+            Name of the subclass to obtain
+        subarray: ctapipe.instrument.SubarrayDescription
+            The current subarray for this TelescopeComponent.
+        config : traitlets.loader.Config
+            Configuration specified by config file or cmdline arguments.
+            Used to set traitlet values.
+            This argument is typically only specified when using this method
+            from within a Tool.
+        parent : ctapipe.core.Tool
+            Tool executable that is calling this component.
+            Passes the correct logger and configuration to the component.
+            This argument is typically only specified when using this method
+            from within a Tool (config need not be passed if parent is used).
+        kwargs
+
+        Returns
+        -------
+        instace
+            Instance of subclass to this class
+        """
+        requested_subclass = cls.non_abstract_subclasses()[name]
+        return requested_subclass(
+            subarray=subarray, config=config, parent=parent, **kwargs
+        )


### PR DESCRIPTION
This was missing and is needed to be able to configure TelescopeComponents using the class enum trait.