### PR TITLE
minor fix to print each line of subarray info

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -120,7 +120,8 @@ class SubarrayDescription:
             }
         )
         out_table["Tel IDs"].format = "<s"
-        printer(out_table)
+        for line in str(out_table).split("\n"):
+            printer(line)
 
     @lazyproperty
     def tel_coords(self):


### PR DESCRIPTION
if info() is called with `printer=logger`, the output was garbled since it was multi-line. This fixes it so each line is logged separately, which looks cosmetically better:

Before fix:
```
2020-12-03 13:43:15,285 INFO [ctapipe.ctapipe-stage1] (subarray.info): Subarray : MonteCarloArray
2020-12-03 13:43:15,285 INFO [ctapipe.ctapipe-stage1] (subarray.info): Num Tels : 19
2020-12-03 13:43:15,287 INFO [ctapipe.ctapipe-stage1] (subarray.info): Footprint: 0.75 km2
2020-12-03 13:43:15,287 INFO [ctapipe.ctapipe-stage1] (subarray.info):
2020-12-03 13:43:15,290 INFO [ctapipe.ctapipe-stage1] (subarray.info):        Type       Count Tel IDs
----------------- ----- -------
   LST_LST_LSTCam     4 1-4
MST_MST_NectarCam    15 5-19
```


after fix:
```
2020-12-03 13:46:42,677 INFO [ctapipe.ctapipe-stage1] (subarray.info): Subarray : MonteCarloArray
2020-12-03 13:46:42,677 INFO [ctapipe.ctapipe-stage1] (subarray.info): Num Tels : 19
2020-12-03 13:46:42,680 INFO [ctapipe.ctapipe-stage1] (subarray.info): Footprint: 0.75 km2
2020-12-03 13:46:42,680 INFO [ctapipe.ctapipe-stage1] (subarray.info):
2020-12-03 13:46:42,958 INFO [ctapipe.ctapipe-stage1] (subarray.info):        Type       Count Tel IDs
2020-12-03 13:46:42,958 INFO [ctapipe.ctapipe-stage1] (subarray.info): ----------------- ----- -------
2020-12-03 13:46:42,958 INFO [ctapipe.ctapipe-stage1] (subarray.info):    LST_LST_LSTCam     4 1-4
2020-12-03 13:46:42,958 INFO [ctapipe.ctapipe-stage1] (subarray.info): MST_MST_NectarCam    15 5-19
```