### PR TITLE
compute impact distance to shower axis

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -176,7 +176,7 @@ def dl2_shower_geometry_file(dl2_tmp_path, prod5_gamma_simtel_path):
             f"--input={prod5_gamma_simtel_path}",
             f"--output={output}",
             "--write-images",
-            "--write-stereo-shower",
+            "--write-showers",
             "--max-events=20",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
@@ -202,7 +202,7 @@ def dl2_proton_geometry_file(dl2_tmp_path, prod5_proton_simtel_path):
             f"--input={prod5_proton_simtel_path}",
             f"--output={output}",
             "--write-images",
-            "--write-stereo-shower",
+            "--write-showers",
             "--max-events=20",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
@@ -228,7 +228,7 @@ def dl2_shower_geometry_file_type(dl2_tmp_path, prod5_gamma_simtel_path):
             f"--input={prod5_gamma_simtel_path}",
             f"--output={output}",
             "--write-images",
-            "--write-stereo-shower",
+            "--write-showers",
             "--max-events=20",
             "--DataWriter.split_datasets_by=tel_type",
         ]

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -508,6 +508,10 @@ class SimulatedCameraContainer(Container):
         None, "Parameters derived from the true_image", type=ImageParametersContainer
     )
 
+    true_impact_distance = Field(
+        nan * u.m, "Distance from shower axis to telescope position", unit=u.m
+    )
+
 
 class SimulatedEventContainer(Container):
     shower = Field(SimulatedShowerContainer(), "True event information")

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -92,7 +92,7 @@ class EventType(enum.Enum):
 
 
 class EventIndexContainer(Container):
-    """ index columns to include in event lists, common to all data levels"""
+    """index columns to include in event lists, common to all data levels"""
 
     container_prefix = ""  # don't want to prefix these
     obs_id = Field(0, "observation identifier")
@@ -251,7 +251,7 @@ class TimingParametersContainer(BaseTimingParametersContainer):
 
 
 class MorphologyContainer(Container):
-    """ Parameters related to pixels surviving image cleaning """
+    """Parameters related to pixels surviving image cleaning"""
 
     num_pixels = Field(-1, "Number of usable pixels")
     num_islands = Field(-1, "Number of distinct islands in the image")
@@ -287,7 +287,7 @@ class CoreParametersContainer(Container):
 
 
 class ImageParametersContainer(Container):
-    """ Collection of image parameters """
+    """Collection of image parameters"""
 
     container_prefix = "params"
     hillas = Field(
@@ -353,7 +353,7 @@ class DL1CameraContainer(Container):
 
 
 class DL1Container(Container):
-    """ DL1 Calibrated Camera Images and associated data"""
+    """DL1 Calibrated Camera Images and associated data"""
 
     tel = Field(Map(DL1CameraContainer), "map of tel_id to DL1CameraContainer")
 
@@ -475,7 +475,7 @@ class SimulatedShowerContainer(Container):
     core_y = Field(nan * u.m, "Simulated core position (y)", unit=u.m)
     h_first_int = Field(nan * u.m, "Height of first interaction", unit=u.m)
     x_max = Field(
-        nan * u.g / (u.cm ** 2), "Simulated Xmax value", unit=u.g / (u.cm ** 2)
+        nan * u.g / (u.cm**2), "Simulated Xmax value", unit=u.g / (u.cm**2)
     )
     shower_primary_id = Field(
         -1,
@@ -606,37 +606,33 @@ class ReconstructedGeometryContainer(Container):
         nan * u.m, "reconstructed x coordinate of the core position", unit=u.m
     )
     core_y = Field(
-        nan * u.m,
-        "reconstructed y coordinate of the core position",
-        unit=u.m
+        nan * u.m, "reconstructed y coordinate of the core position", unit=u.m
     )
     core_uncert_x = Field(
         nan * u.m,
         "reconstructed core position uncertainty along ground frame X axis",
-        unit=u.m
+        unit=u.m,
     )
     core_uncert_y = Field(
         nan * u.m,
         "reconstructed core position uncertainty along ground frame Y axis",
-        unit=u.m
+        unit=u.m,
     )
     core_tilted_x = Field(
         nan * u.m, "reconstructed x coordinate of the core position", unit=u.m
     )
     core_tilted_y = Field(
-        nan * u.m,
-        "reconstructed y coordinate of the core position",
-        unit=u.m
+        nan * u.m, "reconstructed y coordinate of the core position", unit=u.m
     )
     core_tilted_uncert_x = Field(
         nan * u.m,
         "reconstructed core position uncertainty along tilted frame X axis",
-        unit=u.m
+        unit=u.m,
     )
     core_tilted_uncert_y = Field(
         nan * u.m,
         "reconstructed core position uncertainty along tilted frame Y axis",
-        unit=u.m
+        unit=u.m,
     )
     h_max = Field(nan * u.m, "reconstructed height of the shower maximum", unit=u.m)
     h_max_uncert = Field(nan * u.m, "uncertainty of h_max", unit=u.m)
@@ -699,8 +695,21 @@ class ParticleClassificationContainer(Container):
     tel_ids = Field(None, "list of tel_ids used if stereo, or None if Mono")
 
 
+class TelescopeImpactParameterContainer(Container):
+    """
+    Impact Parameter computed from reconstructed shower geometry
+    """
+
+    container_prefix = "impact"
+
+    distance = Field(
+        nan * u.m, "distance of the telescope to the shower axis", unit=u.m
+    )
+    distance_uncert = Field(nan * u.m, "uncertainty in impact_parameter", unit=u.m)
+
+
 class ReconstructedContainer(Container):
-    """ Reconstructed shower info from multiple algorithms """
+    """Reconstructed shower info from multiple algorithms"""
 
     # Note: there is a reason why the hiererchy is
     # `event.dl2.stereo.geometry[algorithm]` and not
@@ -724,6 +733,15 @@ class ReconstructedContainer(Container):
     )
 
 
+class TelescopeReconstructedContainer(ReconstructedContainer):
+    """Telescope-wise reconstructed quantities"""
+
+    impact = Field(
+        Map(TelescopeImpactParameterContainer),
+        "map of algorithm to impact parameter info",
+    )
+
+
 class DL2Container(Container):
     """Reconstructed Shower information for a given reconstruction algorithm,
     including optionally both per-telescope mono reconstruction and per-shower
@@ -731,7 +749,7 @@ class DL2Container(Container):
     """
 
     tel = Field(
-        Map(ReconstructedContainer),
+        Map(TelescopeReconstructedContainer),
         "map of tel_id to single-telescope reconstruction (DL2a)",
     )
     stereo = Field(ReconstructedContainer(), "Stereo Shower reconstruction results")
