### PR TITLE
bump version of ctapipe-extra directory to v0.3.2

### DIFF
--- a/ctapipe/image/tests/test_concentration.py
+++ b/ctapipe/image/tests/test_concentration.py
@@ -13,7 +13,7 @@ def test_concentration():
     conc = concentration_parameters(geom, image, hillas)
 
     assert 0.1 <= conc.cog <= 0.3
-    assert 0.05 <= conc.pixel <= 0.2
+    assert 0.04 <= conc.pixel <= 0.2
     assert 0.3 <= conc.core <= 0.6
 
 

--- a/ctapipe/image/tests/test_reducer.py
+++ b/ctapipe/image/tests/test_reducer.py
@@ -67,8 +67,11 @@ def test_tailcuts_data_volume_reducer(subarray_lst):
                     "min_picture_neighbors": 0,
                     "keep_isolated_pixels": True,
                 },
-                "image_extractor_type": "FixedWindowSum",
-                "FixedWindowSum": {"apply_integration_correction": False},
+                "image_extractor_type": "NeighborPeakWindowSum",
+                "NeighborPeakWindowSum": {
+                    "apply_integration_correction": False,
+                    "window_shift": 0,
+                },
                 "n_end_dilates": 1,
                 "do_boundary_dilation": True,
             }

--- a/ctapipe/image/tests/test_reducer.py
+++ b/ctapipe/image/tests/test_reducer.py
@@ -67,7 +67,8 @@ def test_tailcuts_data_volume_reducer(subarray_lst):
                     "min_picture_neighbors": 0,
                     "keep_isolated_pixels": True,
                 },
-                "image_extractor_type": "NeighborPeakWindowSum",
+                "image_extractor_type": "FixedWindowSum",
+                "FixedWindowSum": {"apply_integration_correction": False},
                 "n_end_dilates": 1,
                 "do_boundary_dilation": True,
             }

--- a/ctapipe/image/tests/test_toy.py
+++ b/ctapipe/image/tests/test_toy.py
@@ -15,13 +15,13 @@ def test_intensity():
     x, y = u.Quantity([0.2, 0.3], u.m)
     width = 0.05 * u.m
     length = 0.15 * u.m
-    intensity = 50
+    intensity = 200
     psi = "30d"
 
     # make a toymodel shower model
     model = Gaussian(x=x, y=y, width=width, length=length, psi=psi)
 
-    _, signal, _ = model.generate_image(geom, intensity=intensity, nsb_level_pe=5,)
+    _, signal, _ = model.generate_image(geom, intensity=intensity, nsb_level_pe=5)
 
     # test if signal reproduces given cog values
     assert np.average(geom.pix_x.to_value(u.m), weights=signal) == approx(0.2, rel=0.15)
@@ -56,9 +56,7 @@ def test_skewed():
     model = SkewedGaussian(
         x=x, y=y, width=width, length=length, psi=psi, skewness=skewness
     )
-    model.generate_image(
-        geom, intensity=intensity, nsb_level_pe=5,
-    )
+    model.generate_image(geom, intensity=intensity, nsb_level_pe=5)
 
     a, loc, scale = model._moments_to_parameters()
     mean, var, skew = skewnorm(a=a, loc=loc, scale=scale).stats(moments="mvs")

--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["get_dataset_path", "find_in_path", "find_all_matching_datasets"]
 
 
-DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.1/"
+DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.2/"
 
 
 def get_searchpath_dirs(searchpath=os.getenv("CTAPIPE_SVC_PATH")):


### PR DESCRIPTION
This is the same as v0.3.1, but with camera readout definitions from prod3b

(the data have been updated on the dataserver)