### PR TITLE
Add cache=True to numba functions

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -257,6 +257,7 @@ def shift_waveforms(waveforms, time_shift_samples):
     [(float64[:], int64, float64[:]), (float32[:], int64, float32[:])],
     "(s),()->(s)",
     nopython=True,
+    cache=True,
 )
 def _shift_waveforms_by_integer(waveforms, integer_shift, shifted_waveforms):
     n_samples = waveforms.size

--- a/ctapipe/fitting.py
+++ b/ctapipe/fitting.py
@@ -5,7 +5,7 @@ import numpy as np
 EPS = 2 * np.finfo(np.float64).eps
 
 
-@njit
+@njit(cache=True)
 def design_matrix(x):
     """
     Build the design matrix for linear regression for
@@ -21,7 +21,7 @@ def design_matrix(x):
     return X
 
 
-@njit
+@njit(cache=True)
 def linear_regression(X, y):
     """
     Analytical linear regression
@@ -40,7 +40,7 @@ def linear_regression(X, y):
     return np.linalg.inv(mat) @ X.T @ y
 
 
-@njit
+@njit(cache=True)
 def residual_sum_of_squares(X, y, beta):
     """Calculate the residual sum of squares
 
@@ -56,7 +56,7 @@ def residual_sum_of_squares(X, y, beta):
     return np.sum(residuals(X, y, beta) ** 2)
 
 
-@njit
+@njit(cache=True)
 def residuals(X, y, beta):
     """Calculate the residuals of a linear regression
 
@@ -72,7 +72,7 @@ def residuals(X, y, beta):
     return y - (X[:, 0] * beta[0] + beta[1])
 
 
-@njit
+@njit(cache=True)
 def _lts_single_sample(X, y, sample_size, max_iterations, eps=1e-12):
 
     # randomly draw 2 points for the initial fit
@@ -105,7 +105,7 @@ def _lts_single_sample(X, y, sample_size, max_iterations, eps=1e-12):
     return beta, error
 
 
-@njit
+@njit(cache=True)
 def lts_linear_regression(
     x, y, samples=20, relative_sample_size=0.85, max_iterations=20, eps=1e-12
 ):

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -44,6 +44,7 @@ from .hillas import hillas_parameters, camera_to_shower_coordinates
     ],
     "(s),(),(),(),()->(),()",
     nopython=True,
+    cache=True,
 )
 def extract_around_peak(
     waveforms, peak_index, width, shift, sampling_rate_ghz, sum_, peak_time
@@ -118,7 +119,7 @@ def extract_around_peak(
     sum_[0] = i_sum
 
 
-@njit(parallel=True)
+@njit(parallel=True, cache=True)
 def neighbor_average_waveform(waveforms, neighbors_indices, neighbors_indptr, lwt):
     """
     Obtain the average waveform built from the neighbors of each pixel
@@ -765,11 +766,7 @@ class TwoPassWindowSum(ImageExtractor):
 
         # this function is applied to all pixels together
         charge_1stpass, pulse_time_1stpass = extract_around_peak(
-            waveforms,
-            peak_index,
-            window_width,
-            window_shift,
-            self.sampling_rate[telid],
+            waveforms, peak_index, window_width, window_shift, self.sampling_rate[telid]
         )
 
         # Get integration correction factors

--- a/ctapipe/image/morphology.py
+++ b/ctapipe/image/morphology.py
@@ -3,7 +3,7 @@ from numba import njit
 from ..containers import MorphologyContainer
 
 
-@njit
+@njit(cache=True)
 def _num_islands_sparse_indices(indices, indptr, mask):
 
     # non-signal pixel get label == 0, we marke the cleaning

--- a/ctapipe/image/statistics.py
+++ b/ctapipe/image/statistics.py
@@ -4,7 +4,7 @@ from numba import njit
 from ..containers import StatisticsContainer
 
 
-@njit()
+@njit(cache=True)
 def skewness(data, mean=None, std=None):
     """Calculate skewnewss (normalized third central moment)
     with allowing precomputed mean and std.
@@ -37,7 +37,7 @@ def skewness(data, mean=None, std=None):
     return np.mean(((data - mean) / std) ** 3)
 
 
-@njit()
+@njit(cache=True)
 def kurtosis(data, mean=None, std=None, fisher=True):
     """Calculate kurtosis (normalized fourth central moment)
     with allowing precomputed mean and std.

--- a/ctapipe/image/timing.py
+++ b/ctapipe/image/timing.py
@@ -15,7 +15,7 @@ from numba import njit
 __all__ = ["timing_parameters"]
 
 
-@njit
+@njit(cache=True)
 def rmse(truth, prediction):
     """Root mean squared error"""
     return np.sqrt(np.mean((truth - prediction) ** 2))


### PR DESCRIPTION
When reviewing, please keep this restrictions in mind: https://numba.pydata.org/numba-doc/latest/developer/caching.html

But I found no obvious violations of those, so I went ahead and added `cache=True` to each numba call we have.

This brings down the startup time of the stage1 tool quite a bit (2 s instead 12s until the first event is processed on my machine)