@@ -1005,7 +1023,7 @@ class SimulatedShowerDistribution(Container):
 
 
 class ArrayEventContainer(Container):
-    """ Top-level container for all event information """
+    """Top-level container for all event information"""
 
     index = Field(EventIndexContainer(), "event indexing information")
     r0 = Field(R0Container(), "Raw Data")

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -466,6 +466,19 @@ class DL0Container(Container):
     tel = Field(Map(DL0CameraContainer), "map of tel_id to DL0CameraContainer")
 
 
+class TelescopeImpactParameterContainer(Container):
+    """
+    Impact Parameter computed from reconstructed shower geometry
+    """
+
+    container_prefix = "impact"
+
+    distance = Field(
+        nan * u.m, "distance of the telescope to the shower axis", unit=u.m
+    )
+    distance_uncert = Field(nan * u.m, "uncertainty in impact_parameter", unit=u.m)
+
+
 class SimulatedShowerContainer(Container):
     container_prefix = "true"
     energy = Field(nan * u.TeV, "Simulated Energy", unit=u.TeV)
@@ -508,9 +521,7 @@ class SimulatedCameraContainer(Container):
         None, "Parameters derived from the true_image", type=ImageParametersContainer
     )
 
-    true_impact_distance = Field(
-        nan * u.m, "Distance from shower axis to telescope position", unit=u.m
-    )
+    impact = Field(TelescopeImpactParameterContainer(), "true impact parameter")
 
 
 class SimulatedEventContainer(Container):
@@ -697,19 +708,6 @@ class ParticleClassificationContainer(Container):
     is_valid = Field(False, "true if classification parameters are valid")
     goodness_of_fit = Field(nan, "goodness of the algorithm fit")
     tel_ids = Field(None, "list of tel_ids used if stereo, or None if Mono")
-
-
-class TelescopeImpactParameterContainer(Container):
-    """
-    Impact Parameter computed from reconstructed shower geometry
-    """
-
-    container_prefix = "impact"
-
-    distance = Field(
-        nan * u.m, "distance of the telescope to the shower axis", unit=u.m
-    )
-    distance_uncert = Field(nan * u.m, "uncertainty in impact_parameter", unit=u.m)
 
 
 class ReconstructedContainer(Container):

--- a/ctapipe/coordinates/__init__.py
+++ b/ctapipe/coordinates/__init__.py
@@ -1,11 +1,15 @@
 """
 Coordinates.
 """
+
+import numpy as np
+
 from astropy.coordinates import (
     AltAz,
     FunctionTransformWithFiniteDifference,
     CIRS,
     frame_transform_graph,
+    spherical_to_cartesian,
 )
 import warnings
 from .telescope_frame import TelescopeFrame
@@ -29,6 +33,7 @@ __all__ = [
     "EastingNorthingFrame",
     "MissingFrameAttributeWarning",
     "project_to_ground",
+    "altaz_to_righthanded_cartesian",
 ]
 
 
@@ -65,3 +70,19 @@ def altaz_to_altaz(from_coo, to_frame):
         return to_frame.realize_frame(from_coo.spherical)
 
     return from_coo.transform_to(CIRS(obstime=obstime)).transform_to(to_frame)
+
+
+def altaz_to_righthanded_cartesian(alt, az):
+    """Turns an alt/az coordinate into a 3d direction in a right-handed coordinate
+    system.  This is because azimuths are in a left-handed system.
+
+    See e.g: https://github.com/astropy/astropy/issues/5300
+
+    Parameters
+    ----------
+    alt: u.Quantity
+        altitude
+    az: u.Quantity
+        azimuth
+    """
+    return np.array(spherical_to_cartesian(r=1, lat=alt, lon=-az))

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -9,6 +9,9 @@ location = EarthLocation.of_site("Roque de los Muchachos")
 
 
 def test_altaz_to_righthanded_cartesian():
+    """
+    check the handedness of the transform
+    """
 
     vec = altaz_to_righthanded_cartesian(alt=0 * u.deg, az=90 * u.deg)
     assert np.allclose(vec, [0, -1, 0])

--- a/ctapipe/coordinates/tests/test_coordinates.py
+++ b/ctapipe/coordinates/tests/test_coordinates.py
@@ -3,8 +3,15 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord, EarthLocation, AltAz
 from astropy.time import Time
 from pytest import approx, raises
+from ctapipe.coordinates import altaz_to_righthanded_cartesian
 
 location = EarthLocation.of_site("Roque de los Muchachos")
+
+
+def test_altaz_to_righthanded_cartesian():
+
+    vec = altaz_to_righthanded_cartesian(alt=0 * u.deg, az=90 * u.deg)
+    assert np.allclose(vec, [0, -1, 0])
 
 
 def test_cam_to_nominal():

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -438,6 +438,7 @@ class DataWriter(Component):
 
         if self._is_simulation:
             writer.exclude("/simulation/event/telescope/images/.*", "true_parameters")
+            writer.exclude("/simulation/event/telescope/images/.*", "impact")
             # no timing information yet for true images
             writer.exclude("/simulation/event/telescope/parameters/.*", r"peak_time_.*")
             writer.exclude("/simulation/event/telescope/parameters/.*", "timing_.*")

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -625,26 +625,26 @@ class DataWriter(Component):
             )
 
             if self.write_parameters:
+
                 writer.write(
                     table_name=f"dl1/event/telescope/parameters/{table_name}",
                     containers=[tel_index, *dl1_camera.parameters.values()],
                 )
 
-                if has_sim_camera:
+                if self._is_simulation:
+                    sim_containers = [
+                        tel_index,
+                        event.simulation.tel[tel_id].impact,
+                    ]
+
+                    if has_sim_camera:
+                        sim_containers.extend(
+                            event.simulation.tel[tel_id].true_parameters.values()
+                        )
+
                     writer.write(
                         f"simulation/event/telescope/parameters/{table_name}",
-                        [
-                            tel_index,
-                            *event.simulation.tel[tel_id].true_parameters.values(),
-                        ],
-                    )
-                if self._is_simulation:
-                    writer.write(
-                        f"simulation/event/telescope/impact/{table_name}",
-                        [
-                            tel_index,
-                            event.simulation.tel[tel_id].impact,
-                        ],
+                        sim_containers,
                     )
 
             if self.write_images:

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -154,12 +154,8 @@ class DataWriter(Component):
         help="Store DL1 image parameters if available", default_value=True
     ).tag(config=True)
 
