### PR TITLE
Generalize URL for downloading test data

### DIFF
--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -70,9 +70,7 @@ def find_all_matching_datasets(pattern, searchpath=None, regexp_group=None, url=
 
     if searchpath is None:
         searchpath = os.getenv("CTAPIPE_SVC_PATH")
-    search_path_dirs = get_searchpath_dirs(searchpath, url)
-
-    print(search_path_dirs)
+    search_path_dirs = get_searchpath_dirs(searchpath, url=url)
 
     # first check search path
     for path in search_path_dirs:
@@ -215,7 +213,7 @@ def try_filetypes(basename, role, file_types, url=DEFAULT_URL, **kwargs):
         for ext, reader in file_types.items():
             filename = basename + ext
             try:
-                path = get_dataset_path(filename, url)
+                path = get_dataset_path(filename, url=url)
                 break
             except (FileNotFoundError, HTTPError):
                 pass

--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -173,6 +173,33 @@ def get_dataset_path(filename, url=DEFAULT_URL):
 
 
 def try_filetypes(basename, role, file_types, url=DEFAULT_URL, **kwargs):
+    """
+    Get the contents of dataset as an `astropy.table.Table` object from
+    different file types if available.
+
+    Parameters
+    ----------
+    basename: str
+        base-name (without extension) of the dataset
+    role: str
+        Provenance role. It should be set to the CTA data hierarchy name when
+        possible (e.g. dl1.sub.svc.arraylayout). This will be recorded in the
+        provenance system.
+    file_types: dict
+        Mapping of file extensions to readers.
+    url : str
+        URL where the dataset is stored.
+    kwargs:
+        extra arguments to pass to Table.read()
+
+    Returns
+    -------
+    table : astropy.table.Table
+        Table containing the data in a dataser from an available file
+        type entry.
+
+    """
+
     path = None
 
     # look first in cache so we don't have to try non-existing downloads

--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -44,7 +44,7 @@ def get_searchpath_dirs(searchpath=os.getenv("CTAPIPE_SVC_PATH"), url=DEFAULT_UR
     return searchpaths
 
 
-def find_all_matching_datasets(pattern, url=DEFAULT_URL, searchpath=None, regexp_group=None):
+def find_all_matching_datasets(pattern, searchpath=None, regexp_group=None, url=DEFAULT_URL):
     """
     Returns a list of resource names (or substrings) matching the given
     pattern, searching first in searchpath (a colon-separated list of

--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -115,7 +115,7 @@ def find_in_path(filename, searchpath, url=DEFAULT_URL):
 
     """
 
-    for directory in get_searchpath_dirs(searchpath, url):
+    for directory in get_searchpath_dirs(searchpath, url=url):
         path = directory / filename
         if path.exists():
             return path

--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -34,7 +34,6 @@ DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.3/"
 def get_searchpath_dirs(searchpath=os.getenv("CTAPIPE_SVC_PATH"), url=DEFAULT_URL):
     """ returns a list of dirs in specified searchpath"""
 
-    print(searchpath)
     if searchpath == "" or searchpath is None:
         searchpaths = []
     else:


### PR DESCRIPTION
This PR make the `DEFAULT_URL`, which is currently

`DEFAULT_URL = "http://cccta-dataserver.in2p3.fr/data/ctapipe-extra/v0.3.3/"`

really the default URL (and not the only choice like it is now) by adding `url=DEFAULT_URL` as a keyword default argument were necessary.

This PR should be complementary to #1638 .