### PR TITLE
Cache files by full url/path

### DIFF
--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -38,7 +38,7 @@ def get_searchpath_dirs(searchpath=os.getenv("CTAPIPE_SVC_PATH")):
     else:
         searchpaths = [Path(p) for p in os.path.expandvars(searchpath).split(":")]
 
-    searchpaths.append(get_cache_path(""))
+    searchpaths.append(get_cache_path(DEFAULT_URL))
 
     return searchpaths
 
@@ -175,7 +175,7 @@ def try_filetypes(basename, role, file_types, **kwargs):
     # look first in cache so we don't have to try non-existing downloads
     for ext, reader in file_types.items():
         filename = basename + ext
-        cache_path = get_cache_path(filename)
+        cache_path = get_cache_path(os.path.join(DEFAULT_URL, filename))
         if cache_path.exists():
             path = cache_path
             break

--- a/ctapipe/utils/download.py
+++ b/ctapipe/utils/download.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import logging
 from tqdm import tqdm
 from urllib.parse import urlparse
+import time
 
 
 log = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ def download_file(url, path, auth=None, chunk_size=10240, progress=False):
                 for chunk in r.iter_content(chunk_size=chunk_size):
                     f.write(chunk)
                     pbar.update(len(chunk))
-        except Exception:
+        except:  # we really want to catch everythin here
             # cleanup part file if something goes wrong
             if part_file.is_file():
                 part_file.unlink()
@@ -116,6 +117,12 @@ def download_file_cached(
     url = base_url + "/" + str(name).lstrip("/")
 
     path = get_cache_path(url, cache_name=cache_name)
+    part_file = path.with_suffix(path.suffix + ".part")
+
+    if part_file.is_file():
+        log.warning("Another download for this file is already running, waiting.")
+        while part_file.is_file():
+            time.sleep(1)
 
     # if we already dowloaded the file, just use it
     if path.is_file():


### PR DESCRIPTION
This caches the downloaded files by full url instead of by just their filename.

Now:
```
In [3]: get_dataset_path('optics.ecsv.txt')
Out[3]: PosixPath('/home/maxnoe/.cache/ctapipe/cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.1/optics.ecsv.txt')
```

This will prevent using old versions of files when the download url is changed.