-    write_stereo_shower = Bool(
+    write_showers = Bool(
         help="Store DL2 stereo shower parameters if available", default_value=False
-    ).tag(config=True)
-
-    write_mono_shower = Bool(
-        help="Store DL2 mono parameters if available", default_value=False
     ).tag(config=True)
 
     compression_level = Int(
@@ -284,10 +280,8 @@ class DataWriter(Component):
         self._write_dl1_telescope_events(self._writer, event)
 
         # write DL2 info if requested
-        if self.write_mono_shower:
+        if self.write_showers:
             self._write_dl2_telescope_events(self._writer, event)
-
-        if self.write_stereo_shower:
             self._write_dl2_stereo_event(self._writer, event)
 
     def finish(self):
@@ -318,7 +312,7 @@ class DataWriter(Component):
             data_levels.append(DataLevel.DL1_IMAGES)
         if self.write_parameters:
             data_levels.append(DataLevel.DL1_PARAMETERS)
-        if self.write_stereo_shower or self.write_mono_shower:
+        if self.write_showers:
             data_levels.append(DataLevel.DL2)
         if self.write_raw_waveforms:
             data_levels.append(DataLevel.R0)
@@ -357,8 +351,7 @@ class DataWriter(Component):
         writable_things = [
             self.write_parameters,
             self.write_images,
-            self.write_mono_shower,
-            self.write_stereo_shower,
+            self.write_showers,
             self.write_waveforms,
             self.write_parameters,
         ]

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -645,6 +645,13 @@ class DataWriter(Component):
                             *event.simulation.tel[tel_id].true_parameters.values(),
                         ],
                     )
+                    writer.write(
+                        f"simulation/event/telescope/impact/{table_name}",
+                        [
+                            tel_index,
+                            event.simulation.tel[tel_id].impact,
+                        ],
+                    )
 
             if self.write_images:
                 if dl1_camera.image is None:

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -638,6 +638,7 @@ class DataWriter(Component):
                             *event.simulation.tel[tel_id].true_parameters.values(),
                         ],
                     )
+                if self._is_simulation:
                     writer.write(
                         f"simulation/event/telescope/impact/{table_name}",
                         [

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -624,27 +624,25 @@ class DataWriter(Component):
                 and event.simulation.tel[tel_id].true_image is not None
             )
 
-            if self.write_parameters:
+            if event.simulation is not None:
+                writer.write(
+                    f"simulation/event/telescope/impact/{table_name}",
+                    [tel_index, event.simulation.tel[tel_id].impact],
+                )
 
+            if self.write_parameters:
                 writer.write(
                     table_name=f"dl1/event/telescope/parameters/{table_name}",
                     containers=[tel_index, *dl1_camera.parameters.values()],
                 )
 
-                if self._is_simulation:
-                    sim_containers = [
-                        tel_index,
-                        event.simulation.tel[tel_id].impact,
-                    ]
-
-                    if has_sim_camera:
-                        sim_containers.extend(
-                            event.simulation.tel[tel_id].true_parameters.values()
-                        )
-
+                if has_sim_camera:
                     writer.write(
                         f"simulation/event/telescope/parameters/{table_name}",
-                        sim_containers,
+                        [
+                            tel_index,
+                            *event.simulation.tel[tel_id].true_parameters.values()
+                        ]
                     )
 
             if self.write_images:

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -270,6 +270,14 @@ class DataWriter(Component):
                 containers=[event.index, event.simulation.shower],
             )
 
+            for tel_id, sim in event.simulation.tel.items():
+                table_name = self.table_name(tel_id, self._subarray.tel[tel_id])
+                tel_index = _get_tel_index(event, tel_id)
+                self._writer.write(
+                    f"simulation/event/telescope/impact/{table_name}",
+                    [tel_index, sim.impact],
+                )
+
         if self.write_waveforms:
             self._write_r1_telescope_events(self._writer, event)
 
@@ -556,11 +564,7 @@ class DataWriter(Component):
     ):
         for tel_id, r1_tel in event.r1.tel.items():
 
-            tel_index = TelEventIndexContainer(
-                obs_id=event.index.obs_id,
-                event_id=event.index.event_id,
-                tel_id=np.int16(tel_id),
-            )
+            tel_index = _get_tel_index(event, tel_id)
             telescope = self._subarray.tel[tel_id]
             table_name = self.table_name(tel_id, str(telescope))
 
@@ -572,11 +576,7 @@ class DataWriter(Component):
     ):
         for tel_id, r0_tel in event.r0.tel.items():
 
-            tel_index = TelEventIndexContainer(
-                obs_id=event.index.obs_id,
-                event_id=event.index.event_id,
-                tel_id=np.int16(tel_id),
-            )
+            tel_index = _get_tel_index(event, tel_id)
             telescope = self._subarray.tel[tel_id]
             table_name = self.table_name(tel_id, str(telescope))
 
@@ -623,12 +623,6 @@ class DataWriter(Component):
                 tel_id in event.simulation.tel
                 and event.simulation.tel[tel_id].true_image is not None
             )
-
-            if event.simulation is not None:
-                writer.write(
-                    f"simulation/event/telescope/impact/{table_name}",
-                    [tel_index, event.simulation.tel[tel_id].impact],
-                )
 
             if self.write_parameters:
                 writer.write(
@@ -680,12 +674,7 @@ class DataWriter(Component):
             telescope = self._subarray.tel[tel_id]
             table_name = self.table_name(tel_id, str(telescope))
 
-            tel_index = TelEventIndexContainer(
-                obs_id=event.index.obs_id,
-                event_id=event.index.event_id,
-                tel_id=np.int16(tel_id),
-            )
-
+            tel_index = _get_tel_index(event, tel_id)
             for container_name, algorithm_map in dl2_tel.items():
                 for algorithm, container in algorithm_map.items():
                     name = (

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -463,33 +463,23 @@ class SimTelEventSource(EventSource):
                 )
 
                 if data.simulation is not None:
+                    if data.simulation.shower is not None:
+                        impact_container = TelescopeImpactParameterContainer(
+                            distance=impact_distances[self.subarray.tel_index_array[tel_id]],
+                            distance_uncert=0 * u.m,
+                        )
+                    else:
+                        impact_container = TelescopeImpactParameterContainer()
+
+                    impact_container.prefix = "true_impact"
+
                     data.simulation.tel[tel_id] = SimulatedCameraContainer(
                         true_image_sum=true_image_sums[
                             self.telescope_indices_original[tel_id]
                         ],
                         true_image=true_image,
-                        true_impact_distance=impact_distances[
-                            self.subarray.tel_index_array[tel_id]
-                        ],
+                        impact=impact_container,
                     )
-
-                if data.simulation.shower is not None:
-                    impact_container = TelescopeImpactParameterContainer(
-                        distance=impact_distances[self.subarray.tel_index_array[tel_id]],
-                        distance_uncert=0 * u.m,
-                    )
-                else:
-                    impact_container = TelescopeImpactParameterContainer()
-
-                impact_container.prefix = "true_impact"
-
-                data.simulation.tel[tel_id] = SimulatedCameraContainer(
-                    true_image_sum=true_image_sums[
-                        self.telescope_indices_original[tel_id]
-                    ],
-                    true_image=true_image,
-                    impact=impact_container,
-                )
 
                 data.pointing.tel[tel_id] = self._fill_event_pointing(
                     tracking_positions[tel_id]

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -18,6 +18,7 @@ from ..containers import (
     SimulatedEventContainer,
     SimulatedShowerContainer,
     SimulationConfigContainer,
+    TelescopeImpactParameterContainer,
     TelescopePointingContainer,
     TelescopeTriggerContainer,
 )
@@ -471,6 +472,24 @@ class SimTelEventSource(EventSource):
                             self.subarray.tel_index_array[tel_id]
                         ],
                     )
