### PR TITLE
Simplify pixel log-likelihood.

### DIFF
--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -54,7 +54,7 @@ class PixelLikelihoodError(RuntimeError):
 def poisson_likelihood_gaussian(image, prediction, spe_width, pedestal):
     """Calculate negative log likelihood for every pixel.
 
-    Gaussian approximation from de Naurois, p. 22 (between (24) and (25)).
+    Gaussian approximation from [denaurois2009]_, p. 22 (between (24) and (25)).
 
     Simplification:
 
@@ -80,12 +80,6 @@ def poisson_likelihood_gaussian(image, prediction, spe_width, pedestal):
 
         - \\ln{P} = \\ln{θ} + \\frac{(s - μ)^2}{θ}
 
-
-    References
-    ----------
-    - de Naurois, Rolland
-      'A high performance likelihood reconstruction of gamma-rays
-      for Imaging Atmospheric Cherenkov Telescopes' (2009)
 
     Parameters
     ----------

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -9,7 +9,7 @@ over a number of potential contributing photoelectrons (which is slow).
 At high signal this simplifies to a gaussian approximation.
 
 The full and gaussian approximations are implemented, in addition to a general purpose
-implementation, which tries to intellegently switch 
+implementation, which tries to intellegently switch
 between the two. Speed tests are below:
 
 neg_log_likelihood_approx(image, prediction, spe, ped)
@@ -129,7 +129,7 @@ def neg_log_likelihood_numeric(
 
     likelihood = epsilon
 
-    ns = np.arange(*poisson(np.max(prediction)).ppf(confidence),)
+    ns = np.arange(*poisson(np.max(prediction)).ppf(confidence))
 
     ns = ns[ns >= 0]
 

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -177,13 +177,15 @@ def neg_log_likelihood(
     approx_mask = prediction > prediction_safety
 
     neg_log_l = 0
-    neg_log_l += neg_log_likelihood_approx(
-        image[approx_mask], prediction[approx_mask], spe_width, pedestal,
-    )
+    if np.sum(approx_mask) > 0:
+        neg_log_l += neg_log_likelihood_approx(
+            image[approx_mask], prediction[approx_mask], spe_width, pedestal,
+        )
 
-    neg_log_l += neg_log_likelihood_numeric(
-        image[~approx_mask], prediction[~approx_mask], spe_width, pedestal,
-    )
+    if np.sum(~approx_mask) > 0:
+        neg_log_l += neg_log_likelihood_numeric(
+            image[~approx_mask], prediction[~approx_mask], spe_width, pedestal,
+        )
 
     return neg_log_l
 

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -146,9 +146,7 @@ def neg_log_likelihood_numeric(
     return -np.sum(np.log(likelihood))
 
 
-def neg_log_likelihood(
-    image, prediction, spe_width, pedestal, prediction_safety=20.0,
-):
+def neg_log_likelihood(image, prediction, spe_width, pedestal, prediction_safety=20.0):
     """
     Safe implementation of the poissonian likelihood implementation,
     adaptively switches between the full solution and the gaussian
