### PR TITLE
Compute and record shower's core position also in the TiltedFrame when using HillasReconstructor

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -512,10 +512,27 @@ class ReconstructedGeometryContainer(Container):
         nan * u.m, "reconstructed x coordinate of the core position", unit=u.m
     )
     core_y = Field(
-        nan * u.m, "reconstructed y coordinate of the core position", unit=u.m
+        nan * u.m,
+        "reconstructed y coordinate of the core position",
+        unit=u.m
     )
     core_uncert = Field(
-        nan * u.m, "uncertainty of the reconstructed core position", unit=u.m
+        nan * u.m,
+        "uncertainty of the reconstructed core position in the ground frame",
+        unit=u.m
+    )
+    core_tilted_x = Field(
+        nan * u.m, "reconstructed x coordinate of the core position", unit=u.m
+    )
+    core_tilted_y = Field(
+        nan * u.m,
+        "reconstructed y coordinate of the core position",
+        unit=u.m
+    )
+    core_uncert_tilted = Field(
+        nan * u.m,
+        "uncertainty of the reconstructed core position in the tilted frame",
+        unit=u.m
     )
     h_max = Field(nan * u.m, "reconstructed height of the shower maximum", unit=u.m)
     h_max_uncert = Field(nan * u.m, "uncertainty of h_max", unit=u.m)

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -226,7 +226,7 @@ class HillasReconstructor(Reconstructor):
         direction, err_est_dir = self.estimate_direction()
 
         # array pointing is needed to define the tilted frame
-        core_pos = self.estimate_core_position(hillas_dict, array_pointing)
+        core_pos_ground, core_pos_tilted = self.estimate_core_position(hillas_dict, array_pointing)
 
         # container class for reconstructed showers
         _, lat, lon = cartesian_to_spherical(*direction)
@@ -240,8 +240,10 @@ class HillasReconstructor(Reconstructor):
         result = ReconstructedGeometryContainer(
             alt=lat,
             az=-lon,
-            core_x=core_pos[0],
-            core_y=core_pos[1],
+            core_x=core_pos_ground.x,
+            core_y=core_pos_ground.y,
+            core_tilted_x=core_pos_tilted.x,
+            core_tilted_y=core_pos_tilted.y,
             tel_ids=[h for h in hillas_dict.keys()],
             average_intensity=np.mean([h.intensity for h in hillas_dict.values()]),
             is_valid=True,
@@ -399,9 +401,9 @@ class HillasReconstructor(Reconstructor):
             x=core_position[0] * u.m, y=core_position[1] * u.m, frame=tilted_frame
         )
 
-        core_pos = project_to_ground(core_pos_tilted)
+        core_pos_ground = project_to_ground(core_pos_tilted)
 
-        return core_pos.x, core_pos.y
+        return core_pos_ground, core_pos_tilted
 
     def estimate_h_max(self):
         """


### PR DESCRIPTION
This makes things easier for calculating the impact parameters for each telescope in the pipeline which shouldn't bother with frames and transformations outside what will be ctapipe-process 