### PR TITLE
Add fits option to meta.to_dict, silences warnings

### DIFF
--- a/ctapipe/io/metadata.py
+++ b/ctapipe/io/metadata.py
@@ -26,14 +26,7 @@ import uuid
 import warnings
 from collections import OrderedDict
 
-from traitlets import (
-    Enum,
-    Unicode,
-    Int,
-    HasTraits,
-    default,
-    Instance,
-)
+from traitlets import Enum, Unicode, Int, HasTraits, default, Instance
 
 from ctapipe.core.provenance import _ActivityProvenance
 from ctapipe.core.traits import AstroTime
@@ -187,14 +180,20 @@ class Reference(HasTraits):
     activity = Instance(Activity)
     instrument = Instance(Instrument)
 
-    def to_dict(self):
-        """ convert Reference metadata to a flat dict"""
-        meta = OrderedDict({"CTA REFERENCE VERSION": "1"})
-        meta.update(_to_dict(self.contact, prefix="CTA CONTACT "))
-        meta.update(_to_dict(self.product, prefix="CTA PRODUCT "))
-        meta.update(_to_dict(self.process, prefix="CTA PROCESS "))
-        meta.update(_to_dict(self.activity, prefix="CTA ACTIVITY "))
-        meta.update(_to_dict(self.instrument, prefix="CTA INSTRUMENT "))
+    def to_dict(self, fits=False):
+        """
+        convert Reference metadata to a flat dict.
+
+        If `fits=True`, this will include the `HIERARCH` keyword in front.
+        """
+        prefix = "CTA " if fits is False else "HIERARCH CTA "
+
+        meta = OrderedDict({prefix + "REFERENCE VERSION": "1"})
+        meta.update(_to_dict(self.contact, prefix=prefix + "CONTACT "))
+        meta.update(_to_dict(self.product, prefix=prefix + "PRODUCT "))
+        meta.update(_to_dict(self.process, prefix=prefix + "PROCESS "))
+        meta.update(_to_dict(self.activity, prefix=prefix + "ACTIVITY "))
+        meta.update(_to_dict(self.instrument, prefix=prefix + "INSTRUMENT "))
         return meta
 
 

--- a/ctapipe/io/metadata.py
+++ b/ctapipe/io/metadata.py
@@ -44,6 +44,9 @@ __all__ = [
 from astropy.time import Time
 
 
+CONVERSIONS = {Time: lambda t: t.utc.iso}
+
+
 class Contact(HasTraits):
     """ Contact information """
 
@@ -162,12 +165,17 @@ def _to_dict(hastraits_instance, prefix=""):
     """ helper to convert a HasTraits to a dict with keys
     in the required CTA format (upper-case, space separated)
     """
-    return {
-        (prefix + k.upper().replace("_", " "))
-        .replace("  ", " ")
-        .strip(): tr.get(hastraits_instance)
-        for k, tr in hastraits_instance.traits().items()
-    }
+    res = {}
+
+    for k, tr in hastraits_instance.traits().items():
+        key = (prefix + k.upper().replace("_", " ")).replace("  ", " ").strip()
+        val = tr.get(hastraits_instance)
+
+        # apply type conversions
+        val = CONVERSIONS.get(type(val), lambda v: v)(val)
+        res[key] = val
+
+    return res
 
 
 class Reference(HasTraits):

--- a/ctapipe/io/tests/test_metadata.py
+++ b/ctapipe/io/tests/test_metadata.py
@@ -29,7 +29,7 @@ def test_construct_and_write_metadata(tmp_path):
             data_model_url="http://google.com",
             format="hdf5",
         ),
-        process=meta.Process(_type="Simulation", subtype="Prod3b", _id=423442),
+        process=meta.Process(type_="Simulation", subtype="Prod3b", id_=423442),
         activity=meta.Activity.from_provenance(prov_activity.provenance),
         instrument=meta.Instrument(
             site="CTA-North",

--- a/ctapipe/io/tests/test_metadata.py
+++ b/ctapipe/io/tests/test_metadata.py
@@ -29,7 +29,7 @@ def test_construct_and_write_metadata(tmp_path):
             data_model_url="http://google.com",
             format="hdf5",
         ),
