### PR TITLE
Fix Container.as_dict for case of flatten=True and add_prefix=True

### DIFF
--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -293,26 +293,27 @@ class Container(metaclass=ContainerMeta):
         """
         if not recursive:
             return dict(self.items(add_prefix=add_prefix))
-        else:
-            d = dict()
-            for key, val in self.items(add_prefix=add_prefix):
-                if isinstance(val, Container) or isinstance(val, Map):
-                    if flatten:
-                        d.update(
-                            {
-                                f"{key}_{k}": v
-                                for k, v in val.as_dict(
-                                    recursive, add_prefix=add_prefix
-                                ).items()
-                            }
-                        )
-                    else:
-                        d[key] = val.as_dict(
-                            recursive=recursive, flatten=flatten, add_prefix=add_prefix
-                        )
+
+        d = dict()
+        for key, val in self.items(add_prefix=add_prefix):
+            if isinstance(val, Container) or isinstance(val, Map):
+                if flatten:
+                    d.update(
+                        {
+                            k: v
+                            for k, v in val.as_dict(
+                                recursive, add_prefix=add_prefix,
+                                flatten=flatten
+                            ).items()
+                        }
+                    )
                 else:
-                    d[key] = val
-            return d
+                    d[key] = val.as_dict(
+                        recursive=recursive, flatten=flatten, add_prefix=add_prefix
+                    )
+            else:
+                d[key] = val
+        return d
 
     def reset(self, recursive=True):
         """

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -296,17 +296,9 @@ class Container(metaclass=ContainerMeta):
 
         d = dict()
         for key, val in self.items(add_prefix=add_prefix):
-            if isinstance(val, Container) or isinstance(val, Map):
+            if isinstance(val, (Container, Map)):
                 if flatten:
