### PR TITLE
Fix Path.validate for None

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -278,11 +278,25 @@ def test_telescope_parameter_path(mock_subarray):
 
         with pytest.raises(TraitError):
             # non existing somewhere in the config
-            c.path = [("*", "", f.name), ("type", "LST_LST_LSTCam", "/does/not/exist")]
+            c.path = [
+                ("type", "*", f.name),
+                ("type", "LST_LST_LSTCam", "/does/not/exist"),
+            ]
 
     with tempfile.TemporaryDirectory() as d:
         with pytest.raises(TraitError):
             c.path = d
+
+    # test with none default:
+    class SomeComponent(TelescopeComponent):
+        path = TelescopeParameter(
+            Path(exists=True, directory_ok=False), default_value=None, allow_none=True
+        )
+
+    s = SomeComponent(subarray=mock_subarray)
+    assert s.path.tel[1] is None
+    s.path = [("type", "*", "setup.py")]
+    assert s.path.tel[1] == pathlib.Path("setup.py").absolute()
 
 
 def test_telescope_parameter_scalar_default(mock_subarray):

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -133,6 +133,12 @@ class Path(TraitType):
         if isinstance(value, bytes):
             value = os.fsdecode(value)
 
+        if value is None:
+            if self.allow_none:
+                return None
+            else:
+                self.error(obj, value)
+
         if not isinstance(value, (str, pathlib.Path)):
             return self.error(obj, value)
 


### PR DESCRIPTION
Path did not work with a default_value=None, allow_none=True with TelescopeParameter due to the missing check in validate