### PR TITLE
Fix TelescopeParameter for traitlets 5.1

### DIFF
--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -490,6 +490,10 @@ class TelescopeParameter(List):
         return normalized_value
 
     def set(self, obj, value):
+        # Support a single value for all (check and convert into a default value)
+        if not isinstance(value, (list, List, UserList, TelescopePatternList)):
+            value = [("type", "*", self._trait.validate(obj, value))]
+
         # Retain existing subarray description
         # when setting new value for TelescopeParameter
         try:


### PR DESCRIPTION
This removal in traitlets seems to be the culprit:

```
@@ -2644,12 +2638,6 @@ class List(Container):
 
         return super(List, self).validate_elements(obj, value)
 
-    def set(self, obj, value):
-        if isinstance(value, str):
-            return super().set(obj, [value])
-        else:
-            return super().set(obj, value)
-
 
```