### PR TITLE
Fix syntax typo in call of TwoPassWindowSum with 2ndPass disabled

### DIFF
--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -1190,23 +1190,23 @@ class TwoPassWindowSum(ImageExtractor):
             Shape: (n_pix)
         """
 
-        self._charge1, self._pulse_time1, correction1 = self._apply_first_pass(
+        charge1, pulse_time1, correction1 = self._apply_first_pass(
             waveforms, telid
         )
 
         # FIXME: properly make sure that output is 32Bit instead of downcasting here
         if self.disable_second_pass:
             return (
-                (self._charge1 * correction1[selected_gain_channel]).astype("float32"),
-                self._pulse_time1.astype("float32"),
+                (charge1 * correction1[selected_gain_channel]).astype("float32"),
+                pulse_time1.astype("float32"),
             )
 
         charge2, pulse_time2 = self._apply_second_pass(
             waveforms,
             telid,
             selected_gain_channel,
-            self._charge1,
-            self._pulse_time1,
+            charge1,
+            pulse_time1,
             correction1,
         )
         # FIXME: properly make sure that output is 32Bit instead of downcasting here

--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -1197,7 +1197,7 @@ class TwoPassWindowSum(ImageExtractor):
         # FIXME: properly make sure that output is 32Bit instead of downcasting here
         if self.disable_second_pass:
             return (
-                (self.charge1 * correction1[selected_gain_channel]).astype("float32"),
+                (self._charge1 * correction1[selected_gain_channel]).astype("float32"),
                 self._pulse_time1.astype("float32"),
             )
 

--- a/ctapipe/image/tests/test_extractor.py
+++ b/ctapipe/image/tests/test_extractor.py
@@ -348,6 +348,22 @@ def test_two_pass_window_sum(subarray):
         assert_allclose(charge, true_charge, rtol=0.1)
         assert_allclose(pulse_time, true_time, rtol=0.1)
 
+    # test only 1st pass
+    extractor.disable_second_pass = True
+    for minCharge, maxCharge in zip(min_charges, max_charges):
+        toymodel = get_test_toymodel(subarray, minCharge, maxCharge)
+        (
+            waveforms,
+            subarray,
+            telid,
+            selected_gain_channel,
+            true_charge,
+            true_time,
+        ) = toymodel
+        charge, pulse_time = extractor(waveforms, telid, selected_gain_channel)
+        assert_allclose(charge, true_charge, rtol=0.1)
+        assert_allclose(pulse_time, true_time, rtol=0.1)
+
 
 def test_waveform_extractor_factory(toymodel):
     waveforms, subarray, telid, selected_gain_channel, true_charge, true_time = toymodel


### PR DESCRIPTION
This typo was resulting in a fatal crash when launching CameraCalibrator with this image extractor when the 2nd pass was disabled (tested from ctapipe-stage1 tool).

Added portion of unit-test which tests also against the case in which 2nd pass is disabled