### PR TITLE
Add write_table and use it in SubarrayDescription.to_hdf

### DIFF
--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -4,7 +4,7 @@ from .hdf5tableio import HDF5TableReader, HDF5TableWriter
 from .tableio import TableWriter, TableReader
 from .tableloader import TableLoader
 from .datalevels import DataLevel
-from .astropy_helpers import read_table
+from .astropy_helpers import read_table, write_table
 from .datawriter import DataWriter, DATA_MODEL_VERSION
 
 from ..core.plugins import detect_and_import_io_plugins
@@ -29,6 +29,7 @@ __all__ = [
     "DL1EventSource",
     "DataLevel",
     "read_table",
+    "write_table",
     "DataWriter",
     "DATA_MODEL_VERSION",
 ]

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import numpy as np
 from astropy.time import Time
 from astropy.units import Quantity
+import codecs
 
 from ..instrument import SubarrayDescription
 from ..core import Component
@@ -388,6 +389,53 @@ class EnumColumnTransform(ColumnTransform):
 
     def get_meta(self, colname):
         return {f"{colname}_TRANSFORM": "enum", f"{colname}_ENUM": self.enum}
+
+
+def _ignore_unexpected_end_of_data(exc):
+    """Error handler that ignores invalid utf-8 due to truncated bytes"""
+    if exc.reason == "unexpected end of data":
+        return "", exc.end
+
+    raise exc
+
+
+codecs.register_error("ignore_unexpected_end", _ignore_unexpected_end_of_data)
+
+
+class StringTransform(ColumnTransform):
+    """
+    Encode strings as utf-8 bytes using a max_length
+
+    Byte values are truncated after ``max_length``, this might result
+    in invalid utf-8!. Trailing utf-8 bytes are ignored when inversing the
+    transform.
+
+    Should not be used anymore when tables starts supporting
+    variable length strings in tables.
+    """
+
+    def __init__(self, max_length):
+        self.max_length = max_length
+        self.dtype = f"S{max_length:d}"
+
+    def __call__(self, value):
+        if isinstance(value, str):
+            return value.encode("utf-8")[: self.max_length]
+        return np.array([v.encode("utf-8") for v in value]).astype(self.dtype)
+
+    def inverse(self, value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+
+        # astropy table columns somehow try to handle byte columns as strings
+        # when iterating, this does not work here, convert to np.array
+        value = np.array(value, copy=False)
+        return np.array(
+            [v.decode("utf-8", errors="ignore_unexpected_end") for v in value]
+        )
+
+    def get_meta(self, colname):
+        return {f"{colname}_TRANSFORM": "string", f"{colname}_MAXLEN": self.max_length}
 
 
 class TelListToMaskTransform(ColumnTransform):

--- a/ctapipe/io/tests/test_write_table.py
+++ b/ctapipe/io/tests/test_write_table.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+from astropy.time import Time
+from astropy.table import Table
+import astropy.units as u
+import numpy as np
+
+
+def test_write_table(tmp_path):
+    from ctapipe.io.astropy_helpers import write_table, read_table
+
+    table = Table(
+        {
+            "a": [1, 2, 3],
+            "b": np.array([1, 2, 3], dtype=np.uint16),
+            "speed": [2.0, 3.0, 4.2] * (u.m / u.s),
+            "time": Time([58e3, 59e3, 60e3], format="mjd"),
+            "name": ["a", "bb", "ccc"],
+        }
+    )
+
+    table.meta["FOO"] = "bar"
+
+    output_path = tmp_path = tmp_path / "table.h5"
+    table_path = "/foo/bar"
+
+    write_table(table, output_path, table_path)
+    read = read_table(output_path, table_path)
+
+    for name, column in table.columns.items():
+        assert name in read.colnames, f"Column {name} not found in output file"
+        assert (
+            read.dtype[name] == table.dtype[name]
+        ), f"Column {name} dtype different in output file"
+
+        # time conversion is not lossless
+        if name == "time":
+            assert np.allclose(column.tai.mjd, read[name].tai.mjd)
+        else:
+            assert np.all(column == read[name]), f"Column {name} differs after reading"
+
+    assert "FOO" in read.meta
+    assert read.meta["FOO"] == "bar"
+
+    # test we can append
+    write_table(table, output_path, table_path, append=True)
+    read = read_table(output_path, table_path)
+    assert len(read) == 2 * len(table)
+
+    # test we can overwrite
+    write_table(table, output_path, table_path, append=False)
+    assert len(read_table(output_path, table_path)) == len(table)


### PR DESCRIPTION
* This adds a pytables based function to write an astropy table
into a hdf5 file using the ctapipe conventions.
This enables writing tables in the same format as used by the
HDF5TableWriter and those tables can be read using read_table.

* It also switches SubarrayDescription.to_hdf / from_hdf to use the new
functions, eliminating the mix of astropy table io using h5py and
ctapipe hdf5 table io using pytables.

* ctapipe files should now only contain datasets written by tables and
use the same way to store metadata consistently.