### PR TITLE
Allow regexp in table name for  TableWriter.exclude()

### DIFF
--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -46,15 +46,16 @@ class TableWriter(Component, metaclass=ABCMeta):
         self.close()
 
     def exclude(self, table_regexp, pattern):
-        """
-        Exclude any columns (Fields)  matching the pattern from being written
+        """Exclude any columns (Fields) matching the pattern from being written. The
+        patterns are matched with re.fullmatch.
 
         Parameters
         ----------
-        table_name: str or regexp
-            name of table on which to apply the exclusion
+        table_regexp: str
+            regexp matching to match table name to apply exclusion
         pattern: str
-            regular expression string to match column name
+            regular expression string to match column name in the table
+
         """
         table_regexp = table_regexp.lstrip("/")
         self._exclusions[table_regexp].append(re.compile(pattern))

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -45,24 +45,26 @@ class TableWriter(Component, metaclass=ABCMeta):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def exclude(self, table_name, pattern):
+    def exclude(self, table_regexp, pattern):
         """
         Exclude any columns (Fields)  matching the pattern from being written
 
         Parameters
         ----------
-        table_name: str
+        table_name: str or regexp
             name of table on which to apply the exclusion
         pattern: str
             regular expression string to match column name
         """
-        table_name = table_name.lstrip("/")
-        self._exclusions[table_name].append(re.compile(pattern))
+        table_regexp = table_regexp.lstrip("/")
+        self._exclusions[table_regexp].append(re.compile(pattern))
 
     def _is_column_excluded(self, table_name, col_name):
-        for pattern in self._exclusions[table_name]:
-            if pattern.fullmatch(col_name):
-                return True
+        for table_regexp, col_regexp_list in self._exclusions.items():
+            if re.fullmatch(table_regexp, table_name):
+                for col_regexp in col_regexp_list:
+                    if col_regexp.fullmatch(col_name):
+                        return True
         return False
 
     def add_column_transform(self, table_name, col_name, transform):


### PR DESCRIPTION
Similar to #1690 , allows the table name to be a regexp in `TableWriter.exclude()`, not just the column name.  This will greatly simplify the setup of DataWriters (like DL1Writer), which now require a large list of exclusions to be generated.  

This feature will be used in #1673 to simplify DataWriter. 

E.g, this allows one to replace code like:

```py3
        table_names_tel_id = [f"tel_{tel_id:03d}" for tel_id in self._subarray.tel]
        table_names_tel_type = [
            str(telescope) for telescope in self._subarray.telescope_types
        ]

        if self.split_datasets_by == "tel_id":
            table_names = table_names_tel_id
        elif self.split_datasets_by == "tel_type":
            table_names = table_names_tel_type
        else:
            table_names = []

        for table_name in table_names:
            if self.write_parameters is False:
                writer.exclude(
                    f"/dl1/event/telescope/images/{table_name}", "image_mask"
                )

            tel_pointing = f"/dl1/monitoring/telescope/pointing/{table_name}"
            writer.exclude(tel_pointing, "trigger_pixels")
            writer.exclude(f"/dl1/event/telescope/images/{table_name}", "parameters")
```
with single lines like:
```py3
writer.exclude("/dl1/monitoring/telescope/pointing/.*", "trigger_pixels")
```