### PR TITLE
Print version info in pytest header

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -11,6 +11,14 @@ from ctapipe.io import SimTelEventSource
 from ctapipe.utils import get_dataset_path
 from ctapipe.utils.filelock import FileLock
 
+from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+
+PYTEST_HEADER_MODULES.clear()
+PYTEST_HEADER_MODULES["numpy"] = "numpy"
+PYTEST_HEADER_MODULES["scipy"] = "scipy"
+PYTEST_HEADER_MODULES["astropy"] = "astropy"
+PYTEST_HEADER_MODULES["numba"] = "numba"
+
 # names of camera geometries available on the data server
 camera_names = [
     "ASTRICam",
@@ -45,7 +53,7 @@ def _global_example_event():
     print("******************** LOAD TEST EVENT ***********************")
 
     # FIXME: switch to prod5b+ file that contains effective focal length
-    with SimTelEventSource(input_url=filename, focal_length_choice='nominal') as reader:
+    with SimTelEventSource(input_url=filename, focal_length_choice="nominal") as reader:
         event = next(iter(reader))
 
     return event
@@ -60,7 +68,7 @@ def example_subarray():
 
     print("******************** LOAD TEST EVENT ***********************")
 
-    with SimTelEventSource(input_url=filename, focal_length_choice='nominal') as reader:
+    with SimTelEventSource(input_url=filename, focal_length_choice="nominal") as reader:
         return reader.subarray
 
 
@@ -85,7 +93,7 @@ def _subarray_and_event_gamma_off_axis_500_gev():
 
     path = get_dataset_path("lst_prod3_calibration_and_mcphotons.simtel.zst")
 
-    with SimTelEventSource(path, focal_length_choice='nominal') as source:
+    with SimTelEventSource(path, focal_length_choice="nominal") as source:
         it = iter(source)
         # we want the second event, first event is a corner clipper
         next(it)

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -14,6 +14,7 @@ from ctapipe.utils.filelock import FileLock
 from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 
 PYTEST_HEADER_MODULES.clear()
+PYTEST_HEADER_MODULES["eventio"] = "eventio"
 PYTEST_HEADER_MODULES["numpy"] = "numpy"
 PYTEST_HEADER_MODULES["scipy"] = "scipy"
 PYTEST_HEADER_MODULES["astropy"] = "astropy"

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-runner
+  - pytest-astropy-header
   - pyyaml
   - scikit-learn
   - scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ show_response = 1
 minversion=3.0
 norecursedirs=build docs/_build
 addopts = -v
+astropy_header = true
 
 
 [aliases]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ tests_require = [
     "pandas>=0.24.0",
     "importlib_resources;python_version<'3.9'",
     "tomli",
+    "pytest_astropy_header",
 ]
 docs_require = [
     "sphinx_rtd_theme",


### PR DESCRIPTION
Looks like this at the start of the test session:

```
❯ pytest ctapipe/io/tests/test_simteleventsource.py
============================================================ test session starts =============================================================
platform linux -- Python 3.8.13, pytest-7.1.1, pluggy-1.0.0 -- /home/maxnoe/.local/anaconda/envs/cta-dev/bin/python
cachedir: .pytest_cache

Running tests with Astropy version 5.0.4.
Running tests in ctapipe/io/tests/test_simteleventsource.py.

Date: 2022-05-24T16:15:32

Platform: Linux-5.10.109-1-MANJARO-x86_64-with-glibc2.10

Executable: /home/maxnoe/.local/anaconda/envs/cta-dev/bin/python

Full Python Version: 
3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:04:18) 
[GCC 10.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
numpy: 1.22.3
scipy: 1.8.0
astropy: 5.0.4
numba: 0.53.1


rootdir: /home/maxnoe/Uni/CTA/ctapipe, configfile: setup.cfg
plugins: xdist-2.5.0, cov-3.0.0, forked-1.4.0, astropy-header-0.1.2
collected 19 items   
```