### PR TITLE
TableLoader

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -425,6 +425,7 @@ good-names=i,
            x,
            y,
            n,
+		   f,
            ex,
            _
 

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -139,6 +139,62 @@ def prod5_proton_simtel_path():
 def dl1_tmp_path(tmp_path_factory):
     return tmp_path_factory.mktemp("dl1")
 
+@pytest.fixture(scope="session")
+def dl2_tmp_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("dl2")
+
+
+@pytest.fixture(scope="session")
+def dl2_shower_geometry_file(dl2_tmp_path, prod5_gamma_simtel_path):
+    """
+    File containing both parameters and shower geometry from a gamma simulation set.
+    """
+    from ctapipe.core import run_tool
+    from ctapipe.tools.process import ProcessorTool
+
+    output = dl2_tmp_path / "gamma.training.h5"
+
+    # prevent running process multiple times in case of parallel tests
+    with FileLock(output.with_suffix(output.suffix + ".lock")):
+        if output.is_file():
+            return output
+
+        argv = [
+            f"--input={prod5_gamma_simtel_path}",
+            f"--output={output}",
+            "--write-images",
+            "--write-stereo-shower",
+            "--max-events=20",
+        ]
+        assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
+        return output
+
+@pytest.fixture(scope="session")
+def dl2_shower_geometry_file_type(dl2_tmp_path, prod5_gamma_simtel_path):
+    """
+    File containing both parameters and shower geometry from a gamma simulation set.
+    """
+    from ctapipe.core import run_tool
+    from ctapipe.tools.process import ProcessorTool
+
+    output = dl2_tmp_path / "gamma_by_type.training.h5"
+
+    # prevent running process multiple times in case of parallel tests
+    with FileLock(output.with_suffix(output.suffix + ".lock")):
+        if output.is_file():
+            return output
+
+        argv = [
+            f"--input={prod5_gamma_simtel_path}",
+            f"--output={output}",
+            "--write-images",
+            "--write-stereo-shower",
+            "--max-events=20",
+            "--DataWriter.split_datasets_by=tel_type",
+        ]
+        assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
+        return output
+
 
 @pytest.fixture(scope="session")
 def dl1_file(dl1_tmp_path, prod5_gamma_simtel_path):

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -166,6 +166,32 @@ def dl1_file(dl1_tmp_path, prod5_gamma_simtel_path):
 
 
 @pytest.fixture(scope="session")
+def dl1_by_type_file(dl1_tmp_path, prod5_gamma_simtel_path):
+    """
+    DL1 file containing both images and parameters from a gamma simulation set.
+    """
+    from ctapipe.tools.stage1 import Stage1Tool
+    from ctapipe.core import run_tool
+
+    output = dl1_tmp_path / "gamma_by_type.dl1.h5"
+
+    # prevent running stage1 multiple times in case of parallel tests
+    with FileLock(output.with_suffix(output.suffix + ".lock")):
+        if output.is_file():
+            return output
+
+        argv = [
+            f"--input={prod5_gamma_simtel_path}",
+            f"--output={output}",
+            "--write-images",
+            "--max-events=20",
+            "--DataWriter.split_datasets_by=tel_type",
+        ]
+        assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
+        return output
+
+
+@pytest.fixture(scope="session")
 def dl1_image_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing only images (DL1A) from a gamma simulation set.

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -170,7 +170,7 @@ def dl1_by_type_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing both images and parameters from a gamma simulation set.
     """
-    from ctapipe.tools.stage1 import Stage1Tool
+    from ctapipe.tools.process import ProcessorTool
     from ctapipe.core import run_tool
 
     output = dl1_tmp_path / "gamma_by_type.dl1.h5"
@@ -187,7 +187,7 @@ def dl1_by_type_file(dl1_tmp_path, prod5_gamma_simtel_path):
             "--max-events=20",
             "--DataWriter.split_datasets_by=tel_type",
         ]
-        assert run_tool(Stage1Tool(), argv=argv, cwd=dl1_tmp_path) == 0
+        assert run_tool(ProcessorTool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output
 
 

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -137,10 +137,13 @@ def prod5_proton_simtel_path():
 
 @pytest.fixture(scope="session")
 def dl1_tmp_path(tmp_path_factory):
+    """Temporary directory for global dl1 test data"""
     return tmp_path_factory.mktemp("dl1")
+
 
 @pytest.fixture(scope="session")
 def dl2_tmp_path(tmp_path_factory):
+    """Temporary directory for global dl2 test data"""
     return tmp_path_factory.mktemp("dl2")
 
 
@@ -168,6 +171,7 @@ def dl2_shower_geometry_file(dl2_tmp_path, prod5_gamma_simtel_path):
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
         return output
+
 
 @pytest.fixture(scope="session")
 def dl2_shower_geometry_file_type(dl2_tmp_path, prod5_gamma_simtel_path):

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -52,8 +52,8 @@ class Tool(Application):
     ``name``, ``description`` and ``examples`` class attributes as
     strings. The ``aliases`` attribute can be set to cause a lower-level
     `~ctapipe.core.Component` parameter to become a high-level command-line
-    parameter (See example below). The `setup()`, `start()`, and
-    `finish()` methods should be defined in the sub-class.
+    parameter (See example below). The `setup`, `start`, and
+    `finish` methods should be defined in the sub-class.
 
     Additionally, any `ctapipe.core.Component` used within the `Tool`
     should have their class in a list in the ``classes`` attribute,
@@ -61,7 +61,7 @@ class Tool(Application):
     tool.
 
     Once a tool is constructed and the virtual methods defined, the
-    user can call the `run()` method to setup and start it.
+    user can call the `run` method to setup and start it.
 
 
     .. code:: python
@@ -254,14 +254,14 @@ class Tool(Application):
     @abstractmethod
     def start(self):
         """main body of tool (override in subclass). This is  automatically
-        called after `initialize()` when the `run()` is called.
+        called after `Tool.initialize` when the `Tool.run` is called.
         """
         pass
 
     @abstractmethod
     def finish(self):
         """finish up (override in subclass). This is called automatically
-        after `start()` when `run()` is called."""
+        after `Tool.start` when `Tool.run` is called."""
         self.log.info("Goodbye")
 
     def run(self, argv=None):

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -406,7 +406,7 @@ class SubarrayDescription:
         telescopes: List[Union[int, str, TelescopeDescription]]
             List of Telescope IDs and descriptions.
             Supported inputs for telescope descriptions are instances of
-            `TelescopeDescription` as well as their string representation.
+            `~ctapipe.instrument.TelescopeDescription` as well as their string representation.
 
         Returns
         -------

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -1,6 +1,7 @@
 """
 Description of Arrays or Subarrays of telescopes
 """
+from typing import Dict, List, Union
 from pathlib import Path
 import warnings
 
@@ -19,9 +20,6 @@ from ..coordinates import GroundFrame, CameraFrame
 from .telescope import TelescopeDescription
 from .camera import CameraDescription, CameraReadout, CameraGeometry
 from .optics import OpticsDescription
-
-
-from typing import Dict, List, Union
 
 
 __all__ = ["SubarrayDescription"]
@@ -406,7 +404,8 @@ class SubarrayDescription:
         telescopes: List[Union[int, str, TelescopeDescription]]
             List of Telescope IDs and descriptions.
             Supported inputs for telescope descriptions are instances of
-            `~ctapipe.instrument.TelescopeDescription` as well as their string representation.
+            `~ctapipe.instrument.TelescopeDescription` as well as their
+            string representation.
 
         Returns
         -------

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -363,17 +363,17 @@ class SubarrayDescription:
             plt.tight_layout()
 
     @lazyproperty
-    def telescope_types(self):
+    def telescope_types(self) -> List[TelescopeDescription]:
         """ list of telescope types in the array"""
         return list({tel for tel in self.tel.values()})
 
     @lazyproperty
