### PR TITLE
Make tests pass independent of cwd

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -317,7 +317,7 @@ def test_telescope_parameter_patterns(mock_subarray):
         comp.tel_param_int = [(12, "", 5)]  # command not string
 
 
-def test_telescope_parameter_path(mock_subarray):
+def test_telescope_parameter_path(mock_subarray, tmp_path):
     class SomeComponent(TelescopeComponent):
         path = TelescopeParameter(Path(exists=True, directory_ok=False))
 
@@ -353,8 +353,10 @@ def test_telescope_parameter_path(mock_subarray):
 
     s = SomeComponent(subarray=mock_subarray)
     assert s.path.tel[1] is None
-    s.path = [("type", "*", "setup.py")]
-    assert s.path.tel[1] == pathlib.Path("setup.py").absolute()
+    path = tmp_path / "foo"
+    path.open("w").close()
+    s.path = [("type", "*", path)]
+    assert s.path.tel[1] == path
 
 
 def test_telescope_parameter_scalar_default(mock_subarray):


### PR DESCRIPTION
This enables running the test suite of an installed ctapipe using `pytest --pyargs ctapipe` again.

One test was failing as it essentially tested for setup.py being in cwd.

In the CI we don't use this method, as it cannot be used for running the doctests.
