### PR TITLE
Allow specifying extractors per telescope, fixes #1660 

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -45,6 +45,7 @@ class CameraCalibrator(TelescopeComponent):
             ImageExtractor, default_value="NeighborPeakWindowSum"
         ),
         default_value="NeighborPeakWindowSum",
+        help="Name of the ImageExtractor subclass to be used.",
     ).tag(config=True)
 
     apply_waveform_time_shift = BoolTelescopeParameter(

--- a/ctapipe/tools/display_integrator.py
+++ b/ctapipe/tools/display_integrator.py
@@ -281,7 +281,7 @@ class DisplayIntegrator(Tool):
             )
             exit()
 
-        extractor_name = self.calibrate.image_extractor.__class__.__name__
+        extractor_name = self.calibrate.image_extractor_type.tel[telid]
 
         plot(self.subarray, event, telid, self.channel, extractor_name)
 


### PR DESCRIPTION
Use a `TelescopeParameter` for `image_extractor_type` and a `dict[image_extractor_type] -> instanceof(ImageExtractor)` for the actual extractors. 