### PR TITLE
Refactor conversions, implement possibility to transform images and peak times to int

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -51,7 +51,7 @@ __all__ = [
 
 
 # see https://github.com/astropy/astropy/issues/6509
-NAN_TIME = Time(np.ma.masked_array(nan, mask=True), format="mjd")
+NAN_TIME = Time(0, format="mjd", scale="tai")
 
 
 class EventType(enum.Enum):

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -58,8 +58,6 @@ def h5_table_to_astropy(h5file, path) -> QTable:
 
     other_attrs = {}
     column_descriptions = {}
-    # column_units = {}  # mapping of colname to unit
-    # time_columns = {}
     column_transforms = {}
     for attr in table.attrs._f_list():  # pylint: disable=W0212
         if attr.endswith("_UNIT"):

--- a/ctapipe/io/dl1eventsource.py
+++ b/ctapipe/io/dl1eventsource.py
@@ -29,7 +29,7 @@ from ctapipe.utils import IndexFinder
 logger = logging.getLogger(__name__)
 
 
-COMPATIBLE_DL1_VERSIONS = ["v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3"]
+COMPATIBLE_DL1_VERSIONS = ["v1.0.0", "v1.0.1", "v1.0.2", "v1.0.3", "v1.1.0"]
 
 
 class DL1EventSource(EventSource):

--- a/ctapipe/io/dl1eventsource.py
+++ b/ctapipe/io/dl1eventsource.py
@@ -10,6 +10,7 @@ from ctapipe.io.datalevels import DataLevel
 from ctapipe.containers import (
     ConcentrationContainer,
     ArrayEventContainer,
+    DL1CameraContainer,
     EventIndexContainer,
     HillasParametersContainer,
     IntensityStatisticsContainer,
@@ -208,11 +209,15 @@ class DL1EventSource(EventSource):
         data.meta["input_url"] = self.input_url
         data.meta["max_events"] = self.max_events
 
+        self.reader = HDF5TableReader(self.file_)
+
         if DataLevel.DL1_IMAGES in self.datalevels:
-            image_iterators = {
-                tel.name: self.file_.root.dl1.event.telescope.images[
-                    tel.name
-                ].iterrows()
+            image_readers = {
+                tel.name: self.reader.read(
+                    f"/dl1/event/telescope/images/{tel.name}",
+                    DL1CameraContainer(),
+                    ignore_columns={"parameters"},
+                )
                 for tel in self.file_.root.dl1.event.telescope.images
             }
             if self.has_simulated_dl1:
@@ -225,7 +230,7 @@ class DL1EventSource(EventSource):
 
         if DataLevel.DL1_PARAMETERS in self.datalevels:
             param_readers = {
-                tel.name: HDF5TableReader(self.file_).read(
+                tel.name: self.reader.read(
                     f"/dl1/event/telescope/parameters/{tel.name}",
                     containers=[
                         HillasParametersContainer(),
@@ -242,7 +247,7 @@ class DL1EventSource(EventSource):
             }
             if self.has_simulated_dl1:
                 simulated_param_readers = {
-                    tel.name: HDF5TableReader(self.file_).read(
+                    tel.name: self.reader.read(
                         f"/simulation/event/telescope/parameters/{tel.name}",
                         containers=[
                             HillasParametersContainer(),
@@ -266,7 +271,9 @@ class DL1EventSource(EventSource):
 
         # Setup iterators for the array events
         events = HDF5TableReader(self.file_).read(
-            "/dl1/event/subarray/trigger", [TriggerContainer(), EventIndexContainer()]
+            "/dl1/event/subarray/trigger",
+            [TriggerContainer(), EventIndexContainer()],
+            ignore_columns={"tel"},
         )
 
         array_pointing_finder = IndexFinder(
@@ -312,25 +319,25 @@ class DL1EventSource(EventSource):
                 data.simulation.shower = next(mc_shower_reader)
 
             for tel in data.trigger.tel.keys():
+                key = f"tel_{tel:03d}"
                 if self.allowed_tels and tel not in self.allowed_tels:
                     continue
                 if self.has_simulated_dl1:
                     simulated = data.simulation.tel[tel]
-                dl1 = data.dl1.tel[tel]
+
                 if DataLevel.DL1_IMAGES in self.datalevels:
-                    if f"tel_{tel:03d}" not in image_iterators.keys():
+                    if key not in image_readers:
                         logger.debug(
                             f"Triggered telescope {tel} is missing "
                             "from the image table."
                         )
                         continue
-                    image_row = next(image_iterators[f"tel_{tel:03d}"])
-                    dl1.image = image_row["image"]
-                    dl1.peak_time = image_row["peak_time"]
-                    dl1.image_mask = image_row["image_mask"]
+
+                    dl1 = next(image_readers[key])
+                    data.dl1.tel[tel] = dl1
 
                     if self.has_simulated_dl1:
-                        if f"tel_{tel:03d}" not in simulated_image_iterators.keys():
+                        if key not in simulated_image_iterators:
                             logger.warning(
                                 f"Triggered telescope {tel} is missing "
                                 "from the simulated image table, but was present at the "
@@ -390,7 +397,7 @@ class DL1EventSource(EventSource):
         """
         # Only unique pointings are stored, so reader.read() wont work as easily
         # Thats why we match the pointings based on trigger time
-        closest_time_index = array_pointing_finder.closest(data.trigger.time)
+        closest_time_index = array_pointing_finder.closest(data.trigger.time.mjd)
         array_pointing = self.file_.root.dl1.monitoring.subarray.pointing
         data.pointing.array_azimuth = u.Quantity(
             array_pointing[closest_time_index]["array_azimuth"],

--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -29,8 +29,9 @@ __all__ = ["DL1Writer", "DL1_DATA_MODEL_VERSION", "write_reference_metadata_head
 
 tables.parameters.NODE_CACHE_SLOTS = 3000  # fixes problem with too many datasets
 
-DL1_DATA_MODEL_VERSION = "v1.0.3"
+DL1_DATA_MODEL_VERSION = "v1.1.0"
 DL1_DATA_MODEL_CHANGE_HISTORY = """
+- v1.1.0: images and peak_times can be stored as scaled integers
 - v1.0.3: true_image dtype changed from float32 to int32
 """
 

--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -18,10 +18,11 @@ from ..containers import (
     TelEventIndexContainer,
 )
 from ..core import Component, Container, Field, Provenance, ToolConfigurationError
-from ..core.traits import Bool, CaselessStrEnum, Int, Path
+from ..core.traits import Bool, CaselessStrEnum, Int, Path, Float, Unicode
 from ..io import EventSource, HDF5TableWriter, TableWriter
 from ..io.simteleventsource import SimTelEventSource
 from ..io import metadata as meta
+from ..io.hdf5tableio import ScaleColumnTransform
 from ..instrument import SubarrayDescription
 
 __all__ = ["DL1Writer", "DL1_DATA_MODEL_VERSION", "write_reference_metadata_headers"]
@@ -138,6 +139,16 @@ class DL1Writer(Component):
     ).tag(config=True)
 
     overwrite = Bool(help="overwrite output file if it exists").tag(config=True)
+
+    transform_image = Bool(default_value=False).tag(config=True)
+    image_dtype = Unicode(default_value="int32").tag(config=True)
+    image_offset = Int(default_value=0).tag(config=True)
+    image_scale = Float(default_value=100.0).tag(config=True)
+
+    transform_peak_time = Bool(default_value=False).tag(config=True)
+    peak_time_dtype = Unicode(default_value="int32").tag(config=True)
+    peak_time_offset = Int(default_value=0).tag(config=True)
+    peak_time_scale = Float(default_value=10.0).tag(config=True)
 
     def __init__(self, event_source: EventSource, config=None, parent=None, **kwargs):
         """
@@ -318,6 +329,28 @@ class DL1Writer(Component):
             writer.exclude(tel_pointing, "n_trigger_pixels")
             writer.exclude(tel_pointing, "trigger_pixels")
             writer.exclude(f"/dl1/event/telescope/images/{table_name}", "parameters")
+
+            if self.transform_image:
+                tr = ScaleColumnTransform(
+                    scale=self.image_scale,
+                    offset=self.image_offset,
+                    source_dtype=np.float32,
+                    target_dtype=np.dtype(self.image_dtype),
+                )
+                writer.add_column_transform(
+                    f"dl1/event/telescope/images/{table_name}", "image", tr
+                )
+
+            if self.transform_peak_time:
+                tr = ScaleColumnTransform(
+                    scale=self.peak_time_scale,
+                    offset=self.peak_time_offset,
+                    source_dtype=np.float32,
+                    target_dtype=np.dtype(self.peak_time_dtype),
+                )
+                writer.add_column_transform(
+                    f"dl1/event/telescope/images/{table_name}", "peak_time", tr
+                )
 
             if self._is_simulation:
                 writer.exclude(

--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -22,7 +22,7 @@ from ..core.traits import Bool, CaselessStrEnum, Int, Path, Float, Unicode
 from ..io import EventSource, HDF5TableWriter, TableWriter
 from ..io.simteleventsource import SimTelEventSource
 from ..io import metadata as meta
-from ..io.hdf5tableio import ScaleColumnTransform
+from ..io.tableio import FixedPointColumnTransform
 from ..instrument import SubarrayDescription
 
 __all__ = ["DL1Writer", "DL1_DATA_MODEL_VERSION", "write_reference_metadata_headers"]
@@ -331,7 +331,7 @@ class DL1Writer(Component):
             writer.exclude(f"/dl1/event/telescope/images/{table_name}", "parameters")
 
             if self.transform_image:
-                tr = ScaleColumnTransform(
+                tr = FixedPointColumnTransform(
                     scale=self.image_scale,
                     offset=self.image_offset,
                     source_dtype=np.float32,
@@ -342,7 +342,7 @@ class DL1Writer(Component):
                 )
 
             if self.transform_peak_time:
-                tr = ScaleColumnTransform(
+                tr = FixedPointColumnTransform(
                     scale=self.peak_time_scale,
                     offset=self.peak_time_offset,
                     source_dtype=np.float32,

--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -143,12 +143,12 @@ class DL1Writer(Component):
     transform_image = Bool(default_value=False).tag(config=True)
     image_dtype = Unicode(default_value="int32").tag(config=True)
     image_offset = Int(default_value=0).tag(config=True)
-    image_scale = Float(default_value=100.0).tag(config=True)
+    image_scale = Float(default_value=10.0).tag(config=True)
 
     transform_peak_time = Bool(default_value=False).tag(config=True)
-    peak_time_dtype = Unicode(default_value="int32").tag(config=True)
+    peak_time_dtype = Unicode(default_value="int16").tag(config=True)
     peak_time_offset = Int(default_value=0).tag(config=True)
-    peak_time_scale = Float(default_value=10.0).tag(config=True)
+    peak_time_scale = Float(default_value=100.0).tag(config=True)
 
     def __init__(self, event_source: EventSource, config=None, parent=None, **kwargs):
         """

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -66,7 +66,8 @@ class TableWriter(Component, metaclass=ABCMeta):
         transform: callable
             function that take a value and returns a new one
         """
-        self._transforms[table_name][col_name] = transform
+        # allow leading slash
+        self._transforms[table_name.lstrip("/")][col_name] = transform
         self.log.debug(
             "Added transform: {}/{} -> {}".format(table_name, col_name, transform)
         )

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -164,7 +164,7 @@ class TableReader(Component, metaclass=ABCMeta):
         """
         if col_name in self._transforms[table_name]:
             tr = self._transforms[table_name][col_name]
-            value = tr(value)
+            value = tr.inverse(value)
         return value
 
     @abstractmethod

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -208,7 +208,7 @@ class ColumnTransform(metaclass=ABCMeta):
     ``TableReader`` will call `.inverse`` the reverse the transformation 
     when a transformation is detected in the file through metadata.
 
-    Transformations implemnt ``get_meta`` to provide the necessary metadata
+    Transformations implement ``get_meta`` to provide the necessary metadata
     for inverting the transformation on reading.
     """
 

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -2,9 +2,11 @@ import re
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
-from ctapipe.core import Component
+import numpy as np
 from astropy.time import Time
 from astropy.units import Quantity
+
+from ..core import Component
 
 
 __all__ = ["TableReader", "TableWriter"]

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -3,6 +3,9 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
 from ctapipe.core import Component
+from astropy.time import Time
+from astropy.units import Quantity
+
 
 __all__ = ["TableReader", "TableWriter"]
 
@@ -193,3 +196,117 @@ class TableReader(Component, metaclass=ABCMeta):
     @abstractmethod
     def close(self):
         pass
+
+
+class ColumnTransform(metaclass=ABCMeta):
+    """
+    A Transformation to be applied before serialization / after deserialization.
+
+    The ``TableWriter`` will call the transform on the data to be stored and
+    ``TableReader`` will call `.inverse`` the reverse the transformation 
+    when a transformation is detected in the file through metadata.
+
+    Transformations implemnt ``get_meta`` to provide the necessary metadata
+    for inverting the transformation on reading.
+    """
+
+    @abstractmethod
+    def __call__(self, value):
+        pass
+
+    def inverse(self, value):
+        """No inverse transform by default"""
+        return value
+
+    def get_meta(self, colname):
+        """Empty meta by default"""
+        return {}
+
+
+class TimeColumnTransform(ColumnTransform):
+    """A Column transformation that converts astropy time objects to MJD TAI"""
+
+    def __init__(self, scale, format):
+        self.scale = scale
+        self.format = format
+
+    def __call__(self, value: Time):
+        """
+        Convert an astropy time object to an mjd value in tai scale
+        """
+        return getattr(getattr(value, self.scale), self.format)
+
+    def inverse(self, value):
+        return Time(value, scale=self.scale, format=self.format, copy=False)
+
+    def get_meta(self, colname):
+        return {
+            f"{colname}_TRANSFORM": "time",
+            f"{colname}_TIME_FORMAT": self.format,
+            f"{colname}_TIME_SCALE": self.scale,
+        }
+
+
+class QuantityColumnTransform(ColumnTransform):
+    """ A Column Transform that transforms quantities to their values in the given unit"""
+
+    def __init__(self, unit):
+        self.unit = unit
+
+    def __call__(self, value):
+        return value.to_value(self.unit)
+
+    def inverse(self, value):
+        return Quantity(value, self.unit, copy=False)
+
+    def get_meta(self, colname):
+        return {
+            f"{colname}_TRANSFORM": "quantity",
+            f"{colname}_UNIT": self.unit.to_string("vounit"),
+        }
+
+
+class FixedPointColumnTransform(ColumnTransform):
+    """
+    Apply a scale, offset and dtype conversion.
+
+    Can be used to store values as fixed point by using an integer dtype
+    and a scale that is a power of 10.
+    """
+
+    def __init__(self, scale, offset, source_dtype, target_dtype):
+        self.scale = scale
+        self.offset = offset
+        self.source_dtype = np.dtype(source_dtype)
+        self.target_dtype = np.dtype(target_dtype)
+
+    def __call__(self, value):
+        return (value * self.scale).astype(self.target_dtype) + self.offset
+
+    def inverse(self, value):
+        return (value - self.offset).astype(self.source_dtype) / self.scale
+
+    def get_meta(self, colname: str):
+        return {
+            f"{colname}_TRANSFORM": "fixed_point",
+            f"{colname}_TRANSFORM_SCALE": self.scale,
+            f"{colname}_TRANSFORM_DTYPE": str(self.source_dtype),
+            f"{colname}_TRANSFORM_OFFSET": self.offset,
+        }
+
+
+class EnumColumnTransform(ColumnTransform):
+    """Store the value of an enum"""
+
+    def __init__(self, enum):
+        self.enum = enum
+
+    @staticmethod
+    def __call__(value):
+        return value.value
+
+    def inverse(self, value):
+        return self.enum(value)
+
+    def get_meta(self, colname):
+        return {f"{colname}_TRANSFORM": "enum", f"{colname}_ENUM": self.enum}

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -61,3 +61,20 @@ def test_h5_table_to_astropy_time(tmp_path):
     table = h5_table_to_astropy(filename, "/events")
     assert isinstance(table["time"], Time)
     assert np.allclose(times.tai.mjd, table["time"].tai.mjd)
+
+
+def test_transforms(tmp_path):
+    path = tmp_path / "test_trans.hdf5"
+
+    data = np.array([100, 110], dtype="int16").view([("waveform", "int16")])
+    print(data)
+
+    with tables.open_file(path, "w") as f:
+        f.create_table("/data", "test", obj=data, createparents=True)
+        f.root.data.test.attrs["waveform_TRANSFORM_SCALE"] = 100.0
+        f.root.data.test.attrs["waveform_TRANSFORM_OFFSET"] = 200
+        f.root.data.test.attrs["waveform_TRANSFORM_DTYPE"] = "float64"
+
+    table = h5_table_to_astropy(path, "/data/test")
+
+    assert np.all(table["waveform"] == [-1.0, -0.9])

--- a/ctapipe/io/tests/test_dl1writer.py
+++ b/ctapipe/io/tests/test_dl1writer.py
@@ -129,10 +129,6 @@ def test_dl1writer_int(tmpdir: Path):
         for tel_id, dl1 in event.dl1.tel.items():
             original_image = events[event.count].dl1.tel[tel_id].image
             read_image = dl1.image
-            print()
-            print(original_image[:10])
-            print(read_image[:10])
-            print()
             assert np.allclose(original_image, read_image, atol=0.1)
 
             original_peaktime = events[event.count].dl1.tel[tel_id].peak_time

--- a/ctapipe/io/tests/test_dl1writer.py
+++ b/ctapipe/io/tests/test_dl1writer.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+import numpy as np
 from ctapipe.io.dl1writer import DL1Writer, DL1_DATA_MODEL_VERSION
 from ctapipe.utils import get_dataset_path
 from ctapipe.io import EventSource
 from ctapipe.calib import CameraCalibrator
 from pathlib import Path
 from ctapipe.instrument import SubarrayDescription
+from copy import deepcopy
 import tables
 import logging
 
@@ -63,3 +65,76 @@ def test_dl1writer(tmpdir: Path):
         assert (
             shower._v_attrs["true_alt_UNIT"] == "deg"
         )  # pylint: disable=protected-access
+
+
+def test_dl1writer_int(tmpdir: Path):
+    """
+    Check that we can write DL1 files
+
+    Parameters
+    ----------
+    tmpdir :
+        temp directory fixture
+    """
+
+    output_path = Path(tmpdir / "events.dl1.h5")
+    source = EventSource(
+        get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"),
+        max_events=20,
+        allowed_tels=[1, 2, 3, 4],
+    )
+    calibrate = CameraCalibrator(subarray=source.subarray)
+
+    events = []
+
+    with DL1Writer(
+        event_source=source,
+        output_path=output_path,
+        write_parameters=False,
+        write_images=True,
+        transform_image=True,
+        image_dtype="int32",
+        image_scale=10,
+        transform_peak_time=True,
+        peak_time_dtype="int16",
+        peak_time_scale=100,
+    ) as write_dl1:
+        write_dl1.log.level = logging.DEBUG
+        for event in source:
+            calibrate(event)
+            write_dl1(event)
+            events.append(deepcopy(event))
+        write_dl1.write_simulation_histograms(source)
+
+    assert output_path.exists()
+
+    # check we can get the subarray description:
+    sub = SubarrayDescription.from_hdf(output_path)
+    assert sub.num_tels > 0
+
+    # check a few things in the output just to make sure there is output. For a
+    # full test of the data model, a verify tool should be created.
+    with tables.open_file(output_path) as h5file:
+        images = h5file.get_node("/dl1/event/telescope/images/tel_001")
+
+        assert len(images) > 0
+        assert images.col("image").dtype == np.int32
+        assert images.col("peak_time").dtype == np.int16
+        assert images.col("image").max() > 0.0
+
+    # make sure it is readable by the event source and matches the images
+
+    for event in EventSource(output_path):
+
+        for tel_id, dl1 in event.dl1.tel.items():
+            original_image = events[event.count].dl1.tel[tel_id].image
+            read_image = dl1.image
+            print()
+            print(original_image[:10])
+            print(read_image[:10])
+            print()
+            assert np.allclose(original_image, read_image, atol=0.1)
+
+            original_peaktime = events[event.count].dl1.tel[tel_id].peak_time
+            read_peaktime = dl1.peak_time
+            assert np.allclose(original_peaktime, read_peaktime, atol=0.01)

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -16,7 +16,8 @@ from ctapipe.containers import (
     HillasParametersContainer,
     LeakageContainer,
 )
-from ctapipe.io.hdf5tableio import ColumnTransform, HDF5TableWriter, HDF5TableReader
+from ctapipe.io.hdf5tableio import HDF5TableWriter, HDF5TableReader
+from ctapipe.io.tableio import ColumnTransform
 
 
 @pytest.fixture(scope="session")

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -16,7 +16,7 @@ from ctapipe.containers import (
     HillasParametersContainer,
     LeakageContainer,
 )
-from ctapipe.io.hdf5tableio import HDF5TableWriter, HDF5TableReader
+from ctapipe.io.hdf5tableio import ColumnTransform, HDF5TableWriter, HDF5TableReader
 
 
 @pytest.fixture(scope="session")
@@ -573,14 +573,16 @@ def test_column_transforms(tmp_path):
 
     cont = SomeContainer()
 
-    def my_transform(x):
+    class MyTransform(ColumnTransform):
         """ makes a length-3 array from x"""
-        return np.ones(3) * x
+
+        def __call__(self, value):
+            return np.ones(3) * value
 
     with HDF5TableWriter(tmp_file, group_name="data") as writer:
         # add user generated transform for the "value" column
         cont.value = 6.0
-        writer.add_column_transform("mytable", "value", my_transform)
+        writer.add_column_transform("mytable", "value", MyTransform())
         writer.write("mytable", cont)
 
     # check that we get a length-3 array when reading back


### PR DESCRIPTION
This adds configuration options to the dl1 writer to be able to convert images and peak times using an offset, a scale and a dtype.

Defaults are converting to int32 using a scale of 100 for images and of 10 for peak times (basically 2 (1) digit fixed point decimal representation).

filesize of an DL1 LST file:

```
-rw-r--r-- 1 maxnoe maxnoe 701M  1. Feb 15:15 LST-1.Run02610.0000.dl1.h5
-rw-r--r-- 1 maxnoe maxnoe 292M  1. Feb 15:59 LST-1.Run02610.0000_int.dl1.h5
```

So we get a little more than 50% size reduction.