### PR TITLE
Add option to load pointing information with TableLoader, fixes #1900

### DIFF
--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -111,9 +111,9 @@ class TableLoader(Component):
     load_instrument = traits.Bool(
         False, help="join subarray instrument information to each event"
     ).tag(config=True)
-    load_pointings = traits.Bool(
-        False, help="join subarray pointings information"
-    ).tag(config=True)
+    load_pointings = traits.Bool(False, help="join subarray pointings information").tag(
+        config=True
+    )
 
     def __init__(self, input_url=None, **kwargs):
         # enable using input_url as posarg
@@ -178,9 +178,10 @@ class TableLoader(Component):
 
     def _join_interp_pointings(self, table, pointings):
         for col in set(pointings.colnames) - set(["time"]):
-            table[col] = np.interp(table['time'].mjd, pointings['time'].mjd,
-                                        pointings[col]).astype(pointings[col].dtype)
-            table[col].unit = pointings[col].unit 
+            table[col] = np.interp(
+                table["time"].mjd, pointings["time"].mjd, pointings[col]
+            ).astype(pointings[col].dtype)
+            table[col].unit = pointings[col].unit
 
         return table
 
@@ -322,11 +323,17 @@ class TableLoader(Component):
             tel_ids = self.subarray.get_tel_ids(telescopes)
 
         table = self._read_telescope_events_for_ids(tel_ids)
-        
+
         # TODO: load telescope trigger and pointing tables instead of appending the
         # subarray one
-        if any([self.load_trigger, self.load_simulated, 
-                self.load_dl2_geometry, self.load_pointings]):
+        if any(
+            [
+                self.load_trigger,
+                self.load_simulated,
+                self.load_dl2_geometry,
+                self.load_pointings,
+            ]
+        ):
             table = self._join_subarray_info(table)
 
         return table
@@ -359,8 +366,14 @@ class TableLoader(Component):
 
         by_type = {k: vstack(ts) for k, ts in by_type.items()}
 
-        if any([self.load_trigger, self.load_simulated, 
-                self.load_dl2_geometry, self.load_pointings]):
+        if any(
+            [
+                self.load_trigger,
+                self.load_simulated,
+                self.load_dl2_geometry,
+                self.load_pointings,
+            ]
+        ):
             for key, table in by_type.items():
                 by_type[key] = self._join_subarray_info(table)
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -176,15 +176,11 @@ class TableLoader(Component):
 
         return table
 
-    def _join_interp_pointings(self, table):
-        pointings = read_table(self.h5file, POINTING_TABLE)
+    def _join_interp_pointings(self, table, pointings):
         for col in set(pointings.colnames) - set(["time"]):
             interp = np.interp(table['time'].value,
                                pointings['time'].value, pointings[col].value)
             table[col] = interp
-
-        if not self.load_trigger:
-            table.remove_columns(["tels_with_trigger", "event_type"])
 
         return table
 
@@ -206,7 +202,9 @@ class TableLoader(Component):
             if not self.load_trigger:
                 trigger = read_table(self.h5file, TRIGGER_TABLE)
                 table = join_allow_empty(table, trigger, SUBARRAY_EVENT_KEYS, "outer")
-            table = self._join_interp_pointings(table)
+                table.remove_columns(["tels_with_trigger", "event_type"])
+            pointings = read_table(self.h5file, POINTING_TABLE)
+            table = self._join_interp_pointings(table, pointings)
 
         if self.load_simulated and SHOWER_TABLE in self.h5file:
             showers = read_table(self.h5file, SHOWER_TABLE)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -178,9 +178,9 @@ class TableLoader(Component):
 
     def _join_interp_pointings(self, table, pointings):
         for col in set(pointings.colnames) - set(["time"]):
-            interp = np.interp(table['time'].value,
-                               pointings['time'].value, pointings[col].value)
-            table[col] = interp
+            table[col] = np.interp(table['time'].mjd, pointings['time'].mjd,
+                                        pointings[col]).astype(pointings[col].dtype)
+            table[col].unit = pointings[col].unit 
 
         return table
 

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -113,7 +113,6 @@ def test_true_parameters(test_file):
 
 def test_read_subarray_events(test_file_dl2):
     """Test reading subarray events"""
-
     from ctapipe.io.tableloader import TableLoader
 
     _, dl2_file = test_file_dl2
@@ -127,9 +126,19 @@ def test_read_subarray_events(test_file_dl2):
         assert "time" in table.colnames
 
 
+def test_pointings(test_file):
+    """Test joining true_parameters poitning information onto subarray events"""
+    from ctapipe.io.tableloader import TableLoader
+
+    _, dl1_file = test_file
+
+    with TableLoader(dl1_file, load_pointings=True) as table_loader:
+        table = table_loader.read_subarray_events()
+        assert "array_altitude" in table.colnames
+
+
 def test_read_telescope_events_type(test_file_dl2):
     """Test reading telescope events for a given telescope type"""
-
     from ctapipe.io.tableloader import TableLoader
 
     _, dl2_file = test_file_dl2
@@ -156,7 +165,6 @@ def test_read_telescope_events_type(test_file_dl2):
 
 def test_read_telescope_events_by_type(test_file_dl2):
     """Test reading telescope events for by types"""
-
     from ctapipe.io.tableloader import TableLoader
 
     _, dl2_file = test_file_dl2


### PR DESCRIPTION
**Description:**
I've added an option for the `TableLoader` to load pointing information from the subarray table, interpolate and adding them to the table.

**Side-Notes:**

- For now it just adds the (interpoalted) `/subarray/pointing` table instead of the `/telescope/pointing` as its done for the trigger information. It doesnt make any difference for simulation data or just one telescope for now (but its faster this way), but has to be adapted in future (Therefore the TODO note).
- I dont know whether its important to get always sorted tables by the keys, but for some parameter combinations, they are not sorted (e.g. if just `load_trigger=True`, because the astropy_helper function `join_allow_empty` just copies the unsorted table if one side is empty. The astropy `join` function sorts by keys). But i think it wouldn't be a problem to just `group_by(keys)` them, if someone needs a sorted one.

Refers to #1900 