### PR TITLE
Add flags to enforce recomputation of dl1/dl2

### DIFF
--- a/ctapipe/tools/dl1_merge.py
+++ b/ctapipe/tools/dl1_merge.py
@@ -122,8 +122,12 @@ class MergeTool(Tool):
     skip_broken_files = Bool(
         help="Skip broken files instead of raising an error", default_value=False
     ).tag(config=True)
-    overwrite = Bool(help="Overwrite output file if it exists").tag(config=True)
-    progress_bar = Bool(help="Show progress bar during processing").tag(config=True)
+    overwrite = Bool(
+        help="Overwrite output file if it exists", default_value=False
+    ).tag(config=True)
+    progress_bar = Bool(
+        help="Show progress bar during processing", default_value=False
+    ).tag(config=True)
     file_pattern = Unicode(
         default_value="*.h5", help="Give a specific file pattern for the input files"
     ).tag(config=True)

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -44,6 +44,12 @@ class ProcessorTool(Tool):
     """
 
     progress_bar = Bool(help="show progress bar during processing").tag(config=True)
+    force_recompute_dl1 = Bool(
+        help="Enforce dl1 recomputation even if already present in the input file"
+    ).tag(config=True)
+    force_recompute_dl2 = Bool(
+        help="Enforce dl2 recomputation even if already present in the input file"
+    ).tag(config=True)
 
     aliases = {
         ("i", "input"): "EventSource.input_url",
@@ -69,6 +75,18 @@ class ProcessorTool(Tool):
             "ProcessorTool.progress_bar",
             "show a progress bar during event processing",
             "don't show a progress bar during event processing",
+        ),
+        **flag(
+            "recompute_dl1",
+            "ProcessorTool.force_recompute_dl1",
+            "Enforce DL1 recomputation even if already present in the input file",
+            "Only compute DL1 if there are no DL1b parameters in the file",
+        ),
+        **flag(
+            "recompute_dl2",
+            "ProcessorTool.force_recompute_dl2",
+            "Enforce DL2 recomputation even if already present in the input file",
+            "Only compute DL2 if there is no shower reconstruction in the file",
         ),
         **flag(
             "write-images",
@@ -150,11 +168,15 @@ class ProcessorTool(Tool):
     @property
     def should_compute_dl2(self):
         """ returns true if we should compute DL2 info """
+        if self.force_recompute_dl2:
+            return True
         return self.write.write_stereo_shower or self.write.write_mono_shower
 
     @property
     def should_compute_dl1(self):
         """returns true if we should compute DL1 info"""
+        if self.force_recompute_dl1:
+            return True
         if DataLevel.DL1_PARAMETERS in self.event_source.datalevels:
             return False
 

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -43,12 +43,16 @@ class ProcessorTool(Tool):
     example, see ctapipe/examples/stage1_config.json in the main code repo.
     """
 
-    progress_bar = Bool(help="show progress bar during processing").tag(config=True)
+    progress_bar = Bool(
+        help="show progress bar during processing", default_value=False
+    ).tag(config=True)
     force_recompute_dl1 = Bool(
-        help="Enforce dl1 recomputation even if already present in the input file"
+        help="Enforce dl1 recomputation even if already present in the input file",
+        default_value=False,
     ).tag(config=True)
     force_recompute_dl2 = Bool(
-        help="Enforce dl2 recomputation even if already present in the input file"
+        help="Enforce dl2 recomputation even if already present in the input file",
+        default_value=False,
     ).tag(config=True)
 
     aliases = {

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -77,13 +77,13 @@ class ProcessorTool(Tool):
             "don't show a progress bar during event processing",
         ),
         **flag(
-            "recompute_dl1",
+            "recompute-dl1",
             "ProcessorTool.force_recompute_dl1",
             "Enforce DL1 recomputation even if already present in the input file",
             "Only compute DL1 if there are no DL1b parameters in the file",
         ),
         **flag(
-            "recompute_dl2",
+            "recompute-dl2",
             "ProcessorTool.force_recompute_dl2",
             "Enforce DL2 recomputation even if already present in the input file",
             "Only compute DL2 if there is no shower reconstruction in the file",


### PR DESCRIPTION
#1726 removed the possibility to rerun stage1/process with the goal of recomputing the DL1 information on a file with both DL1a and DL1b.
This can be useful to test different cleanings or add noise to the images (#1723).

Could be done without the `if` clauses adding another `or`  aswell. I just felt like its the easiest to understand (especially if the compute logic changes at some point.)