### PR TITLE
Remove redundant test code in simtel event source test code

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -144,83 +144,76 @@ def dl1_tmp_path(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def dl1_file(dl1_tmp_path):
+def dl1_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing both images and parameters from a gamma simulation set.
     """
     from ctapipe.tools.stage1 import Stage1Tool
     from ctapipe.core import run_tool
 
-    output = dl1_tmp_path / "images.dl1.h5"
+    output = dl1_tmp_path / "gamma.dl1.h5"
 
     # prevent running stage1 multiple times in case of parallel tests
     with FileLock(output.with_suffix(output.suffix + ".lock")):
         if output.is_file():
             return output
 
-        infile = get_dataset_path("gamma_test_large.simtel.gz")
-
         argv = [
-            f"--input={infile}",
+            f"--input={prod5_gamma_simtel_path}",
             f"--output={output}",
             "--write-images",
             "--max-events=20",
-            "--allowed-tels=[1,2,3]",
         ]
         assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output
 
 
 @pytest.fixture(scope="session")
-def dl1_image_file(dl1_tmp_path,):
+def dl1_image_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing only images (DL1A) from a gamma simulation set.
     """
     from ctapipe.tools.stage1 import Stage1Tool
     from ctapipe.core import run_tool
 
-    output = dl1_tmp_path / "images.dl1.h5"
+    output = dl1_tmp_path / "gamma_images.dl1.h5"
 
     # prevent running stage1 multiple times in case of parallel tests
     with FileLock(output.with_suffix(output.suffix + ".lock")):
         if output.is_file():
             return output
 
-        infile = get_dataset_path("gamma_test_large.simtel.gz")
         argv = [
-            f"--input={infile}",
+            f"--input={prod5_gamma_simtel_path}",
             f"--output={output}",
             "--write-images",
             "--DataWriter.write_parameters=False",
             "--max-events=20",
-            "--allowed-tels=[1,2,3]",
         ]
         assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output
 
 
 @pytest.fixture(scope="session")
-def dl1_parameters_file(dl1_tmp_path):
+def dl1_parameters_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 File containing only parameters (DL1B) from a gamma simulation set.
     """
     from ctapipe.tools.stage1 import Stage1Tool
     from ctapipe.core import run_tool
 
-    output = dl1_tmp_path / "parameters.dl1.h5"
+    output = dl1_tmp_path / "gamma_parameters.dl1.h5"
 
     # prevent running stage1 multiple times in case of parallel tests
     with FileLock(output.with_suffix(output.suffix + ".lock")):
         if output.is_file():
             return output
 
-        infile = get_dataset_path("gamma_test_large.simtel.gz")
         argv = [
-            f"--input={infile}",
+            f"--input={prod5_gamma_simtel_path}",
             f"--output={output}",
             "--write-parameters",
             "--max-events=20",
-            "--allowed-tels=[1,2,3]",
         ]
         assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output
@@ -247,6 +240,29 @@ def dl1_muon_file(dl1_tmp_path):
             f"--output={output}",
             "--write-images",
             "--DataWriter.write_parameters=False",
+        ]
+        assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
+        return output
+
+
+@pytest.fixture(scope="session")
+def dl1_proton_file(dl1_tmp_path, prod5_proton_simtel_path):
+    """
+    DL1 file containing images and parameters for a prod5 proton run
+    """
+    from ctapipe.tools.stage1 import Stage1Tool
+    from ctapipe.core import run_tool
+
+    output = dl1_tmp_path / "proton.dl1.h5"
+
+    with FileLock(output.with_suffix(output.suffix + ".lock")):
+        if output.is_file():
+            return output
+
+        argv = [
+            f"--input={prod5_proton_simtel_path}",
+            f"--output={output}",
+            "--write-images",
         ]
         assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output

--- a/ctapipe/io/tests/test_dl1eventsource.py
+++ b/ctapipe/io/tests/test_dl1eventsource.py
@@ -27,8 +27,8 @@ def test_metadata(dl1_file):
     with DL1EventSource(input_url=dl1_file) as source:
         assert source.is_simulation
         assert source.datalevels == (DataLevel.DL1_IMAGES, DataLevel.DL1_PARAMETERS)
-        assert list(source.obs_ids) == [7514]
-        assert source.simulation_config.corsika_version == 6990
+        assert list(source.obs_ids) == [2]
+        assert source.simulation_config.corsika_version == 7710
 
 
 def test_subarray(dl1_file):
@@ -38,14 +38,13 @@ def test_subarray(dl1_file):
         assert source.subarray.optics_types
 
 
-def test_max_events(dl1_file):
-    max_events = 5
-    with DL1EventSource(input_url=dl1_file, max_events=max_events) as source:
-        count = 0
+def test_max_events(dl1_proton_file):
+    max_events = 3
+    with DL1EventSource(input_url=dl1_proton_file, max_events=max_events) as source:
         assert source.max_events == max_events  # stop iterating after max_events
-        assert len(source) == 20  # total events in file
-        for _ in source:
-            count += 1
+        assert len(source) == 4  # total events in file
+        for count, _ in enumerate(source, start=1):
+            pass
         assert count == max_events
 
 

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -44,23 +44,6 @@ def test_simtel_event_source_on_gamma_test_one_event():
                 assert event.count == 0
                 break
 
-    # test that max_events works:
-    max_events = 5
-    with SimTelEventSource(
-        input_url=gamma_test_large_path, max_events=max_events
-    ) as reader:
-        count = 0
-        for _ in reader:
-            count += 1
-        assert count == max_events
-
-    # test that the allowed_tels mask works:
-    with SimTelEventSource(
-        input_url=gamma_test_large_path, allowed_tels={3, 4}
-    ) as reader:
-        for event in reader:
-            assert set(event.r0.tel).issubset(reader.allowed_tels)
-
 
 def test_that_event_is_not_modified_after_loop():
 
@@ -173,7 +156,7 @@ def test_allowed_telescopes():
     # test that the allowed_tels mask works:
     allowed_tels = {3, 4}
     with SimTelEventSource(
-        input_url=gamma_test_large_path, allowed_tels=allowed_tels
+        input_url=gamma_test_large_path, allowed_tels=allowed_tels, max_events=5
     ) as reader:
         assert not allowed_tels.symmetric_difference(reader.subarray.tel_ids)
         for event in reader:

--- a/ctapipe/tools/tests/test_merge.py
+++ b/ctapipe/tools/tests/test_merge.py
@@ -1,5 +1,6 @@
 import tables
 import tempfile
+import shutil
 
 from ctapipe.core import run_tool
 from pathlib import Path
@@ -50,12 +51,16 @@ def test_pattern(tmp_path: Path, dl1_file, dl1_proton_file):
     # touch a random file to test that the pattern does not use it
     open(dl1_file.parent / "foo.h5", "w").close()
 
+    # copy to make sure we don't have other files in the dl1 dir disturb this
+    for f in (dl1_file, dl1_proton_file):
+        shutil.copy(f, tmp_path)
+
     output = tmp_path / "merged_pattern.dl1.h5"
     ret = run_tool(
-        MergeTool(),
+        tool=MergeTool(),
         argv=[
             "-i",
-            str(dl1_file.parent),
+            str(tmp_path),
             "-p",
             "*.dl1.h5",
             f"--output={output}",

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -61,7 +61,7 @@ def test_stage_1_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
 
     # check we can read telescope parameters
     dl1_features = pd.read_hdf(
-        dl1b_from_dl1a_file, "/dl1/event/telescope/parameters/tel_001"
+        dl1b_from_dl1a_file, "/dl1/event/telescope/parameters/tel_025"
     )
     features = (
         "obs_id",


### PR DESCRIPTION
The exact same code is further down in two individual tests.