### PR TITLE
added a better template for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,7 +36,7 @@ template: |
 
   $CONTRIBUTORS
 
-  ## What is changed since $PREVIOUS_TAG
+  ## What has changed since $PREVIOUS_TAG
 
   Pull-requests containing changes of multiple nature are repeated.
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,43 @@
+categories:
+  - title: "New features"
+    labels:
+      - "new functionality"
+      - "enhancement"
+  - title: "API Changes"
+    labels:
+      - "Breaking change"
+      - "API change"
+  - title: "Data Model Changes"
+    labels:
+      - "data model change"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "Refactoring and Optimization"
+    labels:
+      - "optimization"
+      - "refactoring"
+  - title: "Maintenance"
+    labels:
+      - "build"
+      - "documentation"
+      - "installation"
+      - "maintenance"
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 template: |
-  ## What's Changed since $PREVIOUS_TAG
 
-  $CHANGES
+  ## Summary
+
+  ...
 
   ## Contributors
 
   $CONTRIBUTORS
+
+  ## What is changed since $PREVIOUS_TAG
+
+  Pull-requests containing changes of multiple nature are repeated.
+
+  $CHANGES


### PR DESCRIPTION
Auto-categorizes PRs by topic.  Should make releasing a bit nicer.

The template should look similar to what is used in protopipe here: 
https://github.com/cta-observatory/protopipe/releases

(though I removed the unicode icons)