### PR TITLE
Improved configuration of reference metadata

### DIFF
--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -148,8 +148,8 @@ class DataWriter(Component):
             "Additional metadata keywords and values that describe this data. "
             "This should be a dictionary where the keys will be appended to the "
             "CONTEXT section of the output file's attributes. Keys can be hierarchical "
-            "by using a space between each level, e.g. `SIMULATION PRODUCTION` would make a key "
-            "PRODUCTION grouped under the key SIMULATION"
+            "by using a space between each level, e.g. `SIMULATION PRODUCTION` "
+            "would make a key PRODUCTION grouped under the key SIMULATION"
         )
     ).tag(config=True)
 

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -6,12 +6,12 @@ Class to write DL1 (a,b) and DL2 (a) data from an event stream
 
 import pathlib
 from collections import defaultdict
-from traitlets import Instance, Dict
 from typing import List
 
 import numpy as np
 import tables
 from astropy import units as u
+from traitlets import Dict, Instance
 
 from ..containers import (
     ArrayEventContainer,

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -6,7 +6,8 @@ Class to write DL1 (a,b) and DL2 (a) data from an event stream
 
 import pathlib
 from collections import defaultdict
-from traitlets import Instance
+from traitlets import Instance, Dict
+from typing import List
 
 import numpy as np
 import tables
@@ -60,8 +61,14 @@ PROV = Provenance()
 
 
 def write_reference_metadata_headers(
-    obs_ids, subarray, writer, is_simulation, data_levels, contact_info
-):
+    obs_ids: List[int],
+    subarray: SubarrayDescription,
+    writer: "DataWriter",
+    is_simulation: bool,
+    data_levels,
+    contact_info: meta.Contact,
+    instrument_info: meta.Instrument,
+) -> None:
     """
     Attaches Core Provenence headers to an output HDF5 file.
     Right now this is hard-coded for use with the ctapipe-process tool
@@ -79,6 +86,10 @@ def write_reference_metadata_headers(
     data_levels: List[DataLevel]
         list of data levels that were requested/generated
         (e.g. from `DataWriter.datalevels`)
+    contact_info: meta.Contact
+        contact metadata
+    instrument_info: meta.Instrument
+        instrument metadata
     """
     activity = PROV.current_activity.provenance
     category = "Sim" if is_simulation else "Other"
@@ -101,14 +112,11 @@ def write_reference_metadata_headers(
             id_=",".join(str(x) for x in obs_ids),
         ),
         activity=meta.Activity.from_provenance(activity),
-        instrument=meta.Instrument(
-            site="Other",  # need a way to detect site...
-            class_="Subarray",
-            type_="unknown",
-            version="unknown",
-            id_=subarray.name,
-        ),
+        instrument=instrument_info,
     )
+
+    if reference.instrument.id_ == "unspecified":
+        reference.instrument.id_ = subarray.name
 
     headers = reference.to_dict()
     meta.write_to_hdf5(headers, writer.h5file)
@@ -133,6 +141,17 @@ class DataWriter(Component):
 
     # pylint: disable=too-many-instance-attributes
     contact_info = Instance(meta.Contact, kw={}).tag(config=True)
+    instrument_info = Instance(meta.Instrument, kw={}).tag(config=True)
+
+    context_metadata = Dict(
+        help=(
+            "Additional metadata keywords and values that describe this data. "
+            "This should be a dictionary where the keys will be appended to the "
+            "CONTEXT section of the output file's attributes. Keys can be hierarchical "
+            "by using a space between each level, e.g. `SIMULATION PRODUCTION` would make a key "
+            "PRODUCTION grouped under the key SIMULATION"
+        )
+    ).tag(config=True)
 
     output_path = Path(
         help="output filename", default_value=pathlib.Path("events.dl1.h5")
@@ -226,6 +245,7 @@ class DataWriter(Component):
 
         self.event_source = event_source
         self.contact_info = meta.Contact(parent=self)
+        self.instrument_info = meta.Instrument(parent=self)
 
         self._at_least_one_event = False
         self._is_simulation = event_source.is_simulation
@@ -306,7 +326,11 @@ class DataWriter(Component):
                 is_simulation=self._is_simulation,
                 data_levels=self.datalevels,
                 contact_info=self.contact_info,
+                instrument_info=self.instrument_info,
             )
+
+            self._write_context_metadata_headers()
+
             self._writer.close()
             self._writer = None
 
@@ -750,3 +774,23 @@ class DataWriter(Component):
                 )
 
         self._generate_table_indices(self._writer.h5file, "/dl1/event/subarray")
+
+    def _write_context_metadata_headers(self):
+        """write out any user-defined metadata in the context_metadata field to the
+        headers.
+
+        This will create a set of headers that start with CONTEXT <KEY> = value
+
+        Keys can be hierarchical separated by spaces
+
+        """
+
+        # first append CONTEXT to each key in the dict
+
+        context_dict = {}
+
+        for key, value in self.context_metadata.items():
+            key = " ".join(["CONTEXT", key])
+            context_dict[key] = value
+
+        meta.write_to_hdf5(context_dict, self._writer.h5file)

