### PR TITLE
Components to modify dl1 images

### DIFF
--- a/ctapipe/image/__init__.py
+++ b/ctapipe/image/__init__.py
@@ -67,10 +67,12 @@ from .muon import (
     ring_completeness,
     ring_containment,
 )
+from .modifications import ImageModifier
 from .image_processor import ImageProcessor
 
 
 __all__ = [
+    "ImageModifier",
     "ImageProcessor",
     "hillas_parameters",
     "HillasParameterizationError",

--- a/ctapipe/image/modifications.py
+++ b/ctapipe/image/modifications.py
@@ -6,50 +6,55 @@ from ..core.component import TelescopeComponent
 
 
 def mask_broken(geom, pix_ids):
+    """
+    Create a boolean mask with deselected pixels
+    Does this really need a function?
+    """
     mask = np.ones(shape=geom.pix_id.shape, dtype=bool)
     mask[pix_ids] = 0
     return mask
 
 
-def mask_thresholds(image, upper, lower):
-    mask = np.ones(shape=geom.pix_id.shape, dtype=bool)
-    mask[image > upper] = 0
-    mask[image < lower] = 0
+def mask_thresholds(image, upper=None, lower=None):
+    """
+    Create a boolean mask with pixels selected based on thresholds.
+    Does this really need a function?
+    """
+    mask = np.ones_like(image, dtype=bool)
+    if upper:
+        mask[image > upper] = 0
+    if lower:
+        mask[image < lower] = 0
     return mask
 
 
-def add_noise(
-    image,
-    noise_level,
-    rng=None,
-    mask=None,
-    upper_threshold=None,
-    lower_threshold=None,
-    correct_bias=True,
-):
+def add_noise(image, noise_level, rng=None, correct_bias=True):
+    """
+    Create a new image with added poissonian noise
+    """
     # notes:
     # mask and thresholds is probably not very useful
     # mask is only useful if noise level is a scalar, could also provide the array directly
     # maybe only noise level and bias, selection in tool?
     if not rng:
         rng = np.random.default_rng()
-    if mask is None:
-        mask = np.ones(shape=image.shape, dtype=int)
-    else:
-        mask = mask.astype(int)
-    if upper_threshold:
-        mask &= image < upper_threshold
-    if lower_threshold:
-        mask &= image > lower_threshold
-    mask *= noise_level
     noisy_image = image.copy()
-    noisy_image += rng.poisson(mask)
+    noise = rng.poisson(noise_level)
+    noisy_image += noise
     if correct_bias:
-        noisy_image -= mask
+        # which one to use?
+        # Fluctuations that have no bias per pixel
+        noisy_image -= noise_level
+        # No bias over the whole image
+        # noisy_image -= np.mean(noise)
     return noisy_image
 
 
 def smear_image(image, geom, smear_factor):
+    """
+    Create a new image with values smeared to the direct pixel neighbors
+    Pixels at the camera edge lose charge this way.
+    """
     # make clear what smear factor is supposed to mean and that only direct neighbors are taken into account
     # smear factor can be an array as well -> selection in tool possible!
     # a more sophisticated approach might make use of the pixel area, but thats complicated

--- a/ctapipe/image/modifications.py
+++ b/ctapipe/image/modifications.py
@@ -1,0 +1,99 @@
+from abc import abstractmethod
+import numpy as np
+from ..core.component import TelescopeComponent
+
+# the most important part is the selection api!!
+
+
+def mask_broken(geom, pix_ids):
+    mask = np.ones(shape=geom.pix_id.shape, dtype=bool)
+    mask[pix_ids] = 0
+    return mask
+
+
+def mask_thresholds(image, upper, lower):
+    mask = np.ones(shape=geom.pix_id.shape, dtype=bool)
+    mask[image > upper] = 0
+    mask[image < lower] = 0
+    return mask
+
+
+def add_noise(
+    image,
+    noise_level,
+    rng=None,
+    mask=None,
+    upper_threshold=None,
+    lower_threshold=None,
+    correct_bias=True,
+):
+    # notes:
+    # mask and thresholds is probably not very useful
+    # mask is only useful if noise level is a scalar, could also provide the array directly
+    # maybe only noise level and bias, selection in tool?
+    if not rng:
+        rng = np.random.default_rng()
+    if mask is None:
+        mask = np.ones(shape=image.shape, dtype=int)
+    else:
+        mask = mask.astype(int)
+    if upper_threshold:
+        mask &= image < upper_threshold
+    if lower_threshold:
+        mask &= image > lower_threshold
+    mask *= noise_level
+    noisy_image = image.copy()
+    noisy_image += rng.poisson(mask)
+    if correct_bias:
+        noisy_image -= mask
+    return noisy_image
+
+
+def smear_image(image, geom, smear_factor):
+    # make clear what smear factor is supposed to mean and that only direct neighbors are taken into account
+    # smear factor can be an array as well -> selection in tool possible!
+    # a more sophisticated approach might make use of the pixel area, but thats complicated
+    if geom.pix_type.value == "hexagon":
+        max_neighbors = 6
+    elif geom.pix_type.value == "rectangular":  # thats probably labeld differently
+        max_neighbors = 8  # or 4? lookup neighbor matrix for a rect cam
+    else:
+        print(geom.pix_type)
+        raise Exception("Unknown pixel type")
+
+    diffused_image = (
+        (image * geom.neighbor_matrix).sum(axis=1) * smear_factor / max_neighbors
+    )
+    remaining_image = image * (1 - smear_factor)
+    smeared_image = remaining_image + diffused_image
+    return smeared_image
+
+
+class ImageModifier(TelescopeComponent):
+    """
+    ...
+    """
+
+    @abstractmethod
+    def __call__(self, tel_id: int, image: np.ndarray, **kwargs) -> np.ndarray:
+        """
+        Modifies a given image
+
+        Returns
+        -------
+        np.ndarray
+            modified image
+        """
+        pass
+
+
+class ImageSmearer(ImageModifier):
+    pass
+
+
+class NoiseAdder(ImageModifier):
+    pass
+
+
+class PixelValueSetter(ImageModifier):
+    pass

--- a/ctapipe/image/modifications.py
+++ b/ctapipe/image/modifications.py
@@ -3,31 +3,6 @@ import numpy as np
 from ..core.component import TelescopeComponent
 from ..core.traits import FloatTelescopeParameter, BoolTelescopeParameter
 
-# the most important part is the selection api!!
-
-
-def mask_broken(geom, pix_ids):
-    """
-    Create a boolean mask with deselected pixels
-    Does this really need a function?
-    """
-    mask = np.ones(shape=geom.pix_id.shape, dtype=bool)
-    mask[pix_ids] = 0
-    return mask
-
-
-def mask_thresholds(image, upper=None, lower=None):
-    """
-    Create a boolean mask with pixels selected based on thresholds.
-    Does this really need a function?
-    """
-    mask = np.ones_like(image, dtype=bool)
-    if upper:
-        mask[image > upper] = 0
-    if lower:
-        mask[image < lower] = 0
-    return mask
-
 
 def add_noise(image, noise_level, rng=None, correct_bias=True):
     """
@@ -39,11 +14,7 @@ def add_noise(image, noise_level, rng=None, correct_bias=True):
     noise = rng.poisson(noise_level)
     noisy_image += noise
     if correct_bias:
-        # which one to use?
-        # Fluctuations that have no bias per pixel
         noisy_image -= noise_level
-        # No bias over the whole image
-        # noisy_image -= np.mean(noise)
     return noisy_image
 
 

--- a/ctapipe/image/tests/test_modifications.py
+++ b/ctapipe/image/tests/test_modifications.py
@@ -1,21 +1,65 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from ctapipe.instrument import CameraGeometry
+from ctapipe.image import modifications
 
 # perform tests with methods as well as components!
 
 
 def test_mask_broken():
-    assert False
+    geom = CameraGeometry.from_name("LSTCam")
+    broken_pixel_ids = [1, 5, 10]
+
+    expected = np.ones_like(geom.pix_id, dtype=bool)
+    expected[broken_pixel_ids] = 0
+    mask = modifications.mask_broken(geom, broken_pixel_ids)
+
+    assert (mask == expected).all()
 
 
 def test_mask_thresholds():
-    assert False
+    image = np.array([1, 2, 3, 4, 5])
+    mask = modifications.mask_thresholds(image, 4.5, 2.1)
+    expected = [False, False, True, True, False]
+
+    assert (mask == expected).all()
 
 
 def test_add_noise():
-    assert False
+    image = np.array([0, 0, 5, 1, 0, 0])
+    rng = np.random.default_rng(42)
+    # test different noise per pixel:
+    noise = [6, 8, 0, 7, 9, 12]
+    noisy = modifications.add_noise(image, noise, rng, correct_bias=False)
+    assert image[2] == noisy[2]
+    # For other seeds there exists a probability > 0 for no noise added at all
+    assert noisy.sum() > image.sum()
+
+    # test scalar
+    noisy = modifications.add_noise(image, 20, rng, correct_bias=False)
+    diff_no_bias = noisy - image
+    assert (noisy > image).all()
+
+    # test bias
+    noisy = modifications.add_noise(image, 20, rng, correct_bias=True)
+    assert np.sum(diff_no_bias) > np.sum(noisy - image)
 
 
 def test_smear_image():
-    assert False
+    geom = CameraGeometry.from_name("LSTCam")
+    image = np.zeros_like(geom.pix_id, dtype=np.float64)
+    # select two pixels, one at the edge with only 5 neighbors
+    # Thats why we divide by 6 below
+    signal_pixels = [1, 1853]
+    neighbors = geom.neighbor_matrix[signal_pixels]
+    for signal_value in [1, 5]:
+        image[signal_pixels] = signal_value
+        for s in [0, 0.2, 1]:
+            smeared_light = s * signal_value
+            smeared = modifications.smear_image(image, geom, s)
+            assert np.isclose((image.sum() - smeared.sum() - smeared_light / 6), 0)
+            neighbors_1 = smeared[neighbors[0]]
+            neighbors_1853 = smeared[neighbors[1]]
+            assert_allclose(neighbors_1, smeared_light / 6)
+            assert_allclose(neighbors_1853, smeared_light / 6)
+            assert_allclose(smeared[signal_pixels], signal_value - smeared_light)

--- a/ctapipe/image/tests/test_modifications.py
+++ b/ctapipe/image/tests/test_modifications.py
@@ -3,27 +3,6 @@ from numpy.testing import assert_allclose
 from ctapipe.instrument import CameraGeometry
 from ctapipe.image import modifications
 
-# perform tests with methods as well as components!
-
-
-def test_mask_broken():
-    geom = CameraGeometry.from_name("LSTCam")
-    broken_pixel_ids = [1, 5, 10]
-
-    expected = np.ones_like(geom.pix_id, dtype=bool)
-    expected[broken_pixel_ids] = 0
-    mask = modifications.mask_broken(geom, broken_pixel_ids)
-
-    assert (mask == expected).all()
-
-
-def test_mask_thresholds():
-    image = np.array([1, 2, 3, 4, 5])
-    mask = modifications.mask_thresholds(image, 4.5, 2.1)
-    expected = [False, False, True, True, False]
-
-    assert (mask == expected).all()
-
 
 def test_add_noise():
     image = np.array([0, 0, 5, 1, 0, 0])

--- a/ctapipe/image/tests/test_modifications.py
+++ b/ctapipe/image/tests/test_modifications.py
@@ -1,0 +1,21 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from ctapipe.instrument import CameraGeometry
+
+# perform tests with methods as well as components!
+
+
+def test_mask_broken():
+    assert False
+
+
+def test_mask_thresholds():
+    assert False
+
+
+def test_add_noise():
+    assert False
+
+
+def test_smear_image():
+    assert False

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -8,7 +8,7 @@ from tqdm.autonotebook import tqdm
 from ..calib.camera import CameraCalibrator, GainSelector
 from ..core import Tool
 from ..core.traits import Bool, List, classes_with_traits
-from ..image import ImageCleaner, ImageProcessor
+from ..image import ImageCleaner, ImageProcessor, ImageModifier
 from ..image.extractor import ImageExtractor
 from ..io import DataLevel, DL1Writer, EventSource, SimTelEventSource
 from ..io.dl1writer import DL1_DATA_MODEL_VERSION
@@ -41,6 +41,7 @@ class Stage1Tool(Tool):
         ("t", "allowed-tels"): "EventSource.allowed_tels",
         ("m", "max-events"): "EventSource.max_events",
         "image-cleaner-type": "ImageProcessor.image_cleaner_type",
+        "image-modifier-type": "ImageProcessor.image_modifier_type",
     }
 
     flags = {
@@ -69,6 +70,7 @@ class Stage1Tool(Tool):
     classes = (
         [CameraCalibrator, DL1Writer, ImageProcessor]
         + classes_with_traits(EventSource)
+        + classes_with_traits(ImageModifier)
         + classes_with_traits(ImageCleaner)
         + classes_with_traits(ImageExtractor)
         + classes_with_traits(GainSelector)


### PR DESCRIPTION
As recently discussed (See #1706, #1707 and linked lstchain PR), modifying simulated dl1 images is a useful way to improve data/mc mismatches.
There are different ways to achieve this. I personally feel like it is easiest done in stage-1, although that requires to modify the event loop. Currently I added a `ImageModifier` component, which forced me to also add a `NullModifier`, that does not alter the image. There might be better ways to achieve this in the given traitlets system.
While I feel like this is somewhat hacky, we might want to use this to mask pixels or do other things in real data, so that this would not be used all the time in the end anyway (?).
The advantage of implementing it this way to me is that we already have a tool, that can calculate dl1 from input dl1 files, which is also used for recleaning anyway and also takes care of recalculating parameters. This makes it easy to use from a users perspective and less duplicated effort.
This is certainly a point to be discussed though.

As there are countless ways to modify images and being able to reproduce lstchain results is a plus anyway, I for now implemented the approach @moralejo used in lstchain as a ready to use component. This performs the smearing aswell as the addition of noise.

-------------
- Opinions on using stage-1? Is there any benefit in a new tool?
- Are there better ways than using a dummy modifier? Does it matter?
- It should be easy to perform this on all images at once, just like the cleaning. I think its not worth to do this here though, especially since this would be part of the image processing loop, that could be changed altogether.

-------------
Proof of concept: I processed some simtel events and reprocessed the dl1 file with stage-1, using the `LSTImageModifier`.
![noisy_image](https://user-images.githubusercontent.com/15281090/118799336-e28a7380-b89e-11eb-9836-0ea2a459b506.png)


![sample_charges](https://user-images.githubusercontent.com/15281090/118799230-c5ee3b80-b89e-11eb-94da-9a6eaf7d517d.png)
