### PR TITLE
Faster muon reconstruction using numba

### DIFF
--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -262,8 +262,6 @@ def image_prediction_no_units(
     # The weight is the integral of the ring's radial gaussian profile inside the
     # ring's width
     delta = pixel_diameter_rad / 2
-
-    # Define Gaussian cdf for numba usage
     cdfs = gaussian_cdf(
         [radial_dist + delta, radial_dist - delta], radius_rad, ring_width_rad
     )

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -203,7 +203,7 @@ def gaussian_cdf(x, mu, sig):
     Parameters
     ----------
     x: float
-        point, at which the cfd should be evaluated
+        point, at which the cdf should be evaluated
     mu: float
         gaussian mean
     sig: float

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -39,16 +39,16 @@ def chord_length(radius, rho, phi):
 
     Parameters
     ----------
-    radius: float
+    radius: float or ndarray
         radius of circle
-    rho: float
+    rho: float or ndarray
         fractional distance of impact point from circle center
-    phi: float in radians
+    phi: float or ndarray in radians
         rotation angles to calculate length
 
     Returns
     -------
-    float:
+    float or ndarray:
         chord length
     """
     chord = 1 - (rho ** 2 * np.sin(phi) ** 2)
@@ -207,16 +207,16 @@ def gaussian_cdf(x, mu, sig):
 
     Parameters
     ----------
-    x: float
+    x: float or ndarray
         point, at which the cdf should be evaluated
-    mu: float
+    mu: float or ndarray
         gaussian mean
-    sig: float
-        gaussian standart deviation
+    sig: float or ndarray
+        gaussian standard deviation
 
     Returns
     -------
-    float: cdf-value at x
+    float or ndarray: cdf-value at x
     """
     return 0.5 * (1 + erf((x - mu) / (SQRT2 * sig)))
 

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -10,7 +10,7 @@ To do:
 import numpy as np
 
 from math import sqrt, erf
-from numba import vectorize, double
+from numba import vectorize, guvectorize, double, int32
 
 from scipy.ndimage.filters import correlate1d
 from iminuit import Minuit
@@ -29,7 +29,8 @@ from ...core.traits import FloatTelescopeParameter, IntTelescopeParameter
 # ratio of the areas of the unit circle and a square of side lengths 2
 CIRCLE_SQUARE_AREA_RATIO = np.pi / 4
 
-def chord_length(radius, rho, phi):
+@guvectorize([(double, double, double[:], double[:])], '(),(),(n)->(n)')
+def chord_length(radius, rho, phi, ret_chord):
     """
     Function for integrating the length of a chord across a circle
 
@@ -46,24 +47,17 @@ def chord_length(radius, rho, phi):
     -------
     ndarray: chord length
     """
-    scalar = np.isscalar(phi)
-    phi = np.array(phi, ndmin=1, copy=False)
-
-    chord = 1 - (rho ** 2 * np.sin(phi) ** 2)
-    valid = chord >= 0
-
-    if rho <= 1.0:
-        # muon has hit the mirror
-        chord[valid] = radius * (np.sqrt(chord[valid]) + rho * np.cos(phi[valid]))
-    else:
-        # muon did not hit the mirror
-        chord[valid] = 2 * radius * np.sqrt(chord[valid])
-
-    chord[~valid] = 0
-
-    if scalar:
-        return chord[0]
-    return chord
+    for i in range(len(phi)):
+        ret_chord[i] = 1 - (rho ** 2 * np.sin(phi[i]) ** 2)
+        if ret_chord[i] < 0:
+            ret_chord[i] = 0
+        else:
+            if rho <= 1.0:
+            # muon has hit the mirror
+                ret_chord[i] = radius * (np.sqrt(ret_chord[i]) + rho * np.cos(phi[i]))
+            else:
+            # muon did not hit the mirror
+                ret_chord[i] = 2 * radius * np.sqrt(ret_chord[i])
 
 
 def intersect_circle(mirror_radius, r, angle, hole_radius=0):

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -30,8 +30,8 @@ from ...core.traits import FloatTelescopeParameter, IntTelescopeParameter
 CIRCLE_SQUARE_AREA_RATIO = np.pi / 4
 
 
-@guvectorize([(double, double, double[:], double[:])], "(),(),(n)->(n)")
-def chord_length(radius, rho, phi, ret_chord):
+@vectorize([double(double, double, double)])
+def chord_length(radius, rho, phi):
     """
     Function for integrating the length of a chord across a circle
 
@@ -41,25 +41,28 @@ def chord_length(radius, rho, phi, ret_chord):
         radius of circle
     rho: float
         fractional distance of impact point from circle center
-    phi: ndarray in radians
+    phi: float in radians
         rotation angles to calculate length
 
     Returns
     -------
-    ret_chord: ndarray
+    float:
         chord length
     """
-    for i in range(len(phi)):
-        ret_chord[i] = 1 - (rho ** 2 * np.sin(phi[i]) ** 2)
-        if ret_chord[i] < 0:
-            ret_chord[i] = 0
-        else:
-            if rho <= 1.0:
-                # muon has hit the mirror
-                ret_chord[i] = radius * (np.sqrt(ret_chord[i]) + rho * np.cos(phi[i]))
-            else:
-                # muon did not hit the mirror
-                ret_chord[i] = 2 * radius * np.sqrt(ret_chord[i])
+    chord = 1 - (rho ** 2 * np.sin(phi) ** 2)
+    valid = chord >= 0
+
+    if not valid:
+        return 0
+
+    if rho <= 1.0:
+        # muon has hit the mirror
+        chord = radius * (np.sqrt(chord) + rho * np.cos(phi))
+    else:
+        # muon did not hit the mirror
+        chord = 2 * radius * np.sqrt(chord)
+
+    return chord
 
 
 def intersect_circle(mirror_radius, r, angle, hole_radius=0):

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -28,6 +28,9 @@ from ...core.traits import FloatTelescopeParameter, IntTelescopeParameter
 # ratio of the areas of the unit circle and a square of side lengths 2
 CIRCLE_SQUARE_AREA_RATIO = np.pi / 4
 
+# Sqrt of 2, as it is needed multiple times
+SQRT2 = np.sqrt(2)
+
 
 @vectorize([double(double, double, double)])
 def chord_length(radius, rho, phi):
@@ -215,7 +218,7 @@ def gaussian_cdf(x, mu, sig):
     -------
     float: cdf-value at x
     """
-    return 0.5 * (1 + erf((x - mu) / (np.sqrt(2 * sig ** 2))))
+    return 0.5 * (1 + erf((x - mu) / (SQRT2 * sig)))
 
 
 def image_prediction_no_units(

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -10,13 +10,12 @@ To do:
 import numpy as np
 
 from math import erf
-from numba import vectorize, guvectorize, double
+from numba import vectorize, double
 
 from scipy.ndimage.filters import correlate1d
 from iminuit import Minuit
 from astropy import units as u
 from scipy.constants import alpha
-from scipy.stats import norm
 from astropy.coordinates import SkyCoord
 from functools import lru_cache
 


### PR DESCRIPTION
Small changes to utilize numba for faster muon reconstruction. The major part in the ~1/3 decreased time required for processing muon events is gained in the direct implementation of a gaussian cdf, where the math modules erf-function is needed since standard numba is not aware of scipy. Further speedup is gained from decorating the chord_length function. This does, however, require the definition of an input and output layout that restricts the usage of the function to inputs of dimension 1 (which should be the use-case). As a result, the corresponding unit-tests are failing, as these test the function with scalar values.