--- a/ctapipe/io/metadata.py
+++ b/ctapipe/io/metadata.py
@@ -55,7 +55,7 @@ CONVERSIONS = {Time: lambda t: t.utc.iso, list: str}
 
 
 class Contact(Configurable):
-    """ Contact information """
+    """Contact information"""
 
     name = Unicode("unknown").tag(config=True)
     email = Unicode("unknown").tag(config=True)
@@ -63,7 +63,7 @@ class Contact(Configurable):
 
     @default("name")
     def default_name(self):
-        """ if no name specified, use the system's user name"""
+        """if no name specified, use the system's user name"""
         try:
             return pwd.getpwuid(os.getuid()).pw_gecos
         except RuntimeError:
@@ -90,17 +90,17 @@ class Product(HasTraits):
     # pylint: disable=no-self-use
     @default("creation_time")
     def default_time(self):
-        """ return current time by default """
+        """return current time by default"""
         return Time.now().iso
 
     @default("id_")
     def default_product_id(self):
-        """ default id is a UUID """
+        """default id is a UUID"""
         return str(uuid.uuid4())
 
 
 class Process(HasTraits):
-    """ Process (top-level workflow) information """
+    """Process (top-level workflow) information"""
 
     type_ = Enum(["Observation", "Simulation", "Other"], "Other")
     subtype = Unicode("")
@@ -108,11 +108,11 @@ class Process(HasTraits):
 
 
 class Activity(HasTraits):
-    """ Activity (tool) information """
+    """Activity (tool) information"""
 
     @classmethod
     def from_provenance(cls, activity):
-        """ construct Activity metadata from existing ActivityProvenance object"""
+        """construct Activity metadata from existing ActivityProvenance object"""
         return Activity(
             name=activity["activity_name"],
             type_="software",
@@ -132,12 +132,12 @@ class Activity(HasTraits):
     # pylint: disable=no-self-use
     @default("start_time")
     def default_time(self):
-        """ default time is now """
+        """default time is now"""
         return Time.now().iso
 
 
-class Instrument(HasTraits):
-    """ Instrumental Context """
+class Instrument(Configurable):
+    """Instrumental Context"""
 
     site = Enum(
         [
@@ -155,7 +155,7 @@ class Instrument(HasTraits):
         "Other",
         help="Which site of CTA (or external telescope) "
         "this instrument is associated with",
-    )
+    ).tag(config=True)
     class_ = Enum(
         [
             "Array",
@@ -170,15 +170,21 @@ class Instrument(HasTraits):
             "Other",
         ],
         "Other",
-    )
-    type_ = Unicode("unspecified")
-    subtype = Unicode("unspecified")
-    version = Unicode("unspecified")
-    id_ = Unicode("unspecified")
+    ).tag(config=True)
+    type_ = Unicode("unspecified").tag(config=True)
+    subtype = Unicode("unspecified").tag(config=True)
+    version = Unicode("unspecified").tag(config=True)
+    id_ = Unicode("unspecified").tag(config=True)
+
+    def __repr__(self):
+        return (
+            f"Contact({self.site=}, {self.class_=}, {self.type_=}, "
+            f"{self.subtype=}, {self.version=}, {self.id_=})"
+        )
 
 
 def _to_dict(hastraits_instance, prefix=""):
-    """ helper to convert a HasTraits to a dict with keys
+    """helper to convert a HasTraits to a dict with keys
     in the required CTA format (upper-case, space separated)
     """
     res = {}
@@ -199,8 +205,8 @@ def _to_dict(hastraits_instance, prefix=""):
 
 
 class Reference(HasTraits):
-    """ All the reference Metadata required for a CTA output file, plus a way to turn
-    it into a dict() for easy addition to the header of a file """
+    """All the reference Metadata required for a CTA output file, plus a way to turn
+    it into a dict() for easy addition to the header of a file"""
 
     contact = Instance(Contact)
     product = Instance(Product)
@@ -225,7 +231,7 @@ class Reference(HasTraits):
         return meta
 
 
-def write_to_hdf5(metadata, h5file, path='/'):
+def write_to_hdf5(metadata, h5file, path="/"):
     """
     Write metadata fields to a PyTables HDF5 file handle.
 
@@ -246,7 +252,7 @@ def write_to_hdf5(metadata, h5file, path='/'):
             node._v_attrs[key] = value  # pylint: disable=protected-access
 
 
