### PR TITLE
ctapipe-fileinfo

### DIFF
--- a/ctapipe/tools/fileinfo.py
+++ b/ctapipe/tools/fileinfo.py
@@ -66,7 +66,7 @@ def fileinfo(args):
 
         dataframe = pd.DataFrame(info_total)
         Table.from_pandas(dataframe.T, index=True).write(
-            args.output_table, overwrite=True
+            args.output_table, format=args.output_format, overwrite=True
         )
 
 
@@ -80,7 +80,14 @@ def main():
         nargs="+",
         help="filenames of files in ctapipe format",
     )
-    parser.add_argument("--output-table", help="generate output in tabular format")
+    parser.add_argument(
+        "-t", "--output-table", help="generate output in tabular format"
+    )
+    parser.add_argument(
+        "-f",
+        "--output-format",
+        help="format of output table if not automatically guessed from filename",
+    )
     parser.add_argument(
         "--flat", action="store_true", help="show flat header hierarchy"
     )

--- a/ctapipe/tools/fileinfo.py
+++ b/ctapipe/tools/fileinfo.py
@@ -1,0 +1,93 @@
+"""
+Display information about ctapipe output files (DL1 or DL2)
+"""
+
+from pathlib import Path
+import tables
+import yaml
+from astropy.table import Table
+from ctapipe.tools.utils import get_parser
+
+
+def unflatten(dictionary, separator=" "):
+    """ turn flattened dict keys into nested """
+    hierarch_dict = dict()
+    for key, value in dictionary.items():
+        parts = key.split(separator)
+        tmp_dict = hierarch_dict
+        for part in parts[:-1]:
+            if part not in tmp_dict:
+                tmp_dict[part] = dict()
+            tmp_dict = tmp_dict[part]
+        tmp_dict[parts[-1]] = value
+    return hierarch_dict
+
+
+def fileinfo(args):
+    """
+    Display information about ctapipe output files (DL1 or DL2 in HDF5 format).
+    Optionally create an index table from all headers
+    """
+
+    info_total = {}  # accumulated info for table output
+
+    for filename in args.files:
+        info = {}
+
+        # prevent failure if a non-file is given (e.g. a directory)
+        if Path(filename).is_file() is False:
+            info[filename] = "not a file"
+
+        elif tables.is_hdf5_file(filename) is not True:
+            info[filename] = "unknown file type"
+        else:
+            try:
+                with tables.open_file(filename, mode="r") as infile:
+                    # pylint: disable=W0212,E1101
+                    attrs = {
+                        name: str(infile.root._v_attrs[name])
+                        for name in infile.root._v_attrs._f_list()
+                    }
+                    if args.flat:
+                        info[filename] = attrs
+                    else:
+                        info[filename] = unflatten(attrs)
+
+                    if args.output_table:
+                        info_total[filename] = attrs
+            except tables.exceptions.HDF5ExtError as err:
+                info[filename] = f"ERROR {err}"
+
+        print(yaml.dump(info, indent=4))
+
+    if args.output_table:
+        # use pandas' ability to convert a dict of flat values to a table
+        import pandas as pd  #  pylint: disable=C0415
+
+        dataframe = pd.DataFrame(info_total)
+        Table.from_pandas(dataframe.T, index=True).write(
+            args.output_table, overwrite=True
+        )
+
+
+def main():
+    """ display info """
+    parser = get_parser(fileinfo)
+    parser.add_argument(
+        "files",
+        metavar="FILENAME",
+        type=str,
+        nargs="+",
+        help="filenames of files in ctapipe format",
+    )
+    parser.add_argument("--output-table", help="generate output in tabular format")
+    parser.add_argument(
+        "--flat", action="store_true", help="show flat header hierarchy"
+    )
+    args = parser.parse_args()
+
+    fileinfo(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ctapipe/tools/fileinfo.py
+++ b/ctapipe/tools/fileinfo.py
@@ -66,7 +66,7 @@ def fileinfo(args):
 
         dataframe = pd.DataFrame(info_total)
         Table.from_pandas(dataframe.T, index=True).write(
-            args.output_table, format=args.output_format, overwrite=True
+            args.output_table, format=args.table_format, overwrite=True
         )
 
 
@@ -81,15 +81,15 @@ def main():
         help="filenames of files in ctapipe format",
     )
     parser.add_argument(
-        "-t", "--output-table", help="generate output in tabular format"
+        "-o", "--output-table", help="generate output file in tabular format"
     )
     parser.add_argument(
-        "-f",
-        "--output-format",
-        help="format of output table if not automatically guessed from filename",
+        "-T",
+        "--table-format",
+        help="table format of output-table if not automatically guessed from filename",
     )
     parser.add_argument(
-        "--flat", action="store_true", help="show flat header hierarchy"
+        "-f", "--flat", action="store_true", help="show flat header hierarchy"
     )
     args = parser.parse_args()
 