-    def camera_types(self):
+    def camera_types(self) -> List[CameraDescription]:
         """ list of camera types in the array """
         return list({tel.camera for tel in self.tel.values()})
 
     @lazyproperty
-    def optics_types(self):
+    def optics_types(self) -> List[OpticsDescription]:
         """ list of optics types in the array """
         return list({tel.optics for tel in self.tel.values()})
 

--- a/ctapipe/instrument/telescope.py
+++ b/ctapipe/instrument/telescope.py
@@ -27,7 +27,7 @@ class TelescopeDescription:
     Describes a Cherenkov Telescope and its associated
     `~ctapipe.instrument.OpticsDescription` and `~ctapipe.instrument.CameraDescription`
 
-    Parameters
+    Attributes
     ----------
     name: str
         Telescope name
@@ -40,8 +40,24 @@ class TelescopeDescription:
     """
 
     def __init__(
-        self, name, tel_type, optics: OpticsDescription, camera: CameraDescription
+        self,
+        name: str,
+        tel_type: str,
+        optics: OpticsDescription,
+        camera: CameraDescription,
     ):
+
+        if not isinstance(name, str):
+            raise TypeError("`name` must be a str")
+
+        if not isinstance(tel_type, str):
+            raise TypeError("`tel_type` must be a str")
+
+        if not isinstance(optics, OpticsDescription):
+            raise TypeError("`optics` must be an instance of `OpticsDescription`")
+
+        if not isinstance(camera, CameraDescription):
+            raise TypeError("`camera` must be an instance of `CameraDescription`")
 
         self.name = name
         self.type = tel_type

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from ctapipe.coordinates import TelescopeFrame
 from copy import deepcopy
+import pytest
 
 from ctapipe.instrument import (
     CameraDescription,
@@ -188,3 +189,25 @@ def test_hdf_duplicate_string_repr(tmp_path):
     assert (
         read.tel[1].optics.num_mirror_tiles == read.tel[2].optics.num_mirror_tiles + 1
     )
+
+
+def test_get_tel_ids(example_subarray):
+    from ctapipe.instrument import TelescopeDescription
+
+    subarray = example_subarray
+    sst = TelescopeDescription.from_name("SST-ASTRI", "CHEC")
+
+    telescopes = [1, 2, "MST_MST_FlashCam", sst]
+    tel_ids = subarray.get_tel_ids(telescopes)
+
+    true_tel_ids = (
+        subarray.get_tel_ids_for_type("MST_MST_FlashCam")
+        + subarray.get_tel_ids_for_type(sst)
+        + [1, 2]
+    )
+
+    assert sorted(tel_ids) == sorted(true_tel_ids)
+
+    # test invalid telescope type
+    with pytest.raises(Exception):
+        tel_ids = subarray.get_tel_ids(["It's a-me, Mario!"])

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -1,11 +1,12 @@
 """ Tests for SubarrayDescriptions """
+from copy import deepcopy
+
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from ctapipe.coordinates import TelescopeFrame
-from copy import deepcopy
 import pytest
 
+from ctapipe.coordinates import TelescopeFrame
 from ctapipe.instrument import (
     CameraDescription,
     OpticsDescription,
@@ -192,8 +193,7 @@ def test_hdf_duplicate_string_repr(tmp_path):
 
 
 def test_get_tel_ids(example_subarray):
-    from ctapipe.instrument import TelescopeDescription
-
+    """Test for SubarrayDescription.get_tel_ids"""
     subarray = example_subarray
     sst = TelescopeDescription.from_name("SST-ASTRI", "CHEC")
 

--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -2,7 +2,7 @@ from .eventseeker import EventSeeker
 from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader, HDF5TableWriter
 from .tableio import TableWriter, TableReader
-from .tableloader import get_structure, TableLoader
+from .tableloader import TableLoader
 from .datalevels import DataLevel
 from .astropy_helpers import read_table
 from .datawriter import DataWriter, DATA_MODEL_VERSION
@@ -22,7 +22,6 @@ __all__ = [
     "HDF5TableReader",
     "TableWriter",
     "TableReader",
-    "get_structure",
     "TableLoader",
     "EventSeeker",
     "EventSource",

--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -2,6 +2,7 @@ from .eventseeker import EventSeeker
 from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader, HDF5TableWriter
 from .tableio import TableWriter, TableReader
+from .tableloader import get_structure, TableLoader
 from .datalevels import DataLevel
 from .astropy_helpers import read_table
 from .datawriter import DataWriter, DATA_MODEL_VERSION
@@ -21,6 +22,8 @@ __all__ = [
     "HDF5TableReader",
     "TableWriter",
     "TableReader",
+    "get_structure",
+    "TableLoader",
     "EventSeeker",
     "EventSource",
     "SimTelEventSource",

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -9,7 +9,7 @@ import numpy as np
 import tables
 from astropy.table import join, vstack, Table
 
-from ..core import Component, traits
+from ..core import Component, traits, Provenance
 from ..instrument import SubarrayDescription, TelescopeDescription
 from .astropy_helpers import read_table
 
@@ -86,6 +86,8 @@ class TableLoader(Component):
 
         self.subarray = SubarrayDescription.from_hdf(self.input_url)
         self.h5file = tables.open_file(self.input_url, mode="r")
+
+        Provenance().add_input_file(self.input_url, role="Event data")
 
         try:
             self.structure = get_structure(self.h5file)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -8,7 +8,7 @@ from ..core import Component, traits
 from ..instrument import SubarrayDescription
 from .astropy_helpers import read_table
 
-__all__ = ["get_structure", "TableLoader"]
+__all__ = ["get_tel_ids", "get_structure", "TableLoader"]
 
 PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -79,7 +79,7 @@ class TableLoader(Component):
                 key = f"{PARAMETERS_GROUP}/tel_{tel_id:03d}"
                 condition = None
             else:
-                key = f"{PARAMETERS_GROUP}/{self.subarray.tel[tel_id]:s}"
+                key = f"{PARAMETERS_GROUP}/{self.subarray.tel[tel_id]!s}"
                 condition = f"tel_id == {tel_id}"
 
             if key in self.h5file:
@@ -92,7 +92,7 @@ class TableLoader(Component):
                 key = f"{IMAGES_GROUP}/tel_{tel_id:03d}"
                 condition = None
             else:
-                key = f"{IMAGES_GROUP}/{self.subarray.tel[tel_id]:s}"
+                key = f"{IMAGES_GROUP}/{self.subarray.tel[tel_id]!s}"
                 condition = f"tel_id == {tel_id}"
 
             images = read_table(self.h5file, key, condition=condition)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -31,9 +31,13 @@ def get_tel_ids(
 ) -> List[int]:
     ids = set()
 
+    valid_tel_types = [str(tel_type) for tel_type in subarray.telescope_types]
+
     for telescope in telescopes:
         if isinstance(telescope, int):
             ids.add(telescope)
+        if isinstance(telescope, str) and (telescope not in valid_tel_types):
+            raise ValueError("Invalid telescope type input.")
         ids.update(subarray.get_tel_ids_for_type(telescope))
 
     return sorted(ids)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -1,19 +1,21 @@
 """
