### PR TITLE
Update CI os/install-method/python-version combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", ]
-        install-method: ["pip", "conda"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8"
+            install-method: conda
+
+          - os: ubuntu-latest
+            python-version: "3.9"
+            install-method: conda
+
+          - os: ubuntu-latest
+            python-version: "3.10"
+            install-method: conda
+
+          - os: ubuntu-latest
+            python-version: "3.10"
+            install-method: pip
+
+          - os: macos-latest
+            python-version: "3.8"
+            install-method: conda
+
+          - os: macos-latest
+            python-version: "3.8"
+            install-method: pip
+
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             install-method: pip
 
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.10"
             install-method: conda
 
           - os: macos-latest
@@ -104,7 +104,12 @@ jobs:
         # need to use a login shell for the conda setup to work
         shell: bash -leo pipefail {0}
         run: |
-          pytest -n auto --dist loadscope --cov --cov-report=xml --doctest-modules --doctest-glob='*.rst' ctapipe docs
+          pytest -n auto --dist loadscope \
+            --cov --cov-report=xml \
+            --doctest-modules --doctest-glob='*.rst' \
+            --ignore=docs/conf.py \
+            ctapipe docs
+
           ctapipe-info --version
 
       - uses: codecov/codecov-action@v1

--- a/ctapipe/tools/quickstart.py
+++ b/ctapipe/tools/quickstart.py
@@ -132,7 +132,7 @@ class QuickStartTool(Tool):
     def start(self):
 
         for filename in CONFIGS_TO_WRITE:
-            config = files("ctapipe.tools.tests.resources").joinpath(filename)
+            config = files("ctapipe.tools.tests").joinpath("resources", filename)
             destination = self.workdir / filename
 
             if destination.exists():

--- a/ctapipe/tools/tests/test_merge.py
+++ b/ctapipe/tools/tests/test_merge.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 def run_stage1(input_path, cwd, output_path=None):
-    config = files("ctapipe.tools.tests.resources").joinpath("stage1_config.json")
+    config = files("ctapipe.tools.tests").joinpath("resources", "stage1_config.json")
 
     if output_path is None:
         output_path = Path(

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -21,10 +21,14 @@ except ImportError:
 GAMMA_TEST_LARGE = get_dataset_path("gamma_test_large.simtel.gz")
 
 
+def resource_file(filename):
+    return files("ctapipe.tools.tests").joinpath("resources", filename)
+
+
 def test_stage_1_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
     """  check simtel to DL1 conversion """
 
-    config = files("ctapipe.tools.tests.resources").joinpath("stage1_config.json")
+    config = resource_file("stage1_config.json")
     # DL1A file as input
     dl1b_from_dl1a_file = tmp_path / "dl1b_fromdl1a.dl1.h5"
     assert (
@@ -131,7 +135,7 @@ def test_stage1_datalevels(tmp_path):
         infile.write(b"dummy")
         infile.flush()
 
-    config = files("ctapipe.tools.tests.resources").joinpath("stage1_config.json")
+    config = resource_file("stage1_config.json")
     tool = ProcessorTool()
 
     assert (
@@ -154,7 +158,7 @@ def test_stage1_datalevels(tmp_path):
 
 def test_stage_2_from_simtel(tmp_path):
     """ check we can go to DL2 geometry from simtel file """
-    config = files("ctapipe.tools.tests.resources").joinpath("stage2_config.json")
+    config = resource_file("stage2_config.json")
     output = tmp_path / "test_stage2_from_simtel.DL2.h5"
 
     assert (
@@ -179,7 +183,7 @@ def test_stage_2_from_simtel(tmp_path):
 
 def test_stage_2_from_dl1_images(tmp_path, dl1_image_file):
     """ check we can go to DL2 geometry from DL1 images """
-    config = files("ctapipe.tools.tests.resources").joinpath("stage2_config.json")
+    config = resource_file("stage2_config.json")
     output = tmp_path / "test_stage2_from_dl1image.DL2.h5"
 
     assert (
@@ -204,7 +208,7 @@ def test_stage_2_from_dl1_images(tmp_path, dl1_image_file):
 def test_stage_2_from_dl1_params(tmp_path, dl1_parameters_file):
     """ check we can go to DL2 geometry from DL1 parameters """
 
-    config = files("ctapipe.tools.tests.resources").joinpath("stage2_config.json")
+    config = resource_file("stage2_config.json")
     output = tmp_path / "test_stage2_from_dl1param.DL2.h5"
 
     assert (
@@ -229,7 +233,7 @@ def test_stage_2_from_dl1_params(tmp_path, dl1_parameters_file):
 def test_training_from_simtel(tmp_path):
     """ check we can write both dl1 and dl2 info (e.g. for training input) """
 
-    config = files("ctapipe.tools.tests.resources").joinpath("training_config.json")
+    config = resource_file("training_config.json")
     output = tmp_path / "test_training.DL1DL2.h5"
 
     assert (
@@ -256,7 +260,7 @@ def test_training_from_simtel(tmp_path):
 @pytest.mark.parametrize("filename", CONFIGS_TO_WRITE)
 def test_quickstart_templates(filename):
     """ ensure template configs have an appropriate placeholder for the contact info """
-    config = files("ctapipe.tools.tests.resources").joinpath(filename)
+    config = resource_file(filename)
     text = config.read_text()
 
     assert "YOUR-NAME-HERE" in text, "Missing expected name placeholder"


### PR DESCRIPTION
This adds and removes some builds in our CI config.

To not do too many different builds, instead of doing the full matrix of os / python-version / install-method I went for a sparse matrix of that.

There are now 6 combinatations covering python 3.8, 3.9, 3.10 with linux vs. macos and pip vs. conda.

On linux, all supported python versions are tested with the conda installation.

Additionally, I test the newest python version also with pip.

On macos, the oldest supported python version is tested with pip and conda


This made sense to me, but I don't have strong opinions on the combinations we want to test. I only felt that going for 18 different combinations is too much.