### PR TITLE
Use traits for TelescopeParameter

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -243,6 +243,9 @@ def test_telescope_parameter_patterns(mock_subarray):
 
     comp.tel_param = [("type", "*", 1.0), ("type", "*LSTCam", 16.0), ("id", 16, 10.0)]
 
+    # explicitly set the default for all
+    comp.tel_param = [("*", "*", 1.0), ("type", "*_LSTCam", 5.0)]
+
     with pytest.raises(TraitError):
         comp.tel_param = [("badcommand", "", 1.0)]
 

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -243,9 +243,6 @@ def test_telescope_parameter_patterns(mock_subarray):
 
     comp.tel_param = [("type", "*", 1.0), ("type", "*LSTCam", 16.0), ("id", 16, 10.0)]
 
-    # explicitly set the default for all
-    comp.tel_param = [("*", "*", 1.0), ("type", "*_LSTCam", 5.0)]
-
     with pytest.raises(TraitError):
         comp.tel_param = [("badcommand", "", 1.0)]
 

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -7,6 +7,7 @@ import pathlib
 
 from ctapipe.core import Component, TelescopeComponent
 from ctapipe.core.traits import (
+    Float,
     Path,
     TraitError,
     classes_with_traits,
@@ -221,17 +222,20 @@ def test_telescope_parameter_lookup(mock_subarray):
         telparam_list2[None]
 
 
-def test_telescope_parameter_patterns():
+def test_telescope_parameter_patterns(mock_subarray):
     """ Test validation of TelescopeParameters"""
 
-    with pytest.raises(ValueError):
-        TelescopeParameter(dtype="notatype")
+    with pytest.raises(TypeError):
+        TelescopeParameter(trait=int)
 
-    class SomeComponent(Component):
-        tel_param = TelescopeParameter()
+    with pytest.raises(TypeError):
+        TelescopeParameter(trait=Int)
+
+    class SomeComponent(TelescopeComponent):
+        tel_param = TelescopeParameter(Float(default_value=0.0, allow_none=True))
         tel_param_int = IntTelescopeParameter()
 
-    comp = SomeComponent()
+    comp = SomeComponent(mock_subarray)
 
     # single value allowed (converted to ("default","",val) )
     comp.tel_param = 4.5
@@ -255,6 +259,30 @@ def test_telescope_parameter_patterns():
 
     with pytest.raises(TraitError):
         comp.tel_param_int = [(12, "", 5)]  # command not string
+
+
+def test_telescope_parameter_path(mock_subarray):
+    class SomeComponent(TelescopeComponent):
+        path = TelescopeParameter(Path(exists=True, directory_ok=False))
+
+    c = SomeComponent(subarray=mock_subarray)
+
+    # non existing
+    with pytest.raises(TraitError):
+        c.path = "/does/not/exist"
+
+    with tempfile.NamedTemporaryFile() as f:
+        c.path = f.name
+
+        assert str(c.path.tel[1]) == f.name
+
+        with pytest.raises(TraitError):
+            # non existing somewhere in the config
+            c.path = [("*", "", f.name), ("type", "LST_LST_LSTCam", "/does/not/exist")]
+
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(TraitError):
+            c.path = d
 
 
 def test_telescope_parameter_scalar_default(mock_subarray):
@@ -378,7 +406,7 @@ def test_telescope_parameter_set_retain_subarray(mock_subarray):
 
 def test_telescope_parameter_to_config(mock_subarray):
     """
-    test that the config can be read back from a component with a TelescopeParameter 
+    test that the config can be read back from a component with a TelescopeParameter
     (see Issue #1216)
     """
 
@@ -388,9 +416,7 @@ def test_telescope_parameter_to_config(mock_subarray):
     component = SomeComponent(subarray=mock_subarray)
     component.tel_param1 = 6.0
     config = component.get_current_config()
-    assert config["SomeComponent"]["tel_param1"] == [
-        ("type", "*", 6.0),
-    ]
+    assert config["SomeComponent"]["tel_param1"] == [("type", "*", 6.0)]
 
 
 def test_datetimes():

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -23,6 +23,7 @@ from traitlets import (
     observe,
     Set,
     CRegExp,
+    Undefined,
 )
 from traitlets.config import boolean_flag as flag
 
@@ -93,9 +94,15 @@ class Path(TraitType):
         If False, path must not be a file
     """
 
-    def __init__(self, *args, exists=None, directory_ok=True, file_ok=True, **kwargs):
-        default_value = kwargs.pop("default_value", None)
-
+    def __init__(
+        self,
+        *args,
+        default_value=None,
+        exists=None,
+        directory_ok=True,
+        file_ok=True,
+        **kwargs,
+    ):
         super().__init__(*args, default_value=default_value, allow_none=True, **kwargs)
         self.exists = exists
         self.directory_ok = directory_ok
@@ -179,7 +186,7 @@ def create_class_enum_trait(base_class, default_value, help=None):
         raise ValueError(f"{default_value} is not in choices: {choices}")
 
     return CaselessStrEnum(
-        choices, default_value=default_value, allow_none=False, help=help,
+        choices, default_value=default_value, allow_none=False, help=help
     ).tag(config=True)
 
 
@@ -222,7 +229,7 @@ class TelescopePatternList(UserList):
                 "call attach_subarray() first"
             )
 
-    def attach_subarray(self, subarray: "ctapipe.instrument.SubarrayDescription"):
+    def attach_subarray(self, subarray):
         """
         Register a SubarrayDescription so that the user-specified values can be
         looked up by tel_id. This must be done before using the `.tel[x]` property
@@ -345,60 +352,61 @@ class TelescopeParameter(List):
 
     klass = TelescopePatternList
 
-    def __init__(self, dtype=float, default_value=None, **kwargs):
-        if not isinstance(dtype, type):
-            raise ValueError("dtype should be a type")
-        if isinstance(default_value, dtype):
+    def __init__(self, trait, default_value=Undefined, **kwargs):
+        if not isinstance(trait, TraitType):
+            raise TypeError("trait must be a TraitType instance")
+
+        if (
+            not isinstance(default_value, (UserList, list, List))
+            and default_value is not Undefined
+        ):
+            default_value = trait.validate(self, default_value)
             default_value = [("type", "*", default_value)]
+
         super().__init__(default_value=default_value, **kwargs)
-        self._dtype = dtype
+        self._trait = trait
 
     def validate(self, obj, value):
-        # Support a single value for all (convert into a default value)
-        if isinstance(value, self._dtype):
-            value = [("type", "*", value)]
+        # Support a single value for all (check and convert into a default value)
+        if not isinstance(value, (list, List, UserList)):
+            value = [("type", "*", self._trait.validate(obj, value))]
 
         # Check each value of list
-        normalized_value = TelescopePatternList(None)
-        if isinstance(value, self._dtype):
-            value = [("type", "*", value)]
-        if isinstance(value, (UserList, list)):
-            for pattern in value:
-                # now check for the standard 3-tuple of (command, argument, value)
-                if len(pattern) != 3:
-                    raise TraitError(
-                        "pattern should be a tuple of (command, argument, value)"
-                    )
-                command, arg, val = pattern
-                if not isinstance(val, self._dtype):
-                    raise TraitError(f"Value should be a {self._dtype}")
-                if not isinstance(command, str):
-                    raise TraitError("command must be a string")
-                if command not in ["type", "id"]:
-                    raise TraitError("command must be one of: '*', 'type', 'id'")
-                if command == "type":
-                    if not isinstance(arg, str):
-                        raise TraitError("'type' argument should be a string")
-                if command == "id":
-                    try:
-                        arg = int(arg)
-                    except ValueError:
-                        raise TraitError(
-                            f"Argument of 'id' should be an int (got '{arg}')"
-                        )
+        normalized_value = TelescopePatternList()
 
-                val = self._dtype(val)
-                normalized_value.append((command, arg, val))
-                normalized_value._lookup = TelescopeParameterLookup(normalized_value)
+        for pattern in value:
 
-                if (
-                    isinstance(value, TelescopePatternList)
-                    and value._subarray is not None
-                ):
-                    normalized_value.attach_subarray(value._subarray)
+            # now check for the standard 3-tuple of (command, argument, value)
+            if len(pattern) != 3:
+                raise TraitError(
+                    "pattern should be a tuple of (command, argument, value)"
+                )
 
-        else:
-            raise TraitError(f"Value should be a {self._dtype}")
+            command, arg, val = pattern
+            val = self._trait.validate(obj, val)
+
+            if not isinstance(command, str):
+                raise TraitError("command must be a string")
+
+            if command not in ["*", "type", "id"]:
+                raise TraitError("command must be one of: '*', 'type', 'id'")
+
+            if command == "type":
+                if not isinstance(arg, str):
+                    raise TraitError("'type' argument should be a string")
+
+            if command == "id":
+                try:
+                    arg = int(arg)
+                except ValueError:
+                    raise TraitError(f"Argument of 'id' should be an int (got '{arg}')")
+
+            val = self._trait.validate(obj, val)
+            normalized_value.append((command, arg, val))
+            normalized_value._lookup = TelescopeParameterLookup(normalized_value)
+
+            if isinstance(value, TelescopePatternList) and value._subarray is not None:
+                normalized_value.attach_subarray(value._subarray)
 
         return normalized_value
 
@@ -418,18 +426,18 @@ class FloatTelescopeParameter(TelescopeParameter):
     """ a `TelescopeParameter` with float type (see docs for `TelescopeParameter`)"""
 
     def __init__(self, **kwargs):
-        super().__init__(dtype=float, **kwargs)
+        super().__init__(trait=Float(), **kwargs)
 
 
 class IntTelescopeParameter(TelescopeParameter):
     """ a `TelescopeParameter` with int type (see docs for `TelescopeParameter`)"""
 
     def __init__(self, **kwargs):
-        super().__init__(dtype=int, **kwargs)
+        super().__init__(trait=Int(), **kwargs)
 
 
 class BoolTelescopeParameter(TelescopeParameter):
     """ a `TelescopeParameter` with int type (see docs for `TelescopeParameter`)"""
 
     def __init__(self, **kwargs):
-        super().__init__(dtype=bool, **kwargs)
+        super().__init__(trait=Bool(), **kwargs)

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -388,8 +388,8 @@ class TelescopeParameter(List):
             if not isinstance(command, str):
                 raise TraitError("command must be a string")
 
-            if command not in ["*", "type", "id"]:
-                raise TraitError("command must be one of: '*', 'type', 'id'")
+            if command not in ["type", "id"]:
+                raise TraitError("command must be one of: 'type', 'id'")
 
             if command == "type":
                 if not isinstance(arg, str):


### PR DESCRIPTION
Fixes #1470 

This enables things like `TelescopeParameter(Path(exists=True))`


This needs #1472  for some reason I don't want to investigate, so let's just go ahead with #1472 before merging this here.