### PR TITLE
Traverse classes attribute in `classes_with_traits` to enable more complete `--help-all`

### DIFF
--- a/ctapipe/core/tests/test_tool.py
+++ b/ctapipe/core/tests/test_tool.py
@@ -2,7 +2,7 @@ import os
 import logging
 import tempfile
 import pytest
-from traitlets import Float, TraitError, List, Dict, Int
+from traitlets import Float, TraitError, Dict, Int
 from traitlets.config import Config
 from pathlib import Path
 
@@ -190,7 +190,7 @@ def test_tool_command_line_precedence():
         description = "test"
         userparam = Float(5.0, help="parameter").tag(config=True)
 
-        classes = List([SubComponent])
+        classes = [SubComponent]
         aliases = Dict({"component_param": "SubComponent.component_param"})
 
         def setup(self):

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -7,6 +7,7 @@ import pathlib
 
 from ctapipe.core import Component, TelescopeComponent
 from ctapipe.core.traits import (
+    List,
     Float,
     Path,
     TraitError,
@@ -178,6 +179,30 @@ def test_enum_classes_with_traits():
     """ test that we can get a list of classes that have traits """
     list_of_classes = classes_with_traits(ImageExtractor)
     assert list_of_classes  # should not be empty
+
+
+def test_classes_with_traits():
+    from ctapipe.core import Tool
+
+    class CompA(Component):
+        a = Int().tag(config=True)
+
+    class CompB(Component):
+        classes = List([CompA])
+        b = Int().tag(config=True)
+
+    class CompC(Component):
+        c = Int().tag(config=True)
+
+    class MyTool(Tool):
+        classes = [CompB, CompC]
+
+    with_traits = classes_with_traits(MyTool)
+    assert len(with_traits) == 4
+    assert MyTool in with_traits
+    assert CompA in with_traits
+    assert CompB in with_traits
+    assert CompC in with_traits
 
 
 def test_has_traits():

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -51,7 +51,7 @@ class Tool(Application):
     .. code:: python
 
         from ctapipe.core import Tool
-        from traitlets import (Integer, Float, List, Dict, Unicode)
+        from traitlets import (Integer, Float, Dict, Unicode)
 
         class MyTool(Tool):
             name = "mytool"
@@ -60,8 +60,7 @@ class Tool(Application):
                             'iterations': 'MyTool.iterations'})
 
             # Which classes are registered for configuration
-            classes = List([MyComponent, AdvancedComponent,
-                            SecondaryMyComponent])
+            classes = [MyComponent, AdvancedComponent, SecondaryMyComponent]
 
             # local configuration parameters
             iterations = Integer(5,help="Number of times to run",

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -200,7 +200,27 @@ def classes_with_traits(base_class):
     """ Returns a list of the base class plus its non-abstract children
     if they have traits """
     all_classes = [base_class] + non_abstract_children(base_class)
-    return [cls for cls in all_classes if has_traits(cls)]
+    with_traits = []
+
+    for cls in all_classes:
+        if has_traits(cls):
+            with_traits.append(cls)
+
+        # add subcomponents
+        if hasattr(cls, "classes"):
+            # we will ignore failing classes to not break anyone
+            if isinstance(cls.classes, List):
+                classes = cls.classes.default()
+            else:
+                classes = cls.classes
+
+            try:
+                for component in classes:
+                    with_traits.extend(classes_with_traits(component))
+            except Exception:
+                pass
+
+    return with_traits
 
 
 def has_traits(cls, ignore=("config", "parent")):

--- a/ctapipe/tools/bokeh/file_viewer.py
+++ b/ctapipe/tools/bokeh/file_viewer.py
@@ -44,7 +44,7 @@ class BokehFileViewer(Tool):
         )
     )
 
-    classes = List([EventSource] + traits.classes_with_traits(ImageExtractor))
+    classes = [EventSource] + traits.classes_with_traits(ImageExtractor)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -4,7 +4,7 @@ Calibrate dl0 data to dl1, and plot the photoelectron images.
 from copy import copy
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
-from traitlets import Bool, Dict, Int, List
+from traitlets import Bool, Dict, Int
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Component, Tool
@@ -152,9 +152,7 @@ class DisplayDL1Calib(Tool):
             )
         )
     )
-    classes = List(
-        [EventSource, ImagePlotter] + traits.classes_with_traits(ImageExtractor)
-    )
+    classes = [EventSource, ImagePlotter] + traits.classes_with_traits(ImageExtractor)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ctapipe/tools/display_events_single_tel.py
+++ b/ctapipe/tools/display_events_single_tel.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Tool
-from ctapipe.core.traits import Float, Dict, List
+from ctapipe.core.traits import Float, Dict
 from ctapipe.core.traits import Unicode, Int, Bool
 from ctapipe.image import tailcuts_clean, hillas_parameters, HillasParameterizationError
 from ctapipe.io import EventSource
@@ -65,7 +65,7 @@ class SingleTelEventDisplay(Tool):
         }
     )
 
