### PR TITLE
Rename DL1EventSource to HDF5EventSource, add support for reading R1 waveforms as written by DataWriter

### DIFF
--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -11,7 +11,7 @@ from ..core.plugins import detect_and_import_io_plugins
 
 # import event sources to make them visible to EventSource.from_url
 from .simteleventsource import SimTelEventSource
-from .hdf5eventsource import HDF5EventSource
+from .hdf5eventsource import HDF5EventSource, get_hdf5_datalevels
 
 # import IO plugins with their event sources
 detect_and_import_io_plugins()
@@ -31,4 +31,5 @@ __all__ = [
     "read_table",
     "DataWriter",
     "DATA_MODEL_VERSION",
+    "get_hdf5_datalevels",
 ]

--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -11,7 +11,7 @@ from ..core.plugins import detect_and_import_io_plugins
 
 # import event sources to make them visible to EventSource.from_url
 from .simteleventsource import SimTelEventSource
-from .dl1eventsource import DL1EventSource
+from .hdf5eventsource import HDF5EventSource
 
 # import IO plugins with their event sources
 detect_and_import_io_plugins()
@@ -26,7 +26,7 @@ __all__ = [
     "EventSeeker",
     "EventSource",
     "SimTelEventSource",
-    "DL1EventSource",
+    "HDF5EventSource",
     "DataLevel",
     "read_table",
     "DataWriter",

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -431,7 +431,7 @@ class DataWriter(Component):
                 scale=self.waveform_scale,
                 offset=self.waveform_offset,
                 source_dtype=np.float32,
-                target_dtype=np.dtype(self.image_dtype),
+                target_dtype=np.dtype(self.waveform_dtype),
             )
             writer.add_column_transform_regexp(
                 "r1/event/telescope/.*", "waveform", transform

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -318,7 +318,10 @@ class DataWriter(Component):
             data_levels.append(DataLevel.DL1_PARAMETERS)
         if self.write_stereo_shower or self.write_mono_shower:
             data_levels.append(DataLevel.DL2)
-
+        if self.write_raw_waveforms:
+            data_levels.append(DataLevel.R0)
+        if self.write_waveforms:
+            data_levels.append(DataLevel.R1)
         return data_levels
 
     def _setup_compression(self):

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -3,6 +3,7 @@ from astropy.utils.decorators import lazyproperty
 import logging
 import numpy as np
 import tables
+from ast import literal_eval
 
 from ..core import Container, Field
 from ..instrument import SubarrayDescription
@@ -24,6 +25,7 @@ from ..containers import (
     TimingParametersContainer,
     TriggerContainer,
     ImageParametersContainer,
+    R1CameraContainer,
 )
 from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader
@@ -31,7 +33,7 @@ from .datalevels import DataLevel
 from ..utils import IndexFinder
 
 
-__all__ = ["DL1EventSource"]
+__all__ = ["HDF5EventSource"]
 
 
 logger = logging.getLogger(__name__)
@@ -50,7 +52,7 @@ COMPATIBLE_DL1_VERSIONS = [
 ]
 
 
-class DL1EventSource(EventSource):
+class HDF5EventSource(EventSource):
     """
     Event source for files in the ctapipe DL1 format.
     For general information about the concept of event sources,
@@ -86,7 +88,6 @@ class DL1EventSource(EventSource):
     has_simulated_dl1: Boolean
         Whether the file contains simulated camera images and/or
         image parameters evaluated on these.
-
     """
 
     def __init__(self, input_url=None, config=None, parent=None, **kwargs):
@@ -120,14 +121,6 @@ class DL1EventSource(EventSource):
         self.datamodel_version = self.file_.root._v_attrs[
             "CTA PRODUCT DATA MODEL VERSION"
         ]
-        params = "parameters" in self.file_.root.dl1.event.telescope
-        images = "images" in self.file_.root.dl1.event.telescope
-        if params and images:
-            self._datalevels = (DataLevel.DL1_IMAGES, DataLevel.DL1_PARAMETERS)
-        elif params:
-            self._datalevels = (DataLevel.DL1_PARAMETERS,)
-        elif images:
-            self._datalevels = (DataLevel.DL1_IMAGES,)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
@@ -137,6 +130,7 @@ class DL1EventSource(EventSource):
 
     @staticmethod
     def is_compatible(file_path):
+
         with open(file_path, "rb") as f:
             magic_number = f.read(8)
 
@@ -148,7 +142,9 @@ class DL1EventSource(EventSource):
             if "CTA PRODUCT DATA LEVEL" not in metadata._v_attrnames:
                 return False
 
-            if "DL1" not in metadata["CTA PRODUCT DATA LEVEL"]:
+            # we can now read both R1 and DL1
+            datalevels = set(literal_eval(metadata["CTA PRODUCT DATA LEVEL"]))
+            if not datalevels.intersection(("R1", "DL1_IMAGES", "DL1_PARAMETERS")):
                 return False
 
             if "CTA PRODUCT DATA MODEL VERSION" not in metadata._v_attrnames:
@@ -161,6 +157,7 @@ class DL1EventSource(EventSource):
                     f", supported versions are {COMPATIBLE_DL1_VERSIONS}"
                 )
                 return False