-Class and functions to read DL1 (a,b) and/or DL2 (a) data from an HDF5 file produced with ctapipe-process.
+Class and related functions to read DL1 (a,b) and/or DL2 (a) data
+from an HDF5 file produced with ctapipe-process.
 """
 
 import re
 from collections import defaultdict
+from typing import Dict
 
 import numpy as np
-import tables
 from astropy.table import join, vstack, Table
+import tables
 
 from ..core import Component, traits, Provenance
 from ..instrument import SubarrayDescription
-from .astropy_helpers import read_table
+from .astropy_helpers import read_table, join_allow_empty
 
-__all__ = ["get_structure", "TableLoader"]
+__all__ = ["TableLoader"]
 
 PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"
@@ -31,64 +33,58 @@ TELESCOPE_EVENT_KEYS = ["obs_id", "event_id", "tel_id"]
 
 
 def _empty_telescope_events_table():
+    """
+    Create a new astropy table with correct column names and dtypes
+    for telescope event based data.
+    """
     return Table(names=TELESCOPE_EVENT_KEYS, dtype=[np.int64, np.int64, np.int16])
 
 
 def _empty_subarray_events_table():
+    """
+    Create a new astropy table with correct column names and dtypes
+    for subarray event based data.
+    """
     return Table(names=SUBARRAY_EVENT_KEYS, dtype=[np.int64, np.int64])
 
 
-def _allow_empty_join(left, right, keys, join_type="left", **kwargs):
-    # see https://github.com/astropy/astropy/issues/12012
-
-    left_empty = len(left) == 0
-    right_empty = len(right) == 0
-
-    if join_type == "inner":
-        if left_empty:
-            return left.copy()
-        if right_empty:
-            return right.copy()
-
-    elif join_type == "left":
-        if left_empty or right_empty:
-            return left.copy()
-
-    elif join_type == "right":
-        if left_empty or right_empty:
-            return right.copy()
-
-    elif join_type == "outer":
-        if left_empty:
-            return right.copy()
-
-        if right_empty:
-            return left.copy()
-
-    return join(left, right, keys, join_type=join_type, **kwargs)
-
-
-def get_structure(h5file):
+def _get_structure(h5file):
+    """
+    Check if data is stored by telescope id or by telescope type in h5file.
+    """
 
     if PARAMETERS_GROUP in h5file:
-        g = h5file.root[PARAMETERS_GROUP]
+        group = h5file.root[PARAMETERS_GROUP]
     elif IMAGES_GROUP in h5file:
-        g = h5file.root[IMAGES_GROUP]
+        group = h5file.root[IMAGES_GROUP]
     else:
         raise ValueError(f"No DL1 parameters data in h5file: {h5file}")
 
-    key = next(iter(g._v_children))
+    key = next(iter(group._v_children))  # pylint: disable=protected-access
+
     if by_id_RE.fullmatch(key):
         return "by_id"
-    else:
-        return "by_type"
+
+    return "by_type"
 
 
 class TableLoader(Component):
-    """ A helper class to load and join tables from an HDF5 file produced with ctapipe-process.
+    """
+    Load telescope-event or subarray-event data from ctapipe HDF5 files
 
-    It is recommended to use the methods 'read_events' for a single table based on telescope IDs and
-    'read_events_by_type' for a dictionary of tables based on telescope types.
+
+    This class provides high-level access to data stored in ctapipe HDF5 files,
+    such as created by the ctapipe-process tool (`~ctapipe.tools.process.ProcessorTool`).
+
+    The following `TableLoader` methods load data from all relevant tables,
+    depending on the options, and joins them into single tables:
+    * `TableLoader.read_subarray_events`
+    * `TableLoader.read_telescope_events1
+
+    `TableLoader.read_telescope_events_by_type` retuns a dict with a table per
+    telescope type, which is needed for e.g. DL1 image data that might have
+    different shapes for each of the telescope types as tables do not support
+    variable length columns.
     """
 
     input_url = traits.Path(directory_ok=False, exists=True).tag(config=True)
@@ -128,7 +124,7 @@ class TableLoader(Component):
         Provenance().add_input_file(self.input_url, role="Event data")
 
         try:
-            self.structure = get_structure(self.h5file)
+            self.structure = _get_structure(self.h5file)
         except ValueError:
             self.structure = None
 
@@ -150,6 +146,7 @@ class TableLoader(Component):
             self.instrument_table = table
 
     def close(self):
+        """Close the underlying hdf5 file"""
         self.h5file.close()
 
     def __del__(self):
@@ -177,15 +174,22 @@ class TableLoader(Component):
         return table
 
     def read_subarray_events(self):
+        """Read subarray-based event information.
+
+        Returns
+        -------
+        table: astropy.io.Table
+            Table with primary index columns "obs_id" and "event_id".
+        """
         table = _empty_subarray_events_table()
 
         if self.load_trigger:
             trigger = read_table(self.h5file, TRIGGER_TABLE)
-            table = _allow_empty_join(table, trigger, SUBARRAY_EVENT_KEYS, "outer")
+            table = join_allow_empty(table, trigger, SUBARRAY_EVENT_KEYS, "outer")
 
         if self.load_simulated and SHOWER_TABLE in self.h5file:
             showers = read_table(self.h5file, SHOWER_TABLE)
-            table = _allow_empty_join(table, showers, SUBARRAY_EVENT_KEYS, "outer")
+            table = join_allow_empty(table, showers, SUBARRAY_EVENT_KEYS, "outer")
 
         if self.load_dl2_geometry:
             shower_geometry_group = self.h5file.root[GEOMETRY_GROUP]
@@ -199,7 +203,7 @@ class TableLoader(Component):
                 for col in set(geometry.colnames) - set(SUBARRAY_EVENT_KEYS):
                     geometry.rename_column(col, f"{reconstructor}_{col}")
 
-                table = _allow_empty_join(table, geometry, SUBARRAY_EVENT_KEYS, "outer")
+                table = join_allow_empty(table, geometry, SUBARRAY_EVENT_KEYS, "outer")
 
         return table
 
@@ -216,7 +220,7 @@ class TableLoader(Component):
         Returns
         -------
         table: astropy.io.Table
-            Table with primary column "tel_id".
+            Table with primary index columns "obs_id", "event_id" and "tel_id".
         """
 
         if tel_id is None:
@@ -226,19 +230,19 @@ class TableLoader(Component):
 
         if self.load_dl1_parameters:
             parameters = self._read_telescope_table(PARAMETERS_GROUP, tel_id)
-            table = _allow_empty_join(
+            table = join_allow_empty(
                 table, parameters, join_type="outer", keys=TELESCOPE_EVENT_KEYS
             )
 
         if self.load_dl1_images:
             images = self._read_telescope_table(IMAGES_GROUP, tel_id)
-            table = _allow_empty_join(
+            table = join_allow_empty(
                 table, images, join_type="outer", keys=TELESCOPE_EVENT_KEYS
             )
 
         if self.load_true_images:
             true_images = self._read_telescope_table(TRUE_IMAGES_GROUP, tel_id)
-            table = _allow_empty_join(
+            table = join_allow_empty(
                 table, true_images, join_type="outer", keys=TELESCOPE_EVENT_KEYS
             )
 
@@ -248,12 +252,12 @@ class TableLoader(Component):
             for col in set(true_parameters.colnames) - set(TELESCOPE_EVENT_KEYS):
                 true_parameters.rename_column(col, f"true_{col}")
 
-            table = _allow_empty_join(
+            table = join_allow_empty(
                 table, true_parameters, join_type="outer", keys=TELESCOPE_EVENT_KEYS
             )
 
         if self.load_instrument:
-            table = _allow_empty_join(
+            table = join_allow_empty(
                 table, self.instrument_table, keys=["tel_id"], join_type="left"
             )
 
@@ -269,7 +273,7 @@ class TableLoader(Component):
 
     def _join_subarray_info(self, table):
         subarray_events = self.read_subarray_events()
-        table = _allow_empty_join(
+        table = join_allow_empty(
             table, subarray_events, keys=SUBARRAY_EVENT_KEYS, join_type="left"
         )
         return table
@@ -283,14 +287,14 @@ class TableLoader(Component):
 
         Parameters
         ----------
-        telescopes: Union[None, List[Union[int, str, TelescopeDescription]]]
-            A list containing any combination of telescope IDs and telescope_descriptions.
-            If None, all available telescopes are read.
+        telescopes: Optional[List[Union[int, str, TelescopeDescription]]]
+            A list containing any combination of telescope IDs and/or
+            telescope descriptions. If None, all available telescopes are read.
 
         Returns
         -------
         events: astropy.io.Table
-            Table with primary columns "obs_id", "event_id" and "tel_id".
+            Table with primary index columns "obs_id", "event_id" and "tel_id".
         """
 
         if telescopes is None:
