### PR TITLE
show Frame in CameraGeometry repr

### DIFF
--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -625,7 +625,7 @@ class CameraGeometry:
             npix=len(self.pix_id),
             pixrot=self.pix_rotation,
             camrot=self.cam_rotation,
-            frame=self.frame if self.frame is not None else "None",
+            frame=self.frame,
         )
 
     def __str__(self):

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -617,8 +617,8 @@ class CameraGeometry:
 
     def __repr__(self):
         return (
-            "CameraGeometry(camera_name='{camera_name}', pix_type={pix_type!r}, "
-            "npix={npix}, cam_rot={camrot}, pix_rot={pixrot}, frame={frame})"
+            "CameraGeometry(camera_name='{camera_name}', pix_type={pix_type}, "
+            "npix={npix}, cam_rot={camrot:.3f}, pix_rot={pixrot:.3f}, frame={frame})"
         ).format(
             camera_name=self.camera_name,
             pix_type=self.pix_type,

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -618,13 +618,14 @@ class CameraGeometry:
     def __repr__(self):
         return (
             "CameraGeometry(camera_name='{camera_name}', pix_type={pix_type!r}, "
-            "npix={npix}, cam_rot={camrot}, pix_rot={pixrot})"
+            "npix={npix}, cam_rot={camrot}, pix_rot={pixrot}, frame={frame})"
         ).format(
             camera_name=self.camera_name,
             pix_type=self.pix_type,
             npix=len(self.pix_id),
             pixrot=self.pix_rotation,
             camrot=self.cam_rotation,
+            frame=self.frame.__class__.__name__ if self.frame is not None else "None",
         )
 
     def __str__(self):

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -625,7 +625,7 @@ class CameraGeometry:
             npix=len(self.pix_id),
             pixrot=self.pix_rotation,
             camrot=self.cam_rotation,
-            frame=self.frame.__class__.__name__ if self.frame is not None else "None",
+            frame=self.frame if self.frame is not None else "None",
         )
 
     def __str__(self):


### PR DESCRIPTION
very small change to the CameraGeometry `__repr__()` to also print the current Frame name, and clean up some other attributes.  The frame is useful to know, since it can be transformed.

```py3
>>> t = TelescopeDescription.from_name("LST","LSTCam")
>>> t.camera.geometry

CameraGeometry(camera_name='LSTCam', pix_type=PixelShape.HEXAGON, npix=1855, cam_rot=0.000 deg, 
pix_rot=100.893 deg, frame=<CameraFrame Frame (focal_length=28.0 m, rotation=0.0 rad, telescope_pointing=None, 
obstime=None, location=None)>)



```