### PR TITLE
fix read_table

### DIFF
--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -4,7 +4,7 @@ from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader, HDF5TableWriter
 from .tableio import TableWriter, TableReader
 from .datalevels import DataLevel
-from .astropy_helpers import h5_table_to_astropy as read_table
+from .astropy_helpers import read_table
 from .dl1writer import DL1Writer
 
 from ..core.plugins import detect_and_import_io_plugins

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -6,7 +6,7 @@ Functions to help adapt internal ctapipe data to astropy formats and conventions
 from pathlib import Path
 
 import tables
-from astropy.table import QTable
+from astropy.table import Table
 from astropy.units import Unit
 from astropy.time import Time
 import numpy as np
@@ -21,7 +21,7 @@ from .hdf5tableio import get_hdf5_attr
 __all__ = ["h5_table_to_astropy"]
 
 
-def h5_table_to_astropy(h5file, path) -> QTable:
+def read_table(h5file, path) -> Table:
     """Get a table from a ctapipe-format HDF5 table as an `astropy.table.QTable`
     object, retaining units. This uses the same unit storage convention as
     defined by the `HDF5TableWriter`, namely that the units are in attributes
@@ -37,7 +37,7 @@ def h5_table_to_astropy(h5file, path) -> QTable:
 
     Returns
     -------
-    astropy.table.QTable:
+    astropy.table.Table:
         table in Astropy Format
 
     """
@@ -85,7 +85,7 @@ def h5_table_to_astropy(h5file, path) -> QTable:
             value = table.attrs[attr]
             other_attrs[attr] = str(value) if isinstance(value, np.str_) else value
 
-    astropy_table = QTable(table[:], meta=other_attrs)
+    astropy_table = Table(table[:], meta=other_attrs)
 
     for column, tr in column_transforms.items():
         astropy_table[column] = tr.inverse(astropy_table[column])

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -22,7 +22,7 @@ __all__ = ["h5_table_to_astropy"]
 
 
 def read_table(h5file, path) -> Table:
-    """Get a table from a ctapipe-format HDF5 table as an `astropy.table.QTable`
+    """Get a table from a ctapipe-format HDF5 table as an `astropy.table.Table`
     object, retaining units. This uses the same unit storage convention as
     defined by the `HDF5TableWriter`, namely that the units are in attributes
     named by `<column name>_UNIT` that are parsible by `astropy.units`. Columns

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -7,10 +7,10 @@ from astropy.time import Time
 
 from ctapipe.containers import ReconstructedEnergyContainer, TelescopeTriggerContainer
 from ctapipe.io import HDF5TableWriter
-from ctapipe.io.astropy_helpers import h5_table_to_astropy
+from ctapipe.io.astropy_helpers import read_table
 
 
-def test_h5_table_to_astropy(tmp_path):
+def test_read_table(tmp_path):
 
     # write a simple hdf5 file using
 
@@ -23,7 +23,7 @@ def test_h5_table_to_astropy(tmp_path):
             writer.write("events", container)
 
     # try opening the result
-    table = h5_table_to_astropy(filename, "/events")
+    table = read_table(filename, "/events")
 
     assert "energy" in table.columns
     assert table["energy"].unit == u.TeV
@@ -31,7 +31,7 @@ def test_h5_table_to_astropy(tmp_path):
     assert table["energy"].description is not None
 
     # test using a string
-    table = h5_table_to_astropy(str(filename), "/events")
+    table = read_table(str(filename), "/events")
 
     # test write the table back out to some other format:
     table.write(tmp_path / "test_output.ecsv")
@@ -39,14 +39,14 @@ def test_h5_table_to_astropy(tmp_path):
 
     # test using a file handle
     with tables.open_file(filename) as handle:
-        table = h5_table_to_astropy(handle, "/events")
+        table = read_table(handle, "/events")
 
     # test a bad input
     with pytest.raises(ValueError):
-        table = h5_table_to_astropy(12345, "/events")
+        table = read_table(12345, "/events")
 
 
-def test_h5_table_to_astropy_time(tmp_path):
+def test_read_table_time(tmp_path):
     t0 = Time("2020-01-01T20:00:00.0")
     times = t0 + np.arange(10) * u.s
 
@@ -58,7 +58,7 @@ def test_h5_table_to_astropy_time(tmp_path):
             writer.write("events", container)
 
     # check reading in the times works as expected
-    table = h5_table_to_astropy(filename, "/events")
+    table = read_table(filename, "/events")
     assert isinstance(table["time"], Time)
     assert np.allclose(times.tai.mjd, table["time"].tai.mjd)
 
@@ -75,6 +75,6 @@ def test_transforms(tmp_path):
         f.root.data.test.attrs["waveform_TRANSFORM_OFFSET"] = 200
         f.root.data.test.attrs["waveform_TRANSFORM_DTYPE"] = "float64"
 
-    table = h5_table_to_astropy(path, "/data/test")
+    table = read_table(path, "/data/test")
 
     assert np.all(table["waveform"] == [-1.0, -0.9])


### PR DESCRIPTION
fixes #1576 

read_table returned *QTables* instead of *Tables*, which lead to lots of confusing and annoyances when working with them, since some columns worked differently than others and metadata being lost.  This way all columns in the tables have a consistent interface. 

This just fixes that to return Table (the user can still convert to QTable if needed).  Technically this is an API change, but since the behavior was bug-like, I'm marking it as a bug to be included in v0.10.3. 

Also renamed the function to `read_table` everywhere.  It was already called `ctapipe.io.read_table`, but was aliased as read_table while privately name `h5_table_to_astropy`, which could be confusing. So no change of API will happen there, as h5_table_to_astropy was undocumented. 