### PR TITLE
Use enum for pixel shapes

### DIFF
--- a/ctapipe/instrument/__init__.py
+++ b/ctapipe/instrument/__init__.py
@@ -1,4 +1,4 @@
-from .camera import CameraDescription, CameraGeometry, CameraReadout
+from .camera import CameraDescription, CameraGeometry, CameraReadout, PixelShape
 from .atmosphere import get_atmosphere_profile_functions
 from .telescope import TelescopeDescription
 from .optics import OpticsDescription
@@ -15,4 +15,5 @@ __all__ = [
     "OpticsDescription",
     "SubarrayDescription",
     "guess_telescope",
+    "PixelShape",
 ]

--- a/ctapipe/instrument/camera/__init__.py
+++ b/ctapipe/instrument/camera/__init__.py
@@ -1,10 +1,11 @@
 from .description import CameraDescription
-from .geometry import CameraGeometry, UnknownPixelShapeWarning
+from .geometry import CameraGeometry, UnknownPixelShapeWarning, PixelShape
 from .readout import CameraReadout
 
 __all__ = [
     "CameraDescription",
     "CameraGeometry",
+    "PixelShape",
     "UnknownPixelShapeWarning",
     "CameraReadout",
 ]

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -125,6 +125,10 @@ class CameraGeometry:
 
         if isinstance(pix_type, str):
             pix_type = PixelShape.from_string(pix_type)
+        elif not isinstance(pix_type, PixelShape):
+            raise TypeError(
+                f"pix_type most be a PixelShape or the name of a PixelShape, got {pix_type}"
+            )
 
         self.n_pixels = len(pix_x)
         self.camera_name = camera_name

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -312,7 +312,7 @@ class CameraGeometry:
         elif self.pix_type == PixelShape.SQUARE:
             width = np.sqrt(self.pix_area)
         elif self.pix_type == PixelShape.CIRCLE:
-            width = np.sqrt(self.pix_area / np.pi)
+            width = 2 * np.sqrt(self.pix_area / np.pi)
         else:
             raise NotImplementedError(
                 "Cannot calculate pixel width for type {self.pix_type!r}"

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -315,7 +315,7 @@ class CameraGeometry:
             width = 2 * np.sqrt(self.pix_area / np.pi)
         else:
             raise NotImplementedError(
-                "Cannot calculate pixel width for type {self.pix_type!r}"
+                f"Cannot calculate pixel width for type {self.pix_type!r}"
             )
 
         return width

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -1,7 +1,7 @@
 """ Tests for CameraGeometry """
 import numpy as np
 from astropy import units as u
-from ctapipe.instrument import CameraDescription, CameraGeometry
+from ctapipe.instrument import CameraDescription, CameraGeometry, PixelShape
 import pytest
 
 camera_names = CameraDescription.get_known_camera_names()
@@ -38,7 +38,7 @@ def test_load_lst_camera():
     """ test that a specific camera has the expected attributes """
     geom = CameraGeometry.from_name("LSTCam")
     assert len(geom.pix_x) == 1855
-    assert geom.pix_type == "hexagonal"
+    assert geom.pix_type == PixelShape.HEXAGON
 
 
 def test_position_to_pix_index():
@@ -81,11 +81,11 @@ def test_neighbor_pixels(camera_name):
     n_pix = len(geom.pix_id)
     n_neighbors = [len(x) for x in geom.neighbors]
 
-    if geom.pix_type.startswith("hex"):
+    if geom.pix_type == PixelShape.HEXAGON:
         assert n_neighbors.count(6) > 0.5 * n_pix
         assert n_neighbors.count(6) > n_neighbors.count(4)
 
-    if geom.pix_type.startswith("rect"):
+    if geom.pix_type == PixelShape.SQUARE:
         assert n_neighbors.count(4) > 0.5 * n_pix
         assert n_neighbors.count(5) == 0
         assert n_neighbors.count(6) == 0

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -17,7 +17,7 @@ def test_construct():
         pix_x=x * u.m,
         pix_y=y * u.m,
         pix_area=x * u.m ** 2,
-        pix_type="rectangular",
+        pix_type=PixelShape.SQUARE,
         pix_rotation="10d",
         cam_rotation="12d",
     )
@@ -26,6 +26,30 @@ def test_construct():
     assert geom.pix_area is not None
     assert (geom.pix_rotation.deg - 10) < 1e-5
     assert (geom.cam_rotation.deg - 10) < 1e-5
+
+    with pytest.raises(TypeError):
+        geom = CameraGeometry(
+            camera_name="Unknown",
+            pix_id=np.arange(100),
+            pix_x=x * u.m,
+            pix_y=y * u.m,
+            pix_area=x * u.m ** 2,
+            pix_type="foo",
+            pix_rotation="10d",
+            cam_rotation="12d",
+        )
+
+    # test from string:
+    geom = CameraGeometry(
+        camera_name="Unknown",
+        pix_id=np.arange(100),
+        pix_x=x * u.m,
+        pix_y=y * u.m,
+        pix_area=x * u.m ** 2,
+        pix_type="rectangular",
+        pix_rotation="10d",
+        cam_rotation="12d",
+    )
 
 
 def test_make_rectangular_camera_geometry():

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -123,10 +123,9 @@ class CameraDisplay:
 
         pix_x = self.geom.pix_x.value[self.mask]
         pix_y = self.geom.pix_y.value[self.mask]
-        pix_area = self.geom.pix_area.value[self.mask]
         pix_width = self.geom.pixel_width.value[self.mask]
 
