### PR TITLE
Remove redundant run_array_direction from SimulationCnfig container

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -418,17 +418,6 @@ class SimulationConfigContainer(Container):
     Configuration parameters of the simulation
     """
 
-    run_array_direction = Field(
-        [],
-        (
-            "the tracking/pointing direction in "
-            "[radians]. Depending on 'tracking_mode' "
-            "this either contains: "
-            "[0]=Azimuth, [1]=Altitude in mode 0, "
-            "OR "
-            "[0]=R.A., [1]=Declination in mode 1."
-        ),
-    )
     corsika_version = Field(nan, "CORSIKA version * 1000")
     simtel_version = Field(nan, "sim_telarray version * 1000")
     energy_range_min = Field(

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -531,7 +531,6 @@ class SimTelEventSource(EventSource):
             corsika_wlen_max=mc_run_head["corsika_wlen_max"] * u.nm,
             corsika_low_E_detail=mc_run_head["corsika_low_E_detail"],
             corsika_high_E_detail=mc_run_head["corsika_high_E_detail"],
-            run_array_direction=Angle(self.file_.header["direction"] * u.rad),
         )
 
     @staticmethod


### PR DESCRIPTION
This info is stored already in the pointing container and made it impossible to quickly read this table using pandas.