### PR TITLE
Fix incorrect usage of configuration system in calibration calculators and tool example

### DIFF
--- a/ctapipe/calib/camera/flatfield.py
+++ b/ctapipe/calib/camera/flatfield.py
@@ -91,7 +91,7 @@ class FlatFieldCalculator(Component):
         super().__init__(**kwargs)
         # load the waveform charge extractor
         self.extractor = ImageExtractor.from_name(
-            self.charge_product, config=self.config, subarray=subarray
+            self.charge_product, parent=self, subarray=subarray
         )
 
         self.log.info(f"extractor {self.extractor}")

--- a/ctapipe/calib/camera/pedestals.py
+++ b/ctapipe/calib/camera/pedestals.py
@@ -120,7 +120,7 @@ class PedestalCalculator(Component):
 
         # load the waveform charge extractor
         self.extractor = ImageExtractor.from_name(
-            self.charge_product, config=self.config, subarray=subarray
+            self.charge_product, parent=self, subarray=subarray
         )
         self.log.info(f"extractor {self.extractor}")
 

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -83,11 +83,11 @@ class Tool(Application):
                                  allow_none=False).tag(config=True)
 
             def setup_comp(self):
-                self.comp = MyComponent(self, config=self.config)
-                self.comp2 = SecondaryMyComponent(self, config=self.config)
+                self.comp = MyComponent(self, parent=self)
+                self.comp2 = SecondaryMyComponent(self, parent=self)
 
             def setup_advanced(self):
-                self.advanced = AdvancedComponent(self, config=self.config)
+                self.advanced = AdvancedComponent(self, parent=self)
 
             def setup(self):
                 self.setup_comp()


### PR DESCRIPTION
They were passing `config=self.config` instead of the correct `parent=self`