### PR TITLE
Use sparse matrix approach for neighbor window sum

### DIFF
--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -124,11 +124,12 @@ def neighbor_average_waveform(waveforms, neighbors_indices, neighbors_indptr, lw
     waveforms : ndarray
         Waveforms stored in a numpy array.
         Shape: (n_pix, n_samples)
-    neighbors : ndarray
-        2D array where each row is [pixel index, one neighbor of that pixel].
-        Changes per telescope.
-        Can be obtained from
-        `ctapipe.instrument.CameraGeometry.neighbor_matrix_where`.
+    neighbors_indices : ndarray
+        indices of a scipy csr sparse matrix of neighbors, i.e.
+        `ctapipe.instrument.CameraGeometry.neighbor_matrix_sparse.indices`.
+    neighbors_indptr : ndarray
+        indptr of a scipy csr sparse matrix of neighbors, i.e.
+        `ctapipe.instrument.CameraGeometry.neighbor_matrix_sparse.indptr`.
     lwt: int
         Weight of the local pixel (0: peak from neighbors only,
         1: local pixel counts as much as any neighbor)

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -115,7 +115,7 @@ def extract_around_peak(
 
 
 @njit(parallel=True)
-def neighbor_average_waveform(waveforms, neighbors, lwt):
+def neighbor_average_waveform(waveforms, neighbors_indices, neighbors_indptr, lwt):
     """
     Obtain the average waveform built from the neighbors of each pixel
 
@@ -140,15 +140,26 @@ def neighbor_average_waveform(waveforms, neighbors, lwt):
         Shape: (n_pix, n_samples)
 
     """
-    n_neighbors = neighbors.shape[0]
-    sum_ = waveforms * lwt
-    n = np.full(waveforms.shape, lwt, dtype=np.int32)
-    for i in prange(n_neighbors):
-        pixel = neighbors[i, 0]
-        neighbor = neighbors[i, 1]
-        sum_[pixel] += waveforms[neighbor]
-        n[pixel] += 1
-    return sum_ / n
+
+    n_pixels = waveforms.shape[0]
+    indptr = neighbors_indptr
+    indices = neighbors_indices
+
+    # initialize to waveforms weighted with lwt
+    # so the value of the pixel itself is already taken into account
+    average = waveforms * lwt
+
+    for pixel in prange(n_pixels):
+        neighbors = indices[indptr[pixel] : indptr[pixel + 1]]
+
+        n = lwt
+        for neighbor in neighbors:
+            average[pixel] += waveforms[neighbor]
+            n += 1
+
+        average[pixel] /= n
+
+    return average
 
 
 def subtract_baseline(waveforms, baseline_start, baseline_end):
@@ -540,9 +551,12 @@ class NeighborPeakWindowSum(ImageExtractor):
         )
 
     def __call__(self, waveforms, telid, selected_gain_channel):
-        neighbors = self.subarray.tel[telid].camera.geometry.neighbor_matrix_where
+        neighbors = self.subarray.tel[telid].camera.geometry.neighbor_matrix_sparse
         average_wfs = neighbor_average_waveform(
-            waveforms, neighbors, self.lwt.tel[telid]
+            waveforms,
+            neighbors_indices=neighbors.indices,
+            neighbors_indptr=neighbors.indptr,
+            lwt=self.lwt.tel[telid],
         )
         peak_index = average_wfs.argmax(axis=-1)
         charge, peak_time = extract_around_peak(

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -134,7 +134,7 @@ class CameraGeometry:
             return False
 
         return all(
-            [(self.pix_x == other.pix_x).all(), (self.pix_y == other.pix_y).all(),]
+            [(self.pix_x == other.pix_x).all(), (self.pix_y == other.pix_y).all()]
         )
 
     def guess_radius(self):
@@ -486,19 +486,6 @@ class CameraGeometry:
                 )
 
         return neighbors.tocsr()
-
-    @lazyproperty
-    def neighbor_matrix_where(self):
-        """
-        Obtain a 2D array, where each row is [pixel index, one neighbour
-        of that pixel].
-
-        Returns
-        -------
-        ndarray
-        """
-        coo = self.neighbor_matrix_sparse.tocoo()
-        return np.column_stack([coo.row, coo.col])
 
     @lazyproperty
     def pixel_moment_matrix(self):


### PR DESCRIPTION
Use same neighbor approach like number_of_islands


This results in a speedup from:

```
166.10 ± 66.14 µs
```
to
```
69.12 ± 4.01 µs
```

using:

```py3
import numpy as np
from ctapipe.instrument import TelescopeDescription, SubarrayDescription
import astropy.units as u
from ctapipe.image.extractor import NeighborPeakWindowSum
from timeit import repeat


tel = TelescopeDescription.from_name('LST', 'LSTCam')
geom = tel.camera.geometry
subarray = SubarrayDescription(
    'perf',
    tel_positions={1: [0, 0, 0] * u.m},
    tel_descriptions={1: tel},
)


extractor = NeighborPeakWindowSum(subarray)

waveforms = np.random.normal(size=geom.n_pixels).astype('float32')
selected_gain_channels = np.zeros(geom.n_pixels, dtype=int)


# number_of_islands(geom, mask)
code = '''
extractor(waveforms, 1, selected_gain_channels)
'''

exec(code)

N = 200
times = np.array(repeat(code, number=N, repeat=10, globals=globals()))
print(f'{np.mean(times / N) * 1e6:.2f} ± {np.std(times / N) * 1e6:.2f} µs')
```