@@ -305,7 +309,7 @@ class TableLoader(Component):
 
         return table
 
-    def read_telescope_events_by_type(self, telescopes=None):
+    def read_telescope_events_by_type(self, telescopes=None) -> Dict[str, Table]:
         """Read telescope-based event information.
 
         Parameters
@@ -317,7 +321,7 @@ class TableLoader(Component):
         -------
         tables: dict(astropy.io.Table)
             Dictionary of tables organized by telescope types
-            with primary columns "obs_id", "event_id".
+            Table with primary index columns "obs_id", "event_id" and "tel_id".
         """
 
         if telescopes is None:
@@ -325,16 +329,16 @@ class TableLoader(Component):
         else:
             tel_ids = self.subarray.get_tel_ids(telescopes)
 
-        tables = defaultdict(list)
+        by_type = defaultdict(list)
 
         for tel_id in tel_ids:
             key = str(self.subarray.tel[tel_id])
-            tables[key].append(self._read_telescope_events_for_id(tel_id))
+            by_type[key].append(self._read_telescope_events_for_id(tel_id))
 
-        tables = {k: vstack(ts) for k, ts in tables.items()}
+        by_type = {k: vstack(ts) for k, ts in by_type.items()}
 
         if any([self.load_trigger, self.load_simulated, self.load_dl2_geometry]):
-            for key, table in tables.items():
-                tables[key] = self._join_subarray_info(table)
+            for key, table in by_type.items():
+                by_type[key] = self._join_subarray_info(table)
 
-        return tables
+        return by_type

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -166,12 +166,12 @@ class TableLoader(Component):
                     join_type="outer",
                 )
 
-        if self.shower_table is not None:
+        if self.shower_table is not None and len(table > 0)):
             table = join(
                 table, self.shower_table, keys=["obs_id", "event_id"], join_type="inner"
             )
 