--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -74,9 +74,8 @@ def info(
     plugins=False,
     show_all=False,
 ):
-    """Print various info to the console.
-
-    TODO: explain.
+    """
+    Display information about the current ctapipe installation.
     """
     logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -294,7 +294,7 @@ def test_fileinfo(tmp_path, dl1_image_file):
 
     index_file = tmp_path / "index.fits"
     command = f"ctapipe-fileinfo {dl1_image_file} --output-table {index_file}"
-    output = subprocess.run(command.split(" "), capture_output=True).stdout
+    output = subprocess.run(command.split(" "), capture_output=True, check=True).stdout
     header = yaml.load(output)
     assert "ID" in header[str(dl1_image_file)]["CTA"]["ACTIVITY"]
 
@@ -302,7 +302,7 @@ def test_fileinfo(tmp_path, dl1_image_file):
     assert len(tab["CTA PRODUCT CREATION TIME"]) > 0
 
     command = f"ctapipe-fileinfo {dl1_image_file} --flat"
-    output = subprocess.run(command.split(" "), capture_output=True).stdout
+    output = subprocess.run(command.split(" "), capture_output=True, check=True).stdout
     header = yaml.load(output)
     assert "CTA ACTIVITY ID" in header[str(dl1_image_file)]
 

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -1,18 +1,20 @@
 """
 Test individual tool functionality
 """
+# pylint: disable=C0415,C0103,C0116,C0115
 import sys
+import os
 
+from pathlib import Path
 import matplotlib as mpl
 
+import numpy as np
 import pandas as pd
 import tables
 
 from ctapipe.utils import get_dataset_path
 from ctapipe.core import run_tool
 from ctapipe.io import DataLevel
-import numpy as np
-from pathlib import Path
 
 
 GAMMA_TEST_LARGE = get_dataset_path("gamma_test_large.simtel.gz")
@@ -97,8 +99,8 @@ def test_stage1_datalevels(tmp_path):
 
     class DummyEventSource(EventSource):
         @classmethod
-        def is_compatible(cls, path):
-            with open(path, "rb") as f:
+        def is_compatible(cls, file_path):
+            with open(file_path, "rb") as f:
                 dummy = f.read(5)
                 return dummy == b"dummy"
 
@@ -283,6 +285,28 @@ def test_info():
     from ctapipe.tools.info import info
 
     info(show_all=True)
+
+
+def test_fileinfo(tmp_path, dl1_image_file):
+    """ check we can run ctapipe-fileinfo and get results """
+    import yaml
+    from astropy.table import Table
+
+    index_file = tmp_path / "index.fits"
+    command = f"ctapipe-fileinfo {dl1_image_file} --output-table {index_file}"
+    stream = os.popen(command)
+    output = stream.read()
+    header = yaml.load(output)
+    assert "ID" in header[str(dl1_image_file)]["CTA"]["ACTIVITY"]
+
+    tab = Table.read(index_file)
+    assert len(tab["CTA PRODUCT CREATION TIME"]) > 0
+
+    command = f"ctapipe-fileinfo {dl1_image_file} --flat"
+    stream = os.popen(command)
+    output = stream.read()
+    header = yaml.load(output)
+    assert "CTA ACTIVITY ID" in header[str(dl1_image_file)]
 
 
 def test_dump_triggers(tmp_path):

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -3,7 +3,7 @@ Test individual tool functionality
 """
 # pylint: disable=C0415,C0103,C0116,C0115
 import sys
-import os
+import subprocess
 
 from pathlib import Path
 import matplotlib as mpl
@@ -294,8 +294,7 @@ def test_fileinfo(tmp_path, dl1_image_file):
 
     index_file = tmp_path / "index.fits"
     command = f"ctapipe-fileinfo {dl1_image_file} --output-table {index_file}"
-    stream = os.popen(command)
-    output = stream.read()
+    output = subprocess.run(command.split(" "), capture_output=True).stdout
     header = yaml.load(output)
     assert "ID" in header[str(dl1_image_file)]["CTA"]["ACTIVITY"]
 
