### PR TITLE
Create cache dir only when needed

### DIFF
--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -40,11 +40,12 @@ def get_searchpath_dirs(searchpath=os.getenv("CTAPIPE_SVC_PATH"), url=DEFAULT_UR
         searchpaths = [Path(p) for p in os.path.expandvars(searchpath).split(":")]
 
     searchpaths.append(get_cache_path(url))
-
     return searchpaths
 
 
-def find_all_matching_datasets(pattern, searchpath=None, regexp_group=None, url=DEFAULT_URL):
+def find_all_matching_datasets(
+    pattern, searchpath=None, regexp_group=None, url=DEFAULT_URL
+):
     """
     Returns a list of resource names (or substrings) matching the given
     pattern, searching first in searchpath (a colon-separated list of

--- a/ctapipe/utils/download.py
+++ b/ctapipe/utils/download.py
@@ -72,7 +72,6 @@ def get_cache_path(url, cache_name="ctapipe", env_override="CTAPIPE_CACHE"):
 
     path = os.path.join(url.netloc.rstrip("/"), url.path.lstrip("/"))
     path = base / path
-    path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
 
@@ -117,6 +116,7 @@ def download_file_cached(
     url = base_url + "/" + str(name).lstrip("/")
 
     path = get_cache_path(url, cache_name=cache_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
     part_file = path.with_suffix(path.suffix + ".part")
 
     if part_file.is_file():


### PR DESCRIPTION
This fixes an error for only getting the search paths when the home directory is not writable for some reason (happend on the lapalma cluster for a system user and I know other clusters that don't allow writing to the user home from cluster nodes)