### PR TITLE
Change default of CameraCalibrator.apply_waveform_timeshift to False

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -49,7 +49,7 @@ class CameraCalibrator(TelescopeComponent):
     ).tag(config=True)
 
     apply_waveform_time_shift = BoolTelescopeParameter(
-        default_value=True,
+        default_value=False,
         help=(
             "Apply waveform time shift corrections."
             " The minimal integer shift to synchronize waveforms is applied"

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -224,7 +224,9 @@ def test_dl1_charge_calib(example_subarray):
     # We now use GlobalPeakWindowSum to see the effect of missing charge
     # due to not correcting time offsets.
     calibrator = CameraCalibrator(
-        subarray=subarray, image_extractor=GlobalPeakWindowSum(subarray=subarray)
+        subarray=subarray,
+        image_extractor=GlobalPeakWindowSum(subarray=subarray),
+        apply_waveform_time_shift=True,
     )
     calibrator(event)
     # test with timing corrections, should work


### PR DESCRIPTION
We should not set this option by default, as it's benefits are not clear, it takes considerable computation time and it affects the waveforms.

So switching the default to False until we are sure this is really beneficial.