### PR TITLE
Require python >= 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
           packages:
             - pandoc
             - graphviz
+            - libhdf5-dev # remove when pytables wheel is available for 3.9
 
 before_install:
   - git fetch --tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
     - os: linux
       dist: bionic
       language: python
-      python: 3.9
+      python: 3.9-dev
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,15 @@ matrix:
             - pandoc
             - graphviz
 
-    - os: linux
-      dist: bionic
-      language: python
-      python: 3.9-dev
-      addons:
-        apt:
-          packages:
-            - pandoc
-            - graphviz
-            - libhdf5-dev # remove when pytables wheel is available for 3.9
+#    - os: linux
+#      dist: bionic
+#      language: python
+#      python: 3.9
+#      addons:
+#        apt:
+#          packages:
+#            - pandoc
+#            - graphviz
 
 before_install:
   - git fetch --tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,6 @@ env:
 
 matrix:
   include:
-    - name: conda python 3.6
-      os: linux
-      dist: bionic
-      language: generic
-      env:
-        - PYTHON_VERSION=3.6
-        - CONDA=true
-
     - name: conda python 3.7
       os: linux
       dist: bionic
@@ -24,15 +16,13 @@ matrix:
         - PYTHON_VERSION=3.7
         - CONDA=true
 
-    - os: linux
+    - name: conda python 3.8
+      os: linux
       dist: bionic
-      language: python
-      python: 3.6
-      addons:
-        apt:
-          packages:
-            - pandoc
-            - graphviz
+      language: generic
+      env:
+        - PYTHON_VERSION=3.8
+        - CONDA=true
 
     - os: linux
       dist: bionic
@@ -48,6 +38,16 @@ matrix:
       dist: bionic
       language: python
       python: 3.8
+      addons:
+        apt:
+          packages:
+            - pandoc
+            - graphviz
+
+    - os: linux
+      dist: bionic
+      language: python
+      python: 3.9
       addons:
         apt:
           packages:
@@ -88,4 +88,4 @@ deploy:
   on:
     tags: true
     branch: master
-    condition: $TRAVIS_PYTHON_VERSION = "3.7"
+    condition: $TRAVIS_PYTHON_VERSION = "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,15 +44,6 @@ matrix:
             - pandoc
             - graphviz
 
-#    - os: linux
-#      dist: bionic
-#      language: python
-#      python: 3.9
-#      addons:
-#        apt:
-#          packages:
-#            - pandoc
-#            - graphviz
 
 before_install:
   - git fetch --tags

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,7 +24,7 @@ if [[ "$CONDA" == "true" ]]; then
     conda info -a
 
 	sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
-	travis_wait 20 conda env create -n travis cta-dev --file environment.yml
+	travis_wait 20 conda env create -n travis --file environment.yml
 	conda activate travis
 else
     pip install -U pip

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -23,7 +23,7 @@ if [[ "$CONDA" == "true" ]]; then
     # Useful for debugging any issues with conda
     conda info -a
 
-	sed -i -e "s/- python=.*/- python=$TRAVIS_PYTHON_VERSION/g" environment.yml
+	sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
 	travis_wait 20 conda env create -n cta-dev --file environment.yml
 	conda activate cta-dev
 else

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,8 +24,8 @@ if [[ "$CONDA" == "true" ]]; then
     conda info -a
 
 	sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
-	travis_wait 20 conda env create -n cta-dev --file environment.yml
-	conda activate cta-dev
+	travis_wait 20 conda env create -n travis cta-dev --file environment.yml
+	conda activate travis
 else
     pip install -U pip
 fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ What is ctapipe?
 * Code, feature requests, bug reports, pull requests: https://github.com/cta-observatory/ctapipe
 * Docs: https://cta-observatory.github.io/ctapipe/
 * License: BSD-3
-* Python 3.6 or later (Python 2 is not supported)
+* Python 3.7 or later
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ ctapipe.version.update_release_version()
 setup(
     packages=find_packages(),
     version=ctapipe.version.get_version(pep440=True),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "astropy>=3,<5",
         "bokeh~=1.0",
@@ -85,9 +85,9 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Astronomy",
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This adresses #1466 , so dropping 3.6 for the next release.

There was also a bug in `ci/install.sh` resulting in not installing the correct python version for conda builds (so we didn't even test on 3.6 since conda switched to 3.7 by default)