### PR TITLE
Fix `CameraGeometry.transform` for cam_rotations != 0, fix pix_rotation for square pixels

### DIFF
--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -2,6 +2,7 @@
 """
 Utilities for reading or working with Camera geometry files
 """
+from copy import deepcopy
 import logging
 import warnings
 
@@ -224,11 +225,20 @@ class CameraGeometry:
         if self.frame is None:
             self.frame = CameraFrame()
 
-        coord = SkyCoord(self.pix_x, self.pix_y, frame=self.frame)
+        # we have to derotate, transformations only provide sensible
+        # results after derotation from the camera coordinate system with
+        # custom angle into a not-rotate frame
+        if self.cam_rotation.value != 0:
+            cam = deepcopy(self)
+            cam.rotate(self.cam_rotation)
+        else:
+            cam = self
+
+        coord = SkyCoord(cam.pix_x, cam.pix_y, frame=cam.frame)
         trans = coord.transform_to(frame)
 
         # also transform the unit vectors, to get rotation / mirroring, scale
-        uv = SkyCoord([1, 0], [0, 1], unit=self.pix_x.unit, frame=self.frame)
+        uv = SkyCoord([1, 0], [0, 1], unit=cam.pix_x.unit, frame=cam.frame)
         uv_trans = uv.transform_to(frame)
 
         trans_x_name, trans_y_name = list(
@@ -237,25 +247,33 @@ class CameraGeometry:
         uv_trans_x = getattr(uv_trans, trans_x_name)
         uv_trans_y = getattr(uv_trans, trans_y_name)
 
-        rot = np.arctan2(uv_trans_y[0], uv_trans_y[1])
-        cam_rotation = rot - self.cam_rotation
-        pix_rotation = rot - self.pix_rotation
+        matrix = np.vstack([uv_trans_x.value, uv_trans_y.value])
+        is_mirrored = np.linalg.det(matrix) < 0
 
-        scale = np.sqrt(uv_trans_x[0] ** 2 + uv_trans_y[0] ** 2) / self.pix_x.unit
+        rot = np.arctan2(uv_trans_y[0], uv_trans_y[1])
+
+        if is_mirrored:
+            cam_rotation = -cam.cam_rotation
+            pix_rotation = rot - cam.pix_rotation
+        else:
+            cam_rotation = cam.cam_rotation
+            pix_rotation = cam.pix_rotation - rot
+
+        scale = np.sqrt(uv_trans_x[0] ** 2 + uv_trans_y[0] ** 2) / cam.pix_x.unit
         trans_x = getattr(trans, trans_x_name)
         trans_y = getattr(trans, trans_y_name)
-        pix_area = (self.pix_area * scale ** 2).to(trans_x.unit ** 2)
+        pix_area = (cam.pix_area * scale ** 2).to(trans_x.unit ** 2)
 
         return CameraGeometry(
-            camera_name=self.camera_name,
-            pix_id=self.pix_id,
+            camera_name=cam.camera_name,
+            pix_id=cam.pix_id,
             pix_x=trans_x,
             pix_y=trans_y,
             pix_area=pix_area,
-            pix_type=self.pix_type,
+            pix_type=cam.pix_type,
             pix_rotation=pix_rotation,
             cam_rotation=cam_rotation,
-            neighbors=self._neighbors,
+            neighbors=cam._neighbors,
             apply_derotation=False,
             frame=frame,
         )

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -10,7 +10,7 @@ from astropy import units as u
 from matplotlib import pyplot as plt
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import Normalize, LogNorm, SymLogNorm
-from matplotlib.patches import Ellipse, RegularPolygon, Rectangle, Circle
+from matplotlib.patches import Ellipse, RegularPolygon, Circle
 
 from ctapipe.instrument import PixelShape
 
@@ -105,7 +105,9 @@ class CameraDisplay:
         self._active_pixel_label = None
         self._axes_overlays = []
 
-        self.geom = geometry
+        # derotate camera so we don't duplicate the rotation handling code
+        self.geom = copy.deepcopy(geometry)
+        self.geom.rotate(self.geom.cam_rotation)
 
         if title is None:
             title = f"{geometry.camera_name}"
@@ -113,43 +115,20 @@ class CameraDisplay:
         # initialize the plot and generate the pixels as a
         # RegularPolyCollection
 
-        patches = []
-
         if hasattr(self.geom, "mask"):
             self.mask = self.geom.mask
         else:
             self.mask = np.ones_like(self.geom.pix_x.value, dtype=bool)
 
-        pix_x = self.geom.pix_x.value[self.mask]
-        pix_y = self.geom.pix_y.value[self.mask]
-        pix_width = self.geom.pixel_width.value[self.mask]
-
-        for x, y, w in zip(pix_x, pix_y, pix_width):
-            if self.geom.pix_type == PixelShape.HEXAGON:
-                r = w / np.sqrt(3)
-                patch = RegularPolygon(
-                    (x, y),
-                    6,
-                    radius=r,
-                    orientation=self.geom.pix_rotation.to_value(u.rad),
-                    fill=True,
-                )
-            elif self.geom.pix_type == PixelShape.CIRCLE:
-                patch = Circle((x, y), radius=w / 2, fill=True)
-            elif self.geom.pix_type == PixelShape.SQUARE:
-                patch = Rectangle(
-                    (x - w / 2, y - w / 2),
-                    width=w,
-                    height=w,
-                    angle=self.geom.pix_rotation.to_value(u.deg),
-                    fill=True,
-                )
-            else:
-                raise ValueError(f"Unsupported pixel_shape {self.geom.pix_type}")
-
-            patches.append(patch)
-
+        patches = self.create_patches(
+            shape=self.geom.pix_type,
+            pix_x=self.geom.pix_x.value[self.mask],
+            pix_y=self.geom.pix_y.value[self.mask],
+            pix_width=self.geom.pixel_width.value[self.mask],
+            pix_rotation=self.geom.pix_rotation,
+        )
         self.pixels = PatchCollection(patches, cmap=cmap, linewidth=0)
+
         self.axes.add_collection(self.pixels)
 
         self.pixel_highlighting = copy.copy(self.pixels)
@@ -198,6 +177,60 @@ class CameraDisplay:
 
         self.norm = norm
         self.auto_set_axes_labels()
+
+    @staticmethod
+    def create_patches(shape, pix_x, pix_y, pix_width, pix_rotation=0 * u.deg):
+        if shape == PixelShape.HEXAGON:
+            return CameraDisplay._create_hex_patches(
+                pix_x, pix_y, pix_width, pix_rotation
+            )
+
+        if shape == PixelShape.CIRCLE:
+            return CameraDisplay._create_circle_patches(pix_x, pix_y, pix_width)
+
+        if shape == PixelShape.SQUARE:
+            return CameraDisplay._create_square_patches(
+                pix_x, pix_y, pix_width, pix_rotation
+            )
+
+        raise ValueError(f"Unsupported pixel shape {shape}")
+
+    @staticmethod
+    def _create_hex_patches(pix_x, pix_y, pix_width, pix_rotation):
+        orientation = pix_rotation.to_value(u.rad)
+        return [
+            RegularPolygon(
+                (x, y),
+                6,
+                # convert from incircle to outer circle radius
+                radius=w / np.sqrt(3),
+                orientation=orientation,
+                fill=True,
+            )
+            for x, y, w in zip(pix_x, pix_y, pix_width)
+        ]
+
+    @staticmethod
+    def _create_circle_patches(pix_x, pix_y, pix_width):
+        return [
+            Circle((x, y), radius=w / 2, fill=True)
+            for x, y, w in zip(pix_x, pix_y, pix_width)
+        ]
+
+    @staticmethod
+    def _create_square_patches(pix_x, pix_y, pix_width, pix_rotation):
+        orientation = (pix_rotation + 45 * u.deg).to_value(u.rad)
+        return [
+            RegularPolygon(
+                (x, y),
+                4,
+                # convert from edge length to outer circle radius
+                radius=w / np.sqrt(2),
+                orientation=orientation,
+                fill=True,
+            )
+            for x, y, w in zip(pix_x, pix_y, pix_width)
+        ]
 
     def highlight_pixels(self, pixels, color="g", linewidth=1, alpha=0.75):
         """


### PR DESCRIPTION
Pixel rotation was broken for square pixels, because matplotlib rotates a `plt.Rectangle` around a corner, not the center. Fixed by using `RegularPolygon` with 4 vertices instead of `Rectangle` for square pixels.

`CameraGeometry.transform_to` did not work correctly for `cam_rotation != 0`. I think this was not an issue before, as we always applied derotation when reading simtel files and probably nothing else uses a cam rotation, anyways, fixed now.

I thought this should have been solvable by using the `CameraFrame.rotation` attributes, but it seems they are not correctly handled in the transformation or I did something wrong in the tests. So for now, we rotate in `CameraGeometry.transform_to` 