### PR TITLE
Refactoring of the simulation pointing

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -597,10 +597,10 @@ class SimulationConfigContainer(Container):
         np.nan * u.rad,
         "Array Pointing declination, only filled of constant for the run",
     )
-    array_alt = Field(
+    array_altitude = Field(
         np.nan * u.rad, "Array Pointing altitude, only filled of constant for the run"
     )
-    array_az = Field(
+    array_azimuth = Field(
         np.nan * u.rad, "Array Pointing azimuth, only filled of constant for the run"
     )
 
@@ -784,6 +784,7 @@ class PointingContainer(Container):
     array_altitude = Field(nan * u.rad, "Array pointing altitude", unit=u.rad)
     array_ra = Field(nan * u.rad, "Array pointing right ascension", unit=u.rad)
     array_dec = Field(nan * u.rad, "Array pointing declination", unit=u.rad)
+    tracking_mode = Field(TrackingMode.UNKNOWN, "Tracking mode")
 
 
 class EventCameraCalibrationContainer(Container):

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -589,6 +589,20 @@ class SimulationConfigContainer(Container):
     tracking_mode = Field(
         TrackingMode.UNKNOWN, "Tracking Mode (see docs of `TrackingMode`)"
     )
+    array_ra = Field(
+        np.nan * u.rad,
+        "Array Pointing right ascension, only filled of constant for the run",
+    )
+    array_dec = Field(
+        np.nan * u.rad,
+        "Array Pointing declination, only filled of constant for the run",
+    )
+    array_alt = Field(
+        np.nan * u.rad, "Array Pointing altitude, only filled of constant for the run"
+    )
+    array_az = Field(
+        np.nan * u.rad, "Array Pointing azimuth, only filled of constant for the run"
+    )
 
 
 class TelescopeTriggerContainer(Container):

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -91,8 +91,22 @@ class EventType(enum.Enum):
     UNKNOWN = 255
 
 
+class TrackingMode(enum.Enum):
+    """
+    TrackingMode of the telescopes.
+
+    Defines which coordinates are supposed to be constant during the run.
+    """
+
+    UNKNOWN = -1
+    #: Telescopes are tracking a constant alt/az position for the run
+    ALTAZ = 0
+    #: Telescopes are tracking a constant ra/dec position for the run
+    ICRS = 1
+
+
 class EventIndexContainer(Container):
-    """ index columns to include in event lists, common to all data levels"""
+    """index columns to include in event lists, common to all data levels"""
 
     container_prefix = ""  # don't want to prefix these
     obs_id = Field(0, "observation identifier")
@@ -251,7 +265,7 @@ class TimingParametersContainer(BaseTimingParametersContainer):
 
 
 class MorphologyContainer(Container):
-    """ Parameters related to pixels surviving image cleaning """
+    """Parameters related to pixels surviving image cleaning"""
 
     num_pixels = Field(-1, "Number of usable pixels")
     num_islands = Field(-1, "Number of distinct islands in the image")
@@ -287,7 +301,7 @@ class CoreParametersContainer(Container):
 
 
 class ImageParametersContainer(Container):
-    """ Collection of image parameters """
+    """Collection of image parameters"""
 
     container_prefix = "params"
     hillas = Field(
@@ -353,7 +367,7 @@ class DL1CameraContainer(Container):
 
 
 class DL1Container(Container):
-    """ DL1 Calibrated Camera Images and associated data"""
+    """DL1 Calibrated Camera Images and associated data"""
 
     tel = Field(Map(DL1CameraContainer), "map of tel_id to DL1CameraContainer")
 
@@ -475,7 +489,7 @@ class SimulatedShowerContainer(Container):
     core_y = Field(nan * u.m, "Simulated core position (y)", unit=u.m)
     h_first_int = Field(nan * u.m, "Height of first interaction", unit=u.m)
     x_max = Field(
-        nan * u.g / (u.cm ** 2), "Simulated Xmax value", unit=u.g / (u.cm ** 2)
+        nan * u.g / (u.cm**2), "Simulated Xmax value", unit=u.g / (u.cm**2)
     )
     shower_primary_id = Field(
         -1,
@@ -572,6 +586,9 @@ class SimulationConfigContainer(Container):
     corsika_high_E_detail = Field(
         nan, "More details on high E interaction model (version etc.)"
     )
+    tracking_mode = Field(
+        TrackingMode.UNKNOWN, "Tracking Mode (see docs of `TrackingMode`)"
+    )
 
 
 class TelescopeTriggerContainer(Container):
@@ -606,37 +623,33 @@ class ReconstructedGeometryContainer(Container):
         nan * u.m, "reconstructed x coordinate of the core position", unit=u.m
     )
     core_y = Field(
-        nan * u.m,
-        "reconstructed y coordinate of the core position",
-        unit=u.m
+        nan * u.m, "reconstructed y coordinate of the core position", unit=u.m
     )
     core_uncert_x = Field(
         nan * u.m,
         "reconstructed core position uncertainty along ground frame X axis",
-        unit=u.m
+        unit=u.m,
     )
     core_uncert_y = Field(
         nan * u.m,
         "reconstructed core position uncertainty along ground frame Y axis",
-        unit=u.m
+        unit=u.m,
     )
     core_tilted_x = Field(
         nan * u.m, "reconstructed x coordinate of the core position", unit=u.m
     )
     core_tilted_y = Field(
-        nan * u.m,
-        "reconstructed y coordinate of the core position",
-        unit=u.m
+        nan * u.m, "reconstructed y coordinate of the core position", unit=u.m
     )
     core_tilted_uncert_x = Field(
         nan * u.m,
         "reconstructed core position uncertainty along tilted frame X axis",
-        unit=u.m
+        unit=u.m,
     )
     core_tilted_uncert_y = Field(
         nan * u.m,
         "reconstructed core position uncertainty along tilted frame Y axis",
-        unit=u.m
+        unit=u.m,
     )
     h_max = Field(nan * u.m, "reconstructed height of the shower maximum", unit=u.m)
     h_max_uncert = Field(nan * u.m, "uncertainty of h_max", unit=u.m)
@@ -700,7 +713,7 @@ class ParticleClassificationContainer(Container):
 
 
 class ReconstructedContainer(Container):
-    """ Reconstructed shower info from multiple algorithms """
+    """Reconstructed shower info from multiple algorithms"""
 
     # Note: there is a reason why the hiererchy is
     # `event.dl2.stereo.geometry[algorithm]` and not
@@ -745,12 +758,14 @@ class TelescopePointingContainer(Container):
     between camera and sky coordinates.
     """
 
+    time = Field(NAN_TIME, "Timestamp of the pointing position")
     azimuth = Field(nan * u.rad, "Azimuth, measured N->E", unit=u.rad)
     altitude = Field(nan * u.rad, "Altitude", unit=u.rad)
 
 
 class PointingContainer(Container):
     tel = Field(Map(TelescopePointingContainer), "Telescope pointing positions")
+    time = Field(NAN_TIME, "Timestamp of the pointing position")
     array_azimuth = Field(nan * u.rad, "Array pointing azimuth", unit=u.rad)
     array_altitude = Field(nan * u.rad, "Array pointing altitude", unit=u.rad)
     array_ra = Field(nan * u.rad, "Array pointing right ascension", unit=u.rad)
@@ -1005,7 +1020,7 @@ class SimulatedShowerDistribution(Container):
 
 
 class ArrayEventContainer(Container):
-    """ Top-level container for all event information """
+    """Top-level container for all event information"""
 
     index = Field(EventIndexContainer(), "event indexing information")
     r0 = Field(R0Container(), "Raw Data")

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -20,6 +20,7 @@ from ..containers import (
     SimulatedShowerContainer,
     TelescopePointingContainer,
     TelescopeTriggerContainer,
+    TrackingMode,
 )
 from ..coordinates import CameraFrame
 from ..core.traits import (
@@ -585,6 +586,13 @@ class SimTelEventSource(EventSource):
         # With only one run, we can take the first entry:
         mc_run_head = self.file_.mc_run_headers[-1]
 
+        if self.file_.header["tracking_mode"] == 0:
+            tracking_mode = TrackingMode.ALTAZ
+        elif self.file.header["tracking_mode"] == 1:
+            tracking_mode = TrackingMode.ICRS
+        else:
+            tracking_mode = TrackingMode.UNKNOWN
+
         simulation_config = SimulationConfigContainer(
             corsika_version=mc_run_head["shower_prog_vers"],
             simtel_version=mc_run_head["detector_prog_vers"],
@@ -621,6 +629,7 @@ class SimTelEventSource(EventSource):
             corsika_wlen_max=mc_run_head["corsika_wlen_max"] * u.nm,
             corsika_low_E_detail=mc_run_head["corsika_low_E_detail"],
             corsika_high_E_detail=mc_run_head["corsika_high_E_detail"],
+            tracking_mode=tracking_mode,
         )
         return {obs_id: simulation_config}
 

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -1,4 +1,5 @@
 import copy
+from ctapipe.containers import TrackingMode
 from ctapipe.instrument.camera.geometry import UnknownPixelShapeWarning
 
 import numpy as np
@@ -94,15 +95,19 @@ def test_additional_meta_data_from_simulation_config():
         "min_alt": 1.2217305 * u.rad,
         "max_viewcone_radius": 10.0 * u.deg,
         "corsika_wlen_min": 240 * u.nm,
+        "tracking_mode": TrackingMode.ALTAZ,
     }
 
     for name, expectation in name_expectation.items():
         value = getattr(simulation_config, name)
 
-        assert value.unit == expectation.unit
-        assert np.isclose(
-            value.to_value(expectation.unit), expectation.to_value(expectation.unit)
-        )
+        if hasattr(expectation, "unit"):
+            assert value.unit == expectation.unit
+            assert np.isclose(
+                value.to_value(expectation.unit), expectation.to_value(expectation.unit)
+            )
+        else:
+            assert value == expectation
 
 
 def test_properties():


### PR DESCRIPTION
This should improve the handling of the pointing information and prepare for the proper handling of real observation monitoring data. 

Goal is to remove the "closest timestamp" matching in the hdf5 event source and replace it with filling values from the simulation header for simulations and actual iterpolation from the monitoring table for observations