-        process=meta.Process(_type="Simulation", subtype="Prod3b", _id=423442,),
+        process=meta.Process(_type="Simulation", subtype="Prod3b", _id=423442),
         activity=meta.Activity.from_provenance(prov_activity.provenance),
         instrument=meta.Instrument(
             site="CTA-North",
@@ -52,9 +52,16 @@ def test_construct_and_write_metadata(tmp_path):
     from astropy.table import Table  # pylint: disable=import-outside-toplevel
 
     table = Table(dict(x=[1, 2, 3], y=[15.2, 15.2, 14.5]))
-    table.meta = ref_dict
-    for file_name in [tmp_path / "test.fits", tmp_path / "test.ecsv"]:
-        table.write(file_name)
+    for path in [tmp_path / "test.fits", tmp_path / "test.ecsv"]:
+        if ".fits" in path.suffixes:
+            reference.format = "fits"
+            ref_dict = reference.to_dict(fits=True)
+        else:
+            reference.format = "ecsv"
+            ref_dict = reference.to_dict()
+
+        table.meta = ref_dict
+        table.write(path)
 
     # write to pytables file
 

--- a/ctapipe/tools/display_events_single_tel.py
+++ b/ctapipe/tools/display_events_single_tel.py
@@ -30,13 +30,15 @@ class SingleTelEventDisplay(Tool):
     infile = Path(help="input file to read", exists=True, directory_ok=False).tag(
         config=True
     )
-    tel = Int(help="Telescope ID to display", default=0).tag(config=True)
-    write = Bool(help="Write out images to PNG files", default=False).tag(config=True)
-    clean = Bool(help="Apply image cleaning", default=False).tag(config=True)
-    hillas = Bool(help="Apply and display Hillas parametrization", default=False).tag(
+    tel = Int(help="Telescope ID to display", default_value=0).tag(config=True)
+    write = Bool(help="Write out images to PNG files", default_value=False).tag(
         config=True
     )
-    samples = Bool(help="Show each sample", default=False).tag(config=True)
+    clean = Bool(help="Apply image cleaning", default_value=False).tag(config=True)
+    hillas = Bool(
+        help="Apply and display Hillas parametrization", default_value=False
+    ).tag(config=True)
+    samples = Bool(help="Show each sample", default_value=False).tag(config=True)
     display = Bool(
         help="Display results in interactive window", default_value=True
     ).tag(config=True)
@@ -70,9 +72,7 @@ class SingleTelEventDisplay(Tool):
         self.event_source = self.add_component(
             EventSource.from_url(self.infile, parent=self)
         )
-        self.event_source.allowed_tels = {
-            self.tel,
-        }
+        self.event_source.allowed_tels = {self.tel}
 
         self.calibrator = self.add_component(
             CameraCalibrator(parent=self, subarray=self.event_source.subarray)
@@ -163,7 +163,7 @@ class SingleTelEventDisplay(Tool):
                 "No events for tel {} were found in {}. Try a "
                 "different EventIO file or another telescope".format(
                     self.tel, self.infile
-                ),
+                )
             )
 
 

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -99,9 +99,8 @@ def write_reference_metadata_headers(obs_id, subarray, writer):
         ),
     )
 
-    # convert all values to strings, since hdf5 can't handle Times, etc.:
     # TODO: add activity_stop_time?
-    headers = {k: str(v) for k, v in reference.to_dict().items()}
+    headers = reference.to_dict()
     meta.write_to_hdf5(headers, writer._h5file)
 
 


### PR DESCRIPTION
Before the log was full of warnings related to **implicitly** relying on conversion of too long header keywords using `HIERARCH`. This adds an `fits` option to the `to_dict` method to **explicitly** add `HIERARCH` to silence these warnings.

This did not remove all warnings however, since:

```
  /home/maxnoe/Uni/CTA/ctapipe/ctapipe/io/tests/test_metadata.py:32: DeprecationWarning: Passing unrecoginized arguments to super(Process).__init__(_type='Simulation', _id=423442).
  object.__init__() takes exactly one argument (the instance to initialize)
  This is deprecated in traitlets 4.2.This error will be raised in a future release of traitlets.
    process=meta.Process(_type="Simulation", subtype="Prod3b", _id=423442,),

ctapipe/io/tests/test_metadata.py::test_construct_and_write_metadata
  /home/maxnoe/.local/anaconda/envs/cta-dev/lib/python3.7/site-packages/astropy/io/fits/convenience.py:589: AstropyUserWarning: Attribute `HIERARCH CTA PRODUCT CREATION TIME` of type <class 'astropy.time.core.Time'> cannot be added to FITS Header - skipping
    f"added to FITS Header - skipping", AstropyUserWarning)

ctapipe/io/tests/test_metadata.py::test_construct_and_write_metadata
  /home/maxnoe/.local/anaconda/envs/cta-dev/lib/python3.7/site-packages/astropy/io/fits/convenience.py:589: AstropyUserWarning: Attribute `HIERARCH CTA ACTIVITY START TIME` of type <class 'astropy.time.core.Time'> cannot be added to FITS Header - skipping
    f"added to FITS Header - skipping", AstropyUserWarning)
```

These warnings were probably lost in the large amounts of HIERARCH related warnings