### PR TITLE
add function to get astropy table from ctapipe hdf5 file

### DIFF
--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+"""
+Functions to help adapt internal ctapipe data to astropy formats and conventions
+"""
 
 from pathlib import Path
 
@@ -44,7 +47,7 @@ def h5_table_to_astropy(h5file, path) -> QTable:
 
     other_attrs = {}
     column_units = {}  # mapping of colname to unit
-    for attr in table.attrs._f_list():
+    for attr in table.attrs._f_list():  # pylint: disable=W0212
         if attr.endswith("_UNIT"):
             colname = attr[:-5]
             column_units[colname] = table.attrs[attr]

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -1,37 +1,47 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
+
 import tables
-from astropy.table import Table
+from astropy.table import QTable
 from astropy.units import Unit
+
 
 __all__ = ["h5_table_to_astropy"]
 
 
-def h5_table_to_astropy(h5file, path) -> Table:
-    """Get a table from a ctapipe-format HDF5 table as an `astropy.table.Table`
+def h5_table_to_astropy(h5file, path) -> QTable:
+    """Get a table from a ctapipe-format HDF5 table as an `astropy.table.QTable`
     object, retaining units. This uses the same unit storage convention as
     defined by the `HDF5TableWriter`, namely that the units are in attributes
-    named by `<column name>_UNIT` that are parsible by `astropy.units`.
+    named by `<column name>_UNIT` that are parsible by `astropy.units`. Columns
+    that were Enums will remain as integers.
 
     Parameters
     ----------
-    h5file: Union[str, tables.file.File]
-       input filename or PyTables file handle
+    h5file: Union[str, Path, tables.file.File]
+        input filename or PyTables file handle
     path: str
-       path to table in the file
+        path to table in the file
+
+    Returns
+    -------
+    astropy.table.QTable:
+        table in Astropy Format
 
     """
 
     should_close_file = False
-    if not isinstance(h5file, tables.file.File) and isinstance(h5file, str):
+    if not isinstance(h5file, tables.file.File) and isinstance(h5file, (str, Path)):
         h5file = tables.open_file(h5file)
         should_close_file = True
     else:
         raise ValueError(
-            f"expected a string or PyTables filehandle for argument 'h5file', got {h5file}"
+            f"expected a string, Path, or PyTables "
+            f"filehandle for argument 'h5file', got {h5file}"
         )
 
-    table: tables.table.Table = h5file.get_node(path)
+    table = h5file.get_node(path)
 
     column_units = {}  # mapping of colname to unit
     for attr in table.attrs._f_list():
@@ -39,7 +49,7 @@ def h5_table_to_astropy(h5file, path) -> Table:
             colname = attr[:-5]
             column_units[colname] = table.attrs[attr]
 
-    astropy_table = Table(table[:])
+    astropy_table = QTable(table[:])
 
     for column, unit in column_units.items():
         astropy_table[column].unit = Unit(unit)

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -6,7 +6,6 @@ import tables
 from astropy.table import QTable
 from astropy.units import Unit
 
-
 __all__ = ["h5_table_to_astropy"]
 
 
@@ -43,13 +42,16 @@ def h5_table_to_astropy(h5file, path) -> QTable:
 
     table = h5file.get_node(path)
 
+    other_attrs = {}
     column_units = {}  # mapping of colname to unit
     for attr in table.attrs._f_list():
         if attr.endswith("_UNIT"):
             colname = attr[:-5]
             column_units[colname] = table.attrs[attr]
+        else:
+            other_attrs[attr] = table.attrs[attr]
 
-    astropy_table = QTable(table[:])
+    astropy_table = QTable(table[:], meta=other_attrs)
 
     for column, unit in column_units.items():
         astropy_table[column].unit = Unit(unit)

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -34,9 +34,11 @@ def h5_table_to_astropy(h5file, path) -> QTable:
     """
 
     should_close_file = False
-    if not isinstance(h5file, tables.file.File) and isinstance(h5file, (str, Path)):
+    if isinstance(h5file, (str, Path)):
         h5file = tables.open_file(h5file)
         should_close_file = True
