### PR TITLE
fix bug in CameraDisplay.overlay_moments

### DIFF
--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -419,7 +419,7 @@ class CameraDisplay:
             centroid=(cen_x, cen_y),
             length=length * 2,
             width=width * 2,
-            angle=hillas_parameters.psi.rad,
+            angle=hillas_parameters.psi.to_value("rad"),
             **kwargs,
         )
 

--- a/ctapipe/visualization/tests/test_mpl.py
+++ b/ctapipe/visualization/tests/test_mpl.py
@@ -45,6 +45,17 @@ def test_camera_display_single():
     disp.clear_overlays()
 
 
+def test_hillas_overlay():
+    from ctapipe.visualization import CameraDisplay
+
+    disp = CameraDisplay(CameraGeometry.from_name("LSTCam"))
+    hillas = HillasParametersContainer(
+        x=0.1 * u.m, y=-0.1 * u.m, length=0.5 * u.m, width=0.2 * u.m, psi=90 * u.deg
+    )
+
+    disp.overlay_moments(hillas)
+
+
 @pytest.mark.parametrize("pix_type", PixelShape.__members__.values())
 def test_pixel_shapes(pix_type):
     """ test CameraDisplay functionality """


### PR DESCRIPTION
Since we switched to using Quantity instead of Angle for storing the Hillas Psi value, the plotting code broke (it still assumed Angle).  This fixes it and adds a test.