-                    d.update(
-                        {
-                            k: v
-                            for k, v in val.as_dict(
-                                recursive, add_prefix=add_prefix,
-                                flatten=flatten
-                            ).items()
-                        }
-                    )
+                    d.update(val.as_dict(recursive, add_prefix=add_prefix, flatten=flatten))
                 else:
                     d[key] = val.as_dict(
                         recursive=recursive, flatten=flatten, add_prefix=add_prefix

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -159,13 +159,34 @@ def test_container_as_dict():
         x = Field(0, "some value")
         child = Field(ChildContainer(), "a child")
 
+    class GrandParentContainer(Container):
+        y = Field(2, "some other value")
+        child = Field(ParentContainer(), "child")
+
     cont = ParentContainer()
 
-    the_flat_dict = cont.as_dict(recursive=True, flatten=True)
-    the_dict = cont.as_dict(recursive=True, flatten=False)
+    assert cont.as_dict() == {"x": 0, "child": cont.child}
+    assert cont.as_dict(recursive=True) == {"x": 0, "child": {"z": 1}}
+    assert cont.as_dict(recursive=True, add_prefix=True) == {
+        "parent_x": 0,
+        "parent_child": {
+            "child_z": 1
+        }
+    }
 
-    assert "child_z" in the_flat_dict
-    assert "child" in the_dict and "z" in the_dict["child"]
+    assert cont.as_dict(recursive=True, flatten=True, add_prefix=False) == {
+        "x": 0,
+        "z": 1,
+    }
+
+    assert cont.as_dict(recursive=True, flatten=True, add_prefix=True) == {
+        "parent_x": 0,
+        "child_z": 1,
+    }
+
+    d = GrandParentContainer().as_dict(recursive=True, flatten=True, add_prefix=True)
+    assert d == {'parent_x': 0, 'child_z': 1, 'grandparent_y': 2}
+
 
 
 def test_container_brackets():


### PR DESCRIPTION
This change has the main goal of having
`ImageParametersContainer.as_dict(recursive=True, flatten=True,
add_prefix=True)` produce a dict with the same keys as the column names
in the dl1 parameters table in the hdf5 file.


Before:

```
{'params_hillas_hillas_intensity': nan,
 'params_hillas_hillas_skewness': nan,
 'params_hillas_hillas_kurtosis': nan,
 'params_hillas_hillas_fov_lon': <Quantity nan deg>,
 'params_hillas_hillas_fov_lat': <Quantity nan deg>,
 'params_hillas_hillas_r': <Quantity nan deg>,
 'params_hillas_hillas_phi': <Quantity nan deg>,
 'params_hillas_hillas_length': <Quantity nan deg>,
 'params_hillas_hillas_length_uncertainty': <Quantity nan deg>,
 'params_hillas_hillas_width': <Quantity nan deg>,
 'params_hillas_hillas_width_uncertainty': <Quantity nan deg>,
 'params_hillas_hillas_psi': <Quantity nan deg>,
 'params_timing_timing_intercept': nan,
 'params_timing_timing_deviation': nan,
 'params_timing_timing_slope': <Quantity nan 1 / deg>,
 'params_leakage_leakage_pixels_width_1': nan,
 'params_leakage_leakage_pixels_width_2': nan,
 'params_leakage_leakage_intensity_width_1': nan,
 'params_leakage_leakage_intensity_width_2': nan,
 'params_concentration_concentration_cog': nan,
 'params_concentration_concentration_core': nan,
 'params_concentration_concentration_pixel': nan,
 'params_morphology_morphology_num_pixels': -1,
 'params_morphology_morphology_num_islands': -1,
 'params_morphology_morphology_num_small_islands': -1,
 'params_morphology_morphology_num_medium_islands': -1,
 'params_morphology_morphology_num_large_islands': -1,
 'params_intensity_statistics_intensity_max': nan,
 'params_intensity_statistics_intensity_min': nan,
 'params_intensity_statistics_intensity_mean': nan,
 'params_intensity_statistics_intensity_std': nan,
 'params_intensity_statistics_intensity_skewness': nan,
 'params_intensity_statistics_intensity_kurtosis': nan,
 'params_peak_time_statistics_peak_time_max': nan,
 'params_peak_time_statistics_peak_time_min': nan,
 'params_peak_time_statistics_peak_time_mean': nan,
 'params_peak_time_statistics_peak_time_std': nan,
 'params_peak_time_statistics_peak_time_skewness': nan,
 'params_peak_time_statistics_peak_time_kurtosis': nan,
 'params_core_core_psi': <Quantity nan deg>}
```

After:

```
In [4]: c.as_dict(recursive=True, flatten=True, add_prefix=True)
Out[4]: 
{'hillas_intensity': nan,
 'hillas_skewness': nan,
 'hillas_kurtosis': nan,
 'hillas_fov_lon': <Quantity nan deg>,
 'hillas_fov_lat': <Quantity nan deg>,
 'hillas_r': <Quantity nan deg>,
 'hillas_phi': <Quantity nan deg>,
 'hillas_length': <Quantity nan deg>,
 'hillas_length_uncertainty': <Quantity nan deg>,
 'hillas_width': <Quantity nan deg>,
 'hillas_width_uncertainty': <Quantity nan deg>,
 'hillas_psi': <Quantity nan deg>,
 'timing_intercept': nan,
 'timing_deviation': nan,
 'timing_slope': <Quantity nan 1 / deg>,
 'leakage_pixels_width_1': nan,
 'leakage_pixels_width_2': nan,
 'leakage_intensity_width_1': nan,
 'leakage_intensity_width_2': nan,
 'concentration_cog': nan,
 'concentration_core': nan,
 'concentration_pixel': nan,
 'morphology_num_pixels': -1,
 'morphology_num_islands': -1,
 'morphology_num_small_islands': -1,
 'morphology_num_medium_islands': -1,
 'morphology_num_large_islands': -1,
 'intensity_max': nan,
 'intensity_min': nan,
 'intensity_mean': nan,
 'intensity_std': nan,
 'intensity_skewness': nan,
 'intensity_kurtosis': nan,
 'peak_time_max': nan,
 'peak_time_min': nan,
 'peak_time_mean': nan,
 'peak_time_std': nan,
 'peak_time_skewness': nan,
 'peak_time_kurtosis': nan,
 'core_psi': <Quantity nan deg>}
```