### PR TITLE
Fix minuit version to 1.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - conda-forge::nbsphinx
   - cython
   - graphviz
-  - iminuit
+  - iminuit>=1.3,<2.0.0a0
   - ipython
   - ipywidgets
   - joblib

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "astropy>=3,<5",
         "bokeh~=1.0",
         "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2
-        "iminuit>=1.3",
+        "iminuit~=1.3",
         "joblib",
         "matplotlib~=3.0",
         "numba>=0.43",


### PR DESCRIPTION
In preparation for the upcoming iminuit v2.0, I fixed the version to `1.x` so we are not surprised by failing tests

Once minuit 2 is out, we can make a PR to switch to the new version.