### PR TITLE
Support http(s):// and dataset:// for path traitlet

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -21,6 +21,7 @@ from ctapipe.core.traits import (
     AstroTime,
 )
 from ctapipe.image import ImageExtractor
+from ctapipe.utils.datasets import get_dataset_path, DEFAULT_URL
 
 
 @pytest.fixture(scope="module")
@@ -153,9 +154,13 @@ def test_path_url():
     c.thepath = "file:///foo.hdf5"
     assert c.thepath == pathlib.Path("/foo.hdf5")
 
-    # test not other shemes raise trailet errors
-    with pytest.raises(TraitError):
-        c.thepath = "https://example.org/test.hdf5"
+    # test http downloading
+    c.thepath = DEFAULT_URL + "optics.ecsv.txt"
+    assert c.thepath.name == "optics.ecsv.txt"
+
+    # test dataset://
+    c.thepath = "dataset://optics.ecsv.txt"
+    assert c.thepath == get_dataset_path("optics.ecsv.txt")
 
 
 def test_enum_trait_default_is_right():

--- a/ctapipe/utils/download.py
+++ b/ctapipe/utils/download.py
@@ -75,6 +75,39 @@ def get_cache_path(url, cache_name="ctapipe", env_override="CTAPIPE_CACHE"):
     return path
 
 
+def download_cached(
+    url, cache_name="ctapipe", auth=None, env_prefix="CTAPIPE_DATA_", progress=False
+):
+    path = get_cache_path(url, cache_name=cache_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    part_file = path.with_suffix(path.suffix + ".part")
+
+    if part_file.is_file():
+        log.warning("Another download for this file is already running, waiting.")
+        while part_file.is_file():
+            time.sleep(1)
+
+    # if we already dowloaded the file, just use it
+    if path.is_file():
+        log.debug(f"{url} is available in cache.")
+        return path
+
+    if auth is True:
+        try:
+            auth = (
+                os.environ[env_prefix + "USER"],
+                os.environ[env_prefix + "PASSWORD"],
+            )
+        except KeyError:
+            raise KeyError(
+                f'You need to set the env variables "{env_prefix}USER"'
+                f' and "{env_prefix}PASSWORD" to download test files.'
+            ) from None
+
+    download_file(url=url, path=path, auth=auth, progress=progress)
+    return path
+
+
 def download_file_cached(
     name,
     cache_name="ctapipe",
@@ -114,32 +147,6 @@ def download_file_cached(
 
     base_url = os.environ.get(env_prefix + "URL", default_url).rstrip("/")
     url = base_url + "/" + str(name).lstrip("/")
-
-    path = get_cache_path(url, cache_name=cache_name)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    part_file = path.with_suffix(path.suffix + ".part")
-
-    if part_file.is_file():
-        log.warning("Another download for this file is already running, waiting.")
-        while part_file.is_file():
-            time.sleep(1)
-
-    # if we already dowloaded the file, just use it
-    if path.is_file():
-        log.debug(f"File {name} is available in cache.")
-        return path
-
-    if auth is True:
-        try:
-            auth = (
-                os.environ[env_prefix + "USER"],
-                os.environ[env_prefix + "PASSWORD"],
-            )
-        except KeyError:
-            raise KeyError(
-                f'You need to set the env variables "{env_prefix}USER"'
-                f' and "{env_prefix}PASSWORD" to download test files.'
-            ) from None
-
-    download_file(url=url, path=path, auth=auth, progress=progress)
-    return path
+    return download_cached(
+        url, cache_name=cache_name, auth=auth, env_prefix=env_prefix, progress=progress
+    )


### PR DESCRIPTION
With having `get_dataset_path` and `download_file_cached`, it was rather easy to support `http(s)://` and `dataset://` urls as input for the `Path` traitlet, which I think is a nice feature which was already discussed some time ago.

No test yet.


```
ctapipe-stage1 --input dataset://gamma_test_large.simtel.gz
```

```
ctapipe-stage1 --input http://cccta-dataserver.in2p3.fr/data/Prod5_Reference_Samples/electron_20deg_0deg_run6___cta-prod5-lapalma_desert-2158m-LaPalma-moon-100evts.simtel.zst
```