### PR TITLE
Close event source in ProcessorTool.finish

### DIFF
--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -385,3 +385,10 @@ class EventSource(Component):
         """
         input_url = cls._find_input_url_in_config(config=config, parent=parent)
         return cls.from_url(input_url, config=config, parent=parent, **kwargs)
+
+    def close(self):
+        """Close this event source.
+
+        No-op by default. Should be overriden by sources needing a cleanup-step
+        """
+        pass

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -275,6 +275,7 @@ class ProcessorTool(Tool):
         """
         self.write.write_simulation_histograms(self.event_source)
         self.write.finish()
+        self.event_source.close()
         self._write_processing_statistics()
 
 


### PR DESCRIPTION
Fixes messages from tables about "remaining open files" when using the `HDF5EventSource`