+
         return True
 
     @property
@@ -184,9 +181,20 @@ class DL1EventSource(EventSource):
     def subarray(self):
         return self._subarray_info
 
-    @property
+    @lazyproperty
     def datalevels(self):
-        return self._datalevels
+        datalevels = []
+
+        if "/r1/event/telescope" in self.file_.root:
+            datalevels.append(DataLevel.R1)
+
+        if "/dl1/event/telescope/images" in self.file_.root:
+            datalevels.append(DataLevel.DL1_IMAGES)
+
+        if "/dl1/event/telescope/parameters" in self.file_.root:
+            datalevels.append(DataLevel.DL1_PARAMETERS)
+
+        return tuple(datalevels)
 
     @lazyproperty
     def obs_ids(self):
@@ -232,6 +240,7 @@ class DL1EventSource(EventSource):
             )
             for (config, index) in reader:
                 simulation_configs[index.obs_id] = config
+
         return simulation_configs
 
     def _generate_events(self):
@@ -246,6 +255,14 @@ class DL1EventSource(EventSource):
         data.meta["max_events"] = self.max_events
 
         self.reader = HDF5TableReader(self.file_)
+
+        if DataLevel.R1 in self.datalevels:
+            waveform_readers = {
+                tel.name: self.reader.read(
+                    f"/r1/event/telescope/{tel.name}", R1CameraContainer()
+                )
+                for tel in self.file_.root.r1.event.telescope
+            }
 
         if DataLevel.DL1_IMAGES in self.datalevels:
             image_readers = {
@@ -372,10 +389,16 @@ class DL1EventSource(EventSource):
             if self.is_simulation:
                 data.simulation.shower = next(mc_shower_reader)
 
+            print(data.index.event_id, data.trigger.tels_with_trigger)
             for tel in data.trigger.tel.keys():
+                print(data.index.event_id, tel)
                 key = f"tel_{tel:03d}"
                 if self.allowed_tels and tel not in self.allowed_tels:
                     continue
+
+                if DataLevel.R1 in self.datalevels:
+                    data.r1.tel[tel] = next(waveform_readers[key])
+
                 if self.has_simulated_dl1:
                     simulated = data.simulation.tel[tel]
 

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -52,6 +52,22 @@ COMPATIBLE_DL1_VERSIONS = [
 ]
 
 
+def get_hdf5_datalevels(h5file):
+    """Get the data levels present in the hdf5 file"""
+    datalevels = []
+
+    if "/r1/event/telescope" in h5file.root:
+        datalevels.append(DataLevel.R1)
+
+    if "/dl1/event/telescope/images" in h5file.root:
+        datalevels.append(DataLevel.DL1_IMAGES)
+
+    if "/dl1/event/telescope/parameters" in h5file.root:
+        datalevels.append(DataLevel.DL1_PARAMETERS)
+
+    return tuple(datalevels)
+
+
 class HDF5EventSource(EventSource):
     """
     Event source for files in the ctapipe DL1 format.
@@ -183,18 +199,7 @@ class HDF5EventSource(EventSource):
 
     @lazyproperty
     def datalevels(self):
-        datalevels = []
-
-        if "/r1/event/telescope" in self.file_.root:
-            datalevels.append(DataLevel.R1)
-
-        if "/dl1/event/telescope/images" in self.file_.root:
-            datalevels.append(DataLevel.DL1_IMAGES)
-
-        if "/dl1/event/telescope/parameters" in self.file_.root:
-            datalevels.append(DataLevel.DL1_PARAMETERS)
-
-        return tuple(datalevels)
+        return get_hdf5_datalevels(self.file_)
 
     @lazyproperty
     def obs_ids(self):

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -397,18 +397,6 @@ class SimTelEventSource(EventSource):
         self._fill_array_pointing(data)
 
         for counter, array_event in enumerate(self.file_):
-
-            event_id = array_event.get("event_id", -1)
-            obs_id = self.file_.header["run"]
-            data.count = counter
-            data.index.obs_id = obs_id
-            data.index.event_id = event_id
-
-            self._fill_trigger_info(data, array_event)
-
-            if data.trigger.event_type == EventType.SUBARRAY:
-                self._fill_simulated_event_information(data, array_event)
-
             # this should be done in a nicer way to not re-allocate the
             # data each time (right now it's just deleted and garbage
             # collected)
@@ -418,6 +406,17 @@ class SimTelEventSource(EventSource):
             data.dl1.tel.clear()
             data.pointing.tel.clear()
             data.simulation.tel.clear()
+            data.trigger.tel.clear()
+
+            event_id = array_event.get("event_id", -1)
+            obs_id = self.file_.header["run"]
+            data.count = counter
+            data.index.obs_id = obs_id
+            data.index.event_id = event_id
+
+            self._fill_trigger_info(data, array_event)
+            if data.trigger.event_type == EventType.SUBARRAY:
+                self._fill_simulated_event_information(data, array_event)
 
             telescope_events = array_event["telescope_events"]
             tracking_positions = array_event["tracking_positions"]

--- a/ctapipe/io/tests/conftest.py
+++ b/ctapipe/io/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from ctapipe.io import EventSource, DataWriter
+from ctapipe.utils import get_dataset_path
+
+
+@pytest.fixture(scope="session")
+def r1_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("r1")
+
+
+@pytest.fixture(scope="session")
+def r1_hdf5_file(r1_path):
+    source = EventSource(
+        get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"),
+        max_events=5,
+        allowed_tels=[1, 2, 3, 4],
+    )
+
+    path = r1_path / "test_r1.h5"
+
+    writer = DataWriter(
+        event_source=source,
+        output_path=path,
+        write_parameters=False,
+        write_images=False,
+        write_stereo_shower=False,
+        write_mono_shower=False,
+        write_raw_waveforms=False,
+        write_waveforms=True,
+    )
+
+    for e in source:
+        writer(e)
+
+    writer.finish()
+
+    return path

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -266,28 +266,6 @@ def test_metadata(tmpdir: Path):
             assert meta["CTA CONTACT ORGANIZATION"] == "TU Dortmund"
 
 
-def test_write_only_r1(tmp_path):
-    source = EventSource(
-        get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"),
-        max_events=5,
-        allowed_tels=[1, 2, 3, 4],
-    )
-
-    path = tmp_path / "test_r1.h5"
-
-    writer = DataWriter(
-        event_source=source,
-        output_path=path,
-        write_parameters=False,
-        write_images=False,
-        write_stereo_shower=False,
-        write_mono_shower=False,
-        write_raw_waveforms=False,
-        write_waveforms=True,
-    )
-
-    for e in source:
-        writer(e)
-
-    with tables.open_file(path, "r") as f:
+def test_write_only_r1(r1_hdf5_file):
+    with tables.open_file(r1_hdf5_file, "r") as f:
         assert "r1/event/telescope/tel_001" in f.root

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -264,3 +264,30 @@ def test_metadata(tmpdir: Path):
             assert meta["CTA CONTACT NAME"] == "Maximilian Nöthe"
             assert meta["CTA CONTACT EMAIL"] == "maximilian.noethe@tu-dortmund.de"
             assert meta["CTA CONTACT ORGANIZATION"] == "TU Dortmund"
+
+
+def test_write_only_r1(tmp_path):
+    source = EventSource(
+        get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"),
+        max_events=5,
+        allowed_tels=[1, 2, 3, 4],
+    )
+
+    path = tmp_path / "test_r1.h5"
+
+    writer = DataWriter(
+        event_source=source,
+        output_path=path,
+        write_parameters=False,
+        write_images=False,
+        write_stereo_shower=False,
+        write_mono_shower=False,
+        write_raw_waveforms=False,
+        write_waveforms=True,
+    )
+
+    for e in source:
+        writer(e)
+
+    with tables.open_file(path, "r") as f:
+        assert "r1/event/telescope/tel_001" in f.root

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -1,28 +1,30 @@
 import astropy.units as u
 import numpy as np
-from ctapipe.io import DataLevel, EventSource
-from ctapipe.io.dl1eventsource import DL1EventSource
+from ctapipe.io import DataLevel, EventSource, HDF5EventSource
 from ctapipe.utils import get_dataset_path
 
 
 def test_is_compatible(dl1_file):
     simtel_path = get_dataset_path("gamma_test_large.simtel.gz")
-    assert not DL1EventSource.is_compatible(simtel_path)
-    assert DL1EventSource.is_compatible(dl1_file)
+    assert not HDF5EventSource.is_compatible(simtel_path)
+    assert HDF5EventSource.is_compatible(dl1_file)
     with EventSource(input_url=dl1_file) as source:
-        assert isinstance(source, DL1EventSource)
+        assert isinstance(source, HDF5EventSource)
 
 
 def test_metadata(dl1_file):
-    with DL1EventSource(input_url=dl1_file) as source:
+    with HDF5EventSource(input_url=dl1_file) as source:
         assert source.is_simulation
-        assert source.datalevels == (DataLevel.DL1_IMAGES, DataLevel.DL1_PARAMETERS)
+        assert set(source.datalevels) == {
+            DataLevel.DL1_IMAGES,
+            DataLevel.DL1_PARAMETERS,
+        }
         assert list(source.obs_ids) == [2]
         assert source.simulation_config.corsika_version == 7710
 
 
 def test_subarray(dl1_file):
-    with DL1EventSource(input_url=dl1_file) as source:
+    with HDF5EventSource(input_url=dl1_file) as source:
         assert source.subarray.telescope_types
         assert source.subarray.camera_types
         assert source.subarray.optics_types
@@ -30,7 +32,7 @@ def test_subarray(dl1_file):
 
 def test_max_events(dl1_proton_file):
     max_events = 3
-    with DL1EventSource(input_url=dl1_proton_file, max_events=max_events) as source:
+    with HDF5EventSource(input_url=dl1_proton_file, max_events=max_events) as source:
         assert source.max_events == max_events  # stop iterating after max_events
         assert len(source) == 4  # total events in file
         for count, _ in enumerate(source, start=1):
@@ -40,7 +42,7 @@ def test_max_events(dl1_proton_file):
 
 def test_allowed_tels(dl1_file):
     allowed_tels = {1, 2}
-    with DL1EventSource(input_url=dl1_file, allowed_tels=allowed_tels) as source:
+    with HDF5EventSource(input_url=dl1_file, allowed_tels=allowed_tels) as source:
         assert not allowed_tels.symmetric_difference(source.subarray.tel_ids)
         assert source.allowed_tels == allowed_tels
         for event in source:
@@ -58,7 +60,7 @@ def test_simulation_info(dl1_file):
     """
     reco_lons = []
     reco_concentrations = []
-    with DL1EventSource(input_url=dl1_file) as source:
+    with HDF5EventSource(input_url=dl1_file) as source:
         for event in source:
             assert np.isfinite(event.simulation.shower.energy)
             for tel in event.simulation.tel:
@@ -75,7 +77,7 @@ def test_simulation_info(dl1_file):
 
 
 def test_dl1_a_only_data(dl1_image_file):
-    with DL1EventSource(input_url=dl1_image_file) as source:
+    with HDF5EventSource(input_url=dl1_image_file) as source:
         for event in source:
             for tel in event.dl1.tel:
                 assert event.dl1.tel[tel].image.any()
@@ -84,7 +86,7 @@ def test_dl1_a_only_data(dl1_image_file):
 def test_dl1_b_only_data(dl1_parameters_file):
     reco_lons = []
     reco_concentrations = []
-    with DL1EventSource(input_url=dl1_parameters_file) as source:
+    with HDF5EventSource(input_url=dl1_parameters_file) as source:
         for event in source:
             for tel in event.dl1.tel:
                 reco_lons.append(
@@ -100,7 +102,7 @@ def test_dl1_b_only_data(dl1_parameters_file):
 def test_dl1_data(dl1_file):
     reco_lons = []
     reco_concentrations = []
-    with DL1EventSource(input_url=dl1_file) as source:
+    with HDF5EventSource(input_url=dl1_file) as source:
         for event in source:
             for tel in event.dl1.tel:
                 assert event.dl1.tel[tel].image.any()
@@ -115,7 +117,7 @@ def test_dl1_data(dl1_file):
 
 
 def test_pointing(dl1_file):
-    with DL1EventSource(input_url=dl1_file) as source:
+    with HDF5EventSource(input_url=dl1_file) as source:
         for event in source:
             assert np.isclose(event.pointing.array_azimuth.to_value(u.deg), 0)
             assert np.isclose(event.pointing.array_altitude.to_value(u.deg), 70)
@@ -123,3 +125,15 @@ def test_pointing(dl1_file):
             for tel in event.pointing.tel:
                 assert np.isclose(event.pointing.tel[tel].azimuth.to_value(u.deg), 0)
                 assert np.isclose(event.pointing.tel[tel].altitude.to_value(u.deg), 70)
+
+
+def test_read_r1(r1_hdf5_file):
+    print(r1_hdf5_file)
+    with HDF5EventSource(input_url=r1_hdf5_file) as source:
+        e = None
+
+        for e in source:
+            pass
+
+        assert e is not None
+        assert e.count == 4

--- a/ctapipe/tools/dl1_merge.py
+++ b/ctapipe/tools/dl1_merge.py
@@ -11,7 +11,7 @@ import tables
 import numpy as np
 from tqdm.auto import tqdm
 
-from ..io import metadata as meta, DL1EventSource
+from ..io import metadata as meta, HDF5EventSource
 from ..io import HDF5TableWriter
 from ..core import Provenance, Tool, traits
 from ..core.traits import Bool, Set, Unicode, flag, CInt
@@ -382,7 +382,7 @@ class MergeTool(Tool):
             )
         ):
 
