### PR TITLE
Make output path of provenance.log configurable 

### DIFF
--- a/ctapipe/core/tests/test_tool.py
+++ b/ctapipe/core/tests/test_tool.py
@@ -47,7 +47,7 @@ def test_provenance_dir():
         userparam = Float(5.0, help="parameter").tag(config=True)
 
     tool = MyTool()
-    assert str(tool.provenance_dir) == os.getcwd()
+    assert str(tool.provenance_log) == os.path.join(os.getcwd(), "application.provenance.log")
 
 
 def test_export_config_to_yaml():

--- a/ctapipe/core/tests/test_tool.py
+++ b/ctapipe/core/tests/test_tool.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from traitlets import Float, TraitError, List, Dict
 from traitlets.config import Config
@@ -36,6 +37,17 @@ def test_tool_version():
 
     tool = MyTool()
     assert tool.version_string != ""
+
+
+def test_provenance_dir():
+    """ check that the tool gets the provenance dir"""
+
+    class MyTool(Tool):
+        description = "test"
+        userparam = Float(5.0, help="parameter").tag(config=True)
+
+    tool = MyTool()
+    assert str(tool.provenance_dir) == os.getcwd()
 
 
 def test_export_config_to_yaml():

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -113,7 +113,7 @@ class Tool(Application):
         "%(levelname)s [%(name)s] (%(module)s/%(funcName)s): %(message)s",
         help="The Logging format template",
     ).tag(config=True)
-    provenance_dir = Path(
+    prov_dir = Path(
         default_value=".",
         exists=True,
         file_ok=False,
@@ -132,6 +132,7 @@ class Tool(Application):
         self.log_level = logging.INFO
         self.is_setup = False
         self._registered_components = []
+        self.prov_filename = f"{self.name}.prov.log"
         self.version = version
         self.raise_config_file_errors = True  # override traitlets.Application default
 
@@ -243,7 +244,7 @@ class Tool(Application):
                 self.log.info("Output: %s", output_str)
 
             self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
-            with open(self.provenance_dir / "provenance.log", mode="a+") as provlog:
+            with open(self.prov_dir / self.prov_filename, mode="a+") as provlog:
                 provlog.write(Provenance().as_json(indent=3))
 
         self.exit(exit_status)

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -253,7 +253,6 @@ class Tool(Application):
         """ a formatted version string with version, release, and git hash"""
         return f"{version}"
 
-
     def get_current_config(self):
         """ return the current configuration as a dict (e.g. the values
         of all traits, even if they were not set during configuration)

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -237,7 +237,7 @@ class Tool(Application):
                 self.log.info("Output: %s", output_str)
 
             self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
-            with open("provenance.log", mode="w+") as provlog:
+            with open("provenance.log", mode="a+") as provlog:
                 provlog.write(Provenance().as_json(indent=3))
 
         self.exit(exit_status)

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -243,6 +243,7 @@ class Tool(Application):
                 self.log.info("Output: %s", output_str)
 
             self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
+            self.provenance_log.parent.mkdir(parents=True, exist_ok=True)
             with open(self.provenance_log, mode="a+") as provlog:
                 provlog.write(Provenance().as_json(indent=3))
 

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -113,6 +113,12 @@ class Tool(Application):
         "%(levelname)s [%(name)s] (%(module)s/%(funcName)s): %(message)s",
         help="The Logging format template",
     ).tag(config=True)
+    provenance_dir = Path(
+        default_value=".",
+        exists=True,
+        file_ok=False,
+        help="name of the existing folder where the provenance.log will be created",
+    ).tag(config=True)
 
     _log_formatter_cls = ColoredFormatter
 
@@ -237,7 +243,7 @@ class Tool(Application):
                 self.log.info("Output: %s", output_str)
 
             self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
-            with open("provenance.log", mode="a+") as provlog:
+            with open(self.provenance_dir / "provenance.log", mode="a+") as provlog:
                 provlog.write(Provenance().as_json(indent=3))
 
         self.exit(exit_status)
@@ -246,6 +252,7 @@ class Tool(Application):
     def version_string(self):
         """ a formatted version string with version, release, and git hash"""
         return f"{version}"
+
 
     def get_current_config(self):
         """ return the current configuration as a dict (e.g. the values


### PR DESCRIPTION
This PR intends to solve issue #1421 
It adds `provenance_dir` as a configurable trait of a Tool.