-def read_metadata(h5file, path='/'):
+def read_metadata(h5file, path="/"):
     """
     Read metadata from an hdf5 file
 

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -16,7 +16,7 @@ from ctapipe.utils import get_dataset_path
 
 
 def generate_dummy_dl2(event):
-    """ generate some dummy DL2 info and see if we can write it """
+    """generate some dummy DL2 info and see if we can write it"""
 
     algos = ["HillasReconstructor", "ImPACTReconstructor"]
 
@@ -242,7 +242,9 @@ def test_metadata(tmpdir: Path):
                     "name": "Maximilian Nöthe",
                     "email": "maximilian.noethe@tu-dortmund.de",
                     "organization": "TU Dortmund",
-                }
+                },
+                "Instrument": {"site": "CTA-North", "id_": "alpha"},
+                "context_metadata": {"EXAMPLE": "test_value"},
             }
         }
     )
@@ -264,6 +266,9 @@ def test_metadata(tmpdir: Path):
             assert meta["CTA CONTACT NAME"] == "Maximilian Nöthe"
             assert meta["CTA CONTACT EMAIL"] == "maximilian.noethe@tu-dortmund.de"
             assert meta["CTA CONTACT ORGANIZATION"] == "TU Dortmund"
+            assert meta["CTA INSTRUMENT SITE"] == "CTA-North"
+            assert meta["CTA INSTRUMENT ID"] == "alpha"
+            assert meta["CONTEXT EXAMPLE"] == "test_value"
 
 
 def test_write_only_r1(r1_hdf5_file):

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -14,6 +14,7 @@ from ..io import DataLevel, DataWriter, EventSource, SimTelEventSource, write_ta
 from ..io.datawriter import DATA_MODEL_VERSION
 from ..reco import ShowerProcessor
 from ..utils import EventTypeFilter
+from ..io import metadata
 
 
 COMPATIBLE_DATALEVELS = [
@@ -134,7 +135,14 @@ class ProcessorTool(Tool):
     }
 
     classes = (
-        [CameraCalibrator, DataWriter, ImageProcessor, ShowerProcessor]
+        [
+            CameraCalibrator,
+            DataWriter,
+            ImageProcessor,
+            ShowerProcessor,
+            metadata.Instrument,
+            metadata.Contact,
+        ]
         + classes_with_traits(EventSource)
         + classes_with_traits(ImageCleaner)
         + classes_with_traits(ImageExtractor)
@@ -184,7 +192,7 @@ class ProcessorTool(Tool):
 
     @property
     def should_compute_dl2(self):
-        """ returns true if we should compute DL2 info """
+        """returns true if we should compute DL2 info"""
         if self.force_recompute_dl2:
             return True
         return self.write.write_stereo_shower or self.write.write_mono_shower
@@ -281,7 +289,7 @@ class ProcessorTool(Tool):
 
 
 def main():
-    """ run the tool"""
+    """run the tool"""
     tool = ProcessorTool()
     tool.run()
 


### PR DESCRIPTION
## use case:

The user expects that the metadata in the output file's header is useful, for example to build a file catalog necessary to retrieve the data later.

## what this PR adds:

Part of the reference metadata was already configurable (the Contact info), this adds two additional user-configurable  parts: 
- the `Instrument` metadata (not to be confused with the InstrumentDescription, this is just id information about the instrument, in this case the subarray used). This lets the user set the subarray name, version, and other instrument-related attributes.  If they are not specified, they are automatically filled as before (or left unspecified)
- `CONTEXT` metadata, which is fully user-defined and allows an additional set of context-specific headers to be added as key-value pairs.

## changes

- Added user-defined CONTEXT metadata, which can be added to the config
file
- Made `metadata.Instrument` a configurable class similar to
`metadata.Contact` so values can be overridden in config files

The result is one can create a config file for a subarray definition like:

```yaml
EventSource:
  allowed_tels: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 19, 35]

DataWriter:
  Instrument:  # this is the new configurable info
    site: CTA-North
    class_: Subarray
    id_: alpha
    version: Prod5b
```
And that information will be written to the file's reference headers:

```sh
ctapipe-fileinfo output.h5
...
        INSTRUMENT:
            CLASS: Subarray
            ID: alpha
            SITE: CTA-North
            SUBTYPE: unspecified
            TYPE: unspecified
            VERSION: Prod5b
...
```

Similarly the arbitrary CONTEXT metadata can be  set as follows:

```yaml
DataWriter:
  context_metadata:
    "SIMULATION PRODUCTION": prod5b
    "SIMULATION DATASET":  Prod5b_Paranal_AdvancedBaseline_NSB1x_South_40deg
    "DESCRIPTION": "This is just a test"
```
Using spaces between keys allows a hierarchy (we could also support dots or similar)

```
ctapipe-fileinfo output.h5
...
    CONTEXT:
        DESCRIPTION: This is just a test
        SIMULATION:
            DATASET: Prod5b_Paranal_AdvancedBaseline_NSB1x_South_40deg
            PRODUCTION: prod5b
...
```
This is useful for example for storing parameters that are not automatically read from the MC files into the `SimulationConfigContainer` , or for storing things like calibration versions, etc.

## Still todo:
- [x] make tests
## issues
-  due to how the config system works, you cannot "chain" context metadata, meaning if you specify it in two included config files, the latter one fully replaces the former's dictionary, rather than adding to it.
- the `id_` and `class_` attributes have underscores to avoid linter/IDE complaints about python name conflicts (even if they do not conflict).  This is a bit ugly, could consider removing them and just deal with complaints 