### PR TITLE
Fix naming of image -> true_image for simulated containers.

### DIFF
--- a/ctapipe/io/dl1eventsource.py
+++ b/ctapipe/io/dl1eventsource.py
@@ -238,12 +238,10 @@ class DL1EventSource(EventSource):
                         f"/simulation/event/telescope/parameters/{tel.name}",
                         containers=[
                             HillasParametersContainer(),
-                            TimingParametersContainer(),
                             LeakageContainer(),
                             ConcentrationContainer(),
                             MorphologyContainer(),
                             IntensityStatisticsContainer(),
-                            PeakTimeStatisticsContainer(),
                         ],
                         prefixes=True,
                     )
@@ -333,9 +331,7 @@ class DL1EventSource(EventSource):
                         simulated_image_row = next(
                             simulated_image_iterators[f"tel_{tel:03d}"]
                         )
-                        simulated.image = simulated_image_row["image"]
-                        simulated.peak_time = simulated_image_row["peak_time"]
-                        simulated.image_mask = simulated_image_row["image_mask"]
+                        simulated.true_image = simulated_image_row["true_image"]
 
                 if DataLevel.DL1_PARAMETERS in self.datalevels:
                     if f"tel_{tel:03d}" not in param_readers.keys():
@@ -367,13 +363,13 @@ class DL1EventSource(EventSource):
                         simulated_params = next(
                             simulated_param_readers[f"tel_{tel:03d}"]
                         )
-                        simulated.parameters.hillas = simulated_params[0]
-                        simulated.parameters.timing = simulated_params[1]
-                        simulated.parameters.leakage = simulated_params[2]
-                        simulated.parameters.concentration = simulated_params[3]
-                        simulated.parameters.morphology = simulated_params[4]
-                        simulated.parameters.intensity_statistics = simulated_params[5]
-                        simulated.parameters.peak_time_statistics = simulated_params[6]
+                        simulated.true_parameters.hillas = simulated_params[0]
+                        simulated.true_parameters.leakage = simulated_params[1]
+                        simulated.true_parameters.concentration = simulated_params[2]
+                        simulated.true_parameters.morphology = simulated_params[3]
+                        simulated.true_parameters.intensity_statistics = simulated_params[
+                            4
+                        ]
 
             yield data
 


### PR DESCRIPTION
Also remove not-used containers.

This fixes reading of DL1 from simulations processed with stage1