### PR TITLE
signal extractor SlidingWindowMaxSum 

### DIFF
--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -8,10 +8,12 @@ __all__ = [
     "FixedWindowSum",
     "GlobalPeakWindowSum",
     "LocalPeakWindowSum",
+    "SlidingWindowMaxSum",
     "NeighborPeakWindowSum",
     "BaselineSubtractedNeighborPeakWindowSum",
     "TwoPassWindowSum",
     "extract_around_peak",
+    "extract_sliding_window",
     "neighbor_average_waveform",
     "subtract_baseline",
     "integration_correction",
@@ -118,7 +120,77 @@ def extract_around_peak(
     peak_time[0] /= sampling_rate_ghz
     sum_[0] = i_sum
 
+@guvectorize(
+    [
+        (float64[:], int64, float64, float32[:], float32[:]),
+        (float32[:], int64, float64, float32[:], float32[:]),
+    ],
+    "(s),(),()->(),()",
+    nopython=True,
+)
+def extract_sliding_window(
+    waveforms, width, sampling_rate_ghz, sum_, peak_time
+):
+    """
+    This function performs the following operations:
 
+    - Find the largest sum of width consecutive slices 
+    - Obtain the pulse time within a window defined by a peak finding
+    algorithm, using the weighted average of the samples.
+
+    This function is a numpy universal function which defines the operation
+    applied on the waveform for every channel and pixel. Therefore in the
+    code body of this function:
+        - waveforms is a 1D array of size n_samples.
+        - width is integer
+
+    The ret argument is required by numpy to create the numpy array which is
+    returned. It can be ignored when calling this function.
+
+    Parameters
+    ----------
+    waveforms : ndarray
+        Waveforms stored in a numpy array.
+        Shape: (n_pix, n_samples)
+    width : ndarray or int
+        Window size of integration window for each pixel.
+    sampling_rate_ghz : float
+        Sampling rate of the camera, in units of GHz
+        Astropy units should have to_value('GHz') applied before being passed
+    sum_ : ndarray
+        Return argument for ufunc (ignore)
+        Returns the sum of the waveform samples
+    peak_time : ndarray
+        Return argument for ufunc (ignore)
+        Returns the peak_time in units "ns"
+
+    Returns
+    -------
+    charge : ndarray
+        Extracted charge.
+        Shape: (n_pix)
+
+    """
+
+    # first find the cumulative waveform
+    cwf=np.cumsum(waveforms) 
+    cwf=np.concatenate((np.zeros(1), cwf)) # add zero at the begining so it is easier to substract the two arrays later
+    sums=cwf[width:]-cwf[:-width]
+    maxpos=np.argmax(sums) # start of the window with largest sum
+    sum_[0]=sums[maxpos]
+
+    time_num = float64(0.0)
+    time_den = float64(0.0)
+    # now compute the timing as the average of non negative slices
+    for isample in prange(maxpos, maxpos+width):
+        if waveforms[isample] > 0:
+            time_num += waveforms[isample] * isample
+            time_den += waveforms[isample]
+
+    peak_time[0] = time_num / time_den if time_den > 0 else maxpos+0.5*width
+    # Convert to units of ns
+    peak_time[0] /= sampling_rate_ghz
+    
 @njit(parallel=True, cache=True)
 def neighbor_average_waveform(waveforms, neighbors_indices, neighbors_indptr, lwt):
     """
@@ -521,6 +593,63 @@ class LocalPeakWindowSum(ImageExtractor):
         )
         if self.apply_integration_correction.tel[telid]:
             charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
+        return charge, peak_time
+
+
+class SlidingWindowMaxSum (ImageExtractor):
+    """
+    Sliding window extractor that maximizes the signal in window_width consecutive slices.
+    """
+
+    window_width = IntTelescopeParameter(
+        default_value=7, help="Define the width of the integration window"
+    ).tag(config=True)
+
+    @lru_cache(maxsize=128)
+    def _calculate_correction(self, telid):
+        """
+        Calculate the correction for the extracted charge such that the value
+        returned would equal 1 for a noise-less unit pulse.
+
+        This method is decorated with @lru_cache to ensure it is only
+        calculated once per telescope.
+        
+        WARNING: TO BE DONE properly, the current code reuses the function of 
+        LocalPeakWindowSum assuming that the pulse is symmetric (which normally is not true)
+        The proper approach would be to apply a similar sliding window over the 
+        reference pulse shape and compute the maximum fraction of the pulse contained
+        in window of a given size. Thus the correction for the leakage of signal outside
+        of the integration window is slightly overestimated. 
+        
+
+        Parameters
+        ----------
+        telid : int
+
+        Returns
+        -------
+        correction : ndarray
+        The correction to apply to an extracted charge using this ImageExtractor
+        Has size n_channels, as a different correction value might be required
+        for different gain channels.
+        """
+        
+        readout = self.subarray.tel[telid].camera.readout
+        return integration_correction(
+            readout.reference_pulse_shape,
+            readout.reference_pulse_sample_width.to_value("ns"),
+            (1 / readout.sampling_rate).to_value("ns"),
+            self.window_width.tel[telid],
+            self.window_width.tel[telid]//2 # assuming that shift = 0.5 * window 
+        )
+
+    def __call__(self, waveforms, telid, selected_gain_channel):
+        charge, peak_time = extract_sliding_window(
+            waveforms,
+            self.window_width.tel[telid],
+            self.sampling_rate[telid],
+        )
+        charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
         return charge, peak_time
 
 

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -605,6 +605,10 @@ class SlidingWindowMaxSum (ImageExtractor):
         default_value=7, help="Define the width of the integration window"
     ).tag(config=True)
 
+    apply_integration_correction = BoolTelescopeParameter(
+        default_value=True, help="Apply the integration window correction"
+    ).tag(config=True)
+
     @lru_cache(maxsize=128)
     def _calculate_correction(self, telid):
         """
@@ -649,7 +653,8 @@ class SlidingWindowMaxSum (ImageExtractor):
             self.window_width.tel[telid],
             self.sampling_rate[telid],
         )
-        charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
+        if self.apply_integration_correction.tel[telid]:
+            charge *= self._calculate_correction(telid=telid)[selected_gain_channel]
         return charge, peak_time
 
 

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -618,9 +618,9 @@ class SlidingWindowMaxSum(ImageExtractor):
 
         This method is decorated with @lru_cache to ensure it is only
         calculated once per telescope.
-        
+
         WARNING: TO BE DONE properly, the current code reuses the function of
-        LocalPeakWindowSum assuming that the pulse is symmetric (which normally is not 
+        LocalPeakWindowSum assuming that the pulse is symmetric (which normally is not
         true). The proper approach would be to apply a similar sliding window over the
         reference pulse shape and compute the maximum fraction of the pulse contained
         in window of a given size. Thus the correction for the leakage of signal outside

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -16,6 +16,7 @@ from ctapipe.image.extractor import (
     NeighborPeakWindowSum,
     TwoPassWindowSum,
     FullWaveformSum,
+    SlidingWindowMaxSum,
 )
 from ctapipe.image.toymodel import WaveformModel
 from ctapipe.instrument import SubarrayDescription, TelescopeDescription
@@ -285,6 +286,15 @@ def test_fixed_window_sum(toymodel):
     waveforms, subarray, telid, selected_gain_channel, true_charge, true_time = toymodel
     extractor = FixedWindowSum(subarray=subarray, peak_index=47)
     charge, peak_time = extractor(waveforms, telid, selected_gain_channel)
+    assert_allclose(charge, true_charge, rtol=0.1)
+    assert_allclose(peak_time, true_time, rtol=0.1)
+
+
+def test_sliding_window_max_sum(toymodel):
+    waveforms, subarray, telid, selected_gain_channel, true_charge, true_time = toymodel
+    extractor = SlidingWindowMaxSum(subarray=subarray)
+    charge, peak_time = extractor(waveforms, telid, selected_gain_channel)
+    print(true_charge, charge, true_time, peak_time)
     assert_allclose(charge, true_charge, rtol=0.1)
     assert_allclose(peak_time, true_time, rtol=0.1)
 

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -108,7 +108,6 @@ def test_extract_around_peak(toymodel):
 def test_extract_sliding_window(toymodel):
     waveforms, _, _, _, _, _ = toymodel
     n_pixels, n_samples = waveforms.shape
-    rand = np.random.RandomState(1)
     charge, peak_time = extract_sliding_window(waveforms, 7, 1)
     assert (charge >= 0).all()
     assert (peak_time >= 0).all() and (peak_time <= n_samples).all()

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -6,13 +6,13 @@ the correction for the integration window completeness
 import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
+from traitlets.config.loader import Config
 
 from ctapipe.image.extractor import SlidingWindowMaxSum, ImageExtractor
 from ctapipe.image.toymodel import WaveformModel
 from ctapipe.instrument import SubarrayDescription, TelescopeDescription
 
 from ctapipe.utils import datasets
-from traitlets.config.loader import Config
 
 
 def test_sw_pulse_lst(monkeypatch):

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -12,58 +12,47 @@ from ctapipe.image.extractor import SlidingWindowMaxSum, ImageExtractor
 from ctapipe.image.toymodel import WaveformModel
 from ctapipe.instrument import SubarrayDescription, TelescopeDescription
 
-from ctapipe.utils import datasets
 
-
-def test_sw_pulse_lst(monkeypatch):
+def test_sw_pulse_lst():
     """
     Test function of sliding window extractor for LST camera pulse shape with
 the correction for the integration window completeness
     """
 
-    with monkeypatch.context() as monkey_patch:
-        monkey_patch.setattr(
-            datasets,
-            "DEFAULT_URL",
-            "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.2/",
-        )
+    # prepare array with 1 LST
+    subarray = SubarrayDescription(
+        "LST1",
+        tel_positions={1: np.zeros(3) * u.m},
+        tel_descriptions={
+            1: TelescopeDescription.from_name(optics_name="LST", camera_name="LSTCam")
+        },
+    )
 
-        # prepare array with 1 LST
-        subarray = SubarrayDescription(
-            "LST1",
-            tel_positions={1: np.zeros(3) * u.m},
-            tel_descriptions={
-                1: TelescopeDescription.from_name(
-                    optics_name="LST", camera_name="LSTCam"
-                )
-            },
-        )
+    telid = list(subarray.tel.keys())[0]
 
-        telid = list(subarray.tel.keys())[0]
+    n_pixels = subarray.tel[telid].camera.geometry.n_pixels
+    n_samples = 40
+    readout = subarray.tel[telid].camera.readout
 
-        n_pixels = subarray.tel[telid].camera.geometry.n_pixels
-        n_samples = 40
-        readout = subarray.tel[telid].camera.readout
+    random = np.random.RandomState(1)
+    min_charge = 100
+    max_charge = 1000
+    charge_true = random.uniform(min_charge, max_charge, n_pixels)
+    time_true = random.uniform(
+        n_samples // 2 - 1, n_samples // 2 + 1, n_pixels
+    ) / readout.sampling_rate.to_value(u.GHz)
 
-        random = np.random.RandomState(1)
-        min_charge = 100
-        max_charge = 1000
-        charge_true = random.uniform(min_charge, max_charge, n_pixels)
-        time_true = random.uniform(
-            n_samples // 2 - 1, n_samples // 2 + 1, n_pixels
-        ) / readout.sampling_rate.to_value(u.GHz)
+    waveform_model = WaveformModel.from_camera_readout(readout)
+    waveform = waveform_model.get_waveform(charge_true, time_true, n_samples)
+    selected_gain_channel = np.zeros(charge_true.size, dtype=np.int)
 
-        waveform_model = WaveformModel.from_camera_readout(readout)
-        waveform = waveform_model.get_waveform(charge_true, time_true, n_samples)
-        selected_gain_channel = np.zeros(charge_true.size, dtype=np.int)
+    # define extractor
+    config = Config({"SlidingWindowMaxSum": {"window_width": 8}})
+    extractor = SlidingWindowMaxSum(subarray=subarray)
+    extractor = ImageExtractor.from_name(
+        "SlidingWindowMaxSum", subarray=subarray, config=config
+    )
 
-        # define extractor
-        config = Config({"SlidingWindowMaxSum": {"window_width": 8}})
-        extractor = SlidingWindowMaxSum(subarray=subarray)
-        extractor = ImageExtractor.from_name(
-            "SlidingWindowMaxSum", subarray=subarray, config=config
-        )
-
-        charge, _ = extractor(waveform, telid, selected_gain_channel)
-        print(charge / charge_true)
-        assert_allclose(charge, charge_true, rtol=0.02)
+    charge, _ = extractor(waveform, telid, selected_gain_channel)
+    print(charge / charge_true)
+    assert_allclose(charge, charge_true, rtol=-0.02)

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -8,45 +8,48 @@ from ctapipe.instrument import SubarrayDescription, TelescopeDescription
 
 from ctapipe.utils import datasets
 
-datasets.DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.2/"
 
+def test_sw_pulse_lst(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr(
+            datasets,
+            "DEFAULT_URL",
+            "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.2/",
+        )
 
-def test_sw_pulse_lst():
+        # prepare array with 1 LST
+        subarray = SubarrayDescription(
+            "LST1",
+            tel_positions={1: np.zeros(3) * u.m},
+            tel_descriptions={
+                1: TelescopeDescription.from_name(
+                    optics_name="LST", camera_name="LSTCam"
+                )
+            },
+        )
 
-    # prepare array with 1 LST
-    subarray = SubarrayDescription(
-        "LST1",
-        tel_positions={1: np.zeros(3) * u.m},
-        tel_descriptions={
-            1: TelescopeDescription.from_name(optics_name="LST", camera_name="LSTCam")
-        },
-    )
+        telid = list(subarray.tel.keys())[0]
 
-    telid = list(subarray.tel.keys())[0]
+        n_pixels = subarray.tel[telid].camera.geometry.n_pixels
+        n_samples = 40
+        readout = subarray.tel[telid].camera.readout
 
-    n_pixels = subarray.tel[telid].camera.geometry.n_pixels
-    n_samples = 40
-    readout = subarray.tel[telid].camera.readout
+        random = np.random.RandomState(1)
+        minCharge = 100
+        maxCharge = 1000
+        charge_true = random.uniform(minCharge, maxCharge, n_pixels)
+        time_true = random.uniform(
+            n_samples // 2 - 1, n_samples // 2 + 1, n_pixels
+        ) / readout.sampling_rate.to_value(u.GHz)
 
-    random = np.random.RandomState(1)
-    minCharge = 100
-    maxCharge = 1000
-    charge_true = random.uniform(minCharge, maxCharge, n_pixels)
-    time_true = random.uniform(
-        n_samples // 2 - 1, n_samples // 2 + 1, n_pixels
-    ) / readout.sampling_rate.to_value(u.GHz)
+        waveform_model = WaveformModel.from_camera_readout(readout)
+        waveform = waveform_model.get_waveform(charge_true, time_true, n_samples)
+        selected_gain_channel = np.zeros(charge_true.size, dtype=np.int)
 
-    waveform_model = WaveformModel.from_camera_readout(readout)
-    waveform = waveform_model.get_waveform(charge_true, time_true, n_samples)
-    selected_gain_channel = np.zeros(charge_true.size, dtype=np.int)
-
-    # define extractor
-    extr_width = 8
-    extractor = SlidingWindowMaxSum(subarray=subarray)
-    extractor.window_width = extr_width
-    charge, peak_time = extractor(waveform, telid, selected_gain_channel)
-    print(charge / charge_true)
-    assert_allclose(charge, charge_true, rtol=0.02)
-
-
-test_sw_pulse_lst()
+        # define extractor
+        extr_width = 8
+        extractor = SlidingWindowMaxSum(subarray=subarray)
+        extractor.window_width = extr_width
+        charge, peak_time = extractor(waveform, telid, selected_gain_channel)
+        print(charge / charge_true)
+        assert_allclose(charge, charge_true, rtol=0.02)

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -55,4 +55,4 @@ the correction for the integration window completeness
 
     charge, _ = extractor(waveform, telid, selected_gain_channel)
     print(charge / charge_true)
-    assert_allclose(charge, charge_true, rtol=-0.02)
+    assert_allclose(charge, charge_true, rtol=0.02)

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -16,7 +16,7 @@ from ctapipe.instrument import SubarrayDescription, TelescopeDescription
 def test_sw_pulse_lst():
     """
     Test function of sliding window extractor for LST camera pulse shape with
-the correction for the integration window completeness
+    the correction for the integration window completeness
     """
 
     # prepare array with 1 LST

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -1,0 +1,52 @@
+import numpy as np
+import astropy.units as u
+from numpy.testing import assert_allclose
+
+from ctapipe.image.extractor import SlidingWindowMaxSum
+from ctapipe.image.toymodel import WaveformModel
+from ctapipe.instrument import SubarrayDescription, TelescopeDescription
+
+from ctapipe.utils import datasets
+
+datasets.DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.2/"
+
+
+def test_sw_pulse_lst():
+
+    # prepare array with 1 LST
+    subarray = SubarrayDescription(
+        "LST1",
+        tel_positions={1: np.zeros(3) * u.m},
+        tel_descriptions={
+            1: TelescopeDescription.from_name(optics_name="LST", camera_name="LSTCam")
+        },
+    )
+
+    telid = list(subarray.tel.keys())[0]
+
+    n_pixels = subarray.tel[telid].camera.geometry.n_pixels
+    n_samples = 40
+    readout = subarray.tel[telid].camera.readout
+
+    random = np.random.RandomState(1)
+    minCharge = 100
+    maxCharge = 1000
+    charge_true = random.uniform(minCharge, maxCharge, n_pixels)
+    time_true = random.uniform(
+        n_samples // 2 - 1, n_samples // 2 + 1, n_pixels
+    ) / readout.sampling_rate.to_value(u.GHz)
+
+    waveform_model = WaveformModel.from_camera_readout(readout)
+    waveform = waveform_model.get_waveform(charge_true, time_true, n_samples)
+    selected_gain_channel = np.zeros(charge_true.size, dtype=np.int)
+
+    # define extractor
+    extr_width = 8
+    extractor = SlidingWindowMaxSum(subarray=subarray)
+    extractor.window_width = extr_width
+    charge, peak_time = extractor(waveform, telid, selected_gain_channel)
+    print(charge / charge_true)
+    assert_allclose(charge, charge_true, rtol=0.02)
+
+
+test_sw_pulse_lst()


### PR DESCRIPTION
a new simple signal extractor, slightly slower, but with better accuracy (in particular for weak pulses): SlidingWindowMaxSum

It maximizes the sum on "width" consecutive slices

some speed test using 3 trials of 1000 events of LST1 data:
only r0==> r1 calibration: 14.575s, 14.465s, 14.550s
LocalPeakWindowSum (current extractor) 19.853s, 20.188s, 20.698s
MaxWindowSum (new code): 21.731s, 20.813s, 21.132s

one feature can be improved, namely the correction for the signal outside of the integration window, the current code is reusing LocalPeakWindowSum approach assuming that the shift is half of the total window, which is correct only if the pulse is symmetric (which is not really the case)