+
+                if data.simulation.shower is not None:
+                    impact_container = TelescopeImpactParameterContainer(
+                        distance=impact_distances[self.subarray.tel_index_array[tel_id]],
+                        distance_uncert=0 * u.m,
+                    )
+                else:
+                    impact_container = TelescopeImpactParameterContainer()
+
+                impact_container.prefix = "true_impact"
+
+                data.simulation.tel[tel_id] = SimulatedCameraContainer(
+                    true_image_sum=true_image_sums[
+                        self.telescope_indices_original[tel_id]
+                    ],
+                    true_image=true_image,
+                    impact=impact_container,
+                )
 
                 data.pointing.tel[tel_id] = self._fill_event_pointing(
                     tracking_positions[tel_id]

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -20,10 +20,12 @@ __all__ = ["TableLoader"]
 
 PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"
+GEOMETRY_GROUP = "/dl2/event/subarray/geometry"
 TRIGGER_TABLE = "/dl1/event/subarray/trigger"
 SHOWER_TABLE = "/simulation/event/subarray/shower"
 TRUE_IMAGES_GROUP = "/simulation/event/telescope/images"
 TRUE_PARAMETERS_GROUP = "/simulation/event/telescope/parameters"
+TRUE_IMPACT_GROUP = "/simulation/event/telescope/impact"
 
 DL2_SUBARRAY_GROUP = "/dl2/event/subarray"
 DL2_TELESCOPE_GROUP = "/dl2/event/telescope"
@@ -314,6 +316,10 @@ class TableLoader(Component):
             table = join_allow_empty(
                 table, self.instrument_table, keys=["tel_id"], join_type="left"
             )
+
+        if self.load_simulated and TRUE_IMPACT_GROUP in self.h5file.root:
+            impacts = self._read_telescope_table(TRUE_IMPACT_GROUP, tel_id)
+            table = _join_telescope_events(table, impacts)
 
         return table
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -20,7 +20,6 @@ __all__ = ["TableLoader"]
 
 PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"
-GEOMETRY_GROUP = "/dl2/event/subarray/geometry"
 TRIGGER_TABLE = "/dl1/event/subarray/trigger"
 SHOWER_TABLE = "/simulation/event/subarray/shower"
 TRUE_IMAGES_GROUP = "/simulation/event/telescope/images"

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -154,7 +154,6 @@ class TableLoader(Component):
         if h5file is None and self.input_url is None:
             raise ValueError("Need to specify either input_url or h5file")
 
-        self._should_close = False
         if h5file is None:
             self.h5file = tables.open_file(self.input_url, mode="r")
             self._should_close = True

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -285,7 +285,8 @@ class TableLoader(Component):
 
         if self.load_dl2:
             if DL2_TELESCOPE_GROUP in self.h5file:
-                for group_name in self.h5file[DL2_TELESCOPE_GROUP]._v_children:
+                dl2_tel_group = self.h5file.root[DL2_TELESCOPE_GROUP]
+                for group_name in dl2_tel_group._v_children:
                     group_path = f"{DL2_TELESCOPE_GROUP}/{group_name}"
                     group = self.h5file.root[group_path]
 

--- a/ctapipe/io/tests/conftest.py
+++ b/ctapipe/io/tests/conftest.py
@@ -21,8 +21,7 @@ def r1_hdf5_file(prod5_proton_simtel_path, r1_path):
         output_path=path,
         write_parameters=False,
         write_images=False,
-        write_stereo_shower=False,
-        write_mono_shower=False,
+        write_showers=False,
         write_raw_waveforms=False,
         write_waveforms=True,
     )

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -16,7 +16,7 @@ from ctapipe.utils import get_dataset_path
 
 
 def generate_dummy_dl2(event):
-    """ generate some dummy DL2 info and see if we can write it """
+    """generate some dummy DL2 info and see if we can write it"""
 
     algos = ["HillasReconstructor", "ImPACTReconstructor"]
 
@@ -60,8 +60,7 @@ def test_write(tmpdir: Path):
         output_path=output_path,
         write_parameters=False,
         write_images=True,
-        write_stereo_shower=True,
-        write_mono_shower=True,
+        write_showers=True,
         write_raw_waveforms=True,
         write_waveforms=True,
     ) as writer:
@@ -149,8 +148,7 @@ def test_roundtrip(tmpdir: Path):
         transform_peak_time=True,
         peak_time_dtype="int16",
         peak_time_scale=100,
-        write_stereo_shower=True,
-        write_mono_shower=True,
+        write_showers=True,
     ) as write:
         write.log.level = logging.DEBUG
         for event in source:

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -150,7 +150,7 @@ def test_read_telescope_events_type(test_file_dl2):
         assert "HillasReconstructor_alt" in table.colnames
         assert "true_energy" in table.colnames
         assert "true_image" in table.colnames
-        assert set(table["tel_id"].data).issubset([25, 125, 130])
+        assert {25, 125, 127}.issubset(set(table["tel_id"].data))
         assert "equivalent_focal_length" in table.colnames
 
 

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -83,6 +83,7 @@ def test_load_simulated(test_file):
 
         table = table_loader.read_telescope_events([25])
         assert "true_energy" in table.colnames
