### PR TITLE
cosmetic change to CameraDisplay

### DIFF
--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -95,6 +95,7 @@ class CameraDisplay:
         allow_pick=False,
         autoupdate=True,
         autoscale=True,
+        show_frame=True,
     ):
         self.axes = ax if ax is not None else plt.gca()
         self.pixels = None
@@ -160,23 +161,8 @@ class CameraDisplay:
         self.axes.set_title(title)
         self.axes.autoscale_view()
 
-        # add some descriptive labels
-        frame_name = (
-            self.geom.frame.__class__.__name__
-            if self.geom.frame is not None
-            else "Unknown Frame"
-        )
-        self.axes.text(  # position text relative to Axes
-            1.0,
-            0.0,
-            frame_name,
-            ha="right",
-            va="bottom",
-            transform=self.axes.transAxes,
-            color="grey",
-            fontsize="smaller",
-        )
-
+        if show_frame:
+            self.add_frame_name()
         # set up a patch to display when a pixel is clicked (and
         # pixel_picker is enabled):
 
@@ -498,3 +484,22 @@ class CameraDisplay:
 
         self.axes.set_xlabel(f"{axes_labels[0]}  ({self.geom.pix_x.unit})")
         self.axes.set_ylabel(f"{axes_labels[1]}  ({self.geom.pix_y.unit})")
+
+    def add_frame_name(self, color="grey"):
+        """ label the frame type of the display (e.g. CameraFrame) """
+
+        frame_name = (
+            self.geom.frame.__class__.__name__
+            if self.geom.frame is not None
+            else "Unknown Frame"
+        )
+        self.axes.text(  # position text relative to Axes
+            1.0,
+            0.0,
+            frame_name,
+            ha="right",
+            va="bottom",
+            transform=self.axes.transAxes,
+            color=color,
+            fontsize="smaller",
+        )

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -108,7 +108,7 @@ class CameraDisplay:
         self.geom = geometry
 
         if title is None:
-            title = f"{geometry.camera_name} ({self.geom.frame.__class__.__name__})"
+            title = f"{geometry.camera_name}"
 
         # initialize the plot and generate the pixels as a
         # RegularPolyCollection
@@ -158,9 +158,24 @@ class CameraDisplay:
 
         self.axes.set_aspect("equal", "datalim")
         self.axes.set_title(title)
-        self.axes.set_xlabel(f"X position ({self.geom.pix_x.unit})")
-        self.axes.set_ylabel(f"Y position ({self.geom.pix_y.unit})")
         self.axes.autoscale_view()
+
+        # add some descriptive labels
+        frame_name = (
+            self.geom.frame.__class__.__name__
+            if self.geom.frame is not None
+            else "Unknown Frame"
+        )
+        self.axes.text(  # position text relative to Axes
+            1.0,
+            0.0,
+            frame_name,
+            ha="right",
+            va="bottom",
+            transform=self.axes.transAxes,
+            color="grey",
+            fontsize="smaller",
+        )
 
         # set up a patch to display when a pixel is clicked (and
         # pixel_picker is enabled):
@@ -193,6 +208,7 @@ class CameraDisplay:
             self.image = np.zeros_like(self.geom.pix_id, dtype=np.float)
 
         self.norm = norm
+        self.auto_set_axes_labels()
 
     def highlight_pixels(self, pixels, color="g", linewidth=1, alpha=0.75):
         """
@@ -471,3 +487,16 @@ class CameraDisplay:
 
     def show(self):
         self.axes.figure.show()
+
+    def auto_set_axes_labels(self):
+        """ set the axes labels based on the Frame attribute"""
+        axes_labels = ("X", "Y")
+        if self.geom.frame is not None:
+            axes_labels = list(
+                self.geom.frame.get_representation_component_names().keys()
+            )
+        else:
+            print(f"FRAME: {self.geom.frame}")
+
+        self.axes.set_xlabel(f"{axes_labels[0]}  ({self.geom.pix_x.unit})")
+        self.axes.set_ylabel(f"{axes_labels[1]}  ({self.geom.pix_y.unit})")

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -495,8 +495,6 @@ class CameraDisplay:
             axes_labels = list(
                 self.geom.frame.get_representation_component_names().keys()
             )
-        else:
-            print(f"FRAME: {self.geom.frame}")
 
         self.axes.set_xlabel(f"{axes_labels[0]}  ({self.geom.pix_x.unit})")
         self.axes.set_ylabel(f"{axes_labels[1]}  ({self.geom.pix_y.unit})")


### PR DESCRIPTION
Just a small visual update:

- put Frame name in small text in lower-righthand corner
- use correct axes labels from frame

![image](https://user-images.githubusercontent.com/11677812/91317277-2346d780-e7ba-11ea-98fe-120751b4c746.png)
