### PR TITLE
Fix scipy deprecation warning

### DIFF
--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -31,7 +31,7 @@ from ctapipe.core.traits import (
 )
 from ctapipe.core import TelescopeComponent
 from numba import njit, prange, guvectorize, float64, float32, int64
-from scipy.ndimage.filters import convolve1d
+from scipy.ndimage import convolve1d
 from typing import Tuple
 
 from . import number_of_islands, tailcuts_clean, brightest_island

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -12,7 +12,7 @@ import numpy as np
 from math import erf
 from numba import vectorize, double
 
-from scipy.ndimage.filters import correlate1d
+from scipy.ndimage import correlate1d
 from iminuit import Minuit
 from astropy import units as u
 from scipy.constants import alpha


### PR DESCRIPTION
```
  /home/maxnoe/.local/anaconda/envs/ctapipe_io_nectarcam/lib/python3.8/site-packages/ctapipe/image/extractor.py:34: DeprecationWarning: Please use `convolve1d` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
    from scipy.ndimage.filters import convolve1d

```