### PR TITLE
Raise error in CameraReadout.from_name if no corresponding file can be found

### DIFF
--- a/ctapipe/instrument/camera/description.py
+++ b/ctapipe/instrument/camera/description.py
@@ -69,7 +69,10 @@ class CameraDescription:
         """
 
         geometry = CameraGeometry.from_name(camera_name)
-        readout = CameraReadout.from_name(camera_name)
+        try:
+            readout = CameraReadout.from_name(camera_name)
+        except FileNotFoundError:
+            readout = None
         return cls(camera_name=camera_name, geometry=geometry, readout=readout)
 
     def __str__(self):

--- a/ctapipe/instrument/camera/readout.py
+++ b/ctapipe/instrument/camera/readout.py
@@ -111,25 +111,11 @@ class CameraReadout:
         else:
             verstr = f"-{version:03d}"
 
-        try:
-            tabname = "{camera_name}{verstr}.camreadout".format(
-                camera_name=camera_name, verstr=verstr
-            )
-            table = get_table_dataset(tabname, role="dl0.tel.svc.camera")
-            return CameraReadout.from_table(table)
-        except FileNotFoundError:
-            # TODO: remove case when files have been generated
-            logger.warning(
-                f"Resorting to default CameraReadout,"
-                f" File does not exist: ({tabname})"
-            )
-            reference_pulse_shape = np.array([norm.pdf(np.arange(96), 48, 6)])
-            return cls(
-                camera_name=camera_name,
-                sampling_rate=u.Quantity(1, u.GHz),
-                reference_pulse_shape=reference_pulse_shape,
-                reference_pulse_sample_width=u.Quantity(1, u.ns),
-            )
+        tabname = "{camera_name}{verstr}.camreadout".format(
+            camera_name=camera_name, verstr=verstr
+        )
+        table = get_table_dataset(tabname, role="dl0.tel.svc.camera")
+        return CameraReadout.from_table(table)
 
     def to_table(self):
         """Convert this to an `astropy.table.Table`."""

--- a/ctapipe/instrument/camera/tests/test_readout.py
+++ b/ctapipe/instrument/camera/tests/test_readout.py
@@ -145,5 +145,8 @@ def test_hashing():
 @pytest.mark.parametrize("camera_name", camera_names)
 def test_camera_from_name(camera_name):
     """ check we can construct all cameras from name"""
-    camera = CameraReadout.from_name(camera_name)
-    assert str(camera) == camera_name
+
+    # these two don't have readout definitions on the dataserver
+    if camera_name not in ["MAGICCam", "Whipple109"]:
+        camera = CameraReadout.from_name(camera_name)
+        assert str(camera) == camera_name

--- a/ctapipe/instrument/camera/tests/test_readout.py
+++ b/ctapipe/instrument/camera/tests/test_readout.py
@@ -146,7 +146,10 @@ def test_hashing():
 def test_camera_from_name(camera_name):
     """ check we can construct all cameras from name"""
 
-    # these two don't have readout definitions on the dataserver
-    if camera_name not in ["MAGICCam", "Whipple109"]:
+    try:
         camera = CameraReadout.from_name(camera_name)
         assert str(camera) == camera_name
+    except FileNotFoundError:
+        # these two don't have readout definitions on the dataserver
+        if camera_name not in ["MAGICCam", "Whipple109"]:
+            raise


### PR DESCRIPTION
* Raise error in CameraReadout.from_name if requested data is not available
* Set `readout` to None in `CameraDescription.from_name` if that exception is raised.