### PR TITLE
Parallel tests

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -8,10 +8,13 @@ if [[ "$INSTALL_METHOD" == "conda" ]]; then
   conda update -q conda  # get latest conda version
   # Useful for debugging any issues with conda
   conda info -a
+  conda install -c conda-forge mamba
 
   sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
-  conda env create -n ci --file environment.yml
+  mamba env create -n ci --file environment.yml
   conda activate ci
+  echo 'source $CONDA/etc/profile.d/conda.sh' >> ~/.bash_profile
+  echo 'conda activate ci' >> ~/.bash_profile
 else
   echo "Using pip"
   pip install -U pip setuptools wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             source $CONDA/etc/profile.d/conda.sh
             conda activate ci;
           fi
-          pytest --cov --cov-report=xml -n 4 --dist loadscope
+          pytest --cov --cov-report=xml -n auto --dist loadscope
           ctapipe-info --version
 
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,15 @@ jobs:
           pip freeze
 
       - name: Static codechecks
-        env:
-          INSTALL_METHOD: ${{ matrix.install-method }}
+        # need to use a login shell for the conda setup to work
+        shell: bash -leo pipefail {0}
         run: |
-          if [[ "$INSTALL_METHOD" == "conda" ]]; then
-            source $CONDA/etc/profile.d/conda.sh
-            conda activate ci;
-          fi
           pyflakes ctapipe
 
       - name: Tests
-        env:
-          INSTALL_METHOD: ${{ matrix.install-method }}
+        # need to use a login shell for the conda setup to work
+        shell: bash -leo pipefail {0}
         run: |
-          if [[ "$INSTALL_METHOD" == "conda" ]]; then
-            source $CONDA/etc/profile.d/conda.sh
-            conda activate ci;
-          fi
           pytest --cov --cov-report=xml -n auto --dist loadscope
           ctapipe-info --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           source .github/install.sh
           python --version
-          pip install codecov pytest-cov pyflakes
+          pip install codecov pytest-cov pyflakes pytest-xdist
           pip install -e .[all]
           pip freeze
 
@@ -45,6 +45,7 @@ jobs:
             conda activate ci;
           fi
           pyflakes ctapipe
+
       - name: Tests
         env:
           INSTALL_METHOD: ${{ matrix.install-method }}
@@ -53,7 +54,7 @@ jobs:
             source $CONDA/etc/profile.d/conda.sh
             conda activate ci;
           fi
-          pytest --cov --cov-report=xml
+          pytest --cov --cov-report=xml -n 4 --dist loadscope
           ctapipe-info --version
 
       - uses: codecov/codecov-action@v1

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -11,12 +11,27 @@ from ctapipe.utils import get_dataset_path
 from ctapipe.instrument import CameraGeometry
 
 
-@pytest.fixture(scope="session")
-def camera_geometries():
-    return [
-        CameraGeometry.from_name(name)
-        for name in ["LSTCam", "NectarCam", "CHEC", "FlashCam", "MAGICCam"]
-    ]
+# names of camera geometries available on the data server
+camera_names = [
+    "ASTRICam",
+    "CHEC",
+    "DigiCam",
+    "FACT",
+    "FlashCam",
+    "HESS-I",
+    "HESS-II",
+    "LSTCam",
+    "MAGICCam",
+    "NectarCam",
+    "SCTCam",
+    "VERITAS",
+    "Whipple490",
+]
+
+
+@pytest.fixture(scope="session", params=camera_names)
+def camera_geometry(request):
+    return CameraGeometry.from_name(request.param)
 
 
 @pytest.fixture(scope="session")

--- a/ctapipe/image/tests/test_geometry_converter.py
+++ b/ctapipe/image/tests/test_geometry_converter.py
@@ -14,9 +14,6 @@ from ctapipe.image.toymodel import Gaussian
 import astropy.units as u
 
 
