### PR TITLE
Fix exclusion filter for pointing table

### DIFF
--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -311,7 +311,7 @@ class DL1Writer(Component):
                 )
 
             writer.exclude(
-                f"/dl1/monitoring/telescope/pointing/{table_name}", "trigger_pixels"
+                f"/dl1/monitoring/telescope/pointing/{table_name}", "n_trigger_pixels"
             )
             writer.exclude(f"/dl1/event/telescope/images/{table_name}", "parameters")
             if self._is_simulation:


### PR DESCRIPTION
The `n_` was missing, resulting in `n_trigger_pixels` being added to the telescope pointing table