-        if self.load_trigger and len(table) > 0:
+        if self.load_trigger:
             table = join(
                 table,
                 self.trigger_table,

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -8,6 +8,8 @@ from ..core import Component, traits
 from ..instrument import SubarrayDescription
 from .astropy_helpers import read_table
 
+__all__ = ["get_structure", "TableLoader"]
+
 PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"
 TRIGGER_TABLE = "/dl1/event/subarray/trigger"
@@ -15,6 +17,7 @@ SHOWER_TABLE = "/simulation/event/subarray/shower"
 TRUE_IMAGES_GROUP = "/simulation/event/telescope/images"
 
 by_id_RE = re.compile(r"tel_\d+")
+
 
 
 def get_structure(h5file):

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -64,13 +64,19 @@ class TableLoader(Component):
 
     input_url = traits.Path(directory_ok=False, exists=True).tag(config=True)
 
-    load_dl1_images = traits.Bool(False).tag(config=True)
-    load_dl1_parameters = traits.Bool(True).tag(config=True)
-    load_dl2_geometry = traits.Bool(False).tag(config=True)
-    load_simulated = traits.Bool(False).tag(config=True)
-    load_true_images = traits.Bool(False).tag(config=True)
-    load_trigger = traits.Bool(True).tag(config=True)
-    load_instrument = traits.Bool(False).tag(config=True)
+    load_dl1_images = traits.Bool(False, help="load extracted images").tag(config=True)
+    load_dl1_parameters = traits.Bool(
+        True, help="load reconstructed image parameters").tag(config=True)
+    load_dl2_geometry = traits.Bool(
+        False, help="load reconstructed shower geometry information").tag(config=True)
+    load_simulated = traits.Bool(
+        False, help="load simulated shower information").tag(config=True)
+    load_true_images = traits.Bool(
+        False, help="load simulated shower images").tag(config=True)
+    load_trigger = traits.Bool(
+        True, help="load subarray trigger information").tag(config=True)
+    load_instrument = traits.Bool(
+        False, help="join subarray instrument information to each event").tag(config=True)
 
     def __init__(self, input_url=None, **kwargs):
         # enable using input_url as posarg

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -72,14 +72,13 @@ class TableLoader(Component):
     """
     Load telescope-event or subarray-event data from ctapipe HDF5 files
 
-
     This class provides high-level access to data stored in ctapipe HDF5 files,
     such as created by the ctapipe-process tool (`~ctapipe.tools.process.ProcessorTool`).
 
     The following `TableLoader` methods load data from all relevant tables,
     depending on the options, and joins them into single tables:
     * `TableLoader.read_subarray_events`
-    * `TableLoader.read_telescope_events1
+    * `TableLoader.read_telescope_events`
 
     `TableLoader.read_telescope_events_by_type` retuns a dict with a table per
     telescope type, which is needed for e.g. DL1 image data that might have

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -56,7 +56,11 @@ def get_structure(h5file):
 
 
 class TableLoader(Component):
-    """ A helper class to load and join tables from a DL1 file"""
+    """ A helper class to load and join tables from an HDF5 file produced with ctapipe-process.
+
+    It is recommended to use the methods 'read_events' for a single table based on telescope IDs and
+    'read_events_by_type' for a dictionary of tables based on telescope types.
+    """
 
     input_url = traits.Path(directory_ok=False, exists=True).tag(config=True)
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -12,13 +12,25 @@ __all__ = ["get_structure", "TableLoader"]
 
 PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"
+GEOMETRY_GROUP = "/dl2/event/subarray/geometry"
 TRIGGER_TABLE = "/dl1/event/subarray/trigger"
 SHOWER_TABLE = "/simulation/event/subarray/shower"
 TRUE_IMAGES_GROUP = "/simulation/event/telescope/images"
 
 by_id_RE = re.compile(r"tel_\d+")
 
+def get_tel_ids(
+    subarray: SubarrayDescription,
+    telescopes: List[Union[int, str, TelescopeDescription]]
+) -> List[int]:
+    ids = set()
 
+    for telescope in telescopes:
+        if isinstance(telescope, int):
+            ids.add(telescope)
+        ids.update(subarray.get_tel_ids_for_type(telescope))
+
+    return sorted(ids)
 
 def get_structure(h5file):
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -1,0 +1,117 @@
+import re
+
+import tables
+from astropy.table import join, vstack, Table
+
+from ..core import Component, traits
+from ..instrument import SubarrayDescription
+from .astropy_helpers import read_table
+
+PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
+IMAGES_GROUP = "/dl1/event/telescope/images"
+TRIGGER_TABLE = "/dl1/event/subarray/trigger"
+
+by_id_RE = re.compile(r"tel_\d+")
+
+
+def get_structure(h5file):
+
+    if PARAMETERS_GROUP in h5file:
+        g = h5file.root[PARAMETERS_GROUP]
+    elif IMAGES_GROUP in h5file:
+        g = h5file.root[IMAGES_GROUP]
+    else:
+        raise ValueError(f"No DL1 parameters data in h5file: {h5file}")
+
+    key = next(iter(g._v_children))
+    if by_id_RE.fullmatch(key):
+        return "by_id"
+    else:
+        return "by_type"
+
+
+class TableLoader(Component):
+    """ A helper class to load and join tables from a DL1 file"""
+
+    input_url = traits.Path(directory_ok=False, exists=True).tag(config=True)
+
+    load_dl1_images = traits.Bool(False).tag(config=True)
+    load_dl1_parameters = traits.Bool(True).tag(config=True)
+    load_dl2 = traits.Bool(False).tag(config=True)
+    load_simulated = traits.Bool(False).tag(config=True)
+    load_true_images = traits.Bool(False).tag(config=True)
+    load_trigger = traits.Bool(True).tag(config=True)
+    load_instrument = traits.Bool(False).tag(config=True)
+
+    def __init__(self, input_url=None, **kwargs):
+        # enable using input_url as posarg
+        if input_url not in {None, traits.Undefined}:
+            kwargs["input_url"] = input_url
+        super().__init__(**kwargs)
+
+        self.subarray = SubarrayDescription.from_hdf(self.input_url)
+        self.h5file = tables.open_file(self.input_url, mode="r")
+
+        try:
+            self.structure = get_structure(self.h5file)
+        except ValueError:
+            self.structure = None
+
+        self.trigger_table = read_table(self.h5file, TRIGGER_TABLE)
+
+    def close(self):
+        self.h5file.close()
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def load_telescope_events(self, tel_id):
+        table = None
+
+        if self.load_dl1_parameters:
+            if self.structure == "by_id":
+                key = f"{PARAMETERS_GROUP}/tel_{tel_id:03d}"
+                condition = None
+            else:
+                key = f"{PARAMETERS_GROUP}/{self.subarray.tel[tel_id]:s}"
+                condition = f"tel_id == {tel_id}"
+
+            if key in self.h5file:
+                table = read_table(self.h5file, key, condition=condition)
+            else:
+                table = Table()
+
+        if self.load_dl1_images:
+            if self.structure == "by_id":
+                key = f"{IMAGES_GROUP}/tel_{tel_id:03d}"
+                condition = None
+            else:
+                key = f"{IMAGES_GROUP}/{self.subarray.tel[tel_id]:s}"
+                condition = f"tel_id == {tel_id}"
+
+            images = read_table(self.h5file, key, condition=condition)
+            if table is None:
+                table = images
+            else:
+                table = join(
+                    table,
+                    images,
+                    keys=["obs_id", "event_id", "tel_id"],
+                    join_type="outer",
+                )
+
+        if self.load_trigger:
+            table = join(
+                table,
+                self.trigger_table,
+                keys=["obs_id", "event_id"],
+                join_type="inner",
+            )
+
+        return table

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -253,12 +253,12 @@ class TableLoader(Component):
         return tables
 
     def read_events_for_type(self, tel_type):
-        """Read telescope-based event information.
+        """Read event information for a single telescope type.
 
         Parameters
         ----------
-        labels: list
-            Any list combination of tel_ids, tel_types, or telescope_descriptions.
+        tel_type: str or ctapipe.instrument.TelescopeDescription
+            Identifier for the telescope describing type, optics and camera.
 
         Returns
         -------
@@ -282,6 +282,18 @@ class TableLoader(Component):
         return table
 
     def read_telescope_events_for_id(self, tel_id):
+        """Read telescope-based event information for a single telescope.
+
+        Parameters
+        ----------
+        tel_id: int
+            Telescope identification number.
+
+        Returns
+        -------
+        table: astropy.io.Table
+            Table with primary column "tel_id".
+        """
 
         if tel_id is None:
             raise ValueError("Please, specify a telescope ID.")

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -199,8 +199,8 @@ class TableLoader(Component):
 
         Parameters
         ----------
-        labels: list
-            Any list combination of tel_ids, tel_types, or telescope_descriptions.
+        labels: List[Union[int, str, TelescopeDescription]]
+            Any list containing a combination of telescope IDs or telescope_descriptions.
 
         Returns
         -------
@@ -227,8 +227,8 @@ class TableLoader(Component):
 
         Parameters
         ----------
-        labels: list
-            Any list combination of tel_ids, tel_types, or telescope_descriptions.
+        labels: List[Union[int, str, TelescopeDescription]]
+            Any list containing a combination of telescope IDs or telescope_descriptions.
 
         Returns
         -------

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -1,3 +1,7 @@
+"""
+Class and functions to read DL1 (a,b) and/or DL2 (a) data from an HDF5 file produced with ctapipe-process.
+"""
+
 import re
 from typing import List, Union
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -3,6 +3,7 @@ Class and functions to read DL1 (a,b) and/or DL2 (a) data from an HDF5 file prod
 """
 
 import re
+from collections import defaultdict
 
 import numpy as np
 import tables
@@ -23,6 +24,48 @@ TRUE_IMAGES_GROUP = "/simulation/event/telescope/images"
 TRUE_PARAMETERS_GROUP = "/simulation/event/telescope/parameters"
 
 by_id_RE = re.compile(r"tel_\d+")
+
+
+SUBARRAY_EVENT_KEYS = ["obs_id", "event_id"]
+TELESCOPE_EVENT_KEYS = ["obs_id", "event_id", "tel_id"]
+
+
+def _empty_telescope_events_table():
+    return Table(names=TELESCOPE_EVENT_KEYS, dtype=[np.int64, np.int64, np.int16])
+
+
+def _empty_subarray_events_table():
+    return Table(names=SUBARRAY_EVENT_KEYS, dtype=[np.int64, np.int64])
+
+
+def _allow_empty_join(left, right, keys, join_type="left", **kwargs):
+    # see https://github.com/astropy/astropy/issues/12012
+
+    left_empty = len(left) == 0
+    right_empty = len(right) == 0
+
+    if join_type == "inner":
+        if left_empty:
+            return left.copy()
+        if right_empty:
+            return right.copy()
+
+    elif join_type == "left":
+        if left_empty or right_empty:
+            return left.copy()
+
+    elif join_type == "right":
+        if left_empty or right_empty:
+            return right.copy()
+
+    elif join_type == "outer":
+        if left_empty:
+            return right.copy()
+
+        if right_empty:
+            return left.copy()
+
+    return join(left, right, keys, join_type=join_type, **kwargs)
 
 
 def get_structure(h5file):
@@ -106,10 +149,6 @@ class TableLoader(Component):
             table.remove_columns(["optics_index", "camera_index"])
             self.instrument_table = table
 
-        self.shower_table = None
-        if self.load_simulated and SHOWER_TABLE in self.h5file:
-            self.shower_table = read_table(self.h5file, SHOWER_TABLE)
-
     def close(self):
         self.h5file.close()
 
@@ -133,71 +172,120 @@ class TableLoader(Component):
         if key in self.h5file:
             table = read_table(self.h5file, key, condition=condition)
         else:
-            table = Table()
+            table = _empty_telescope_events_table()
 
         return table
 
-    def read_subarray_events(self, table=None):
-
-        if self.shower_table:
-            if (table is not None) and len(table) > 0:
-                table = join(
-                    table,
-                    self.shower_table,
-                    keys=["obs_id", "event_id"],
-                    join_type="inner",
-                )
-            else:
-                table = self.shower_table
+    def read_subarray_events(self):
+        table = _empty_subarray_events_table()
 
         if self.load_trigger:
-            if (table is not None) and len(table) > 0:
-                table = join(
-                    table,
-                    read_table(self.h5file, TRIGGER_TABLE),
-                    keys=["obs_id", "event_id"],
-                    join_type="inner",
-                )
-            else:
-                table = read_table(self.h5file, TRIGGER_TABLE)
+            trigger = read_table(self.h5file, TRIGGER_TABLE)
+            table = _allow_empty_join(table, trigger, SUBARRAY_EVENT_KEYS, "outer")
+
+        if self.load_simulated and SHOWER_TABLE in self.h5file:
+            showers = read_table(self.h5file, SHOWER_TABLE)
+            table = _allow_empty_join(table, showers, SUBARRAY_EVENT_KEYS, "outer")
 
         if self.load_dl2_geometry:
-
             shower_geometry_group = self.h5file.root[GEOMETRY_GROUP]
 
-            for i, reconstructor in enumerate(shower_geometry_group._v_children):
-
+            for reconstructor in shower_geometry_group._v_children:
                 geometry = read_table(self.h5file, f"{GEOMETRY_GROUP}/{reconstructor}")
 
                 # rename DL2 columns to explicit reconstructor
                 # TBD: we could skip this if only 1 reconstructor is present
                 # or simply find another way to deal with multiple reconstructions
-                for col in set(geometry.colnames) - {"obs_id", "event_id"}:
+                for col in set(geometry.colnames) - set(SUBARRAY_EVENT_KEYS):
                     geometry.rename_column(col, f"{reconstructor}_{col}")
 
-                if ((table is None) or (len(table) == 0)) and (i == 0):
-                    table = geometry
-                else:
-                    table = join(
-                        table, geometry, keys=["obs_id", "event_id"], join_type="left"
-                    )
+                table = _allow_empty_join(table, geometry, SUBARRAY_EVENT_KEYS, "outer")
+
         return table
 
-    def read_telescope_events(self, tel_ids):
+    def _read_telescope_events_for_id(self, tel_id):
+        """Read telescope-based event information for a single telescope.
+
+        This is the most low-level function doing the actual reading.
+
+        Parameters
+        ----------
+        tel_id: int
+            Telescope identification number.
+
+        Returns
+        -------
+        table: astropy.io.Table
+            Table with primary column "tel_id".
+        """
+
+        if tel_id is None:
+            raise ValueError("Please, specify a telescope ID.")
+
+        table = _empty_telescope_events_table()
+
+        if self.load_dl1_parameters:
+            parameters = self._read_telescope_table(PARAMETERS_GROUP, tel_id)
+            table = _allow_empty_join(
+                table, parameters, join_type="outer", keys=TELESCOPE_EVENT_KEYS
+            )
+
+        if self.load_dl1_images:
+            images = self._read_telescope_table(IMAGES_GROUP, tel_id)
+            table = _allow_empty_join(
+                table, images, join_type="outer", keys=TELESCOPE_EVENT_KEYS
+            )
+
+        if self.load_true_images:
+            true_images = self._read_telescope_table(TRUE_IMAGES_GROUP, tel_id)
+            table = _allow_empty_join(
+                table, true_images, join_type="outer", keys=TELESCOPE_EVENT_KEYS
+            )
+
+        if self.load_true_parameters:
+            true_parameters = self._read_telescope_table(TRUE_PARAMETERS_GROUP, tel_id)
+
+            for col in set(true_parameters.colnames) - set(TELESCOPE_EVENT_KEYS):
+                true_parameters.rename_column(col, f"true_{col}")
+
+            table = _allow_empty_join(
+                table, true_parameters, join_type="outer", keys=TELESCOPE_EVENT_KEYS
+            )
+
+        if self.load_instrument:
+            table = _allow_empty_join(
+                table, self.instrument_table, keys=["tel_id"], join_type="left"
+            )
+
+        return table
+
+    def _read_telescope_events_for_ids(self, tel_ids):
 
         table = vstack(
-            [self.read_telescope_events_for_id(tel_id) for tel_id in tel_ids]
+            [self._read_telescope_events_for_id(tel_id) for tel_id in tel_ids]
         )
 
         return table
 
-    def read_events(self, telescopes=None):
-        """Read telescope-based event information.
+    def _join_subarray_info(self, table):
+        subarray_events = self.read_subarray_events()
+        table = _allow_empty_join(
+            table, subarray_events, keys=SUBARRAY_EVENT_KEYS, join_type="left"
+        )
+        return table
+
+    def read_telescope_events(self, telescopes=None):
+        """
+        Read telescope-based event information.
+
+        If the corresponding traitlets are True, also subarray event information
+        is joined onto the table.
 
         Parameters
         ----------
-        labels: List[Union[int, str, TelescopeDescription]]
-            Any list containing a combination of telescope IDs or telescope_descriptions.
+        telescopes: Union[None, List[Union[int, str, TelescopeDescription]]]
+            A list containing any combination of telescope IDs and telescope_descriptions.
+            If None, all available telescopes are read.
 
         Returns
         -------
@@ -210,16 +298,14 @@ class TableLoader(Component):
         else:
             tel_ids = self.subarray.get_tel_ids(telescopes)
 
-        if any([self.load_dl1_images, self.load_dl1_parameters, self.load_true_images]):
-            table = self.read_telescope_events(tel_ids)
-        else:
-            table = None
+        table = self._read_telescope_events_for_ids(tel_ids)
 
-        table = self.read_subarray_events(table)
+        if any([self.load_trigger, self.load_simulated, self.load_dl2_geometry]):
+            table = self._join_subarray_info(table)
 
         return table
 
-    def read_events_by_tel_type(self, telescopes=None):
+    def read_telescope_events_by_type(self, telescopes=None):
         """Read telescope-based event information.
 
         Parameters
@@ -239,105 +325,16 @@ class TableLoader(Component):
         else:
             tel_ids = self.subarray.get_tel_ids(telescopes)
 
-        selected_subarray = self.subarray.select_subarray(tel_ids)
-        selected_tel_types = selected_subarray.telescope_types
+        tables = defaultdict(list)
 
-        tables = {}
-        for tel_type in selected_tel_types:
+        for tel_id in tel_ids:
+            key = str(self.subarray.tel[tel_id])
+            tables[key].append(self._read_telescope_events_for_id(tel_id))
 
-            tables[str(tel_type)] = self.read_events_for_type(tel_type)
+        tables = {k: vstack(ts) for k, ts in tables.items()}
+
+        if any([self.load_trigger, self.load_simulated, self.load_dl2_geometry]):
+            for key, table in tables.items():
+                tables[key] = self._join_subarray_info(table)
 
         return tables
-
-    def read_events_for_type(self, tel_type):
-        """Read event information for a single telescope type.
-
-        Parameters
-        ----------
-        tel_type: str or ctapipe.instrument.TelescopeDescription
-            Identifier for the telescope describing type, optics and camera.
-
-        Returns
-        -------
-        tables: dict(astropy.io.Table)
-            Dictionary of tables organized by telescope types
-            with primary columns "obs_id", "event_id".
-        """
-        tel_ids = self.subarray.get_tel_ids_for_type(tel_type)
-
-        if any([self.load_dl1_images, self.load_dl1_parameters, self.load_true_images]):
-            table = self.read_telescope_events(tel_ids)
-        else:
-            table = None
-
-        table = self.read_subarray_events(table)
-
-        return table
-
-    def read_telescope_events_for_id(self, tel_id):
-        """Read telescope-based event information for a single telescope.
-
-        Parameters
-        ----------
-        tel_id: int
-            Telescope identification number.
-
-        Returns
-        -------
-        table: astropy.io.Table
-            Table with primary column "tel_id".
-        """
-
-        if tel_id is None:
-            raise ValueError("Please, specify a telescope ID.")
-
-        table = None
-
-        if self.load_dl1_parameters:
-            table = self._read_telescope_table(PARAMETERS_GROUP, tel_id)
-
-        if self.load_dl1_images:
-            images = self._read_telescope_table(IMAGES_GROUP, tel_id)
-
-            if table is None or len(table) == 0:
-                table = images
-            else:
-                table = join(
-                    table,
-                    images,
-                    keys=["obs_id", "event_id", "tel_id"],
-                    join_type="outer",
-                )
-
-        if self.load_true_images:
-            true_images = self._read_telescope_table(TRUE_IMAGES_GROUP, tel_id)
-            if table is None or len(table) == 0:
-                table = true_images
-            else:
-                table = join(
-                    table,
-                    true_images,
-                    keys=["obs_id", "event_id", "tel_id"],
-                    join_type="outer",
-                )
-
-        if self.load_true_parameters:
-            true_parameters = self._read_telescope_table(TRUE_PARAMETERS_GROUP, tel_id)
-            for col in set(true_parameters.colnames) - {"obs_id", "event_id", "tel_id"}:
-                true_parameters.rename_column(col, f"true_{col}")
-            if table is None or len(table) == 0:
-                table = true_parameters
-            else:
-                table = join(
-                    table,
-                    true_parameters,
-                    keys=["obs_id", "event_id", "tel_id"],
-                    join_type="outer",
-                )
-
-        if self.load_instrument and len(table) > 0:
-            table = join(
-                table, self.instrument_table, keys=["tel_id"], join_type="inner"
-            )
-
-        return table

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -5,6 +5,7 @@ import numpy as np
 
 @pytest.fixture(params=["by_type", "by_id"])
 def test_file(request, dl1_file, dl1_by_type_file):
+    """Test dl1 files in both structures"""
     if request.param == "by_type":
         f = dl1_by_type_file
     else:
@@ -15,6 +16,7 @@ def test_file(request, dl1_file, dl1_by_type_file):
 
 @pytest.fixture(params=["by_type", "by_id"])
 def test_file_dl2(request, dl2_shower_geometry_file, dl2_shower_geometry_file_type):
+    """Test dl2 files in both structures"""
     if request.param == "by_type":
         f = dl2_shower_geometry_file
     else:
@@ -24,15 +26,17 @@ def test_file_dl2(request, dl2_shower_geometry_file, dl2_shower_geometry_file_ty
 
 
 def test_get_structure(test_file):
-    from ctapipe.io.tableloader import get_structure
+    """Test _get_structure"""
+    from ctapipe.io.tableloader import _get_structure
 
     expected, path = test_file
 
     with tables.open_file(path, "r") as f:
-        assert get_structure(f) == expected
+        assert _get_structure(f) == expected
 
 
 def test_telescope_events_for_tel_id(test_file):
+    """Test loading data for a single telescope"""
     from ctapipe.io.tableloader import TableLoader
 
     _, dl1_file = test_file
@@ -55,6 +59,7 @@ def test_telescope_events_for_tel_id(test_file):
 
 
 def test_load_instrument(test_file):
+    """Test joining instrument data onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
 
     _, dl1_file = test_file
@@ -67,6 +72,7 @@ def test_load_instrument(test_file):
 
 
 def test_load_simulated(test_file):
+    """Test joining simulation info onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
 
     _, dl1_file = test_file
@@ -80,6 +86,7 @@ def test_load_simulated(test_file):
 
 
 def test_true_images(test_file):
+    """Test joining true images onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
 
     _, dl1_file = test_file
@@ -92,6 +99,7 @@ def test_true_images(test_file):
 
 
 def test_true_parameters(test_file):
+    """Test joining true parameters onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
 
     _, dl1_file = test_file
@@ -104,6 +112,7 @@ def test_true_parameters(test_file):
 
 
 def test_read_subarray_events(test_file_dl2):
+    """Test reading subarray events"""
 
     from ctapipe.io.tableloader import TableLoader
 
@@ -119,6 +128,7 @@ def test_read_subarray_events(test_file_dl2):
 
 
 def test_read_telescope_events_type(test_file_dl2):
+    """Test reading telescope events for a given telescope type"""
 
     from ctapipe.io.tableloader import TableLoader
 
@@ -145,6 +155,7 @@ def test_read_telescope_events_type(test_file_dl2):
 
 
 def test_read_telescope_events_by_type(test_file_dl2):
+    """Test reading telescope events for by types"""
 
     from ctapipe.io.tableloader import TableLoader
 

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -118,6 +118,21 @@ def test_true_images(test_file):
         assert "true_image" in table.colnames
 
 
+def test_true_parameters(test_file):
+    from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
+
+    with TableLoader(
+        dl1_file, load_dl1_parameters=False,
+        load_true_images=True,
+        load_true_parameters=True
+    ) as table_loader:
+        table = table_loader.read_telescope_events_for_id(tel_id=25)
+        assert "true_image" in table.colnames
+        assert "true_hillas_intensity" in table.colnames
+
+
 def test_read_subarray_events(test_file_dl2):
 
     from ctapipe.io.tableloader import TableLoader

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -1,24 +1,42 @@
+import pytest
 import tables
+import numpy as np
 
 
-def test_get_structure(dl1_file):
+@pytest.fixture(params=["by_type", "by_id"])
+def test_file(request, dl1_file, dl1_by_type_file):
+    if request.param == "by_type":
+        f = dl1_by_type_file
+    else:
+        f = dl1_file
+
+    return request.param, f
+
+
+def test_get_structure(test_file):
     from ctapipe.io.tableloader import get_structure
 
-    with tables.open_file(dl1_file, "r") as f:
-        assert get_structure(f) == "by_id"
+    expected, path = test_file
+
+    with tables.open_file(path, "r") as f:
+        assert get_structure(f) == expected
 
 
-def test_load_events(dl1_file):
+def test_load_events(test_file):
     from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
 
     with TableLoader(dl1_file) as table_loader:
         table = table_loader.load_telescope_events(tel_id=25)
         assert "hillas_length" in table.colnames
         assert "time" in table.colnames
         assert "event_type" in table.colnames
+        assert np.all(table["tel_id"] == 25)
 
     with TableLoader(dl1_file, load_dl1_images=True) as table_loader:
         table = table_loader.load_telescope_events(tel_id=25)
         assert "image" in table.colnames
+        assert np.all(table["tel_id"] == 25)
 
     assert not table_loader.h5file.isopen

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -1,0 +1,24 @@
+import tables
+
+
+def test_get_structure(dl1_file):
+    from ctapipe.io.tableloader import get_structure
+
+    with tables.open_file(dl1_file, "r") as f:
+        assert get_structure(f) == "by_id"
+
+
+def test_load_events(dl1_file):
+    from ctapipe.io.tableloader import TableLoader
+
+    with TableLoader(dl1_file) as table_loader:
+        table = table_loader.load_telescope_events(tel_id=25)
+        assert "hillas_length" in table.colnames
+        assert "time" in table.colnames
+        assert "event_type" in table.colnames
+
+    with TableLoader(dl1_file, load_dl1_images=True) as table_loader:
+        table = table_loader.load_telescope_events(tel_id=25)
+        assert "image" in table.colnames
+
+    assert not table_loader.h5file.isopen

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -22,21 +22,68 @@ def test_get_structure(test_file):
         assert get_structure(f) == expected
 
 
-def test_load_events(test_file):
+def test_read_events_for_tel_id(test_file):
     from ctapipe.io.tableloader import TableLoader
 
     _, dl1_file = test_file
 
     with TableLoader(dl1_file) as table_loader:
-        table = table_loader.load_telescope_events(tel_id=25)
+        table = table_loader.read_telescope_events_for_id(tel_id=25)
         assert "hillas_length" in table.colnames
         assert "time" in table.colnames
         assert "event_type" in table.colnames
         assert np.all(table["tel_id"] == 25)
 
     with TableLoader(dl1_file, load_dl1_images=True) as table_loader:
-        table = table_loader.load_telescope_events(tel_id=25)
+        table = table_loader.read_telescope_events_for_id(tel_id=25)
         assert "image" in table.colnames
         assert np.all(table["tel_id"] == 25)
 
     assert not table_loader.h5file.isopen
+
+
+def test_load_instrument(test_file):
+    from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
+
+    with TableLoader(dl1_file, load_instrument=True) as table_loader:
+        expected = table_loader.subarray.tel[25].optics.equivalent_focal_length
+        table = table_loader.read_telescope_events_for_id(tel_id=25)
+        assert "equivalent_focal_length" in table.colnames
+        assert np.all(table["equivalent_focal_length"] == expected)
+
+
+def test_load_simulated(test_file):
+    from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
+
+    with TableLoader(dl1_file, load_simulated=True) as table_loader:
+        table = table_loader.read_telescope_events_for_id(tel_id=25)
+        assert "true_energy" in table.colnames
+
+
+def test_true_images(test_file):
+    from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
+
+    with TableLoader(
+        dl1_file, load_dl1_parameters=False, load_true_images=True
+    ) as table_loader:
+        table = table_loader.read_telescope_events_for_id(tel_id=25)
+        assert "true_image" in table.colnames
+
+
+@pytest.mark.parametrize(
+    "telescope_description", ["MST_MST_NectarCam", "MST_MST_FlashCam"]
+)
+def test_read_events_for_type(telescope_description, test_file):
+    from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
+
+    with TableLoader(dl1_file, load_instrument=True) as table_loader:
+        table = table_loader.read_telescope_events_for_type(telescope_description)
+        assert np.all(table["tel_description"] == telescope_description)

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -21,6 +21,27 @@ def test_file_dl2(request, dl2_shower_geometry_file, dl2_shower_geometry_file_ty
 
     return request.param, f
 
+def test_get_tel_ids(test_file):
+
+    from ctapipe.io.tableloader import get_tel_ids
+    from ctapipe.instrument import SubarrayDescription
+    from ctapipe.instrument import TelescopeDescription
+
+    _, dl1_file = test_file
+
+    sst = TelescopeDescription(tel_type="SST", name="ASTRI", optics="ASTRI", camera="CHEC")
+    
+    subarray = SubarrayDescription.from_hdf(dl1_file)
+
+    labels = [1,2,"MST_MST_FlashCam", sst]
+
+    tel_ids = get_tel_ids(subarray, labels)
+
+    true_tel_ids = (subarray.get_tel_ids_for_type("MST_MST_FlashCam") + 
+                       subarray.get_tel_ids_for_type(sst) +
+                       [1,2])
+
+    assert sorted(tel_ids) == sorted(true_tel_ids)
 
 def test_get_structure(test_file):
     from ctapipe.io.tableloader import get_structure

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -12,6 +12,15 @@ def test_file(request, dl1_file, dl1_by_type_file):
 
     return request.param, f
 
+@pytest.fixture(params=["by_type", "by_id"])
+def test_file_dl2(request, dl2_shower_geometry_file, dl2_shower_geometry_file_type):
+    if request.param == "by_type":
+        f = dl2_shower_geometry_file
+    else:
+        f = dl2_shower_geometry_file_type
+
+    return request.param, f
+
 
 def test_get_structure(test_file):
     from ctapipe.io.tableloader import get_structure

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -23,34 +23,6 @@ def test_file_dl2(request, dl2_shower_geometry_file, dl2_shower_geometry_file_ty
     return request.param, f
 
 
-def test_get_tel_ids(test_file):
-
-    from ctapipe.io.tableloader import get_tel_ids
-    from ctapipe.instrument import SubarrayDescription
-    from ctapipe.instrument import TelescopeDescription
-
-    _, dl1_file = test_file
-
-    sst = TelescopeDescription(tel_type="SST", name="ASTRI",
-                               optics="ASTRI", camera="CHEC")
-
-    subarray = SubarrayDescription.from_hdf(dl1_file)
-
-    labels = [1, 2, "MST_MST_FlashCam", sst]
-
-    tel_ids = get_tel_ids(subarray, labels)
-
-    true_tel_ids = (subarray.get_tel_ids_for_type("MST_MST_FlashCam")
-                    + subarray.get_tel_ids_for_type(sst)
-                    + [1, 2])
-
-    assert sorted(tel_ids) == sorted(true_tel_ids)
-
-    # test invalid telescope type
-    with pytest.raises(Exception):
-        tel_ids = get_tel_ids(subarray, ["It's a-me, Mario!"])
-
-
 def test_get_structure(test_file):
     from ctapipe.io.tableloader import get_structure
 
@@ -65,9 +37,7 @@ def test_read_events_for_tel_id(test_file):
 
     _, dl1_file = test_file
 
-    loader = TableLoader(dl1_file,
-                         load_dl1_parameters=True,
-                         load_trigger=True)
+    loader = TableLoader(dl1_file, load_dl1_parameters=True, load_trigger=True)
 
     with loader as table_loader:
         table = table_loader.read_events([25])
@@ -124,9 +94,10 @@ def test_true_parameters(test_file):
     _, dl1_file = test_file
 
     with TableLoader(
-        dl1_file, load_dl1_parameters=False,
+        dl1_file,
+        load_dl1_parameters=False,
         load_true_images=True,
-        load_true_parameters=True
+        load_true_parameters=True,
     ) as table_loader:
         table = table_loader.read_telescope_events_for_id(tel_id=25)
         assert "true_image" in table.colnames

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -46,6 +46,10 @@ def test_get_tel_ids(test_file):
 
     assert sorted(tel_ids) == sorted(true_tel_ids)
 
+    # test invalid telescope type
+    with pytest.raises(Exception):
+        tel_ids = get_tel_ids(subarray, ["It's a-me, Mario!"])
+
 
 def test_get_structure(test_file):
     from ctapipe.io.tableloader import get_structure

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -21,6 +21,8 @@ COMPATIBLE_DATALEVELS = [
     DataLevel.DL1_PARAMETERS,
 ]
 
+__all__ = ["ProcessorTool"]
+
 
 class ProcessorTool(Tool):
     """
@@ -209,6 +211,9 @@ class ProcessorTool(Tool):
             )
 
     def start(self):
