### PR TITLE
Add black code formatter to environment.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - astropy
   - h5py=2
+  - black
   - bokeh=1
   - conda-forge::nbsphinx
   - cython


### PR DESCRIPTION
See: https://github.com/cta-observatory/ctapipe/issues/1599#issuecomment-778081216

We add the pre-commit hook which uses the black code formatter, but did not include it in the conda environment