### PR TITLE
Minor visual bugfix: better html repr for Tool and Component

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -228,7 +228,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
             or "Undocumented"
         )
         lines = [
-            "<div style='border:1px solid black; width: 800px; padding:2em'; word-wrap:break-word;>",
+            "<div style='border:1px solid black; max-width: 700px; padding:2em'; word-wrap:break-word;>",
             f"<b>{name}</b>",
             f"<p> {docstring} </p>",
             "<table>",

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -2,6 +2,8 @@
 from abc import ABCMeta
 from inspect import isabstract
 from logging import getLogger
+from docutils.core import publish_parts
+from inspect import cleandoc
 
 from traitlets import TraitError
 from traitlets.config import Configurable
@@ -219,22 +221,45 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         """nice HTML rep, with blue for non-default values"""
         traits = self.traits()
         name = self.__class__.__name__
+        docstring = (
+            publish_parts(cleandoc(self.__class__.__doc__), writer_name="html")[
+                "html_body"
+            ]
+            or "Undocumented"
+        )
         lines = [
+            "<div style='border:1px solid black; width: 800px; padding:2em'; word-wrap:break-word;>",
             f"<b>{name}</b>",
-            f"<p> {self.__class__.__doc__ or 'Undocumented!'} </p>",
+            f"<p> {docstring} </p>",
             "<table>",
+            "    <colgroup>",
+            "        <col span='1' style=' '>",
+            "        <col span='1' style='width: 20em;'>",
+            "        <col span='1' >",
+            "    </colgroup>",
+            "    <tbody>",
         ]
         for key, val in self.get_current_config()[name].items():
+            htmlval = (
+                str(val).replace("/", "/<wbr>").replace("_", "_<wbr>")
+            )  # allow breaking at boundary
+
             # traits of the current component
             if key in traits:
                 thehelp = f"{traits[key].help} (default: {traits[key].default_value})"
                 lines.append(f"<tr><th>{key}</th>")
                 if val != traits[key].default_value:
-                    lines.append(f"<td><span style='color:blue'>{val}</span></td>")
+                    lines.append(
+                        f"<td style='text-align: left;'><span style='color:blue; max-width:30em;'>{htmlval}</span></td>"
+                    )
                 else:
-                    lines.append(f"<td>{val}</td>")
-                lines.append(f'<td style="text-align:left"><i>{thehelp}</i></td></tr>')
+                    lines.append(f"<td style='text-align: left;'>{htmlval}</td>")
+                lines.append(
+                    f"<td style='text-align: left;'><i>{thehelp}</i></td></tr>"
+                )
+        lines.append("    </tbody>")
         lines.append("</table>")
+        lines.append("</div>")
         return "\n".join(lines)
 
 

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -77,7 +77,9 @@ class Field:
         if self.ndim is not None:
             desc += f" as a {self.ndim}-D array"
         if self.dtype is not None:
-            desc += f" with type {self.dtype}"
+            desc += f" with dtype {self.dtype}"
+        if self.type is not None:
+            desc += f" with type {self.type}"
 
         return desc
 
@@ -143,7 +145,7 @@ class Field:
 
 
 class DeprecatedField(Field):
-    """ used to mark which fields may be removed in next version """
+    """used to mark which fields may be removed in next version"""
 
     def __init__(self, default, description="", unit=None, ucd=None, reason=""):
         super().__init__(default=default, description=description, unit=unit, ucd=ucd)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -77,13 +77,13 @@ class TableLoader(Component):
 
     The following `TableLoader` methods load data from all relevant tables,
     depending on the options, and joins them into single tables:
+
     * `TableLoader.read_subarray_events`
     * `TableLoader.read_telescope_events`
-
-    `TableLoader.read_telescope_events_by_type` retuns a dict with a table per
-    telescope type, which is needed for e.g. DL1 image data that might have
-    different shapes for each of the telescope types as tables do not support
-    variable length columns.
+    * `TableLoader.read_telescope_events_by_type` retuns a dict with a table per
+      telescope type, which is needed for e.g. DL1 image data that might have
+      different shapes for each of the telescope types as tables do not support
+      variable length columns.
     """
 
     input_url = traits.Path(directory_ok=False, exists=True).tag(config=True)

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "importlib_resources;python_version<'3.9'",
         "jinja2~=3.0.2",  # for sphinx 3.5, update when moving to 4.x
         "pyyaml>=5.1",
+        "docutils",
     ],
     # here are optional dependencies (as "tag" : "dependency spec")
     extras_require={


### PR DESCRIPTION
The `Tool` and `Component` html *repr* , used when displaying the class in a Jupyter notebook, has been somewhat broken for a while: it normally shows the docstring and options of the Component, but many were incorrectly formatted resulting in ugly/unreadable results.   

The small PR Fixes the HTML *repr*  for `Component` and `Tool` in Jupyter by:

* using `inspect.cleandoc` to remove whitespace from docstring correctly
* using `docutils` to render RST docstrings correctly
* better table column widths supporting long values like Paths

The result looks like this for e.g. TableLoader:

<img width="666" alt="image" src="https://user-images.githubusercontent.com/11677812/166685160-45c3be90-699a-47ad-8953-60aefc68eaab.png">

Since the entire docstring is not needed, just the short description, it may be also nice to find a way to extract only the first block of the docstring and display only that, but for now this is at least renders them correctly. 
