### PR TITLE
Implement public interface for 2d index to/from id

### DIFF
--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -407,6 +407,21 @@ class CameraGeometry:
         """
         return ~np.any(~np.isclose(self.pix_area.value, self.pix_area[0].value), axis=0)
 
+    
+    def pixel_id_to_index2d(self, pixel_id):
+        rows, cols = self._pixel_positions_2d
+        return rows[pixel_id], cols[pixel_id]
+
+    def index2d_to_pixel_id(self, row, col):
+        return self._pixel_ids_2d[row, col]
+
+    @lazyproperty
+    def _pixel_ids_2d(self):
+        img = self.pix_id
+        img2d = self.image_to_cartesian_representation(img)
+        img2d = np.nan_to_num(img2d, nan=-1).astype(np.int32)
+        return img2d
+
     @lazyproperty
     def _pixel_positions_2d(self):
         """
@@ -484,12 +499,15 @@ class CameraGeometry:
         """
         rows, cols = self._pixel_positions_2d
         image = np.atleast_2d(image)  # this allows for multiple images at once
+
         image_2d = np.full((image.shape[0], rows.max() + 1, cols.max() + 1), np.nan)
         image_2d[:, rows, cols] = image
+
         if self.pix_type == PixelShape.SQUARE:
             image_2d = np.flip(image_2d, axis=1)
         else:
             image_2d = np.flip(image_2d)
+
         return np.squeeze(image_2d)  # removes the extra dimension for single images
 
     def image_from_cartesian_representation(self, image_2d):

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -407,19 +407,25 @@ class CameraGeometry:
         """
         return ~np.any(~np.isclose(self.pix_area.value, self.pix_area[0].value), axis=0)
 
-    
-    def pixel_id_to_index2d(self, pixel_id):
+    def image_index_to_cartesian_index(self, pixel_index):
+        '''
+        Convert pixel index in the 1d image representation to row and col
+        '''
         rows, cols = self._pixel_positions_2d
-        return rows[pixel_id], cols[pixel_id]
+        return rows[pixel_index], cols[pixel_index]
 
-    def index2d_to_pixel_id(self, row, col):
-        return self._pixel_ids_2d[row, col]
+    def cartesian_index_to_image_index(self, row, col):
+        '''
+        Convert cartesian index (row, col) to pixel index in 1d representation.
+        '''
+        return self._pixel_indices_cartesian[row, col]
 
     @lazyproperty
-    def _pixel_ids_2d(self):
-        img = self.pix_id
+    def _pixel_indices_cartesian(self):
+        img = np.arange(self.n_pixels)
         img2d = self.image_to_cartesian_representation(img)
-        img2d = np.nan_to_num(img2d, nan=-1).astype(np.int32)
+        invalid = np.iinfo(np.int32).min
+        img2d = np.nan_to_num(img2d, nan=invalid).astype(np.int32)
         return img2d
 
     @lazyproperty

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -471,11 +471,20 @@ class CameraGeometry:
             pixel_row = rows_1d
             pixel_column = cols_1d
 
+            # flip image so that imshow looks like original camera display
+            pixel_row = pixel_row.max() - pixel_row
+            pixel_column = pixel_column.max() - pixel_column
+
         elif self.pix_type is PixelShape.SQUARE:
             pixel_row = get_orthogonal_grid_indices(self.pix_y, np.sqrt(self.pix_area))
             pixel_column = get_orthogonal_grid_indices(
                 self.pix_x, np.sqrt(self.pix_area)
             )
+
+            # flip image so that imshow looks like original camera display
+            pixel_row = pixel_row.max() - pixel_row
+        else:
+            raise ValueError(f"Unsupported pixel shape {self.pix_type}")
 
         return pixel_row, pixel_column
 
@@ -503,11 +512,6 @@ class CameraGeometry:
         image_2d = np.full((image.shape[0], rows.max() + 1, cols.max() + 1), np.nan)
         image_2d[:, rows, cols] = image
 
-        if self.pix_type == PixelShape.SQUARE:
-            image_2d = np.flip(image_2d, axis=1)
-        else:
-            image_2d = np.flip(image_2d)
-
         return np.squeeze(image_2d)  # removes the extra dimension for single images
 
     def image_from_cartesian_representation(self, image_2d):
@@ -533,10 +537,7 @@ class CameraGeometry:
         # to a different shape compared to a multi image array
         if image_2d.ndim == 2:
             image_2d = image_2d[np.newaxis, :]
-        if self.pix_type == PixelShape.SQUARE:
-            image_2d = np.flip(image_2d, axis=1)
-        else:
-            image_2d = np.flip(image_2d)
+
         image_flat = np.zeros((image_2d.shape[0], rows.shape[0]), dtype=image_2d.dtype)
         image_flat[:] = image_2d[:, rows, cols]
         image_1d = image_flat

--- a/ctapipe/instrument/camera/image_conversion.py
+++ b/ctapipe/instrument/camera/image_conversion.py
@@ -272,8 +272,8 @@ def get_orthogonal_grid_edges(pix_x, pix_y, scale_aspect=True):
 
     # finding the size of the square patches
 
-    d_x = 99
-    d_y = 99
+    d_x = np.inf
+    d_y = np.inf
     x_base = pix_x[0]
     y_base = pix_y[0]
     for x, y in zip(pix_x, pix_y):

--- a/ctapipe/instrument/camera/tests/test_image_conversion.py
+++ b/ctapipe/instrument/camera/tests/test_image_conversion.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from ctapipe.image.toymodel import Gaussian
+import pytest
 
 
 def create_mock_image(geom, psi=25 * u.deg):
@@ -50,3 +51,9 @@ def test_multiple_images(camera_geometry):
     # in general this introduces extra pixels in the 2d array, which are set to nan
     assert np.nansum(images) == np.nansum(images_2d)
     assert_allclose(images, images_1d)
+
+
+@pytest.mark.parametrize("pixel_id", [0, 1, 100])
+def test_pixel_coordinates_roundtrip(pixel_id, camera_geometry):
+    row, col = camera_geometry.pixel_id_to_index2d(pixel_id)
+    assert camera_geometry.index2d_to_pixel_id(row, col) == pixel_id

--- a/ctapipe/instrument/camera/tests/test_image_conversion.py
+++ b/ctapipe/instrument/camera/tests/test_image_conversion.py
@@ -55,5 +55,5 @@ def test_multiple_images(camera_geometry):
 
 @pytest.mark.parametrize("pixel_id", [0, 1, 100])
 def test_pixel_coordinates_roundtrip(pixel_id, camera_geometry):
-    row, col = camera_geometry.pixel_id_to_index2d(pixel_id)
-    assert camera_geometry.index2d_to_pixel_id(row, col) == pixel_id
+    row, col = camera_geometry.image_index_to_cartesian_index(pixel_id)
+    assert camera_geometry.cartesian_index_to_image_index(row, col) == pixel_id


### PR DESCRIPTION
Add public methods to go from pixel id to index in 2d representation and back. Turns out, due to the flipping, the mapping does not hold. (The new test is failing)