-camera_names = CameraDescription.get_known_camera_names()
-
-
 def create_mock_image(geom):
     """
     creates a mock image, which parameters are adapted to the camera size
@@ -32,16 +29,14 @@ def create_mock_image(geom):
     )
 
     _, image, _ = model.generate_image(
-        geom, intensity=0.5 * geom.n_pixels, nsb_level_pe=3,
+        geom, intensity=0.5 * geom.n_pixels, nsb_level_pe=3
     )
     return image
 
 
-@pytest.mark.parametrize("rot", [3,])
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_convert_geometry(camera_name, rot):
-
-    geom = CameraGeometry.from_name(camera_name)
+@pytest.mark.parametrize("rot", [3])
+def test_convert_geometry(camera_geometry, rot):
+    geom = camera_geometry
     image = create_mock_image(geom)
     hillas_0 = hillas_parameters(geom, image)
 
@@ -81,13 +76,11 @@ def test_convert_geometry(camera_name, rot):
     # TODO: test other parameters
 
 
-@pytest.mark.parametrize("rot", [3,])
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_convert_geometry_mock(camera_name, rot):
+@pytest.mark.parametrize("rot", [3])
+def test_convert_geometry_mock(camera_geometry, rot):
     """here we use a different key for the back conversion to trigger the mock conversion
     """
-
-    geom = CameraGeometry.from_name(camera_name)
+    geom = camera_geometry
     image = create_mock_image(geom)
     hillas_0 = hillas_parameters(geom, image)
 
@@ -106,22 +99,3 @@ def test_convert_geometry_mock(camera_name, rot):
 
     hillas_1 = hillas_parameters(geom, image1d)
     assert np.abs(hillas_1.phi - hillas_0.phi).deg < 1.0
-
-
-# def plot_cam(geom, geom2d, geom1d, image, image2d, image1d):
-#     # plt.viridis()
-#     plt.figure(figsize=(12, 4))
-#     ax = plt.subplot(1, 3, 1)
-#     CameraDisplay(geom, image=image).add_colorbar()
-#     plt.subplot(1, 3, 2, sharex=ax, sharey=ax)
-#     CameraDisplay(geom2d, image=image2d).add_colorbar()
-#     plt.subplot(1, 3, 3, sharex=ax, sharey=ax)
-#     CameraDisplay(geom1d, image=image1d).add_colorbar()
-#
-#
-# if __name__ == "__main__":
-#     import logging
-#     logging.basicConfig(level=logging.DEBUG)
-#     for camera_name in CameraGeometry.get_known_camera_names():
-#         test_convert_geometry(camera_name, 3)
-#     plt.show()

--- a/ctapipe/image/tests/test_geometry_converter.py
+++ b/ctapipe/image/tests/test_geometry_converter.py
@@ -9,7 +9,6 @@ from ctapipe.image.geometry_converter import (
     array_2d_to_chec,
 )
 from ctapipe.image.hillas import hillas_parameters
-from ctapipe.instrument import CameraDescription, CameraGeometry
 from ctapipe.image.toymodel import Gaussian
 import astropy.units as u
 

--- a/ctapipe/instrument/camera/tests/test_description.py
+++ b/ctapipe/instrument/camera/tests/test_description.py
@@ -1,14 +1,6 @@
 from ctapipe.instrument import CameraDescription
 
 
-def test_known_camera_names(camera_geometries):
+def test_known_camera_names(camera_geometry):
     """ Check that we can get a list of known camera names """
-    cams = CameraDescription.get_known_camera_names()
-    assert len(cams) > 4
-    assert "FlashCam" in cams
-    assert "NectarCam" in cams
-
-    # TODO: Requires camreadout files to be generated
-    # for cam in cams:
-    #     camera = CameraDescription.from_name(cam)
-    #     camera.info()
+    assert camera_geometry.camera_name in CameraDescription.get_known_camera_names()

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -1,7 +1,7 @@
 """ Tests for CameraGeometry """
 import numpy as np
 from astropy import units as u
-from ctapipe.instrument import CameraDescription, CameraGeometry, PixelShape
+from ctapipe.instrument import CameraGeometry, PixelShape
 import pytest
 
 

--- a/ctapipe/instrument/camera/tests/test_geometry.py
+++ b/ctapipe/instrument/camera/tests/test_geometry.py
@@ -4,8 +4,6 @@ from astropy import units as u
 from ctapipe.instrument import CameraDescription, CameraGeometry, PixelShape
 import pytest
 
-camera_names = CameraDescription.get_known_camera_names()
-
 
 def test_construct():
     """ Check we can make a CameraGeometry from scratch """
@@ -93,15 +91,13 @@ def test_find_neighbor_pixels():
     assert set(neigh[11]) == {16, 6, 10, 12}
 
 
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_neighbor_pixels(camera_name):
+def test_neighbor_pixels(camera_geometry):
     """
     test if each camera has a reasonable number of neighbor pixels (4 for
     rectangular, and 6 for hexagonal.  Other than edge pixels, the majority
     should have the same value
     """
-
-    geom = CameraGeometry.from_name(camera_name)
+    geom = camera_geometry
     n_pix = len(geom.pix_id)
     n_neighbors = [len(x) for x in geom.neighbors]
 
@@ -116,7 +112,7 @@ def test_neighbor_pixels(camera_name):
 
     # whipple has inhomogenious pixels that mess with pixel neighborhood
     # calculation
-    if camera_name != "Whipple490":
+    if not geom.camera_name.startswith("Whipple"):
         assert np.all(geom.neighbor_matrix == geom.neighbor_matrix.T)
         assert n_neighbors.count(1) == 0  # no pixel should have a single neighbor
 
@@ -229,15 +225,13 @@ def test_slicing():
     assert len(sliced2.pix_x) == 5
 
 
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_slicing_rotation(camera_name):
+def test_slicing_rotation(camera_geometry):
     """ Check that we can rotate and slice """
-    cam = CameraGeometry.from_name(camera_name)
-    cam.rotate("25d")
+    camera_geometry.rotate("25d")
 
-    sliced1 = cam[5:10]
+    sliced1 = camera_geometry[5:10]
 
-    assert sliced1.pix_x[0] == cam.pix_x[5]
+    assert sliced1.pix_x[0] == camera_geometry.pix_x[5]
 
 
 def test_rectangle_patch_neighbors():
@@ -296,19 +290,17 @@ def test_hashing():
     assert len(set([cam1, cam2, cam3])) == 2
 
 
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_camera_from_name(camera_name):
+def test_camera_from_name(camera_geometry):
     """ check we can construct all cameras from name"""
-    camera = CameraGeometry.from_name(camera_name)
-    assert str(camera) == camera_name
+    camera = CameraGeometry.from_name(camera_geometry.camera_name)
+    assert str(camera) == camera_geometry.camera_name
 
 
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_camera_coordinate_transform(camera_name):
+def test_camera_coordinate_transform(camera_geometry):
     """test conversion of the coordinates stored in a camera frame"""
     from ctapipe.coordinates import EngineeringCameraFrame, CameraFrame, TelescopeFrame
 
-    geom = CameraGeometry.from_name(camera_name)
+    geom = camera_geometry
     trans_geom = geom.transform_to(EngineeringCameraFrame())
 
     unit = geom.pix_x.unit

--- a/ctapipe/instrument/camera/tests/test_readout.py
+++ b/ctapipe/instrument/camera/tests/test_readout.py
@@ -1,7 +1,7 @@
 """ Tests for CameraGeometry """
 import numpy as np
 from astropy import units as u
-from ctapipe.instrument import CameraDescription, CameraReadout
+from ctapipe.instrument import CameraReadout
 import pytest
 
 

--- a/ctapipe/instrument/camera/tests/test_readout.py
+++ b/ctapipe/instrument/camera/tests/test_readout.py
@@ -4,8 +4,6 @@ from astropy import units as u
 from ctapipe.instrument import CameraDescription, CameraReadout
 import pytest
 
-camera_names = CameraDescription.get_known_camera_names()
-
 
 def test_construct():
     """ Check we can make a CameraReadout from scratch """
@@ -142,14 +140,13 @@ def test_hashing():
     assert len({readout1, readout2, readout3}) == 2
 
 
-@pytest.mark.parametrize("camera_name", camera_names)
-def test_camera_from_name(camera_name):
+def test_camera_from_name(camera_geometry):
     """ check we can construct all cameras from name"""
 
     try:
-        camera = CameraReadout.from_name(camera_name)
-        assert str(camera) == camera_name
+        camera = CameraReadout.from_name(camera_geometry.camera_name)
+        assert str(camera) == camera_geometry.camera_name
     except FileNotFoundError:
-        # these don't have readout definitions on the dataserver
-        if camera_name not in ["MAGICCam", "Whipple109", "FACT"]:
+        # Most non-cta cameras don't have readout provided on the data server
+        if camera_geometry.camera_name in ["LSTCam", "NectarCam", "FlashCam", "CHEC"]:
             raise

--- a/ctapipe/instrument/tests/test_telescope.py
+++ b/ctapipe/instrument/tests/test_telescope.py
@@ -29,17 +29,13 @@ def test_hash():
     assert len(set(telescopes)) == 3
 
 
-OPTICS_NAMES = OpticsDescription.get_known_optics_names()
-CAMERA_NAMES = CameraDescription.get_known_camera_names()
-
-
-@pytest.mark.parametrize("camera_name", CAMERA_NAMES)
-@pytest.mark.parametrize("optics_name", OPTICS_NAMES)
-def test_telescope_from_name(optics_name, camera_name):
+@pytest.mark.parametrize("optics_name", ["LST", "MST"])
+def test_telescope_from_name(optics_name, camera_geometry):
     """ Check we can construct all telescopes from their names """
+    camera_name = camera_geometry.camera_name
     tel = TelescopeDescription.from_name(optics_name, camera_name)
     assert optics_name in str(tel)
     assert camera_name in str(tel)
     assert tel.camera.geometry.pix_x.shape[0] > 0
     assert tel.optics.equivalent_focal_length.to("m") > 0
-    assert tel.type in ["MST", "SST", "LST", "UNKNOWN"]
+    assert tel.type in {"MST", "SST", "LST", "UNKNOWN"}

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -796,14 +796,3 @@ def test_write_default_container(cls, tmp_path):
                 pytest.xfail()
             else:
                 raise
-
-
-if __name__ == "__main__":
-
-    import logging
-
-    logging.basicConfig(level=logging.DEBUG)
-
-    test_write_container("test.h5")
-    test_read_container("test.h5")
-    test_read_whole_table("test.h5")

--- a/ctapipe/tools/camdemo.py
+++ b/ctapipe/tools/camdemo.py
@@ -43,10 +43,8 @@ class CameraDemo(Tool):
         "much faster but may cause some draw "
         "artifacts)",
     ).tag(config=True)
-    camera = traits.CaselessStrEnum(
-        CameraDescription.get_known_camera_names(),
-        default_value="NectarCam",
-        help="Name of camera to display",
+    camera = traits.Unicode(
+        default_value="NectarCam", help="Name of camera to display"
     ).tag(config=True)
 
     optics = traits.CaselessStrEnum(

--- a/ctapipe/tools/camdemo.py
+++ b/ctapipe/tools/camdemo.py
@@ -18,11 +18,7 @@ from ctapipe.image import (
     hillas_parameters,
     HillasParameterizationError,
 )
-from ctapipe.instrument import (
-    TelescopeDescription,
-    OpticsDescription,
-    CameraDescription,
-)
+from ctapipe.instrument import TelescopeDescription, OpticsDescription
 from ctapipe.visualization import CameraDisplay
 
 

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -8,7 +8,6 @@ import pytest
 
 import matplotlib as mpl
 
-import tempfile
 import pandas as pd
 import tables
 
@@ -251,6 +250,7 @@ def test_muon_reconstruction(tmp_path, dl1_muon_file):
         assert np.count_nonzero(np.isnan(table["muonring_radius"])) == 0
 
     assert run_tool(MuonAnalysis(), ["--help-all"]) == 0
+
 
 def test_display_summed_images(tmp_path):
     from ctapipe.tools.display_summed_images import ImageSumDisplayerTool

--- a/ctapipe/utils/download.py
+++ b/ctapipe/utils/download.py
@@ -5,6 +5,7 @@ import logging
 from tqdm.auto import tqdm
 from urllib.parse import urlparse
 import time
+from contextlib import contextmanager
 
 __all__ = ["download_file", "download_cached", "download_file_cached"]
 
@@ -76,37 +77,49 @@ def get_cache_path(url, cache_name="ctapipe", env_override="CTAPIPE_CACHE"):
     return path
 
 
+@contextmanager
+def file_lock(path):
+    # if the file already exists, we wait until it does not exist anymore
+    if path.is_file():
+        log.warning("Another download for this file is already running, waiting.")
+        while path.is_file():
+            time.sleep(0.1)
+
+    # create the lock_file file
+    path.open("w").close()
+    try:
+        yield
+    finally:
+        path.unlink()
+
+
 def download_cached(
     url, cache_name="ctapipe", auth=None, env_prefix="CTAPIPE_DATA_", progress=False
 ):
     path = get_cache_path(url, cache_name=cache_name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    part_file = path.with_suffix(path.suffix + ".part")
+    lock_file = path.with_suffix(path.suffix + ".lock")
 
-    if part_file.is_file():
-        log.warning("Another download for this file is already running, waiting.")
-        while part_file.is_file():
-            time.sleep(1)
+    with file_lock(lock_file):
+        # if we already dowloaded the file, just use it
+        if path.is_file():
+            log.debug(f"{url} is available in cache.")
+            return path
 
-    # if we already dowloaded the file, just use it
-    if path.is_file():
-        log.debug(f"{url} is available in cache.")
+        if auth is True:
+            try:
+                auth = (
+                    os.environ[env_prefix + "USER"],
+                    os.environ[env_prefix + "PASSWORD"],
+                )
+            except KeyError:
+                raise KeyError(
+                    f'You need to set the env variables "{env_prefix}USER"'
+                    f' and "{env_prefix}PASSWORD" to download test files.'
+                ) from None
+
+        download_file(url=url, path=path, auth=auth, progress=progress)
         return path
-
-    if auth is True:
-        try:
-            auth = (
-                os.environ[env_prefix + "USER"],
-                os.environ[env_prefix + "PASSWORD"],
-            )
-        except KeyError:
-            raise KeyError(
-                f'You need to set the env variables "{env_prefix}USER"'
-                f' and "{env_prefix}PASSWORD" to download test files.'
-            ) from None
-
-    download_file(url=url, path=path, auth=auth, progress=progress)
-    return path
 
 
 def download_file_cached(


### PR DESCRIPTION
To speed up the continous integration and running the tests locally, I here enable the possibility to use `pytest-xdist` to run the test suite on multiple cores.

For this, the test discovery has to be deterministic, for which I needed to fix the tests using `get_known_camera_names`, as that list was randomly ordered. I directly went for the solution discussed here #1728, which also fixes #1641.

Second, I also had to fix the usage of temporary paths and fixtures in the hdf5 tests, so they do not rely on the order of the tests and instead use the temp path fixtures correctly.