### PR TITLE
Store true_image_sum also when true image is not written

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -494,7 +494,7 @@ class SimulatedCameraContainer(Container):
     container_prefix = ""
 
     true_image_sum = Field(
-        np.nan, "Sum of the detected Cherenkov photons in the camera"
+        np.int32(-1), "Total number of detected Cherenkov photons in the camera"
     )
     true_image = Field(
         None,

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -76,6 +76,8 @@ def read_table(
         # methods
         path = os.path.join("/", path)
         table = h5file.get_node(path)
+        if not isinstance(table, tables.Table):
+            raise IOError(f"Node {path} is a {table.__class__.__name__}, must be a Table")
         transforms, descriptions, meta = _parse_hdf5_attrs(table)
 
         if condition is None:

--- a/ctapipe/tools/tests/test_merge.py
+++ b/ctapipe/tools/tests/test_merge.py
@@ -97,12 +97,17 @@ def test_skip_images(tmp_path, dl1_file, dl1_proton_file):
         ],
         cwd=tmp_path,
     )
+    assert ret == 0
 
     with tables.open_file(output, "r") as f:
         assert "images" not in f.root.dl1.event.telescope
+        assert "images" in f.root.simulation.event.telescope
         assert "parameters" in f.root.dl1.event.telescope
 
-    assert ret == 0
+    t = read_table(output, "/simulation/event/telescope/images/tel_001")
+    assert "true_image" not in t.colnames
+    assert "true_image_sum" in t.colnames
+
 
 
 def test_allowed_tels(tmp_path, dl1_file, dl1_proton_file):

--- a/ctapipe/utils/arrays.py
+++ b/ctapipe/utils/arrays.py
@@ -1,13 +1,16 @@
+'''
+Some utility functions to work with numpy (rec) arrays
+'''
 import numpy as np
 from numpy.lib.recfunctions import repack_fields
 
 
-def recarray_drop_columns(a, columns):
+def recarray_drop_columns(array, columns):
     '''
     Remove columns from rec array
     '''
-    to_use = [col for col in a.dtype.names if col not in columns]
-    subset = a.view(subset_dtype(a.dtype, to_use))
+    to_use = [col for col in array.dtype.names if col not in columns]
+    subset = array.view(subset_dtype(array.dtype, to_use))
     return repack_fields(subset)
 
 

--- a/ctapipe/utils/arrays.py
+++ b/ctapipe/utils/arrays.py
@@ -1,0 +1,26 @@
+import numpy as np
+from numpy.lib.recfunctions import repack_fields
+
+
+def recarray_drop_columns(a, columns):
+    '''
+    Remove columns from rec array
+    '''
+    to_use = [col for col in a.dtype.names if col not in columns]
+    subset = a.view(subset_dtype(a.dtype, to_use))
+    return repack_fields(subset)
+
+
+def subset_dtype(dtype, names):
+    '''
+    Create a new dtype only containing a subset of the columns
+    '''
+    formats = [dtype.fields[name][0] for name in names]
+    offsets = [dtype.fields[name][1] for name in names]
+    itemsize = dtype.itemsize
+    return np.dtype(dict(
+        names=names,
+        formats=formats,
+        offsets=offsets,
+        itemsize=itemsize
+    ))

--- a/ctapipe/utils/tests/test_arrays.py
+++ b/ctapipe/utils/tests/test_arrays.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+
+def test_drop_columns():
+    from ctapipe.utils.arrays import recarray_drop_columns
+    array = np.empty(
+        1000,
+        dtype=[
+            ('x', float),
+            ('N', int),
+            ('valid', bool),
+            ('tel_id', np.uint16)
+        ]
+    )
+    assert array.dtype.itemsize == 19
+
+    dropped = recarray_drop_columns(array, columns=['N', 'tel_id'])
+    assert dropped.dtype.names == ('x', 'valid')
+    assert dropped.dtype.itemsize == 9

--- a/ctapipe/utils/tests/test_arrays.py
+++ b/ctapipe/utils/tests/test_arrays.py
@@ -1,19 +1,16 @@
+"""Tests for the array utils"""
 import numpy as np
 
 
 def test_drop_columns():
+    """Test drop columns"""
     from ctapipe.utils.arrays import recarray_drop_columns
+
     array = np.empty(
-        1000,
-        dtype=[
-            ('x', float),
-            ('N', int),
-            ('valid', bool),
-            ('tel_id', np.uint16)
-        ]
+        1000, dtype=[("x", float), ("N", int), ("valid", bool), ("tel_id", np.uint16)]
     )
     assert array.dtype.itemsize == 19
 
-    dropped = recarray_drop_columns(array, columns=['N', 'tel_id'])
-    assert dropped.dtype.names == ('x', 'valid')
+    dropped = recarray_drop_columns(array, columns=["N", "tel_id"])
+    assert dropped.dtype.names == ("x", "valid")
     assert dropped.dtype.itemsize == 9


### PR DESCRIPTION
This will also keep the true_image_sum in the merge tool, even when `--skip-images` is given.

Fixes #1891 