-        for x, y, area, w in zip(pix_x, pix_y, pix_area, pix_width):
+        for x, y, w in zip(pix_x, pix_y, pix_width):
             if self.geom.pix_type == PixelShape.HEXAGON:
                 r = w / np.sqrt(3)
                 patch = RegularPolygon(

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -13,6 +13,8 @@ from matplotlib.colors import Normalize, LogNorm, SymLogNorm
 from matplotlib.patches import Ellipse, RegularPolygon, Rectangle
 from numpy import sqrt
 
+from ctapipe.instrument import PixelShape
+
 __all__ = ["CameraDisplay"]
 
 logger = logging.getLogger(__name__)
@@ -126,7 +128,7 @@ class CameraDisplay:
         pix_area = self.geom.pix_area.value[self.mask]
 
         for x, y, area in zip(pix_x, pix_y, pix_area):
-            if self.geom.pix_type.startswith("hex"):
+            if self.geom.pix_type == PixelShape.HEXAGON:
                 r = sqrt(area * 2 / 3 / sqrt(3)) + 2 * PIXEL_EPSILON
                 poly = RegularPolygon(
                     (x, y),
@@ -135,12 +137,16 @@ class CameraDisplay:
                     orientation=self.geom.pix_rotation.to_value(u.rad),
                     fill=True,
                 )
-            else:
-                r = sqrt(area) + PIXEL_EPSILON
+
+            elif self.geom.pix_type == PixelShape.CIRCLE:
+                raise NotImplementedError("Circle not supported")
+
+            elif self.geom.pix_type == PixelShape.SQUARE:
+                w = self.geom.pixel_width.value + PIXEL_EPSILON
                 poly = Rectangle(
-                    (x - r / 2, y - r / 2),
-                    width=r,
-                    height=r,
+                    (x - w / 2, y - w / 2),
+                    width=w,
+                    height=w,
                     angle=self.geom.pix_rotation.to_value(u.deg),
                     fill=True,
                 )

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -10,7 +10,7 @@ from astropy import units as u
 from matplotlib import pyplot as plt
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import Normalize, LogNorm, SymLogNorm
-from matplotlib.patches import Ellipse, RegularPolygon, Rectangle
+from matplotlib.patches import Ellipse, RegularPolygon, Rectangle, Circle
 from numpy import sqrt
 
 from ctapipe.instrument import PixelShape
@@ -18,8 +18,6 @@ from ctapipe.instrument import PixelShape
 __all__ = ["CameraDisplay"]
 
 logger = logging.getLogger(__name__)
-
-PIXEL_EPSILON = 0.0005  # a bit of extra size to pixels to avoid aliasing
 
 
 def polar_to_cart(rho, phi):
@@ -126,24 +124,22 @@ class CameraDisplay:
         pix_x = self.geom.pix_x.value[self.mask]
         pix_y = self.geom.pix_y.value[self.mask]
         pix_area = self.geom.pix_area.value[self.mask]
+        pix_width = self.geom.pixel_width.value[self.mask]
 
-        for x, y, area in zip(pix_x, pix_y, pix_area):
+        for x, y, area, w in zip(pix_x, pix_y, pix_area, pix_width):
             if self.geom.pix_type == PixelShape.HEXAGON:
-                r = sqrt(area * 2 / 3 / sqrt(3)) + 2 * PIXEL_EPSILON
-                poly = RegularPolygon(
+                r = w / np.sqrt(3)
+                patch = RegularPolygon(
                     (x, y),
                     6,
                     radius=r,
                     orientation=self.geom.pix_rotation.to_value(u.rad),
                     fill=True,
                 )
-
             elif self.geom.pix_type == PixelShape.CIRCLE:
-                raise NotImplementedError("Circle not supported")
-
+                patch = Circle((x, y), radius=w / 2, fill=True)
             elif self.geom.pix_type == PixelShape.SQUARE:
-                w = self.geom.pixel_width.value + PIXEL_EPSILON
-                poly = Rectangle(
+                patch = Rectangle(
                     (x - w / 2, y - w / 2),
                     width=w,
                     height=w,
@@ -151,7 +147,7 @@ class CameraDisplay:
                     fill=True,
                 )
 
-            patches.append(poly)
+            patches.append(patch)
 
         self.pixels = PatchCollection(patches, cmap=cmap, linewidth=0)
         self.axes.add_collection(self.pixels)
@@ -179,12 +175,13 @@ class CameraDisplay:
         self._active_pixel.set_visible(False)
         self.axes.add_patch(self._active_pixel)
 
+        if hasattr(self._active_pixel, "xy"):
+            center = self._active_pixel.xy
+        else:
+            center = self._active_pixel.center
+
         self._active_pixel_label = self.axes.text(
-            self._active_pixel.xy[0],
-            self._active_pixel.xy[1],
-            "0",
-            horizontalalignment="center",
-            verticalalignment="center",
+            *center, "0", horizontalalignment="center", verticalalignment="center"
         )
         self._active_pixel_label.set_visible(False)
 

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -271,7 +271,7 @@ class CameraDisplay:
             self.pixels.norm = LogNorm()
             self.pixels.autoscale()  # this is to handle matplotlib bug #5424
         elif norm == "symlog":
-            self.pixels.norm = SymLogNorm(linthresh=1.0)
+            self.pixels.norm = SymLogNorm(linthresh=1.0, base=10)
             self.pixels.autoscale()
         elif isinstance(norm, Normalize):
             self.pixels.norm = norm


### PR DESCRIPTION
When preparing to update the bokeh event viewer according to #1330 and #1247, 
I found working with these strings very clumsy.

Replaced the string with an enum, which should make many things much more straight forward.