### PR TITLE
Fix CameraGeometry coordinate conversion for spherical frames

### DIFF
--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -213,7 +213,7 @@ class CameraGeometry:
             pix_id=self.pix_id,
             pix_x=trans_x,
             pix_y=trans_y,
-            pix_area=self.pix_area,
+            pix_area=self.guess_pixel_area(trans_x, trans_y, self.pix_type),
             pix_type=self.pix_type,
             pix_rotation=pix_rotation,
             cam_rotation=cam_rotation,

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -204,7 +204,6 @@ class CameraGeometry:
 
         rot = np.arctan2(uv_y[0], uv_y[1])
         det = np.linalg.det([uv_x.value, uv_y.value])
-        print(f"DEBUG: det={det}, rot={rot.to('deg')}")
 
         cam_rotation = rot - self.cam_rotation
         pix_rotation = rot - self.pix_rotation
@@ -227,8 +226,8 @@ class CameraGeometry:
         return hash(
             (
                 self.camera_name,
-                self.pix_x[0].to_value(u.m),
-                self.pix_y[0].to_value(u.m),
+                self.pix_x[0].value,
+                self.pix_y[0].value,
                 self.pix_type,
                 self.pix_rotation.deg,
             )
@@ -330,9 +329,7 @@ class CameraGeometry:
 
         """
 
-        pixel_centers = np.column_stack(
-            [self.pix_x.to_value(u.m), self.pix_y.to_value(u.m)]
-        )
+        pixel_centers = np.column_stack([self.pix_x.value, self.pix_y.value])
         return KDTree(pixel_centers)
 
     @lazyproperty
@@ -705,9 +702,9 @@ class CameraGeometry:
             logger.warning(
                 " Method not implemented for cameras with varying pixel sizes"
             )
-
-        points_searched = np.dstack([x.to_value(u.m), y.to_value(u.m)])
-        circum_rad = self._pixel_circumferences[0].to_value(u.m)
+        unit = x.unit
+        points_searched = np.dstack([x.to_value(unit), y.to_value(unit)])
+        circum_rad = self._pixel_circumferences[0].to_value(unit)
         kdtree = self._kdtree
         dist, pix_indices = kdtree.query(
             points_searched, distance_upper_bound=circum_rad
@@ -739,13 +736,13 @@ class CameraGeometry:
                 # compare with inside pixel:
                 xprime = (
                     points_searched[0][index, 0]
-                    - self.pix_x[borderpix_index].to_value(u.m)
-                    + self.pix_x[insidepix_index].to_value(u.m)
+                    - self.pix_x[borderpix_index].to_value(unit)
+                    + self.pix_x[insidepix_index].to_value(unit)
                 )
                 yprime = (
                     points_searched[0][index, 1]
-                    - self.pix_y[borderpix_index].to_value(u.m)
-                    + self.pix_y[insidepix_index].to_value(u.m)
+                    - self.pix_y[borderpix_index].to_value(unit)
+                    + self.pix_y[insidepix_index].to_value(unit)
                 )
                 dist_check, index_check = kdtree.query(
                     [xprime, yprime], distance_upper_bound=circum_rad

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -204,7 +204,7 @@ class CameraGeometry:
             pix_type=self.pix_type,
             pix_rotation=pix_rotation,
             cam_rotation=cam_rotation,
-            neighbors=None,
+            neighbors=self._neighbors,
             apply_derotation=False,
             frame=frame,
         )

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -174,11 +174,11 @@ class CameraGeometry:
         if self.frame is None:
             self.frame = CameraFrame()
 
-        coord = SkyCoord(x=self.pix_x, y=self.pix_y, frame=self.frame)
+        coord = SkyCoord(self.pix_x, self.pix_y, frame=self.frame)
         trans = coord.transform_to(frame)
 
         # also transform the unit vectors, to get rotation / mirroring
-        uv = SkyCoord(x=[1, 0], y=[0, 1], unit=u.m, frame=self.frame)
+        uv = SkyCoord([1, 0], [0, 1], unit=self.pix_x.unit, frame=self.frame)
         uv_trans = uv.transform_to(frame)
 
         if hasattr(uv_trans, "y"):
@@ -186,12 +186,12 @@ class CameraGeometry:
             uv_y = uv_trans.y
             trans_x = trans.x
             trans_y = trans.y
-        elif hasattr(uv_trans, "fov_lat"):  # in case it's TelescopeFrame
+        elif hasattr(uv_trans, "fov_lat"):  # in case its TelescopeFrame
             uv_x = uv_trans.fov_lon
             uv_y = uv_trans.fov_lat
             trans_x = trans.fov_lon
             trans_y = trans.fov_lat
-        elif hasattr(uv_trans, "lat"):
+        elif hasattr(uv_trans, "lat"):  # in case its a sky frame
             uv_x = uv_trans.lon
             uv_y = uv_trans.lat
             trans_x = trans.lon

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -204,9 +204,10 @@ class CameraGeometry:
 
         rot = np.arctan2(uv_y[0], uv_y[1])
         det = np.linalg.det([uv_x.value, uv_y.value])
+        print(f"DEBUG: det={det}, rot={rot.to('deg')}")
 
-        cam_rotation = rot + det * self.cam_rotation
-        pix_rotation = rot + det * self.pix_rotation
+        cam_rotation = rot - self.cam_rotation
+        pix_rotation = rot - self.pix_rotation
 
         return CameraGeometry(
             camera_name=self.camera_name,

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -181,26 +181,14 @@ class CameraGeometry:
         uv = SkyCoord([1, 0], [0, 1], unit=self.pix_x.unit, frame=self.frame)
         uv_trans = uv.transform_to(frame)
 
-        if hasattr(uv_trans, "y"):
-            uv_x = uv_trans.x
-            uv_y = uv_trans.y
-            trans_x = trans.x
-            trans_y = trans.y
-        elif hasattr(uv_trans, "fov_lat"):  # in case its TelescopeFrame
-            uv_x = uv_trans.fov_lon
-            uv_y = uv_trans.fov_lat
-            trans_x = trans.fov_lon
-            trans_y = trans.fov_lat
-        elif hasattr(uv_trans, "lat"):  # in case its a sky frame
-            uv_x = uv_trans.lon
-            uv_y = uv_trans.lat
-            trans_x = trans.lon
-            trans_y = trans.lat
-        else:
-            raise RuntimeError(
-                f"Unable to transform to frame {frame}, "
-                "which has unknown representation"
-            )
+        # some trickers has to be done to deal with the fact that
+        # not all frames use the same x/y attributes. Therefore we get the
+        # component names, and access them by string:
+        frame_attrs = list(uv_trans.frame.get_representation_component_names().keys())
+        uv_x = getattr(uv_trans, frame_attrs[0])
+        uv_y = getattr(uv_trans, frame_attrs[1])
+        trans_x = getattr(trans, frame_attrs[0])
+        trans_y = getattr(trans, frame_attrs[1])
 
         rot = np.arctan2(uv_y[0], uv_y[1])
         det = np.linalg.det([uv_x.value, uv_y.value])

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -3,22 +3,21 @@
 Utilities for reading or working with Camera geometry files
 """
 import logging
+import warnings
+from typing import TypeVar
 
 import numpy as np
-from typing import TypeVar
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates import BaseCoordinateFrame
 from astropy.table import Table
 from astropy.utils import lazyproperty
-from scipy.spatial import cKDTree as KDTree
 from scipy.sparse import lil_matrix, csr_matrix
-from astropy.coordinates import BaseCoordinateFrame
-import warnings
+from scipy.spatial import cKDTree as KDTree
 
+from ctapipe.coordinates import CameraFrame
 from ctapipe.utils import get_table_dataset
 from ctapipe.utils.linalg import rotation_matrix_2d
-from ctapipe.coordinates import CameraFrame
-
 
 __all__ = ["CameraGeometry", "UnknownPixelShapeWarning"]
 
@@ -181,9 +180,9 @@ class CameraGeometry:
         uv = SkyCoord([1, 0], [0, 1], unit=self.pix_x.unit, frame=self.frame)
         uv_trans = uv.transform_to(frame)
 
-        # some trickers has to be done to deal with the fact that
-        # not all frames use the same x/y attributes. Therefore we get the
-        # component names, and access them by string:
+        # some trickery has to be done to deal with the fact that not all frames
+        # use the same x/y attributes. Therefore we get the component names, and
+        # access them by string:
         frame_attrs = list(uv_trans.frame.get_representation_component_names().keys())
         uv_x = getattr(uv_trans, frame_attrs[0])
         uv_y = getattr(uv_trans, frame_attrs[1])

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -300,6 +300,11 @@ def test_camera_coordinate_transform(camera_name):
     x = sky_geom.pix_x.to_value(u.deg)
     assert len(x) == len(geom.pix_x)
 
+    # and test going backward from spherical to cartesian:
+
+    geom_cam = sky_geom.transform_to(CameraFrame)
+    assert np.allclose(geom_cam.pix_x.to_value(unit), gepm.pix_x.to_value(unit))
+
 
 def test_guess_area():
     x = u.Quantity([0, 1, 2], u.cm)

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -292,8 +292,8 @@ def test_camera_coordinate_transform(camera_name):
     assert np.allclose(geom.pix_y.to_value(unit), -trans_geom.pix_x.to_value(unit))
 
     # also test converting into a spherical frame:
-
-    geom.frame = CameraFrame(focal_length=1.2 * u.m)
+    focal_length = 1.2 * u.m
+    geom.frame = CameraFrame(focal_length=focal_length)
     telescope_frame = TelescopeFrame()
     sky_geom = geom.transform_to(telescope_frame)
 
@@ -302,8 +302,8 @@ def test_camera_coordinate_transform(camera_name):
 
     # and test going backward from spherical to cartesian:
 
-    geom_cam = sky_geom.transform_to(CameraFrame)
-    assert np.allclose(geom_cam.pix_x.to_value(unit), gepm.pix_x.to_value(unit))
+    geom_cam = sky_geom.transform_to(CameraFrame(focal_length=focal_length))
+    assert np.allclose(geom_cam.pix_x.to_value(unit), geom.pix_x.to_value(unit))
 
 
 def test_guess_area():

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -44,10 +44,7 @@ def test_load_lst_camera():
 def test_position_to_pix_index():
     """ test that we can lookup a pixel from a coordinate"""
     geom = CameraGeometry.from_name("LSTCam")
-    x, y = (
-        0.80 * u.m,
-        0.79 * u.m,
-    )
+    x, y = (0.80 * u.m, 0.79 * u.m)
     pix_id = geom.position_to_pix_index(x, y)
     assert pix_id == 1790
 
@@ -178,7 +175,7 @@ def test_precal_neighbors():
         pix_x=np.arange(3) * u.deg,
         pix_y=np.arange(3) * u.deg,
         pix_area=np.ones(3) * u.deg ** 2,
-        neighbors=[[1,], [0, 2], [1,]],
+        neighbors=[[1], [0, 2], [1]],
         pix_type="rectangular",
         pix_rotation="0deg",
         cam_rotation="0deg",
@@ -285,7 +282,7 @@ def test_camera_from_name(camera_name):
 @pytest.mark.parametrize("camera_name", camera_names)
 def test_camera_coordinate_transform(camera_name):
     """test conversion of the coordinates stored in a camera frame"""
-    from ctapipe.coordinates import EngineeringCameraFrame
+    from ctapipe.coordinates import EngineeringCameraFrame, CameraFrame, TelescopeFrame
 
     geom = CameraGeometry.from_name(camera_name)
     trans_geom = geom.transform_to(EngineeringCameraFrame())
@@ -293,6 +290,15 @@ def test_camera_coordinate_transform(camera_name):
     unit = geom.pix_x.unit
     assert np.allclose(geom.pix_x.to_value(unit), -trans_geom.pix_y.to_value(unit))
     assert np.allclose(geom.pix_y.to_value(unit), -trans_geom.pix_x.to_value(unit))
+
+    # also test converting into a spherical frame:
+
+    geom.frame = CameraFrame(focal_length=1.2 * u.m)
+    telescope_frame = TelescopeFrame()
+    sky_geom = geom.transform_to(telescope_frame)
+
+    x = sky_geom.pix_x.to_value(u.deg)
+    assert len(x) == len(geom.pix_x)
 
 
 def test_guess_area():

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -27,6 +27,7 @@ from ..instrument.guess import guess_telescope, UNKNOWN_TELESCOPE
 from ..containers import MCHeaderContainer
 from .eventsource import EventSource
 from .datalevels import DataLevel
+from ..coordinates import CameraFrame
 
 X_MAX_UNIT = u.g / (u.cm ** 2)
 
@@ -53,7 +54,7 @@ def parse_simtel_time(simtel_time):
     )
 
 
