### PR TITLE
Extractor status flag

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -174,6 +174,7 @@ class CameraCalibrator(TelescopeComponent):
         time_shift = event.calibration.tel[telid].dl1.time_shift
         readout = self.subarray.tel[telid].camera.readout
         n_pixels, n_samples = waveforms.shape
+        is_valid = True
 
         # subtract any remaining pedestal before extraction
         if dl1_calib.pedestal_offset is not None:
@@ -205,7 +206,7 @@ class CameraCalibrator(TelescopeComponent):
                     remaining_shift = time_shift
 
             extractor = self.image_extractors[self.image_extractor_type.tel[telid]]
-            charge, peak_time = extractor(
+            charge, peak_time, is_valid = extractor(
                 waveforms, telid=telid, selected_gain_channel=selected_gain_channel
             )
 
@@ -218,6 +219,7 @@ class CameraCalibrator(TelescopeComponent):
 
         event.dl1.tel[telid].image = charge
         event.dl1.tel[telid].peak_time = peak_time
+        event.dl1.tel[telid].is_valid = is_valid
 
     def __call__(self, event):
         """

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -340,6 +340,15 @@ class DL1CameraContainer(Container):
         dtype=np.bool_,
         ndim=1,
     )
+    is_valid = Field(
+        False,
+        (
+            "True if image extraction succeeded, False if failed "
+            "or in the case of TwoPass methods, that the first "
+            "pass only was returned."
+        ),
+    )
+
     parameters = Field(None, "Image parameters", type=ImageParametersContainer)
 
 

--- a/ctapipe/image/reducer.py
+++ b/ctapipe/image/reducer.py
@@ -180,7 +180,7 @@ class TailCutsDataVolumeReducer(DataVolumeReducer):
         camera_geom = self.subarray.tel[telid].camera.geometry
         # Pulse-integrate waveforms
         extractor = self.image_extractors[self.image_extractor_type.tel[telid]]
-        charge, _ = extractor(
+        charge, peaktime, is_valid = extractor(
             waveforms, telid=telid, selected_gain_channel=selected_gain_channel
         )
 

--- a/ctapipe/image/tests/test_sliding_window_correction.py
+++ b/ctapipe/image/tests/test_sliding_window_correction.py
@@ -53,6 +53,7 @@ def test_sw_pulse_lst():
         "SlidingWindowMaxSum", subarray=subarray, config=config
     )
 
-    charge, _ = extractor(waveform, telid, selected_gain_channel)
+    charge, _, is_valid = extractor(waveform, telid, selected_gain_channel)
     print(charge / charge_true)
     assert_allclose(charge, charge_true, rtol=0.02)
+    assert is_valid


### PR DESCRIPTION
changes the return value of ImageExtractors to include a is_valid flag, which is also added to the DL1 data model.

- In most extractors (that have no failure modes), the return value is just hard-coded to True
- in TwoPassWindowSum, where the second pass can fail, it returns False if the second pass failed (meaning the resulting images are from the first-pass only), unless it was requested to only run the first pass.

This is needed, since those events where TwoPass fails need to be filtered.   Protopipe already implements this, but it should move to ctapipe.