### PR TITLE
Update EventSeeker

### DIFF
--- a/ctapipe/io/eventseeker.py
+++ b/ctapipe/io/eventseeker.py
@@ -31,18 +31,18 @@ class EventSeeker(Component):
 
     To obtain a particular event in a hessio file:
 
-    >>> from ctapipe.io.hessioeventsource import SimTelEventSource
+    >>> from ctapipe.io import SimTelEventSource
     >>> event_source = SimTelEventSource(input_url="/path/to/file")
     >>> seeker = EventSeeker(event_source=event_source)
-    >>> event = seeker[2]
+    >>> event = seeker.get_event_index(2)
     >>> print(event.count)
 
     To obtain a particular event in a hessio file from its event_id:
 
-    >>> from ctapipe.io.hessioeventsource import SimTelEventSource
+    >>> from ctapipe.io import SimTelEventSource
     >>> event_source = SimTelEventSource(input_url="/path/to/file")
     >>> seeker = EventSeeker(event_source=event_source)
-    >>> event = seeker["101"]
+    >>> event = seeker.get_event_id(101)
     >>> print(event.count)
 
     **NOTE**: Event_index refers to the number associated to the event
@@ -50,26 +50,9 @@ class EventSeeker(Component):
     read from the file.
     Whereas the event_id refers to the ID attatched to the event from the
     external source of the file (software or camera or CTA array).
