### PR TITLE
Fix EventSource.__new__ already calling  __init__ of source

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -6,7 +6,6 @@ from logging import getLogger
 from traitlets import TraitError
 from traitlets.config import Configurable
 
-from ctapipe.core.plugins import detect_and_import_io_plugins
 
 __all__ = ["non_abstract_children", "Component", "TelescopeComponent"]
 


### PR DESCRIPTION
Becasue `__new__` returned already fully initialized subclasses, the created event source was initialized twice.

This fixes it by only calling `__new__(subclass)` instead of returning the fully initialised source.