@@ -303,8 +302,7 @@ def test_fileinfo(tmp_path, dl1_image_file):
     assert len(tab["CTA PRODUCT CREATION TIME"]) > 0
 
     command = f"ctapipe-fileinfo {dl1_image_file} --flat"
-    stream = os.popen(command)
-    output = stream.read()
+    output = subprocess.run(command.split(" "), capture_output=True).stdout
     header = yaml.load(output)
     assert "CTA ACTIVITY ID" in header[str(dl1_image_file)]
 

--- a/ctapipe/tools/utils.py
+++ b/ctapipe/tools/utils.py
@@ -15,17 +15,15 @@ __all__ = [
 class ArgparseFormatter(
     argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
 ):
-    """ArgumentParser formatter_class argument.
-    """
+    """ArgumentParser formatter_class argument."""
 
     pass
 
 
 def get_parser(function=None, description="N/A"):
-    """Make an ArgumentParser how we like it.
-    """
+    """Make an ArgumentParser how we like it."""
     if function:
-        description = function.__doc__.split("\n")[0]
+        description = function.__doc__
     parser = argparse.ArgumentParser(
         description=description, formatter_class=ArgparseFormatter
     )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ entry_points["console_scripts"] = [
     "ctapipe-display-dl1 = ctapipe.tools.display_dl1:main",
     "ctapipe-stage1 = ctapipe.tools.stage1:main",
     "ctapipe-merge = ctapipe.tools.dl1_merge:main",
+    "ctapipe-fileinfo = ctapipe.tools.fileinfo:main",
 ]
 tests_require = ["pytest", "pandas>=0.24.0"]
 docs_require = [


### PR DESCRIPTION
Just a small fast command-line utility to display information about ctapipe output files. 

- the output is all reference headers in YAML format  (hierarchical by default, but a `--flat` option is available)
- you can optionally write an index table for all files with all headers as columns (uses pandas DataFrame's ability to convert a list of dicts into a table, and then uses astropy.table to write it to any format you want, e.g. `files.fits` or `files.ecsv`)
- files not in hdf5 format are skipped (with a message)
- incomplete hdf5 files will return `{}` (no header)
- you can colorize the output by piping it through `pygmentize -l yaml`

### Help: 
```
% ctapipe-fileinfo --help                                                                                        

usage: ctapipe-fileinfo [-h] [--output-table OUTPUT_TABLE] [--flat] FILENAME [FILENAME ...]

    Display information about ctapipe output files (DL1 or DL2 in HDF5 format).
    Optionally create an index table from all headers


positional arguments:
  FILENAME              filenames of files in ctapipe format

optional arguments:
  -h, --help            show this help message and exit
  --output-table OUTPUT_TABLE
                        generate output in tabular format (default: None)
  --flat                show flat header hierarchy (default: False)
```

### Example 2:

```
%  ctapipe-fileinfo *.DL1.h5

proton_20deg_0deg_run153___cta-prod5-paranal_desert-2147m-Paranal-dark_merged.DL1.h5:
    CTA:
        ACTIVITY:
            ID: eb09130c-1a4e-4a0a-96a0-2607ebca70b1
            NAME: ctapipe-merge
            SOFTWARE:
                NAME: ctapipe
                VERSION: 0.10.5
            START:
                TIME: '2021-03-15 15:30:01.948'
            TYPE: software
        CONTACT:
            EMAIL: ''
            NAME: ''
            ORGANIZATION: CTA Consortium
        INSTRUMENT:
            CLASS: Subarray
            ID: MonteCarloArray
            SITE: Other
            SUBTYPE: unspecified
            TYPE: unknown
            VERSION: unknown
        PROCESS:
            ID: '0'
            SUBTYPE: ''
            TYPE: Simulation
        PRODUCT:
            CREATION:
                TIME: '2021-03-15 15:30:57.161'
            DATA:
                ASSOCIATION: Subarray
                CATEGORY: S
                LEVEL: DL1
                MODEL:
                    NAME: ASWG DL1
                    URL: ''
                    VERSION: v1.1.0
            DESCRIPTION: Merged DL1 Data Product
            FORMAT: hdf5
            ID: 98f44cd6-f642-4af0-aa55-7da1621f0c5e
        REFERENCE:
            VERSION: '1'
```

### Example of table output:
```
ctapipe-fileinfo --output-table index.fits
```
![image](https://user-images.githubusercontent.com/11677812/126649533-640b7cb0-463f-4652-944c-56c163765b82.png)
