### PR TITLE
Add condition option to read_table

### DIFF
--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -30,12 +30,24 @@ def read_table(h5file, path, start=None, stop=None, step=None, condition=None) -
     This uses the same conventions as the `~ctapipe.io.HDF5TableWriter`,
     with the exception of Enums, that will remain as integers.
 
+    (start, stop, step) behave like python slices.
+
     Parameters
     ----------
     h5file: Union[str, Path, tables.file.File]
         input filename or PyTables file handle
     path: str
         path to table in the file
+    start: int or None
+        if given, this is the first row to be loaded
+    stop: int or None
+        if given, this is the last row to be loaded (not inclusive)
+    step: int or None
+        step between rows.
+    condition: str
+        A numexpr expression to only load rows fulfilling this condition.
+        For example, use "hillas_length > 0" to only load rows where the
+        hillas length is larger than 0 (so not nan and not 0).
 
     Returns
     -------

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -134,3 +134,20 @@ def test_file_closed(tmp_path):
     # the file
     with tables.open_file(path, "w"):
         pass
+
+
+def test_condition(tmp_path):
+    # write a simple hdf5 file using
+
+    container = ReconstructedEnergyContainer()
+    filename = tmp_path / "test_astropy_table.h5"
+
+    with HDF5TableWriter(filename) as writer:
+        for energy in [np.nan, 100, np.nan, 50, -1.0] * u.TeV:
+            container.energy = energy
+            writer.write("events", container)
+
+    # try opening the result
+    table = read_table(filename, "/events", condition="energy > 0")
+    assert len(table) == 2
+    assert np.all(table["energy"] == [100, 50] * u.TeV)


### PR DESCRIPTION
This adds the possibility to use `tables` `read_where` method using a `numexpr` expression to only load rows fulfilling condition.

Very handy for example to load data from only one telescope from a `by_type` table: `condition="tel_id == 1"` or only load reconstructed events: `condition = "hillas_length > 0"`