+        """
+        Process events
+        """
         self.log.info("(re)compute DL1: %s", self.should_compute_dl1)
         self.log.info("(re)compute DL2: %s", self.should_compute_dl2)
         self.event_source.subarray.info(printer=self.log.info)
@@ -233,6 +238,9 @@ class ProcessorTool(Tool):
             self.write(event)
 
     def finish(self):
+        """
+        Last steps after processing events.
+        """
         self.write.write_simulation_histograms(self.event_source)
         self.write.finish()
         self._write_processing_statistics()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,7 @@ nitpick_ignore = [
     ("py:class", "traitlets.config.application.Application"),
     ("py:obj", "traitlets.config.boolean_flag"),
     ("py:obj", "traitlets.TraitError"),
+    ("py:obj", "-v"),
     ("py:meth", "MetaHasDescriptors.__init__"),
     ("py:meth", "HasTraits.__new__"),
     ("py:meth", "BaseDescriptor.instance_init"),

--- a/docs/ctapipe_api/io/index.rst
+++ b/docs/ctapipe_api/io/index.rst
@@ -165,6 +165,9 @@ Reference/API
 .. automodapi:: ctapipe.io.tableio
     :no-inheritance-diagram:
 
+.. automodapi:: ctapipe.io.tableloader
+    :no-inheritance-diagram:
+
 .. automodapi:: ctapipe.io.hdf5tableio
     :no-inheritance-diagram:
 

--- a/docs/ctapipe_api/tools/index.rst
+++ b/docs/ctapipe_api/tools/index.rst
@@ -83,3 +83,6 @@ Reference/API
 
 .. automodapi:: ctapipe.tools
     :no-inheritance-diagram:
+
+.. automodapi:: ctapipe.tools.process
+    :no-inheritance-diagram:


### PR DESCRIPTION
I adapted this from the class in the dl1 benchmarks workshop, but changed the structure a bit.

I added options for what to load and for now a single method `load_telescope_events(tel_id)` to read / join all needed columns for one telescope.

Methods to come:

- loading only stereo data
- loading events for multiple tel_ids (as dict by type or just as single table).
- more?


Needs #1769 