### PR TITLE
Fix _dev_version being included in wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,6 @@ recursive-include docs *
 prune build
 prune docs/_build
 prune docs/api
-exclude ctapipe/_dev_version.py
+prune ctapipe/_dev_version
 
 global-exclude *.pyc *.o

--- a/ctapipe/_dev_version/__init__.py
+++ b/ctapipe/_dev_version/__init__.py
@@ -4,6 +4,6 @@
 try:
     from setuptools_scm import get_version
 
-    version = get_version(root="..", relative_to=__file__)
+    version = get_version(root="../..", relative_to=__file__)
 except Exception as e:
     raise ImportError(f"setuptools_scm broken or not installed: {e}")

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ docs_require = [
 ]
 
 setup(
-    packages=find_packages(),
+    packages=find_packages(exclude="ctapipe._dev_version"),
     python_requires=">=3.7",
     install_requires=[
         "astropy>=4.0.5,<5",


### PR DESCRIPTION
Building wheels does not honor `MANIFEST.in`, that is only used for source dists.

To exclude the `_dev_version.py` from wheels, it has to be a package excluded in `find_package`