-def build_camera(cam_settings, pixel_settings, telescope):
+def build_camera(cam_settings, pixel_settings, telescope, frame):
     pixel_shape = cam_settings["pixel_shape"][0]
     try:
         pix_type, pix_rotation = CameraGeometry.simtel_shape_to_type(pixel_shape)
@@ -75,6 +76,7 @@ def build_camera(cam_settings, pixel_settings, telescope):
         pix_rotation=pix_rotation,
         cam_rotation=-Angle(cam_settings["cam_rot"], u.rad),
         apply_derotation=True,
+        frame=frame,
     )
     readout = CameraReadout(
         telescope.camera_name,
@@ -283,11 +285,6 @@ class SimTelEventSource(EventSource):
             except ValueError:
                 telescope = UNKNOWN_TELESCOPE
 
-            camera = self._camera_cache.get(telescope.camera_name)
-            if camera is None:
-                camera = build_camera(cam_settings, pixel_settings, telescope)
-                self._camera_cache[telescope.camera_name] = camera
-
             optics = OpticsDescription(
                 name=telescope.name,
                 num_mirrors=telescope.n_mirrors,
@@ -295,6 +292,16 @@ class SimTelEventSource(EventSource):
                 mirror_area=u.Quantity(cam_settings["mirror_area"], u.m ** 2),
                 num_mirror_tiles=cam_settings["n_mirrors"],
             )
+
+            camera = self._camera_cache.get(telescope.camera_name)
+            if camera is None:
+                camera = build_camera(
+                    cam_settings,
+                    pixel_settings,
+                    telescope,
+                    frame=CameraFrame(focal_length=optics.equivalent_focal_length),
+                )
+                self._camera_cache[telescope.camera_name] = camera
 
             tel_descriptions[tel_id] = TelescopeDescription(
                 name=telescope.name,

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -108,7 +108,7 @@ class CameraDisplay:
         self.geom = geometry
 
         if title is None:
-            title = geometry.camera_name
+            title = f"{geometry.camera_name} ({self.geom.frame.__class__.__name__})"
 
         # initialize the plot and generate the pixels as a
         # RegularPolyCollection


### PR DESCRIPTION
As shown in #1191, it was not easy to transform a `CameraGeometry` from the `CameraFrame` to `TelescopeFrame`, or indeed other spherical frames. 

This PR does several related things:
1. modifies `SimTelEventSource` to properly construct CameraGeometries in the SubarrayDescription that have frames initialized to `CameraFrame(focal_length=flen)`
2. adds a unit test to demonstrate the correct way to convert a CameraGeometry from `CameraFrame` to `TelescopeFrame`
3. fixes `CameraGeometry.transform_to()` to work with non-cartesian frames

~~Note that the fix in part 3 introduces a bit of a "code smell": the attributes of the transformed coordinates — e.g. `(x, y)`, `(lon, lat)`, `(fov_lon, fov_lat)`—are chosen using an if/elif chain.  Perhaps there is a more generic way to get the first and second coordinates of different Frame representations?~~

edit: code-smell removed,  also added unit test to go from Spherical to Cartesian camera representations