### PR TITLE
Do not calculate errors on time fit parameters, fixes #1420

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -171,9 +171,7 @@ class TimingParametersContainer(Container):
     slope = Field(
         nan / u.m, "Slope of arrival times along main shower axis", unit=1 / u.m
     )
-    slope_err = Field(nan / u.m, "Uncertainty `slope`", unit=1 / u.m)
     intercept = Field(nan, "intercept of arrival times along main shower axis")
-    intercept_err = Field(nan, "Uncertainty `intercept`")
     deviation = Field(
         nan,
         "Root-mean-square deviation of the pulse times "

--- a/ctapipe/image/timing.py
+++ b/ctapipe/image/timing.py
@@ -66,10 +66,6 @@ def timing_parameters(geom, image, peak_time, hillas_parameters, cleaning_mask=N
         pix_x, pix_y, x, y, hillas_parameters.psi.to_value(u.rad)
     )
 
-    # use polyfit just to get the covariance matrix and errors
-    (_s, _i), cov = np.polyfit(longi, peak_time, deg=1, w=np.sqrt(image), cov=True)
-    slope_err, intercept_err = np.sqrt(np.diag(cov))
-
     # re-fit using a robust-to-outlier algorithm
     beta, error = lts_linear_regression(x=longi, y=peak_time, samples=5)
 
@@ -78,9 +74,5 @@ def timing_parameters(geom, image, peak_time, hillas_parameters, cleaning_mask=N
     deviation = rmse(longi * beta[0] + beta[1], peak_time)
 
     return TimingParametersContainer(
-        slope=beta[0] / unit,
-        intercept=beta[1],
-        deviation=deviation,
-        slope_err=slope_err / unit,
-        intercept_err=intercept_err,
+        slope=beta[0] / unit, intercept=beta[1], deviation=deviation
     )


### PR DESCRIPTION
The errors were calculated using a different fit method, which makes them invalid for the actual results.

Since they don't seem to be used anywhere, just removing them is the best option I think.