-            if not DL1EventSource.is_compatible(current_file):
+            if not HDF5EventSource.is_compatible(current_file):
                 self.log.critical(
                     f"input file {current_file} is not a supported DL1 file"
                 )

--- a/ctapipe/tools/dl1_merge.py
+++ b/ctapipe/tools/dl1_merge.py
@@ -11,7 +11,7 @@ import tables
 import numpy as np
 from tqdm.auto import tqdm
 
-from ..io import metadata as meta, HDF5EventSource
+from ..io import metadata as meta, HDF5EventSource, get_hdf5_datalevels
 from ..io import HDF5TableWriter
 from ..core import Provenance, Tool, traits
 from ..core.traits import Bool, Set, Unicode, flag, CInt
@@ -425,7 +425,9 @@ class MergeTool(Tool):
         )
 
     def finish(self):
+        datalevels = [d.name for d in get_hdf5_datalevels(self.output_file)]
         self.output_file.close()
+
         activity = PROV.current_activity.provenance
         process_type_ = "Observation"
         if self.is_simulation is True:
@@ -436,7 +438,7 @@ class MergeTool(Tool):
             product=meta.Product(
                 description="Merged DL1 Data Product",
                 data_category="Sim",  # TODO: copy this from the inputs
-                data_level=["DL1"],  # TODO: copy this from inputs
+                data_level=datalevels,
                 data_association="Subarray",
                 data_model_name="ASWG",  # TODO: copy this from inputs
                 data_model_version=self.data_model_version,

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -192,6 +192,22 @@ class ProcessorTool(Tool):
 
         return self.write.write_parameters or self.should_compute_dl2
 
+    @property
+    def should_calibrate(self):
+        if self.force_recompute_dl1:
+            True
+
+        if (
+            self.write.write_images
+            and DataLevel.DL1_IMAGES not in self.event_source.datalevels
+        ):
+            return True
+
+        if self.should_compute_dl1:
+            return DataLevel.DL1_IMAGES not in self.event_source.datalevels
+
+        return False
+
     def _write_processing_statistics(self):
         """write out the event selection stats, etc."""
         # NOTE: don't remove this, not part of DataWriter
@@ -231,7 +247,9 @@ class ProcessorTool(Tool):
         ):
 
             self.log.debug("Processessing event_id=%s", event.index.event_id)
-            self.calibrate(event)
+
+            if self.should_calibrate:
+                self.calibrate(event)
 
             if self.should_compute_dl1:
                 self.process_images(event)

--- a/docs/ctapipe_api/io/index.rst
+++ b/docs/ctapipe_api/io/index.rst
@@ -180,7 +180,7 @@ Reference/API
 .. automodapi:: ctapipe.io.simteleventsource
     :no-inheritance-diagram:
 
-.. automodapi:: ctapipe.io.dl1eventsource
+.. automodapi:: ctapipe.io.hdf5eventsource
     :no-inheritance-diagram:
 
 .. automodapi:: ctapipe.io.eventseeker


### PR DESCRIPTION
* This makes us able to read R1 data back from files written using the `DataWriter.write_waveforms`
* It also enables *only* writing the R1 waveforms

This was motivated for LST to write out calibrated DL0 calibration events so @FrancaCassol can start developing the calibration pipeline in ctapipe without having to redo the low-level calibrations over and over again.