### PR TITLE
Change definition of concentration_cog, fixes #1571

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -153,7 +153,7 @@ class ConcentrationContainer(Container):
 
     container_prefix = "concentration"
     cog = Field(
-        nan, "Percentage of photo-electrons in the three pixels closest to the cog"
+        nan, "Percentage of photo-electrons inside one pixel diameter of the cog"
     )
     core = Field(nan, "Percentage of photo-electrons inside the hillas ellipse")
     pixel = Field(nan, "Percentage of photo-electrons in the brightest pixel")

--- a/ctapipe/image/concentration.py
+++ b/ctapipe/image/concentration.py
@@ -1,6 +1,7 @@
 import numpy as np
 import astropy.units as u
 
+from ..instrument import CameraGeometry
 from ..containers import ConcentrationContainer
 from .hillas import camera_to_shower_coordinates
 from ..utils.quantities import all_to_value
@@ -8,7 +9,7 @@ from ..utils.quantities import all_to_value
 __all__ = ["concentration_parameters"]
 
 
-def concentration_parameters(geom, image, hillas_parameters):
+def concentration_parameters(geom: CameraGeometry, image, hillas_parameters):
     """
     Calculate concentraion values.
 
@@ -21,16 +22,16 @@ def concentration_parameters(geom, image, hillas_parameters):
     h = hillas_parameters
     unit = h.x.unit
 
-    pix_x, pix_y, x, y, length, width = all_to_value(
-        geom.pix_x, geom.pix_y, h.x, h.y, h.length, h.width, unit=unit
+    pix_x, pix_y, x, y, length, width, pixel_width = all_to_value(
+        geom.pix_x, geom.pix_y, h.x, h.y, h.length, h.width, geom.pixel_width, unit=unit
     )
 
     delta_x = pix_x - x
     delta_y = pix_y - y
 
-    # sort pixels by distance to cog
-    cog_pixels = np.argsort(delta_x ** 2 + delta_y ** 2)
-    conc_cog = np.sum(image[cog_pixels[:3]]) / h.intensity
+    # take pixels within one pixel diameter from the cog
+    mask_cog = (delta_x ** 2 + delta_y ** 2) < pixel_width ** 2
+    conc_cog = np.sum(image[mask_cog]) / h.intensity
 
     if hillas_parameters.width.value != 0:
         # get all pixels inside the hillas ellipse

--- a/ctapipe/image/tests/test_concentration.py
+++ b/ctapipe/image/tests/test_concentration.py
@@ -10,7 +10,7 @@ def test_concentration():
 
     hillas = hillas_parameters(geom[clean_mask], image[clean_mask])
 
-    conc = concentration_parameters(geom, image, hillas)
+    conc = concentration_parameters(geom[clean_mask], image[clean_mask], hillas)
 
     assert 0.1 <= conc.cog <= 0.3
     assert 0.05 <= conc.pixel <= 0.2
@@ -26,6 +26,20 @@ def test_width_0():
 
     conc = concentration_parameters(geom, image, hillas)
     assert conc.core == 0
+
+
+def test_no_pixels_near_cog():
+    geom, image, clean_mask = create_sample_image("30d")
+
+    hillas = hillas_parameters(geom[clean_mask], image[clean_mask])
+
+    # remove pixels close to cog from the cleaning pixels
+    clean_mask &= ((geom.pix_x - hillas.x) ** 2 + (geom.pix_y - hillas.y) ** 2) >= (
+        2 * geom.pixel_width ** 2
+    )
+
+    conc = concentration_parameters(geom[clean_mask], image[clean_mask], hillas)
+    assert conc.cog == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This changes the definition of concentration_cog from
"the three closest pixels to the cog" to
"pixel closer to the cog than the pixel diameter".

This has two advantages:
* no need for argsort: 50 % faster
* works if a masked geometry / image is passed as expected, before
  the three closest pixels to the cog could be very far away from the
  cog, e.g. for muon rings.