@@ -177,14 +175,14 @@ def neg_log_likelihood(
     approx_mask = prediction > prediction_safety
 
     neg_log_l = 0
-    if np.sum(approx_mask) > 0:
+    if np.any(approx_mask):
         neg_log_l += neg_log_likelihood_approx(
-            image[approx_mask], prediction[approx_mask], spe_width, pedestal,
+            image[approx_mask], prediction[approx_mask], spe_width, pedestal
         )
 
-    if np.sum(~approx_mask) > 0:
+    if not np.all(approx_mask):
         neg_log_l += neg_log_likelihood_numeric(
-            image[~approx_mask], prediction[~approx_mask], spe_width, pedestal,
+            image[~approx_mask], prediction[~approx_mask], spe_width, pedestal
         )
 
     return neg_log_l
@@ -257,10 +255,7 @@ def mean_poisson_likelihood_full(prediction, spe_width, ped):
     width = np.sqrt(width)
 
     for p in range(len(prediction)):
-        int_range = (
-            prediction[p] - 10 * width[p],
-            prediction[p] + 10 * width[p],
-        )
+        int_range = (prediction[p] - 10 * width[p], prediction[p] + 10 * width[p])
         mean_like[p] = quad(
             _integral_poisson_likelihood_full,
             int_range[0],
@@ -298,9 +293,7 @@ def chi_squared(image, prediction, ped, error_factor=2.9):
     if image.shape is not prediction.shape:
         PixelLikelihoodError(
             "Image and prediction arrays have different dimensions Image "
-            "shape: {} Prediction shape: {}".format(
-                image.shape, prediction.shape
-            )
+            "shape: {} Prediction shape: {}".format(image.shape, prediction.shape)
         )
 
     chi_square = (image - prediction) * (image - prediction)

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -98,7 +98,9 @@ def neg_log_likelihood_approx(image, prediction, spe_width, pedestal):
     return np.sum(neg_log_l)
 
 
-def neg_log_likelihood_numeric(image, prediction, spe_width, pedestal, confidence=(0.001, 0.999)):
+def neg_log_likelihood_numeric(
+    image, prediction, spe_width, pedestal, confidence=(0.001, 0.999)
+):
     """
     Calculate likelihood of prediction given the measured signal,
     full numerical integration from [denaurois2009]_.
@@ -127,26 +129,25 @@ def neg_log_likelihood_numeric(image, prediction, spe_width, pedestal, confidenc
 
     likelihood = epsilon
 
-    ns = np.arange(
-        *poisson(np.max(prediction)).ppf(confidence),
-    )
+    ns = np.arange(*poisson(np.max(prediction)).ppf(confidence),)
 
     ns = ns[ns >= 0]
 
     for n in ns:
         theta = pedestal ** 2 + n * spe_width ** 2
-        _l = prediction ** n * np.exp(-prediction) / theta * np.exp(-(image - n) ** 2 / (2 * theta))
+        _l = (
+            prediction ** n
+            * np.exp(-prediction)
+            / theta
+            * np.exp(-((image - n) ** 2) / (2 * theta))
+        )
         likelihood += _l
 
-    return - np.sum(np.log(likelihood))
+    return -np.sum(np.log(likelihood))
 
 
 def neg_log_likelihood(
-    image,
-    prediction,
-    spe_width,
-    pedestal,
-    prediction_safety=20.0,
+    image, prediction, spe_width, pedestal, prediction_safety=20.0,
 ):
     """
     Safe implementation of the poissonian likelihood implementation,
@@ -177,17 +178,11 @@ def neg_log_likelihood(
 
     neg_log_l = 0
     neg_log_l += neg_log_likelihood_approx(
-        image[approx_mask],
-        prediction[approx_mask],
-        spe_width,
-        pedestal,
+        image[approx_mask], prediction[approx_mask], spe_width, pedestal,
     )
 
     neg_log_l += neg_log_likelihood_numeric(
-        image[~approx_mask],
-        prediction[~approx_mask],
-        spe_width,
-        pedestal,
+        image[~approx_mask], prediction[~approx_mask], spe_width, pedestal,
     )
 
     return neg_log_l
@@ -260,7 +255,10 @@ def mean_poisson_likelihood_full(prediction, spe_width, ped):
     width = np.sqrt(width)
 
     for p in range(len(prediction)):
-        int_range = (prediction[p] - 10 * width[p], prediction[p] + 10 * width[p])
+        int_range = (
+            prediction[p] - 10 * width[p],
+            prediction[p] + 10 * width[p],
+        )
         mean_like[p] = quad(
             _integral_poisson_likelihood_full,
             int_range[0],
@@ -298,7 +296,9 @@ def chi_squared(image, prediction, ped, error_factor=2.9):
     if image.shape is not prediction.shape:
         PixelLikelihoodError(
             "Image and prediction arrays have different dimensions Image "
-            "shape: {} Prediction shape: {}".format(image.shape, prediction.shape)
+            "shape: {} Prediction shape: {}".format(
+                image.shape, prediction.shape
+            )
         )
 
     chi_square = (image - prediction) * (image - prediction)

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -5,9 +5,8 @@ This calculation is taken from [denaurois2009]_.
 
 The likelihood is essentially a poissonian convolved with a gaussian, at low signal
 a full possonian approach must be adopted, which requires the sum of contibutions
-over a number of potential contributing photoelectrons (which is slow and can fail
-at high signals due to the factorial which mst be calculated). At high signal this
-simplifies to a gaussian approximation.
+over a number of potential contributing photoelectrons (which is slow).
+At high signal this simplifies to a gaussian approximation.
 
 The full and gaussian approximations are implemented, in addition to a general purpose
 implementation, which tries to intellegently switch 

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -12,13 +12,13 @@ The full and gaussian approximations are implemented, in addition to a general p
 implementation, which tries to intellegently switch 
 between the two. Speed tests are below:
 
-poisson_likelihood_gaussian(image, prediction, spe, ped)
+neg_log_likelihood_approx(image, prediction, spe, ped)
 29.8 µs per loop
 
-poisson_likelihood_full(image, prediction, spe, ped)
+neg_log_likelihood_numeric(image, prediction, spe, ped)
 93.4 µs per loop
 
-poisson_likelihood(image, prediction, spe, ped)
+neg_log_likelihood(image, prediction, spe, ped)
 59.9 µs per loop
 
 TODO:
@@ -32,9 +32,9 @@ from scipy.integrate import quad
 from scipy.stats import poisson
 
 __all__ = [
-    "poisson_likelihood_gaussian",
-    "poisson_likelihood_full",
-    "poisson_likelihood",
+    "neg_log_likelihood_approx",
+    "neg_log_likelihood_numeric",
+    "neg_log_likelihood",
     "mean_poisson_likelihood_gaussian",
     "mean_poisson_likelihood_full",
     "PixelLikelihoodError",
@@ -46,10 +46,10 @@ class PixelLikelihoodError(RuntimeError):
     pass
 
 
-def poisson_likelihood_gaussian(image, prediction, spe_width, pedestal):
-    """Calculate negative log likelihood for every pixel.
+def neg_log_likelihood_approx(image, prediction, spe_width, pedestal):
+    """Calculate negative log likelihood for telescope.
 
-    Gaussian approximation from [denaurois2009]_, p. 22 (between (24) and (25)).
+    Gaussian approximation from [denaurois2009]_, p. 22 (equation between (24) and (25)).
 
     Simplification:
 
@@ -222,7 +222,7 @@ def _integral_poisson_likelihood_full(s, prediction, spe_width, ped):
     Wrapper function around likelihood calculation, used in numerical
     integration.
     """
-    like = poisson_likelihood(s, prediction, spe_width, ped)
+    like = neg_log_likelihood(s, prediction, spe_width, ped)
     return like * np.exp(-0.5 * like)
 
 

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -1,9 +1,7 @@
 """
 Class for calculation of likelihood of a pixel expectation, given the pixel amplitude,
-the level of noise in the pixel and the photoelectron resolution. This calculation is
-taken from:
-de Naurois & Rolland, Astroparticle Physics, Volume 32, Issue 5, p. 231-252 (2009)
-https://arxiv.org/abs/0907.2610
+the level of noise in the pixel and the photoelectron resolution.
+This calculation is taken from [denaurois2009]_.
 
 The likelihood is essentially a poissonian convolved with a gaussian, at low signal
 a full possonian approach must be adopted, which requires the sum of contibutions

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -196,9 +196,8 @@ def neg_log_likelihood(
     return neg_log_l
 
 
-def mean_poisson_likelihood_gaussian(prediction, spe_width, ped):
-    """
-    Calculation of the mean  likelihood for a give expectation
+def mean_poisson_likelihood_gaussian(prediction, spe_width, pedestal):
+    """Calculation of the mean likelihood for a give expectation
     value of pixel intensity in the gaussian approximation.
     This is useful in the calculation of the goodness of fit.
 
@@ -207,22 +206,18 @@ def mean_poisson_likelihood_gaussian(prediction, spe_width, ped):
     prediction: ndarray
         Predicted pixel amplitudes from model
     spe_width: ndarray
-        width of single p.e. distribution
-    ped: ndarray
-        width of pedestal
+        Width of single p.e. distribution
+    pedestal: ndarray
+        Width of pedestal
 
     Returns
     -------
-    ndarray: mean likelihood for give pixel expectation
+    float
     """
-    prediction = np.asarray(prediction)
-    spe_width = np.asarray(spe_width)
-    ped = np.asarray(ped)
+    theta = pedestal ** 2 + prediction * (1 + spe_width ** 2)
+    mean_log_likelihood = 1 + np.log(2 * np.pi) + np.log(theta)
 
-    mean_like = 1 + np.log(2 * math.pi)
-    mean_like += np.log(ped * ped + prediction * (1 + spe_width * spe_width))
-
-    return mean_like
+    return np.sum(mean_log_likelihood)
 
 
 def _integral_poisson_likelihood_full(s, prediction, spe_width, ped):

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -89,13 +89,13 @@ def poisson_likelihood_gaussian(image, prediction, spe_width, pedestal):
 
     Returns
     -------
-    ndarray: Negative log-likelihood for each pixel.
+    float
     """
     theta = pedestal ** 2 + prediction * (1 + spe_width ** 2)
 
     neg_log_l = np.log(theta) + (image - prediction) ** 2 / theta
 
-    return neg_log_l
+    return np.sum(neg_log_l)
 
 
 def neg_log_likelihood_numeric(image, prediction, spe_width, pedestal, confidence=(0.001, 0.999)):

--- a/ctapipe/image/tests/test_pixel_likelihood.py
+++ b/ctapipe/image/tests/test_pixel_likelihood.py
@@ -1,5 +1,45 @@
 import numpy as np
-from ctapipe.image import neg_log_likelihood, neg_log_likelihood_approx
+from ctapipe.image import (
+    neg_log_likelihood,
+    neg_log_likelihood_approx,
+    mean_poisson_likelihood_gaussian,
+    chi_squared,
+    mean_poisson_likelihood_full,
+)
+
+
+def test_chi_squared():
+    image = np.array([20, 20, 20])
+    prediction = np.array([20, 20, 20])
+    bad_prediction = np.array([1, 1, 1])
+
+    ped = 1
+
+    chi = chi_squared(image, prediction, ped)
+    bad_chi = chi_squared(image, bad_prediction, ped)
+
+    assert chi < bad_chi
+
+
+def test_mean_poisson_likelihoood_gaussian():
+    prediction = np.array([1, 1, 1], dtype="float")
+    spe = 0.5
+
+    small_mean_likelihood = mean_poisson_likelihood_gaussian(prediction, spe, 0)
+    large_mean_likelihood = mean_poisson_likelihood_gaussian(prediction, spe, 1)
+
+    assert small_mean_likelihood < large_mean_likelihood
+
+
+def test_mean_poisson_likelihood_full():
+    prediction = np.array([30.0, 30.0])
+
+    spe = np.array([0.5])
+
+    small_mean_likelihood = mean_poisson_likelihood_full(prediction, spe, [0])
+    large_mean_likelihood = mean_poisson_likelihood_full(prediction, spe, [1])
+
+    assert small_mean_likelihood < large_mean_likelihood
 
 
 def test_full_likelihood():

--- a/ctapipe/image/tests/test_pixel_likelihood.py
+++ b/ctapipe/image/tests/test_pixel_likelihood.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ctapipe.image import poisson_likelihood_full, poisson_likelihood_gaussian
+from ctapipe.image import neg_log_likelihood, neg_log_likelihood_approx
 
 
 def test_full_likelihood():
@@ -11,30 +11,29 @@ def test_full_likelihood():
     spe = 0.5  # Single photo-electron width
     pedestal = 1  # width of the pedestal distribution
 
-    image_small = [0, 1, 2]
-    expectation_small = [1, 1, 1]
+    image_small = np.array([0, 1, 2])
+    expectation_small = np.array([1, 1, 1])
 
-    full_like_small = poisson_likelihood_full(
-        image_small, expectation_small, spe, pedestal
+    full_like_small = neg_log_likelihood(image_small, expectation_small, spe, pedestal)
+    exp_diff = full_like_small - np.sum(
+        np.asarray([2.75630505, 2.62168656, 3.39248449])
     )
-    exp_diff = full_like_small - np.asarray([2.75630505, 2.62168656, 3.39248449])
-    exp_diff = np.sum(np.abs(exp_diff))
+
     # Check against known values
-    print(exp_diff)
     assert exp_diff / np.sum(full_like_small) < 1e-4
 
-    image_large = [40, 50, 60]
-    expectation_large = [50, 50, 50]
-    full_like_large = poisson_likelihood_full(
-        image_large, expectation_large, spe, pedestal
-    )
+    image_large = np.array([40, 50, 60])
+    expectation_large = np.array([50, 50, 50])
+
+    full_like_large = neg_log_likelihood(image_large, expectation_large, spe, pedestal)
     # Check against known values
-    exp_diff = full_like_large - np.asarray([7.45489137, 5.99305388, 7.66226007])
-    exp_diff = np.sum(np.abs(exp_diff))
+    exp_diff = full_like_large - np.sum(
+        np.asarray([7.45489137, 5.99305388, 7.66226007])
+    )
 
     assert exp_diff / np.sum(full_like_large) < 1e-4
 
-    gaus_like_large = poisson_likelihood_gaussian(
+    gaus_like_large = neg_log_likelihood_approx(
         image_large, expectation_large, spe, pedestal
     )
 

--- a/ctapipe/reco/ImPACT.py
+++ b/ctapipe/reco/ImPACT.py
@@ -18,7 +18,7 @@ from ctapipe.coordinates import (
     GroundFrame,
     project_to_ground,
 )
-from ctapipe.image import poisson_likelihood_gaussian, mean_poisson_likelihood_gaussian
+from ctapipe.image import neg_log_likelihood, mean_poisson_likelihood_gaussian
 from ctapipe.instrument import get_atmosphere_profile_functions
 from ctapipe.containers import (
     ReconstructedShowerContainer,
@@ -484,7 +484,7 @@ class ImPACTReconstructor(Reconstructor):
         prediction *= self.template_scale
 
         # Get likelihood that the prediction matched the camera image
-        like = poisson_likelihood_gaussian(self.image, prediction, self.spe, self.ped)
+        like = neg_log_likelihood(self.image, prediction, self.spe, self.ped)
         like[np.isnan(like)] = 1e9
         like *= np.invert(ma.getmask(self.image))
         like = ma.MaskedArray(like, mask=ma.getmask(self.image))

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -8,7 +8,7 @@ References
 .. [denaurois2009] de Naurois, M., Roland, L. "A high performance
 	likelihood reconstruction of gamma-rays for imaging
 	atmospheric Cherenkov telescopes". Astroparticle Physics
-	32.5, (2009)
+	32.5, (2009), https://arxiv.org/abs/0907.2610
 
 .. [temme2016] Temme T.F., "On the hunt for photons: analysis of Crab Nebula
 		data obtainedby the first G-APD Cherenkov telescope" 2016


### PR DESCRIPTION
in the attempt to work on  #1272:

* simplify the log-likelihood analytically
* discard constants and factors which are not needed in minimization

but now the function `ctapipe.image.pixel_likelihood.poisson_likelihood_gaussian` is basically the same as `ctapipe.image.muon.intensity_fitter.negative_log_likelihood` in #1390 and duplicate code is not good.

Maybe do smth like `ctapipe.image.pixel_likelihood.negative_log_likelihood` and use this in the Muon and ImPACT fitting?