### PR TITLE
Unit tests: fix mutated camera geometry fixtures

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -29,7 +29,7 @@ camera_names = [
 ]
 
 
-@pytest.fixture(scope="session", params=camera_names)
+@pytest.fixture(scope="function", params=camera_names)
 def camera_geometry(request):
     return CameraGeometry.from_name(request.param)
 


### PR DESCRIPTION
This fixes some tests failing due to some tests in the geometry module modifying the global fixture.