-
-    To obtain a slice of events in a hessio file:
-
-    >>> from ctapipe.io import SimTelEventSource
-    >>> event_source = SimTelEventSource(input_url="/path/to/file")
-    >>> seeker = EventSeeker(event_source=event_source)
-    >>> event_list = seeker[3:6]
-    >>> print([event.count for event in event_list])
-
-    To obtain a list of events in a hessio file:
-
-    >>> from ctapipe.io import SimTelEventSource
-    >>> event_source = SimTelEventSource(input_url="/path/to/file")
-    >>> seeker = EventSeeker(event_source)
-    >>> event_indicis = [2, 6, 8]
-    >>> event_list = seeker[event_indicis]
-    >>> print([event.count for event in event_list])
     """
 
-    def __init__(self, reader, config=None, parent=None, **kwargs):
+    def __init__(self, event_source, config=None, parent=None, **kwargs):
         """
         Class to handle generic input files. Enables obtaining the "source"
         generator, regardless of the type of file (either hessio or camera
@@ -77,8 +60,8 @@ class EventSeeker(Component):
 
         Parameters
         ----------
-        reader : `ctapipe.io.eventfilereader.EventSource`
-            A subclass of `ctapipe.io.eventfilereader.EventFileReader` that
+        event_source : `ctapipe.io.eventsource.EventSource`
+            A subclass of `ctapipe.io.eventsource.EventSource` that
             defines how the event container is filled for a particular file
             format
         config : traitlets.loader.Config
@@ -93,16 +76,10 @@ class EventSeeker(Component):
         """
         super().__init__(config=config, parent=parent, **kwargs)
 
-        if reader.is_stream:
-            raise IOError(
-                "Reader is not compatible as input to the "
-                "event_source is a stream (seeking not possible)"
-            )
-
-        self._reader = reader
+        self._event_source = event_source
 
         self._num_events = None
-        self._source = self._reader.__iter__()
+        self._source = self._event_source.__iter__()
         self._current_event = None
         self._has_fast_seek = False  # By default seeking iterates through
         self._getevent_warn = True
@@ -111,7 +88,9 @@ class EventSeeker(Component):
         """
         Recreate the generator so it starts from the beginning
         """
-        self._source = self._reader.__iter__()
+        if self._event_source.is_stream:
+            raise IOError("Back-seeking is not possible for event source")
+        self._source = self._event_source.__iter__()
         self._current_event = None
 
     def __iter__(self):
@@ -121,71 +100,21 @@ class EventSeeker(Component):
             self._current_event = event
             yield event
 
-    def __getitem__(self, item):
-        """
-        Obtain a particular event
-
-        Parameters
-        ----------
-        item : int or str
-            If `item` is an int, then this is the event_index for the event
-            obtained. If `item` is a str, then this is the event_id for the
-            event obtained.
-
-        Returns
-        -------
-        event : ctapipe.io.container
-            The event container filled with the requested event's information
-
-        """
-
-        # Handling of different input types (int, string, slice, list)
-        current = None
-        use_event_id = False
-        if isinstance(item, int):
-            if self._current_event:
-                current = self._current_event.count
-            if item < 0:
-                item = len(self) + item
-                if item < 0 or item >= len(self):
-                    msg = "Event index {} out of range [0, {}]".format(item, len(self))
-                    raise IndexError(msg)
-        elif isinstance(item, str):
-            item = int(item)
-            use_event_id = True
-            if self._current_event:
-                current = self._current_event.index.event_id
-        elif isinstance(item, slice):
-            it = range(item.start or 0, item.stop or len(self), item.step or 1)
-            events = [self[i] for i in it]
-            return events
-        elif isinstance(item, list):
-            events = [self[i] for i in item]
-            return events
-        else:
-            raise TypeError("{} indexing is not supported".format(type(item)))
-
-        # Return a copy of the current event if we have already reached it
-        if current is not None and item == current:
-            return deepcopy(self._current_event)
-
-        # If requested event is less than the current event position: reset
-        if current is not None and item < current:
-            self._reset()
+    def get_event_index(self, event_index):
+        if self._current_event is not None:
+            if event_index == self._current_event.count:
+                return deepcopy(self._current_event)
+            if event_index < self._current_event.count:
+                self._reset()
 
         # Check we are within max_events range
-        max_events = self._reader.max_events
-        if not use_event_id and max_events and item >= max_events:
-            msg = "Event index {} outside of specified max_events {}".format(
-                item, max_events
-            )
+        max_events = self._event_source.max_events
+        if max_events and event_index >= max_events:
+            msg = f"Event index {event_index} is beyond max_events {max_events}"
             raise IndexError(msg)
 
         try:
-            if not use_event_id:
-                event = self._reader._get_event_by_index(item)
-            else:
-                event = self._reader._get_event_by_id(item)
+            event = self._event_source._get_event_by_index(event_index)
         except AttributeError:
             if self._getevent_warn:
                 self.log.warning(
@@ -193,10 +122,28 @@ class EventSeeker(Component):
                     "events... (potentially long process)"
                 )
                 self._getevent_warn = False
-            if not use_event_id:
-                event = self._get_event_by_index(item)
-            else:
-                event = self._get_event_by_id(item)
+            event = self._get_event_by_index(event_index)
+
+        self._current_event = event
+        return deepcopy(event)
+
+    def get_event_id(self, event_id):
+        if self._current_event is not None:
+            if event_id == self._current_event.index.event_id:
+                return deepcopy(self._current_event)
+            if event_id < self._current_event.index.event_id:
+                self._reset()
+
+        try:
+            event = self._event_source._get_event_by_id(event_id)
+        except AttributeError:
+            if self._getevent_warn:
+                self.log.warning(
+                    "Seeking to event by looping through "
+                    "events... (potentially long process)"
+                )
+                self._getevent_warn = False
+            event = self._get_event_by_id(event_id)
 
         self._current_event = event
         return deepcopy(event)
@@ -207,7 +154,7 @@ class EventSeeker(Component):
         until it finds the requested event index.
         If a file format allows random event access, then is can define its
         own `get_event_by_index` method in its
-        `ctapipe.io.eventfilereader.EventSource` to allow this class to
+        `ctapipe.io.eventsource.EventSource` to allow this class to
         utilise that method instead.
 
         Parameters
@@ -232,7 +179,7 @@ class EventSeeker(Component):
         until it finds the requested event id.
         If a file format allows random event access, then is can define its
         own `get_event_by_id` method in its
-        `ctapipe.io.eventfilereader.EventSource` to allow this class to
+        `ctapipe.io.eventsource.EventSource` to allow this class to
         utilise that method instead.
 
         Parameters
@@ -256,7 +203,7 @@ class EventSeeker(Component):
         Method for getting number of events in file. By default this is
         obtained by looping through the file and counting the events. If a
         file format has a more efficient method of supplying this information,
-        the `ctapipe.io.eventfilereader.EventSource` for that file format
+        the `ctapipe.io.eventsource.EventSource` for that file format
         can define its own `__len__` method, which this class will then
         use instead.
 
@@ -268,7 +215,7 @@ class EventSeeker(Component):
         # Only need to calculate once
         if not self._num_events:
             try:
-                count = len(self._reader)
+                count = len(self._event_source)
             except TypeError:
                 self.log.warning(
                     "Obtaining length of file by looping through "

--- a/ctapipe/io/eventseeker.py
+++ b/ctapipe/io/eventseeker.py
@@ -101,11 +101,21 @@ class EventSeeker(Component):
             yield event
 
     def get_event_index(self, event_index):
-        if self._current_event is not None:
-            if event_index == self._current_event.count:
-                return deepcopy(self._current_event)
-            if event_index < self._current_event.count:
-                self._reset()
+        """
+        Obtain the event via its event index
+
+        Parameters
+        ----------
+        event_index : int
+            The event_index to seek.
+
+        Returns
+        -------
+        event : ctapipe.io.container
+            The event container filled with the requested event's information
+        """
+        if self._current_event and event_index == self._current_event.count:
+            return deepcopy(self._current_event)
 
         # Check we are within max_events range
         max_events = self._event_source.max_events
@@ -116,33 +126,32 @@ class EventSeeker(Component):
         try:
             event = self._event_source._get_event_by_index(event_index)
         except AttributeError:
-            if self._getevent_warn:
-                self.log.warning(
-                    "Seeking to event by looping through "
-                    "events... (potentially long process)"
-                )
-                self._getevent_warn = False
             event = self._get_event_by_index(event_index)
 
         self._current_event = event
         return deepcopy(event)
 
     def get_event_id(self, event_id):
-        if self._current_event is not None:
-            if event_id == self._current_event.index.event_id:
-                return deepcopy(self._current_event)
-            if event_id < self._current_event.index.event_id:
-                self._reset()
+        """
+        Obtain the event via its event id
+
+        Parameters
+        ----------
+        event_id : int
+            The event_id to seek.
+
+        Returns
+        -------
+        event : ctapipe.io.container
+            The event container filled with the requested event's information
+
+        """
+        if self._current_event and event_id == self._current_event.index.event_id:
+            return deepcopy(self._current_event)
 
         try:
             event = self._event_source._get_event_by_id(event_id)
         except AttributeError:
-            if self._getevent_warn:
-                self.log.warning(
-                    "Seeking to event by looping through "
-                    "events... (potentially long process)"
-                )
-                self._getevent_warn = False
             event = self._get_event_by_id(event_id)
 
         self._current_event = event
@@ -168,6 +177,14 @@ class EventSeeker(Component):
             The event container filled with the requested event's information
 
         """
+        if self._getevent_warn:
+            msg = "Seeking event by iterating through events.. (potentially long process)"
+            self.log.warning(msg)
+            self._getevent_warn = False
+
+        if self._current_event and index < self._current_event.count:
+            self._reset()
+
         for event in self._source:
             if event.count == index:
                 return event
@@ -193,6 +210,14 @@ class EventSeeker(Component):
             The event container filled with the requested event's information
 
         """
+        if self._getevent_warn:
+            msg = "Seeking event by iterating through events.. (potentially long process)"
+            self.log.warning(msg)
+            self._getevent_warn = False
+
+        if self._current_event and event_id < self._current_event.index.event_id:
+            self._reset()
+
         for event in self:  # Event Ids may not be in order
             if event.index.event_id == event_id:
                 return event

--- a/ctapipe/io/eventseeker.py
+++ b/ctapipe/io/eventseeker.py
@@ -215,10 +215,9 @@ class EventSeeker(Component):
             self.log.warning(msg)
             self._getevent_warn = False
 
-        if self._current_event and event_id < self._current_event.index.event_id:
-            self._reset()
+        self._reset()  # Event ids may not be in order, so always reset
 
-        for event in self:  # Event Ids may not be in order
+        for event in self._source:
             if event.index.event_id == event_id:
                 return event
         raise IndexError(f"Event id {event_id} not found in file")

--- a/ctapipe/io/tests/test_eventseeker.py
+++ b/ctapipe/io/tests/test_eventseeker.py
@@ -10,52 +10,63 @@ def test_eventseeker():
 
     with SimTelEventSource(input_url=dataset, back_seekable=True) as reader:
 
-        seeker = EventSeeker(reader=reader)
+        seeker = EventSeeker(event_source=reader)
 
-        event = seeker[1]
+        event = seeker.get_event_index(1)
         assert event.count == 1
-        event = seeker[0]
+        event = seeker.get_event_index(0)
         assert event.count == 0
 
-        event = seeker["31007"]
+        event = seeker.get_event_id(31007)
         assert event.index.event_id == 31007
 
-        events = seeker[0:2]
-
-        for i, event in enumerate(events):
-            assert event.count == i
-
-        events = seeker[[0, 1]]
-        for i, event in enumerate(events):
-            assert event.count == i
-
-        ids = ["23703", "31007"]
-        events = seeker[ids]
-
-        for i, event in zip(ids, events):
-            assert event.index.event_id == int(i)
-
         with pytest.raises(IndexError):
-            event = seeker[200]
-
-        with pytest.raises(ValueError):
-            event = seeker["t"]
+            seeker.get_event_index(200)
 
         with pytest.raises(TypeError):
-            event = seeker[dict()]
+            seeker.get_event_index("1")
+
+        with pytest.raises(TypeError):
+            seeker.get_event_index("t")
+
+        with pytest.raises(TypeError):
+            seeker.get_event_index(dict())
 
     with SimTelEventSource(
         input_url=dataset, max_events=5, back_seekable=True
     ) as reader:
-        seeker = EventSeeker(reader=reader)
+        seeker = EventSeeker(event_source=reader)
         with pytest.raises(IndexError):
-            event = seeker[5]
+            event = seeker.get_event_index(5)
             assert event is not None
 
-    class StreamFileReader(SimTelEventSource):
-        def is_stream(self):
-            return True
 
-    with StreamFileReader(input_url=dataset) as reader:
+def test_eventseeker_edit():
+    with SimTelEventSource(input_url=dataset, back_seekable=True) as reader:
+        seeker = EventSeeker(event_source=reader)
+        event = seeker.get_event_index(1)
+        assert event.count == 1
+        event.count = 2
+        assert event.count == 2
+        event = seeker.get_event_index(1)
+        assert event.count == 1
+
+
+def test_eventseeker_simtel():
+    # Ensure the EventSeeker can forward seek even if back-seeking is not possible
+    with SimTelEventSource(input_url=dataset, back_seekable=False) as reader:
+        seeker = EventSeeker(event_source=reader)
+        event = seeker.get_event_index(1)
+        assert event.count == 1
+        event = seeker.get_event_index(1)
+        assert event.count == 1
+        event = seeker.get_event_index(2)
+        assert event.count == 2
+        event = seeker.get_event_index(2)
+        assert event.count == 2
+        event = seeker.get_event_index(4)
+        assert event.count == 4
         with pytest.raises(IOError):
-            seeker = EventSeeker(reader=reader)
+            seeker.get_event_index(1)
+        event = seeker.get_event_index(5)
+        assert event.count == 5

--- a/ctapipe/tools/bokeh/file_viewer.py
+++ b/ctapipe/tools/bokeh/file_viewer.py
@@ -153,7 +153,7 @@ class BokehFileViewer(Tool):
     @event_index.setter
     def event_index(self, val):
         try:
-            self.event = self.seeker[val]
+            self.event = self.seeker.get_event_index(val)
         except IndexError:
             self.log.warning(f"Event Index {val} does not exist")
 
@@ -164,7 +164,7 @@ class BokehFileViewer(Tool):
     @event_id.setter
     def event_id(self, val):
         try:
-            self.event = self.seeker[str(val)]
+            self.event = self.seeker.get_event_id(val)
         except IndexError:
             self.log.warning(f"Event ID {val} does not exist")
 

--- a/ctapipe/tools/display_integrator.py
+++ b/ctapipe/tools/display_integrator.py
@@ -274,10 +274,10 @@ class DisplayIntegrator(Tool):
         )
 
     def start(self):
-        event_num = self.event_index
         if self.use_event_id:
-            event_num = str(event_num)
-        event = self.eventseeker[event_num]
+            event = self.eventseeker.get_event_id(self.event_index)
+        else:
+            event = self.eventseeker.get_event_index(self.event_index)
 
         # Calibrate
         self.calibrate(event)

--- a/docs/tutorials/raw_data_exploration.ipynb
+++ b/docs/tutorials/raw_data_exploration.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "event = seeker[0]  # get first event\n",
+    "event = seeker.get_event_index(0)  # get first event\n",
     "event"
    ]
   },
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "event = seeker[1] # get the next event\n",
+    "event = seeker.get_event_index(1) # get the next event\n",
     "print(event.r0.tels_with_data)"
    ]
   },


### PR DESCRIPTION
- Replace `__get_item__` with `get_event_index` and `get_event_id` (resolves #1064)
- Always allow forward seeking (resolves #1076 & #1063)