+    elif isinstance(h5file, tables.file.File):
+        pass
     else:
         raise ValueError(
             f"expected a string, Path, or PyTables "

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import tables
+from astropy.table import Table
+from astropy.units import Unit
+
+__all__ = ["h5_table_to_astropy"]
+
+
+def h5_table_to_astropy(h5file, path) -> Table:
+    """Get a table from a ctapipe-format HDF5 table as an `astropy.table.Table`
+    object, retaining units. This uses the same unit storage convention as
+    defined by the `HDF5TableWriter`, namely that the units are in attributes
+    named by `<column name>_UNIT` that are parsible by `astropy.units`.
+
+    Parameters
+    ----------
+    h5file: Union[str, tables.file.File]
+       input filename or PyTables file handle
+    path: str
+       path to table in the file
+
+    """
+
+    should_close_file = False
+    if not isinstance(h5file, tables.file.File) and isinstance(h5file, str):
+        h5file = tables.open_file(h5file)
+        should_close_file = True
+    else:
+        raise ValueError(
+            f"expected a string or PyTables filehandle for argument 'h5file', got {h5file}"
+        )
+
+    table: tables.table.Table = h5file.get_node(path)
+
+    column_units = {}  # mapping of colname to unit
+    for attr in table.attrs._f_list():
+        if attr.endswith("_UNIT"):
+            colname = attr[:-5]
+            column_units[colname] = table.attrs[attr]
+
+    astropy_table = Table(table[:])
+
+    for column, unit in column_units.items():
+        astropy_table[column].unit = Unit(unit)
+
+    if should_close_file:
+        h5file.close()
+
+    return astropy_table

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import numpy as np
+from astropy import units as u
+from ctapipe.io import HDF5TableWriter
+from ctapipe.io.astropy_helpers import h5_table_to_astropy
+from ctapipe.containers import ReconstructedEnergyContainer
+
+
+def test_h5_table_to_astropy(tmp_path):
+
+    # write a simple hdf5 file using
+
+    container = ReconstructedEnergyContainer()
+    filename = tmp_path / "test_astropy_table.h5"
+
+    with HDF5TableWriter(filename) as writer:
+        for energy in np.logspace(1, 2, 10) * u.TeV:
+            container.energy = energy
+            writer.write("events", container)
+
+    # try opening the result
+    table = h5_table_to_astropy(filename, "/events")
+
+    assert "energy" in table.columns
+    assert table["energy"].unit == u.TeV

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import numpy as np
 from astropy import units as u
+import tables
 
 from ctapipe.containers import ReconstructedEnergyContainer
 from ctapipe.io import HDF5TableWriter
@@ -25,3 +26,11 @@ def test_h5_table_to_astropy(tmp_path):
     assert "energy" in table.columns
     assert table["energy"].unit == u.TeV
     assert "CTAPIPE_VERSION" in table.meta
+
+    # test using a string
+    table = h5_table_to_astropy(str(filename), "/events")
+
+    # test using a file handle
+    handle = tables.open_file(filename)
+    table = h5_table_to_astropy(handle, "/events")
+    handle.close()

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import numpy as np
 from astropy import units as u
+
+from ctapipe.containers import ReconstructedEnergyContainer
 from ctapipe.io import HDF5TableWriter
 from ctapipe.io.astropy_helpers import h5_table_to_astropy
-from ctapipe.containers import ReconstructedEnergyContainer
 
 
 def test_h5_table_to_astropy(tmp_path):
@@ -23,3 +24,4 @@ def test_h5_table_to_astropy(tmp_path):
 
     assert "energy" in table.columns
     assert table["energy"].unit == u.TeV
+    assert "CTAPIPE_VERSION" in table.meta

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -2,6 +2,7 @@
 import numpy as np
 from astropy import units as u
 import tables
+import pytest
 
 from ctapipe.containers import ReconstructedEnergyContainer
 from ctapipe.io import HDF5TableWriter
@@ -34,3 +35,7 @@ def test_h5_table_to_astropy(tmp_path):
     handle = tables.open_file(filename)
     table = h5_table_to_astropy(handle, "/events")
     handle.close()
+
+    # test a bad input
+    with pytest.raises(ValueError):
+        table = h5_table_to_astropy(12345, "/events")

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -32,9 +32,8 @@ def test_h5_table_to_astropy(tmp_path):
     table = h5_table_to_astropy(str(filename), "/events")
 
     # test using a file handle
-    handle = tables.open_file(filename)
-    table = h5_table_to_astropy(handle, "/events")
-    handle.close()
+    with tables.open_file(filename) as handle:
+        table = h5_table_to_astropy(handle, "/events")
 
     # test a bad input
     with pytest.raises(ValueError):


### PR DESCRIPTION
this just provides: 

```py
from ctapipe.io.astropy_helpers import h5_table_to_astropy
t = h5_table_to_astropy("gammas2.dl1.h5", "/dl1/event/telescope/parameters/tel_001")
t
```

```
<QTable length=50>
obs_id event_id tel_id  hillas_intensity        hillas_x             hillas_y       ... peak_time_min peak_time_mean peak_time_std   peak_time_skewness    peak_time_kurtosis
                                                   m                    m           ...
int32   int64   int16       float64             float64              float64        ...    float32       float32        float32           float64               float64
------ -------- ------ ------------------ -------------------- -------------------- ... ------------- -------------- ------------- --------------------- ---------------------
   101     1503      1  151.8677215576172  0.18290526905116353   0.3103048900205065 ...      8.831734      10.528524      1.492059    0.7524924874305725   -0.8947949409484863
   101     1506      1  195.8453986644745   0.1657280817609988 -0.15308384378334355 ...      9.131325       9.969362     0.4076317   -0.9799400568008423 -0.015481710433959961
   101     2900      1  984.3376245498657   0.6704040242695486  0.47259416766985674 ...      8.647298      11.999297     1.7776399 -0.010056410916149616   -0.8698732852935791
```

With correct units re-attached, and any other user metadata still recorded:

```py3
t.meta
```
```
{'CTAPIPE_VERSION': '0.8.0.post22+gitea2cf40'}
```

It also works correctly for tables with vector columns, like images:
```python
In [5]: t = h5_table_to_astropy("gammas2.dl1.h5", "/dl1/event/telescope/images/tel_001")

In [6]: t
Out[6]:
<QTable length=50>
obs_id event_id tel_id        image [1855]           peak_time [1855]    image_mask [1855]
int32   int64   int16           float32                  float32                bool
------ -------- ------ -------------------------- ---------------------- -----------------
   101     1503      1   1.1831577 .. -0.47390354      26.475227 .. 29.0    False .. False
   101     1506      1  -0.14622755 .. 0.47994235  27.13752 .. 17.578224    False .. False
   101     2900      1   1.8219908 .. -0.11884633        3.840397 .. 1.0    False .. False
   101     4007      1   -0.53255767 .. 1.7376837      25.0 .. 2.1106777    False .. False
   101     7007      1   -0.9513076 .. -2.6859846       22.21572 .. 19.0    False .. False
   101    10002      1    -0.56497747 .. 0.975543 11.490385 .. 17.094572    False .. False
   101    13306      1    -1.2410553 .. 2.0778234        6.0 .. 2.206301    False .. False
```