### PR TITLE
Remove travis-sphinx from docs dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ docs_require = [
     "numpydoc",
     "jupyter",
     "notebook",
-    "travis-sphinx",
     "graphviz",
 ]
 


### PR DESCRIPTION
Since we are not using Travis CI anymore this is a stale dependency now.