+        assert "true_impact_distance" in table.colnames
 
 
 def test_true_images(test_file):
@@ -152,6 +153,7 @@ def test_read_telescope_events_type(test_file_dl2):
         assert "true_image" in table.colnames
         assert {25, 125, 127}.issubset(set(table["tel_id"].data))
         assert "equivalent_focal_length" in table.colnames
+        assert "HillasReconstructor_impact_distance" in table.colnames
 
 
 def test_read_telescope_events_by_type(test_file_dl2):

--- a/ctapipe/reco/__init__.py
+++ b/ctapipe/reco/__init__.py
@@ -9,9 +9,10 @@ from .hillas_intersection import HillasIntersection
 from .shower_processor import ShowerProcessor
 from .impact import ImPACTReconstructor
 
-
-__all__ = ["Reconstructor",
-           "ShowerProcessor",
-           "HillasReconstructor",
-           "ImPACTReconstructor",
-           "HillasIntersection"]
+__all__ = [
+    "Reconstructor",
+    "ShowerProcessor",
+    "HillasReconstructor",
+    "ImPACTReconstructor",
+    "HillasIntersection",
+]

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -138,8 +138,8 @@ class HillasPlane:
 
         # astropy's coordinates system rotates counter clockwise. Apparently we assume it to
         # be clockwise
-        self.a = np.array(altaz_to_righthanded_cartesian(alt=p1.alt, az=p1.az)).ravel()
-        self.b = np.array(altaz_to_righthanded_cartesian(alt=p2.alt, az=p2.az)).ravel()
+        self.a = altaz_to_righthanded_cartesian(alt=p1.alt, az=p1.az)
+        self.b = altaz_to_righthanded_cartesian(alt=p2.alt, az=p2.az)
 
         # a and c form an orthogonal basis for the great circle
         # not really necessary since the norm can be calculated

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -21,11 +21,11 @@ from ctapipe.coordinates import (
     TiltedGroundFrame,
     project_to_ground,
     MissingFrameAttributeWarning,
+    altaz_to_righthanded_cartesian,
 )
 from astropy.coordinates import (
     SkyCoord,
     AltAz,
-    spherical_to_cartesian,
     cartesian_to_spherical,
 )
 import warnings
@@ -138,8 +138,8 @@ class HillasPlane:
 
         # astropy's coordinates system rotates counter clockwise. Apparently we assume it to
         # be clockwise
-        self.a = np.array(spherical_to_cartesian(1, p1.alt, -p1.az)).ravel()
-        self.b = np.array(spherical_to_cartesian(1, p2.alt, -p2.az)).ravel()
+        self.a = np.array(altaz_to_righthanded_cartesian(alt=p1.alt, az=p1.az)).ravel()
+        self.b = np.array(altaz_to_righthanded_cartesian(alt=p2.alt, az=p2.az)).ravel()
 
         # a and c form an orthogonal basis for the great circle
         # not really necessary since the norm can be calculated

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -8,7 +8,7 @@ from ..containers import ReconstructedGeometryContainer
 from ..coordinates import GroundFrame, TiltedGroundFrame, altaz_to_righthanded_cartesian
 from ..instrument.subarray import SubarrayDescription
 
-__all__ = ["shower_impact_distance"]
+__all__ = ["shower_impact_distance", "impact_distance"]
 
 
 def impact_distance(point: np.ndarray, direction: np.ndarray, test_points: np.ndarray):

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+"""
+Functions to compute the impact distance from a simulated or reconstructed
+shower axis (Defined by the line from the impact point on the ground in the
+reconstructed sky direction) to each telescope's ground position.
+"""
 
 from typing import Union
 

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+
+from ..containers import ReconstructedGeometryContainer
+from ..coordinates import GroundFrame, TiltedGroundFrame
+from ..instrument.subarray import SubarrayDescription
+
+__all__ = ["shower_impact_distance"]
+
+
+def impact_distance(point: np.ndarray, direction: np.ndarray, test_points: np.ndarray):
+    """Compute impact distance from a line defined by a point and a direction vector
+    with an array of points
+
+    Parameters
+    ----------
+    point: np.ndarray
+       point defining the line
+    direction: np.ndarray
+       direction vector
+    test_points: np.ndarray
+       array of test points
+    """
+    return np.linalg.norm(
+        np.cross(test_points - point, direction), axis=1
+    ) / np.linalg.norm(direction)
+
+
+def shower_impact_distance(
+    shower_geom: ReconstructedGeometryContainer, subarray: SubarrayDescription
+):
+    """computes the impact distance of the shower axis to the telescope positions
+
+    Parameters
+    ----------
+    shower_geom: ReconstructedGeometryContainer
+        reconstructed shower geometry, must contain a core and alt/az position
+    subarray: SubarrayDescription
+        SubarrayDescription from which to extract the telescope positions
+
+    Returns
+    -------
+    np.ndarray:
+       array of impact distances to each telescope (packed by tel index)
+    """
+
+    # core position in the ground frame
+    core_position = np.array(
+        [
+            shower_geom.core_x.to_value(u.m),
+            shower_geom.core_y.to_value(u.m),
+            0,
+        ]
+    )
+
+    # sky direction of the shower (defines the shower axis)
+    sky_direction = SkyCoord(
+        alt=shower_geom.alt, az=shower_geom.az, frame="altaz"
+    ).cartesian.xyz.value
+
+    # telescope positions in the ground frame
+    telescope_positions = subarray.tel_coords.cartesian.xyz.to_value("m").T
+
+    return (
+        impact_distance(
+            point=core_position,
+            direction=sky_direction,
+            test_points=telescope_positions,
+        )
+        * u.m
+    )
+
+
+def shower_impact_distance_with_frames(
+    shower_geom: ReconstructedGeometryContainer, subarray: SubarrayDescription
+):
+    """an alternate and slower implementation for cross-check testing purposes.
+
+    Here we make a TiltedFrame that is aligned with the shower axis and
+    transform both the telescopes and the impact point into that frame. Then the
+    cartesian distance in the X-Y plane should be the impact distance.
+    """
+
+    tilted = TiltedGroundFrame(
+        pointing_direction=SkyCoord(
+            alt=shower_geom.alt, az=shower_geom.az, frame="altaz"
+        )
+    )
+
+    core_pos_shower_tilted = (
+        SkyCoord(
+            x=shower_geom.core_x,
+            y=shower_geom.core_y,
+            z=0 * u.m,
+            frame=GroundFrame(),
+        )
+        .transform_to(tilted)
+        .cartesian.xyz
+    )
+
+    tel_pos_shower_tilted = subarray.tel_coords.transform_to(tilted).cartesian.xyz.T
+
+    # compute cartesian distance in the tilted frame (only x,y coordinates needed):
+    delta = tel_pos_shower_tilted - core_pos_shower_tilted
+    return np.hypot(delta[:, 0], delta[:, 1])

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -2,12 +2,11 @@
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import SkyCoord, spherical_to_cartesian
+from astropy.coordinates import SkyCoord
 
 from ..containers import ReconstructedGeometryContainer
