### PR TITLE
Fix reading of optics table, write version number, fixes #1416, fixes #1359

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -223,6 +223,7 @@ class SubarrayDescription:
                     tel_description=descs,
                 )
             )
+            tab.meta["TAB_VER"] = "1.0"
 
         elif kind == "optics":
             unique_types = set(self.tels.values())
@@ -245,6 +246,7 @@ class SubarrayDescription:
                 "equivalent_focal_length": focal_length,
             }
             tab = Table(cols)
+            tab.meta["TAB_VER"] = "2.0"
 
         else:
             raise ValueError(f"Table type '{kind}' not known")

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -262,10 +262,17 @@ def test_dump_instrument(tmpdir):
     sys.argv = ["dump_instrument"]
     tmpdir.chdir()
 
-    tool = DumpInstrumentTool(infile=GAMMA_TEST_LARGE)
+    tool = DumpInstrumentTool()
 
-    assert run_tool(tool) == 0
+    assert run_tool(tool, [f"--infile={GAMMA_TEST_LARGE}"]) == 0
     assert tmpdir.join("FlashCam.camgeom.fits.gz").exists()
+
+    assert run_tool(tool, [f"--infile={GAMMA_TEST_LARGE}", "--format=ecsv"]) == 0
+    assert tmpdir.join("MonteCarloArray.optics.ecsv.txt").exists()
+
+    assert run_tool(tool, [f"--infile={GAMMA_TEST_LARGE}", "--format=hdf5"]) == 0
+    assert tmpdir.join("subarray.h5").exists()
+
     assert run_tool(tool, ["--help-all"]) == 0
 
 


### PR DESCRIPTION
* Add TAB_VER to layout table and optics table
* Support reading both version 1 and 2 of optics table
* Test with file from ctapipe-extra (version 1) and what dump instrument currently writes (version 2)