### PR TITLE
Fix parent handling in EventSource.from_config

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -11,6 +11,39 @@ from ctapipe.core.plugins import detect_and_import_io_plugins
 __all__ = ["non_abstract_children", "Component", "TelescopeComponent"]
 
 
+def find_config_in_hierarchy(parent, class_name, trait_name):
+    """
+    Find the value of a config item in the hierarchy by going up the hierarchy
+    from the parent and then down again to the child.
+    This is needed as parent.config is the full config and not the
+    config starting at the level of the parent.
+    """
+
+    config = parent.config
+
+    # find the path from the config root to the desired object
+    hierarchy = [class_name]
+    while parent is not None:
+        hierarchy.append(parent.__class__.__name__)
+        parent = parent.parent
+
+    hierarchy = list(reversed(hierarchy))
+
+    # go down to the config value searched
+
+    # root key is optional
+    root = hierarchy.pop(0)
+    if root in config:
+        subconfig = config[root]
+    else:
+        subconfig = config
+
+    for name in hierarchy:
+        subconfig = subconfig[name]
+
+    return subconfig[trait_name]
+
+
 def non_abstract_children(base):
     """
     Return all non-abstract subclasses of a base class recursively.
@@ -156,8 +189,6 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         get dict{name: cls} of non abstract subclasses,
         subclasses can possibly be definded in plugins
         """
-        detect_and_import_io_plugins()
-
         subclasses = {base.__name__: base for base in non_abstract_children(cls)}
         return subclasses
 

--- a/ctapipe/core/tests/test_component.py
+++ b/ctapipe/core/tests/test_component.py
@@ -40,6 +40,37 @@ def test_non_abstract_children():
     assert AbstractChild not in kids
 
 
+def test_get_config_from_hierarchy():
+    from ctapipe.core.component import find_config_in_hierarchy
+
+    class Bottom(Component):
+        val = Float(0).tag(config=True)
+
+    class Middle(Component):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.bottom = Bottom(parent=self)
+
+    class Top(Component):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.middle = Middle(parent=self)
+
+    # test with root present
+    c = Config({"Top": {"Middle": {"Bottom": {"val": 5}}}})
+    t = Top(config=c)
+
+    val = find_config_in_hierarchy(t.middle, "Bottom", "val")
+    assert val == 5
+
+    # test with root not present
+    c = Config({"Middle": {"Bottom": {"val": 5}}})
+    t = Top(config=c)
+
+    val = find_config_in_hierarchy(t.middle, "Bottom", "val")
+    assert val == 5
+
+
 class SubComponent(Component):
     """ An Example Component, this is the help text"""
 

--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -7,10 +7,15 @@ from .datalevels import DataLevel
 from .astropy_helpers import h5_table_to_astropy as read_table
 from .dl1writer import DL1Writer
 
+from ..core.plugins import detect_and_import_io_plugins
 
 # import event sources to make them visible to EventSource.from_url
 from .simteleventsource import SimTelEventSource
 from .dl1eventsource import DL1EventSource
+
+# import IO plugins with their event sources
+detect_and_import_io_plugins()
+
 
 __all__ = [
     "get_array_layout",

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -4,9 +4,12 @@ Handles reading of different event/waveform containing files
 from abc import abstractmethod
 from traitlets.config.loader import LazyConfigValue
 
-from ctapipe.core import Component, non_abstract_children, ToolConfigurationError
-from ctapipe.core import Provenance
-from ctapipe.core.plugins import detect_and_import_io_plugins
+from ctapipe.core import ToolConfigurationError, Provenance
+from ctapipe.core.component import (
+    Component,
+    non_abstract_children,
+    find_config_in_hierarchy,
+)
 from ctapipe.core.traits import Path, Int, Set
 
 __all__ = ["EventSource", "event_source"]
@@ -295,7 +298,6 @@ class EventSource(Component):
         # to make sure it's compatible and to raise the correct error
         input_url = EventSource.input_url.validate(obj=None, value=input_url)
 
-        detect_and_import_io_plugins()
         available_classes = non_abstract_children(cls)
 
         for subcls in available_classes:
@@ -336,10 +338,27 @@ class EventSource(Component):
         if config is not None and parent is not None:
             raise ValueError("Only one of config or parent must be provided")
 
-        if config is None:
-            config = parent.config
+        input_url = None
 
-        if isinstance(config.EventSource.input_url, LazyConfigValue):
-            config.EventSource.input_url = cls.input_url.default_value
+        # config was passed
+        if config is not None:
+            if not isinstance(config.input_url, LazyConfigValue):
+                input_url = config.input_url
+            elif not isinstance(config.EventSource.input_url, LazyConfigValue):
+                input_url = config.EventSource.input_url
+            else:
+                input_url = cls.input_url.default_value
 
-        return event_source(config.EventSource.input_url, config=config, **kwargs)
+        # parent was passed
+        else:
+            # first look at appropriate position in the config hierarcy
+            input_url = find_config_in_hierarchy(parent, "EventSource", "input_url")
+
+            # if not found, check top level
+            if isinstance(input_url, LazyConfigValue):
+                if not isinstance(parent.config.EventSource.input_url, LazyConfigValue):
+                    input_url = parent.config.EventSource.input_url
+                else:
+                    input_url = cls.input_url.default_value
+
+        return cls.from_url(input_url, config=config, parent=parent, **kwargs)

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -67,7 +67,8 @@ class Stage1Tool(Tool):
     }
 
     classes = List(
-        [CameraCalibrator, EventSource, DL1Writer, ImageProcessor]
+        [CameraCalibrator, DL1Writer, ImageProcessor]
+        + classes_with_traits(EventSource)
         + classes_with_traits(ImageCleaner)
         + classes_with_traits(ImageExtractor)
         + classes_with_traits(GainSelector)


### PR DESCRIPTION
This also moves   io plugin detection into io.__init__, we had a few redundant calls specified at two places before. (nonabstract_children, event source directly before calling nonabstract children).

With this, setting input_url for the event souce should be fully supported now, if tools / components use `EventSource.from_config(parent=self)`.