-from ..coordinates import GroundFrame, TiltedGroundFrame
+from ..coordinates import GroundFrame, TiltedGroundFrame, altaz_to_righthanded_cartesian
 from ..instrument.subarray import SubarrayDescription
-
 
 __all__ = ["shower_impact_distance"]
 
@@ -58,9 +57,8 @@ def shower_impact_distance(
     )
 
     # sky direction of the shower (defines the shower axis)
-    # NOTE: remember that in sky direction the azimuth needs to be negative
-    sky_direction = spherical_to_cartesian(
-        r=1, lat=shower_geom.alt, lon=-shower_geom.az
+    sky_direction = altaz_to_righthanded_cartesian(
+        alt=shower_geom.alt, az=shower_geom.az
     )
 
     # telescope positions in the ground frame

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
+from typing import Union
+
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
-from ..containers import ReconstructedGeometryContainer
+from ..containers import ReconstructedGeometryContainer, SimulatedShowerContainer
 from ..coordinates import GroundFrame, TiltedGroundFrame, altaz_to_righthanded_cartesian
 from ..instrument.subarray import SubarrayDescription
 
@@ -30,7 +32,8 @@ def impact_distance(point: np.ndarray, direction: np.ndarray, test_points: np.nd
 
 
 def shower_impact_distance(
-    shower_geom: ReconstructedGeometryContainer, subarray: SubarrayDescription
+    shower_geom: Union[ReconstructedGeometryContainer, SimulatedShowerContainer],
+    subarray: SubarrayDescription,
 ):
     """computes the impact distance of the shower axis to the telescope positions
 

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -2,11 +2,12 @@
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, spherical_to_cartesian
 
 from ..containers import ReconstructedGeometryContainer
 from ..coordinates import GroundFrame, TiltedGroundFrame
 from ..instrument.subarray import SubarrayDescription
+
 
 __all__ = ["shower_impact_distance"]
 
@@ -57,9 +58,10 @@ def shower_impact_distance(
     )
 
     # sky direction of the shower (defines the shower axis)
-    sky_direction = SkyCoord(
-        alt=shower_geom.alt, az=shower_geom.az, frame="altaz"
-    ).cartesian.xyz.value
+    # NOTE: remember that in sky direction the azimuth needs to be negative
+    sky_direction = spherical_to_cartesian(
+        r=1, lat=shower_geom.alt, lon=-shower_geom.az
+    )
 
     # telescope positions in the ground frame
     telescope_positions = subarray.tel_coords.cartesian.xyz.to_value("m").T

--- a/ctapipe/reco/impact_distance.py
+++ b/ctapipe/reco/impact_distance.py
@@ -65,15 +65,16 @@ def shower_impact_distance(
     )
 
     # telescope positions in the ground frame
-    telescope_positions = subarray.tel_coords.cartesian.xyz.to_value("m").T
+    telescope_positions = subarray.tel_coords.cartesian.xyz.to_value(u.m).T
 
-    return (
+    return u.Quantity(
         impact_distance(
             point=core_position,
             direction=sky_direction,
             test_points=telescope_positions,
-        )
-        * u.m
+        ),
+        u.m,
+        copy=False,
     )
 
 

--- a/ctapipe/reco/shower_processor.py
+++ b/ctapipe/reco/shower_processor.py
@@ -7,11 +7,12 @@ This processor will be able to process a shower/event in 3 steps:
 - estimation of classification (optional, currently unavailable)
 
 """
-from ctapipe.core import Component
-from ctapipe.core.traits import create_class_enum_trait
-from ctapipe.containers import ArrayEventContainer
-from ctapipe.instrument import SubarrayDescription
-from ctapipe.reco import Reconstructor
+from ..containers import ArrayEventContainer, TelescopeImpactParameterContainer
+from ..core import Component
+from ..core.traits import create_class_enum_trait
+from ..instrument import SubarrayDescription
+from . import Reconstructor
+from .impact_distance import shower_impact_distance
 
 
 class ShowerProcessor(Component):
@@ -23,8 +24,10 @@ class ShowerProcessor(Component):
 
     Input events must already contain dl1 parameters.
     """
+
     reconstructor_type = create_class_enum_trait(
-        Reconstructor, default_value="HillasReconstructor",
+        Reconstructor,
+        default_value="HillasReconstructor",
         help="The stereo geometry reconstructor to be used",
     )
 
@@ -69,3 +72,18 @@ class ShowerProcessor(Component):
         """
         k = self.reconstructor_type
         event.dl2.stereo.geometry[k] = self.reconstructor(event)
+
+        # compute and store the impact parameter for each reconstruction (for
+        # now there is only one, but in the future this should be a loop over
+        # reconstructors)
+
+        # for the stereo reconstructor:
+        impact_distances = shower_impact_distance(
+            shower_geom=event.dl2.stereo.geometry[k], subarray=self.subarray
+        )
+
+        for tel_index, impact_distance in enumerate(impact_distances):
+            tel_id = self.subarray.tel_ids[tel_index]
+            event.dl2.tel[tel_id].impact[k] = TelescopeImpactParameterContainer(
+                distance=impact_distance
+            )

--- a/ctapipe/reco/tests/test_impact_distance.py
+++ b/ctapipe/reco/tests/test_impact_distance.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+import numpy as np
+from astropy import units as u
+from ctapipe.containers import ReconstructedGeometryContainer
+from ctapipe.instrument.subarray import SubarrayDescription
+from ctapipe.reco.impact_distance import (
+    impact_distance,
+    shower_impact_distance,
+    shower_impact_distance_with_frames,
+)
+
+
+def test_impact_distance():
+    """just test a few limit cases. the more detailed tests are done in
+    test_shower_impact_distance_off_axis"""
+
+    # test on axis (coming from  zenith onto an array)
+    point = np.array([0, 0, 0])
+    direction = np.array([0, 0, 1])  # coming perfectly down from zenith
+    test_points = np.array([[0, 0, 0], [0, 1, 0], [0, 2, 100], [0, 3, -100]])
+    impacts = impact_distance(point=point, direction=direction, test_points=test_points)
+
+    expected_impacts = np.array([0, 1, 2, 3])
+    assert np.allclose(impacts, expected_impacts)
+
+    # test at perfectly off-axis (coming in parallel to the array from x-direction)
+
+    direction = np.array([1, 0, 0])  # coming from the x-direction
+    test_points = np.array(
+        [[0, 0, 0], [0, 1, 0], [0, 2, 0], [0, 3, 0]]
+    )  # points along y axis
+    impacts = impact_distance(point=point, direction=direction, test_points=test_points)
+    expected_impacts = np.array(
+        [0, 1, 2, 3]
+    )  # expect the impacts to be equal to the y's
+    assert np.allclose(impacts, expected_impacts)
+
+    # test at perfectly off-axis (coming in parallel to the array from y-direction)
+
+    direction = np.array([0, 1, 0])  # coming from the x-direction
+    test_points = np.array(
+        [[0, 0, 0], [0, 1, 0], [0, 2, 0], [0, 3, 0]]
+    )  # points along y axis
+    impacts = impact_distance(point=point, direction=direction, test_points=test_points)
+    expected_impacts = np.array(
+        [0, 0, 0, 0]
+    )  # expect the impacts to be equal to the y's
+    assert np.allclose(impacts, expected_impacts)
+
+
+def test_shower_impact_distance():
+    """test several boundary cases using the function that takes a Subarray and
+    Container
+    """
+
+    sub = SubarrayDescription(
+        name="test",
+        tel_positions={1: [0, 0, 0] * u.m, 2: [0, 1, 0] * u.m, 3: [0, 2, 0] * u.m},
+        tel_descriptions={1: None, 2: None, 3: None},
+    )
+
+    # coming from zenith to the center of the array, the impact distance should
+    # be the cartesian distance
+    shower_geom = ReconstructedGeometryContainer(
+        core_x=0 * u.m, core_y=0 * u.m, alt=90 * u.deg, az=0 * u.deg
+    )
+    impact_distances = shower_impact_distance(shower_geom=shower_geom, subarray=sub)
+    assert np.allclose(impact_distances, [0, 1, 2] * u.m)
+
+    # alt=0  az=0 should be aligned to x-axis (north in ground frame)
+    # therefore the distances should also be just the y-offset of the telecope
+    shower_geom = ReconstructedGeometryContainer(
+        core_x=0 * u.m, core_y=0 * u.m, alt=0 * u.deg, az=0 * u.deg
+    )
+    impact_distances = shower_impact_distance(shower_geom=shower_geom, subarray=sub)
+    assert np.allclose(impact_distances, [0, 1, 2] * u.m)
+
+    # alt=0  az=90 should be aligned to y-axis (east in ground frame)
+    # therefore the distances should also be just the x-offset of the telecope
+    shower_geom = ReconstructedGeometryContainer(
+        core_x=0 * u.m, core_y=0 * u.m, alt=0 * u.deg, az=90 * u.deg
+    )
+    impact_distances = shower_impact_distance(shower_geom=shower_geom, subarray=sub)
+    assert np.allclose(impact_distances, [0, 0, 0] * u.m)
+
+
+def test_compare_3d_and_frame_impact_distance(
+    example_subarray: SubarrayDescription,
+):
+    """Test another (slower) way of computing the impact distance, using Frames and compare
+    to the implemented method.
+    """
+
+    for alt in [90, 0, 50, 60] * u.deg:
+        for az in [0, 90, 45, 270, 360] * u.deg:
+
+            shower_geom = ReconstructedGeometryContainer(
+                core_x=0 * u.m, core_y=0 * u.m, alt=alt, az=az
+            )
+            impact_distances_3d = shower_impact_distance(
+                shower_geom=shower_geom, subarray=example_subarray
+            )
+
+            impact_distances_frame = shower_impact_distance_with_frames(
+                shower_geom=shower_geom, subarray=example_subarray
+            )
+
+            assert np.allclose(
+                impact_distances_frame, impact_distances_3d
+            ), f"failed at {alt=} {az=}"

--- a/ctapipe/reco/tests/test_impact_distance.py
+++ b/ctapipe/reco/tests/test_impact_distance.py
@@ -92,8 +92,8 @@ def test_shower_impact_distance():
 def test_compare_3d_and_frame_impact_distance(
     example_subarray: SubarrayDescription,
 ):
-    """Test another (slower) way of computing the impact distance, using Frames and compare
-    to the implemented method.
+    """Test another (slower) way of computing the impact distance, using Frames
+    and compare to the implemented method.
     """
 
     for alt in [90, 0, 50, 60] * u.deg:

--- a/ctapipe/reco/tests/test_impact_distance.py
+++ b/ctapipe/reco/tests/test_impact_distance.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+"""
+tests for impact distance computations
+"""
+
 import numpy as np
 from astropy import units as u
 from ctapipe.containers import ReconstructedGeometryContainer

--- a/ctapipe/resources/base_config.yaml
+++ b/ctapipe/resources/base_config.yaml
@@ -23,7 +23,7 @@ DataWriter:
   overwrite: false # do not overwrite existing files
   write_images: false # store DL1 images
   write_parameters: false # store DL1 parameters
-  write_stereo_shower: false # store DL2 stereo geometry
+  write_showers: false # store DL2 stereo geometry
   write_raw_waveforms: false # write R0 waveforms
   write_waveforms: false # write R1 waveforms
 
@@ -91,7 +91,7 @@ ImageProcessor:
       - ["enough_charge", "lambda im: im.sum() > 50"]
 
 # The ShowerProcessor performs the DL1 to DL2a (reconstructed shower geometry)
-# transition. It is run only if the parameter DataWriter.write_stereo_shower=True.
+# transition. It is run only if the parameter DataWriter.write_showers=True.
 ShowerProcessor:
   # choose between HillasReconstructor and HillasIntersection (two
   # implementations of the standard stereo line-intersection method)

--- a/ctapipe/resources/image_modification_config.json
+++ b/ctapipe/resources/image_modification_config.json
@@ -8,8 +8,7 @@
         "overwrite": false,
         "write_images": true,
         "write_parameters": true,
-        "write_stereo_shower": false,
-        "write_mono_shower": false,
+        "write_showers": false,
         "transform_image": true,
         "transform_peak_time": true
     },

--- a/ctapipe/resources/stage1_config.json
+++ b/ctapipe/resources/stage1_config.json
@@ -8,8 +8,7 @@
         "overwrite": false,
         "write_images": true,
         "write_parameters": true,
-        "write_stereo_shower": false,
-        "write_mono_shower": false,
+        "write_shower": false,
         "transform_image": true,
         "transform_peak_time": true
     },

--- a/ctapipe/resources/stage1_config.json
+++ b/ctapipe/resources/stage1_config.json
@@ -8,7 +8,7 @@
         "overwrite": false,
         "write_images": true,
         "write_parameters": true,
-        "write_shower": false,
+        "write_showers": false,
         "transform_image": true,
         "transform_peak_time": true
     },

--- a/ctapipe/resources/stage1_config.toml
+++ b/ctapipe/resources/stage1_config.toml
@@ -10,7 +10,7 @@ organization = "YOUR-ORGANIZATION"
 overwrite = false
 write_images = true
 write_parameters = true
-write_shower = false
+write_showers = false
 transform_image = true
 transform_peak_time = true
 

--- a/ctapipe/resources/stage1_config.toml
+++ b/ctapipe/resources/stage1_config.toml
@@ -10,8 +10,7 @@ organization = "YOUR-ORGANIZATION"
 overwrite = false
 write_images = true
 write_parameters = true
-write_stereo_shower = false
-write_mono_shower = false
+write_shower = false
 transform_image = true
 transform_peak_time = true
 

--- a/ctapipe/resources/stage1_config.yaml
+++ b/ctapipe/resources/stage1_config.yaml
@@ -12,4 +12,4 @@
 DataWriter:
   write_images: true
   write_parameters: true
-  write_stereo_shower: false
+  write_showers: false

--- a/ctapipe/resources/stage2_config.json
+++ b/ctapipe/resources/stage2_config.json
@@ -8,8 +8,7 @@
         "overwrite": false,
         "write_images": false,
         "write_parameters": false,
-        "write_stereo_shower": true,
-        "write_mono_shower": true,
+        "write_shower": true,
         "transform_image": true,
         "transform_peak_time": true
     },

--- a/ctapipe/resources/stage2_config.json
+++ b/ctapipe/resources/stage2_config.json
@@ -8,7 +8,7 @@
         "overwrite": false,
         "write_images": false,
         "write_parameters": false,
-        "write_shower": true,
+        "write_showers": true,
         "transform_image": true,
         "transform_peak_time": true
     },

--- a/ctapipe/resources/stage2_config.yaml
+++ b/ctapipe/resources/stage2_config.yaml
@@ -13,4 +13,4 @@
 DataWriter:
   write_images: false
   write_parameters: false
-  write_stereo_shower: true
+  write_showers: true

--- a/ctapipe/resources/training_config.json
+++ b/ctapipe/resources/training_config.json
@@ -8,8 +8,7 @@
         "overwrite": false,
         "write_images": false,
         "write_parameters": true,
-        "write_stereo_shower": true,
-        "write_mono_shower": true,
+        "write_showers": true,
         "transform_image": true,
         "transform_peak_time": true
     },

--- a/ctapipe/resources/training_config.yaml
+++ b/ctapipe/resources/training_config.yaml
@@ -14,4 +14,4 @@
 DataWriter:
   write_images: false
   write_parameters: true
-  write_stereo_shower: true
+  write_showers: true

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -111,16 +111,10 @@ class ProcessorTool(Tool):
             "don't store DL1/Event/Telescope parameters in output",
         ),
         **flag(
-            "write-stereo-shower",
-            "DataWriter.write_stereo_shower",
-            "store DL2/Event/Subarray parameters in output",
-            "don't DL2/Event/Subarray parameters in output",
-        ),
-        **flag(
-            "write-mono-shower",
-            "DataWriter.write_mono_shower",
-            "store DL2/Event/Telescope parameters in output",
-            "don't store DL2/Event/Telescope parameters in output",
+            "write-showers",
+            "DataWriter.write_showers",
+            "store DL2/Event parameters in output",
+            "don't DL2/Event parameters in output",
         ),
         **flag(
             "write-index-tables",
@@ -184,10 +178,10 @@ class ProcessorTool(Tool):
 
     @property
     def should_compute_dl2(self):
-        """ returns true if we should compute DL2 info """
+        """returns true if we should compute DL2 info"""
         if self.force_recompute_dl2:
             return True
-        return self.write.write_stereo_shower or self.write.write_mono_shower
+        return self.write.write_showers
 
     @property
     def should_compute_dl1(self):
@@ -281,7 +275,7 @@ class ProcessorTool(Tool):
 
 
 def main():
-    """ run the tool"""
+    """run the tool"""
     tool = ProcessorTool()
     tool.run()
 

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -64,7 +64,7 @@ def test_multiple_configs(dl1_image_file):
     # ensure the overwriting works (base config has this option disabled)
     assert (
         tool.get_current_config()["ProcessorTool"]["DataWriter"]["write_showers"]
-        == True
+        is True
     )
 
 

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -63,7 +63,7 @@ def test_multiple_configs(dl1_image_file):
 
     # ensure the overwriting works (base config has this option disabled)
     assert (
-        tool.get_current_config()["ProcessorTool"]["DataWriter"]["write_stereo_shower"]
+        tool.get_current_config()["ProcessorTool"]["DataWriter"]["write_showers"]
         == True
     )
 

--- a/docs/tutorials/ctapipe_overview.ipynb
+++ b/docs/tutorials/ctapipe_overview.ipynb
@@ -699,7 +699,7 @@
     "\n",
     "f = tempfile.NamedTemporaryFile(suffix='.hdf5')\n",
     "\n",
-    "with DataWriter(source, output_path=f.name, overwrite=True, write_stereo_shower=True) as writer:\n",
+    "with DataWriter(source, output_path=f.name, overwrite=True, write_showers=True) as writer:\n",
     "    \n",
     "    for event in source:\n",
     "        energy = event.simulation.shower.energy\n",


### PR DESCRIPTION
Creating some functions to correctly compute and store impact distance from the shower axis to the telescopes on the ground.  Fixes #1892 

To do: 
* [x] tests for reading from events
* [x] add to ShowerProcessor (or make a Component)
* [x] figure out where to put this in the output for both reco and simulation 
* [x] update `TableLoader` to read and merge this information
* [x] ~~update `ctapipe-merge` to merge this information~~ → deferred to another PR...

For the output, it could be an array column in the  shower-wise ReconstructedShowerContainer in `/{dl2,simulation}/event/subarray/geometry/HillasReconstructor`, for example, or should we put it per-telescope in the `/{dl2,simulation}/event/telescope/`?  It's really a per-telescope quantity, but it's more useful in the per-shower container.

