### PR TITLE
use 2020 resolver for pip installs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - source ci/install.sh
   - python --version
   - pip install travis-sphinx codecov pytest-cov
-  - pip install -e .[all]
+  - pip install --use-feature=2020-resolver -e .[all]
 
 script:
   - pytest --cov=ctapipe


### PR DESCRIPTION
right now the build fails for python=3.8 using pip due to a version conflict between h5py and numpy.

Testing if new resolver fixes that.