### PR TITLE
Speed up trigger time creation in SimTelEventSource

### DIFF
--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -54,11 +54,9 @@ NANOSECONDS_PER_DAY = (1 * u.day).to_value(u.ns)
 
 
 def parse_simtel_time(simtel_time):
+    """Convert a unix time second / nanosecond tuple into astropy.time.Time"""
     return Time(
-        u.Quantity(simtel_time[0], u.s),
-        u.Quantity(simtel_time[1], u.ns),
-        format="unix",
-        scale="utc",
+        simtel_time[0], simtel_time[1] * 1e-9, format="unix", scale="utc"  # ns to s
     )
 
 


### PR DESCRIPTION
This shaves off 2/3 of the runtime of `fill_trigger_info`. (40s of 390s for a stage1 run on a La Palma Prod3b benchmark file)

Edit, and another 10s with the second commit.