### PR TITLE
to support eventio 1.5 update dtype of true_image

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -399,7 +399,7 @@ class SimulatedCameraContainer(Container):
         None,
         "Numpy array of camera image in PE as simulated before noise has been added. "
         "Shape: (n_pixel)",
-        dtype=np.float32,
+        dtype=np.int32,
         ndim=1,
     )
 

--- a/ctapipe/io/dl1eventsource.py
+++ b/ctapipe/io/dl1eventsource.py
@@ -28,7 +28,7 @@ from ctapipe.utils import IndexFinder
 logger = logging.getLogger(__name__)
 
 
-COMPATIBLE_DL1_VERSIONS = ["v1.0.0", "v1.0.1", "v1.0.2"]
+COMPATIBLE_DL1_VERSIONS = ["v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3"]
 
 
 class DL1EventSource(EventSource):

--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -28,7 +28,11 @@ __all__ = ["DL1Writer", "DL1_DATA_MODEL_VERSION", "write_reference_metadata_head
 
 tables.parameters.NODE_CACHE_SLOTS = 3000  # fixes problem with too many datasets
 
-DL1_DATA_MODEL_VERSION = "v1.0.2"
+DL1_DATA_MODEL_VERSION = "v1.0.3"
+DL1_DATA_MODEL_CHANGE_HISTORY = """
+- v1.0.3: true_image dtype changed from float32 to int32
+"""
+
 PROV = Provenance()
 
 

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -398,7 +398,7 @@ class SimTelEventSource(EventSource):
                 true_image = (
                     array_event.get("photoelectrons", {})
                     .get(tel_id - 1, {})
-                    .get("photoelectrons", np.zeros(n_pixels, dtype="float32"))
+                    .get("photoelectrons", np.zeros(n_pixels, dtype="int32"))
                 )
 
                 data.simulation.tel[tel_id] = SimulatedCameraContainer(

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -398,7 +398,7 @@ class SimTelEventSource(EventSource):
                 true_image = (
                     array_event.get("photoelectrons", {})
                     .get(tel_id - 1, {})
-                    .get("photoelectrons", np.zeros(n_pixels, dtype="int32"))
+                    .get("photoelectrons", None)
                 )
 
                 data.simulation.tel[tel_id] = SimulatedCameraContainer(

--- a/ctapipe/tools/display_integrator.py
+++ b/ctapipe/tools/display_integrator.py
@@ -20,8 +20,10 @@ def plot(subarray, event, telid, chan, extractor_name):
     # Extract required images
     dl0 = event.dl0.tel[telid].waveform
 
-    t_pe = event.simulation.tel[telid].true_image
     dl1 = event.dl1.tel[telid].image
+    t_pe = event.simulation.tel[telid].true_image
+    if t_pe is None:
+        t_pe = np.zeros_like(dl1)
     max_time = np.unravel_index(np.argmax(dl0), dl0.shape)[1]
     max_charges = np.max(dl0, axis=1)
     max_pix = int(np.argmax(max_charges))

--- a/environment.yml
+++ b/environment.yml
@@ -42,4 +42,4 @@ dependencies:
   - xz
   - zlib
   - zstandard
-  - conda-forge::eventio>=1.1.1
+  - conda-forge::eventio>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         "astropy>=4,<5",
         "bokeh~=1.0",
-        "eventio>=1.1.1,<2.0.0a0",  # at least 1.1.1, but not 2
+        "eventio>=1.5.0,<2.0.0a0",  # at least 1.1.1, but not 2
         "iminuit~=1.3",
         "joblib",
         "matplotlib~=3.0",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         "astropy>=4,<5",
         "bokeh~=1.0",
-        "eventio>=1.5.0,<2.0.0a0",  # at least 1.1.1, but not 2
+        "eventio>=1.5.0,<2.0.0a0",
         "iminuit~=1.3",
         "joblib",
         "matplotlib~=3.0",


### PR DESCRIPTION
all CI pipelines currently fail since eventio1.5 now stores the true_image field as a int instead of a float.  This should fix it, and require eventio>=1.5