### PR TITLE
Update dl1writer.py docstring

### DIFF
--- a/ctapipe/io/dl1writer.py
+++ b/ctapipe/io/dl1writer.py
@@ -114,7 +114,7 @@ class DL1Writer(Component):
     ).tag(config=True)
 
     write_parameters = Bool(
-        help="Compute and store image parameters", default_value=True
+        help="Store image parameters", default_value=True
     ).tag(config=True)
 
     compression_level = Int(


### PR DESCRIPTION
Please let me know if I missed something but I think the docstring is lying in the dl1_writer, the option is only to write the parameters.