-    classes = List([EventSource, CameraCalibrator])
+    classes = [EventSource, CameraCalibrator]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ctapipe/tools/display_integrator.py
+++ b/ctapipe/tools/display_integrator.py
@@ -5,7 +5,7 @@ with the integration window.
 """
 import numpy as np
 from matplotlib import pyplot as plt
-from traitlets import Dict, List, Int, Bool, Enum
+from traitlets import Dict, Int, Bool, Enum
 
 from ctapipe.core import traits
 from ctapipe.calib import CameraCalibrator
@@ -241,7 +241,7 @@ class DisplayIntegrator(Tool):
             )
         )
     )
-    classes = List([EventSource] + traits.classes_with_traits(ImageExtractor))
+    classes = [EventSource] + traits.classes_with_traits(ImageExtractor)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ctapipe/tools/display_summed_images.py
+++ b/ctapipe/tools/display_summed_images.py
@@ -9,7 +9,7 @@ from matplotlib import pyplot as plt
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Tool
-from ctapipe.core.traits import Unicode, Integer, Dict, List, Path
+from ctapipe.core.traits import Unicode, Integer, Dict, Path
 from ctapipe.io import SimTelEventSource
 from ctapipe.visualization import CameraDisplay
 from ctapipe.utils import get_dataset_path
@@ -49,7 +49,7 @@ class ImageSumDisplayerTool(Tool):
         }
     )
 
-    classes = List([CameraCalibrator, SimTelEventSource])
+    classes = [CameraCalibrator, SimTelEventSource]
 
     def setup(self):
         # load up the telescope types table (need to first open a file, a bit of

--- a/ctapipe/tools/extract_charge_resolution.py
+++ b/ctapipe/tools/extract_charge_resolution.py
@@ -15,7 +15,7 @@ from ctapipe.analysis.camera.charge_resolution import ChargeResolutionCalculator
 from ctapipe.calib import CameraCalibrator
 from ctapipe.core import Provenance, Tool, traits
 from ctapipe.image.extractor import ImageExtractor
-from ctapipe.io.simteleventsource import SimTelEventSource
+from ctapipe.io import EventSource
 
 
 class ChargeResolutionGenerator(Tool):
@@ -39,14 +39,16 @@ class ChargeResolutionGenerator(Tool):
 
     aliases = Dict(
         dict(
-            f="SimTelEventSource.input_url",
+            f="EventSource.input_url",
             max_events="SimTelEventSource.max_events",
-            T="SimTelEventSource.allowed_tels",
+            T="EventSource.allowed_tels",
             O="ChargeResolutionGenerator.output_path",
         )
     )
 
-    classes = List([SimTelEventSource] + traits.classes_with_traits(ImageExtractor))
+    classes = traits.classes_with_traits(EventSource) + traits.classes_with_traits(
+        ImageExtractor
+    )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -57,7 +59,7 @@ class ChargeResolutionGenerator(Tool):
     def setup(self):
         self.log_format = "%(levelname)s: %(message)s [%(name)s.%(funcName)s]"
 
-        self.eventsource = SimTelEventSource(parent=self)
+        self.eventsource = EventSource(parent=self)
 
         self.calibrator = CameraCalibrator(
             parent=self, subarray=self.eventsource.subarray

--- a/ctapipe/tools/plot_charge_resolution.py
+++ b/ctapipe/tools/plot_charge_resolution.py
@@ -26,7 +26,7 @@ class ChargeResolutionViewer(Tool):
             o="ChargeResolutionPlotter.output_path",
         )
     )
-    classes = List([ChargeResolutionPlotter])
+    classes = [ChargeResolutionPlotter]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -66,7 +66,7 @@ class Stage1Tool(Tool):
         ),
     }
 
-    classes = List(
+    classes = (
         [CameraCalibrator, DL1Writer, ImageProcessor]
         + classes_with_traits(EventSource)
         + classes_with_traits(ImageCleaner)
@@ -146,3 +146,7 @@ def main():
     """ run the tool"""
     tool = Stage1Tool()
     tool.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/Tools.ipynb
+++ b/docs/examples/Tools.ipynb
@@ -198,7 +198,7 @@
     "    )\n",
     "\n",
     "    # Which classes are registered for configuration\n",
-    "    classes = List([MyComponent, AdvancedComponent, SecondaryMyComponent, TelescopeWiseComponent])\n",
+    "    classes = [MyComponent, AdvancedComponent, SecondaryMyComponent, TelescopeWiseComponent]\n",
     "\n",
     "    # local configuration parameters\n",
     "    iterations = Integer(5,help=\"Number of times to run\",allow_none=False).tag(config=True)\n",

--- a/examples/simple_event_writer.py
+++ b/examples/simple_event_writer.py
@@ -9,7 +9,7 @@ An HDF5 file is written with image MC and moment parameters
 from tqdm import tqdm
 
 from ctapipe.core import Tool
-from ctapipe.core.traits import Path, Unicode, List, Dict, Bool
+from ctapipe.core.traits import Path, Unicode, Dict, Bool
 from ctapipe.io import EventSource, HDF5TableWriter
 
 from ctapipe.calib import CameraCalibrator
@@ -35,7 +35,7 @@ class SimpleEventWriter(Tool):
             "progress": "SimpleEventWriter.progress",
         }
     )
-    classes = List([EventSource, CameraCalibrator])
+    classes = [EventSource, CameraCalibrator]
 
     def setup(self):
         self.log.info("Configure EventSource...")

--- a/examples/tool_example.py
+++ b/examples/tool_example.py
@@ -52,7 +52,7 @@ class MyTool(Tool):
 
     name = Unicode("myapp")
     running = Bool(False, help="Is the app running?").tag(config=True)
-    classes = List([BComponent, AComponent])
+    classes = [BComponent, AComponent]
 
     aliases = Dict(
         dict(


### PR DESCRIPTION
Note: traitlets itself does not use `List` but `list` for `classes`, I don't know why we started with that.

This results in `--help-all` to basically show the help for, well, `all`. Including for example the configurable items in the plugin components.