### PR TITLE
Directly return peak position from neighbor average waveform

### DIFF
--- a/ctapipe/image/__init__.py
+++ b/ctapipe/image/__init__.py
@@ -45,7 +45,7 @@ from .extractor import (
     TwoPassWindowSum,
     extract_around_peak,
     extract_sliding_window,
-    neighbor_average_waveform,
+    neighbor_average_maximum,
     subtract_baseline,
     integration_correction,
 )
@@ -110,7 +110,7 @@ __all__ = [
     "TwoPassWindowSum",
     "extract_around_peak",
     "extract_sliding_window",
-    "neighbor_average_waveform",
+    "neighbor_average_maximum",
     "subtract_baseline",
     "integration_correction",
     "DataVolumeReducer",


### PR DESCRIPTION
This is a small change to not compute the full array of average neighbor waveforms for each pixel and then in a separate numpy call calculate the peak position but do it directly in the same numba function.

This reduces memory usage and call overhead, runtime is divided in half from 800 to 400 µs for this test case:


```
import numpy as np
from ctapipe.instrument import TelescopeDescription, SubarrayDescription
import astropy.units as u
from ctapipe.image.extractor import NeighborPeakWindowSum
from timeit import repeat


tel = TelescopeDescription.from_name('LST', 'LSTCam')
geom = tel.camera.geometry
subarray = SubarrayDescription(
    'perf',
    tel_positions={1: [0, 0, 0] * u.m},
    tel_descriptions={1: tel},
)


extractor = NeighborPeakWindowSum(subarray)

waveforms = np.random.normal(size=(geom.n_pixels, 40)).astype('float32')
selected_gain_channels = np.zeros(geom.n_pixels, dtype=int)


# number_of_islands(geom, mask)
code = '''
extractor(waveforms, 1, selected_gain_channels)
'''

exec(code)

N = 200
times = np.array(repeat(code, number=N, repeat=10, globals=globals()))
print(f'{np.mean(times / N) * 1e6:.2f} ± {np.std(times / N) * 1e6:.2f} µs')
```
