### PR TITLE
correctly print subarray info for prod5

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -92,7 +92,6 @@ class SubarrayDescription:
 
         # print the per-telescope-type informatino:
         table = self.to_table().group_by("tel_description")
-        ttypes = [str(d) for d in self.telescope_types]
         n_tels = {}
         tel_ids = {}
 
@@ -115,7 +114,7 @@ class SubarrayDescription:
 
         out_table = Table(
             {
-                "Type": ttypes,
+                "Type": list(n_tels.keys()),
                 "Count": list(n_tels.values()),
                 "Tel IDs": list(tel_ids.values()),
             }


### PR DESCRIPTION
This fixes a bug in `SubarrayDescription.info()`.  The old version assumed that the telescopes were grouped already  by tel_description and in contiguous ranges, but that is not the case in general (particularly in prod5), so  it would print for example:
```
Subarray : MonteCarloArray
Num Tels : 60
Footprint: 0.70 km2

                TYPE  Num IDmin  IDmax
=====================================
      LST_LST_LSTCam    4    1 ..   4
   MST_MST_NectarCam   28    5 ..  47
    MST_MST_FlashCam   28   20 ..  60
```

This new version correctly groups the tel_ids, and the output look like:
```
Subarray : MonteCarloArray
Num Tels : 60
Footprint: 0.70 km2

       Type       Count   Tel IDs
----------------- ----- ------------
   LST_LST_LSTCam     4 1-4
 MST_MST_FlashCam    28 20-33, 34-60
MST_MST_NectarCam    28 5-18, 19-47
```