### PR TITLE
Fix codecov missing coverage for cli tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             source $CONDA/etc/profile.d/conda.sh
             conda activate ci;
           fi
-          pytest --cov=ctapipe --cov-report=xml
+          pytest --cov --cov-report=xml
           ctapipe-info --version
 
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
In lstchain we found that using `pytest --cov=<path>` lead to codecov not showing coverage for command line tools, since it was  not recognizing paths in the xml that were not starting at the base of the repository.