### PR TITLE
Fix tutorial text

### DIFF
--- a/docs/tutorials/coordinates_example.ipynb
+++ b/docs/tutorials/coordinates_example.ipynb
@@ -424,7 +424,7 @@
     }
    },
    "source": [
-    "Let's play a bit with 3 MSTs with divergent pointing"
+    "Let's play a bit with 3 LSTs with divergent pointing"
    ]
   },
   {


### PR DESCRIPTION
- The geometry of an LST is selected, but the text later mentions MSTs.