### PR TITLE
Tool exit stack

### DIFF
--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -75,8 +75,16 @@ class Tool(Application):
     which will automatically add their configuration parameters to the
     tool.
 
-    Once a tool is constructed and the virtual methods defined, the
-    user can call the `run` method to setup and start it.
+    Once a tool is constructed and the abstract methods are implemented,
+    the user can call the `run` method to setup and start it.
+
+    Tools have an `~contextlib.ExitStack` to guarantee cleanup tasks are
+    run when the tool terminates, also in case of errors. If a task needs
+    a cleanup, it must be a context manager and ``Tool.enter_context``
+    must be called on the object. This will guarantee that the ``__exit__``
+    method of the context manager is called after the tool has finished
+    executing. This happens after the ``finish`` method has run or
+    in case of exceptions.
 
 
     .. code:: python

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 import textwrap
 from abc import abstractmethod
+from contextlib import ExitStack
 from inspect import cleandoc
 from subprocess import CalledProcessError
 from tempfile import mkdtemp
@@ -96,16 +97,16 @@ class Tool(Application):
             iterations = Integer(5,help="Number of times to run",
                                  allow_none=False).tag(config=True)
 
-            def setup_comp(self):
+            def setup(self):
                 self.comp = MyComponent(self, parent=self)
                 self.comp2 = SecondaryMyComponent(self, parent=self)
 
-            def setup_advanced(self):
-                self.advanced = AdvancedComponent(self, parent=self)
+                # correct use of component that is a context manager
+                # using it like this makes sure __exit__ will be called
+                # at the end of Tool.run, even in case of exceptions
+                self.comp3 = self.enter_context(MyComponent(parent=self))
 
-            def setup(self):
-                self.setup_comp()
-                self.setup_advanced()
+                self.advanced = AdvancedComponent(parent=self)
 
             def start(self):
                 self.log.info("Performing {} iterations..."\
@@ -149,6 +150,7 @@ class Tool(Application):
     ).tag(config=True)
 
     log_config = Dict(default_value={}).tag(config=True)
+
     log_file = Path(
         default_value=None,
         exists=None,
@@ -156,11 +158,13 @@ class Tool(Application):
         help="Filename for the log",
         allow_none=True,
     ).tag(config=True)
+
     log_file_level = Enum(
         values=Application.log_level.values,
         default_value="INFO",
         help="Logging Level for File Logging",
     ).tag(config=True)
+
     quiet = Bool(default_value=False).tag(config=True)
 
     _log_formatter_cls = ColoredFormatter
@@ -172,8 +176,9 @@ class Tool(Application):
         return self.name + ".provenance.log"
 
     def __init__(self, **kwargs):
-        # make sure there are some default aliases in all Tools:
         super().__init__(**kwargs)
+
+        # make sure there are some default aliases in all Tools:
         aliases = {
             ("c", "config"): "Tool.config_files",
             "log-level": "Tool.log_level",
@@ -203,6 +208,20 @@ class Tool(Application):
         self.log = logging.getLogger(f"{self.module_name}.{self.name}")
         self.trait_warning_handler = CollectTraitWarningsHandler()
         self.update_logging_config()
+        self._exit_stack = ExitStack()
+
+    def enter_context(self, context_manager):
+        """
+        Add a new context manager to the `~contextlib.ExitStack` of this Tool
+
+        This method should be used with things that need a cleanup step,
+        also in case of exception. ``enter_context`` will call
+        ``context_manager.__enter__`` and return its result.
+
+        This will guarantee that ``context_manager.__exit__`` is called when
+        `~ctapipe.core.Tool.run` finishes, even when an error occurs.
+        """
+        return self._exit_stack.enter_context(context_manager)
 
     def initialize(self, argv=None):
         """handle config and any other low-level setup"""
@@ -345,45 +364,48 @@ class Tool(Application):
 
         exit_status = 0
 
-        try:
-            self.initialize(argv)
-            self.log.info(f"Starting: {self.name}")
-            Provenance().start_activity(self.name)
-            self.setup()
-            self.is_setup = True
-            self.log.debug(f"CONFIG: {self.get_current_config()}")
-            Provenance().add_config(self.get_current_config())
+        with self._exit_stack:
+            try:
+                self.initialize(argv)
+                self.log.info(f"Starting: {self.name}")
+                Provenance().start_activity(self.name)
+                self.setup()
+                self.is_setup = True
+                self.log.debug(f"CONFIG: {self.get_current_config()}")
+                Provenance().add_config(self.get_current_config())
 
-            # check for any traitlets warnings using our custom handler
-            if len(self.trait_warning_handler.errors) > 0:
-                raise ToolConfigurationError("Found config errors")
+                # check for any traitlets warnings using our custom handler
+                if len(self.trait_warning_handler.errors) > 0:
+                    raise ToolConfigurationError("Found config errors")
 
-            # remove handler to not impact performance with regex matching
-            self.log.removeHandler(self.trait_warning_handler)
+                # remove handler to not impact performance with regex matching
+                self.log.removeHandler(self.trait_warning_handler)
 
-            self.start()
-            self.finish()
-            self.log.info(f"Finished: {self.name}")
-            Provenance().finish_activity(activity_name=self.name)
-        except (ToolConfigurationError, TraitError) as err:
-            self.log.error("%s", err)
-            self.log.error("Use --help for more info")
-            exit_status = 2  # wrong cmd line parameter
-            if raises:
-                raise
-        except KeyboardInterrupt:
-            self.log.warning("WAS INTERRUPTED BY CTRL-C")
-            Provenance().finish_activity(activity_name=self.name, status="interrupted")
-            exit_status = 130  # Script terminated by Control-C
-        except Exception as err:
-            self.log.exception(f"Caught unexpected exception: {err}")
-            Provenance().finish_activity(activity_name=self.name, status="error")
-            exit_status = 1  # any other error
-            if raises:
-                raise
-        finally:
-            if not {"-h", "--help", "--help-all"}.intersection(self.argv):
-                self.write_provenance()
+                self.start()
+                self.finish()
+                self.log.info(f"Finished: {self.name}")
+                Provenance().finish_activity(activity_name=self.name)
+            except (ToolConfigurationError, TraitError) as err:
+                self.log.error("%s", err)
+                self.log.error("Use --help for more info")
+                exit_status = 2  # wrong cmd line parameter
+                if raises:
+                    raise
+            except KeyboardInterrupt:
+                self.log.warning("WAS INTERRUPTED BY CTRL-C")
+                Provenance().finish_activity(
+                    activity_name=self.name, status="interrupted"
+                )
+                exit_status = 130  # Script terminated by Control-C
+            except Exception as err:
+                self.log.exception(f"Caught unexpected exception: {err}")
+                Provenance().finish_activity(activity_name=self.name, status="error")
+                exit_status = 1  # any other error
+                if raises:
+                    raise
+            finally:
+                if not {"-h", "--help", "--help-all"}.intersection(self.argv):
+                    self.write_provenance()
 
         self.exit(exit_status)
 
@@ -579,3 +601,45 @@ def run_tool(tool: Tool, argv=None, cwd=None, raises=True):
         return e.code
     finally:
         os.chdir(current_cwd)
+
+
+def test_exit_stack():
+    """Test that components that are context managers are properly handled"""
+
+    class TestManager:
+        def __init__(self):
+            self.enter_called = False
+            self.exit_called = False
+
+        def __enter__(self):
+            self.enter_called = True
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.exit_called = True
+
+    class AtExitTool(Tool):
+        def setup(self):
+            self.manager = self.enter_context(TestManager())
+
+    tool = AtExitTool()
+    assert not tool.manager.enter_called
+    assert not tool.manager.exit_called
+    run_tool(tool)
+    assert tool.manager.enter_called
+    assert tool.manager.exit_called
+
+    # test this also works when there is an exception in the user code
+    class FailTool(Tool):
+        def setup(self):
+            self.manager = self.enter_context(TestManager())
+
+        def start(self):
+            raise Exception("Failed")
+
+    tool = FailTool()
+    assert not tool.manager.enter_called
+    assert not tool.manager.exit_called
+    run_tool(tool)
+    assert tool.manager.enter_called
+    assert tool.manager.exit_called

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -204,6 +204,9 @@ class HDF5EventSource(EventSource):
 
         version = self.file_.root._v_attrs["CTA PRODUCT DATA MODEL VERSION"]
         self.datamodel_version = tuple(map(int, version.lstrip("v").split(".")))
+        self._obs_ids = tuple(
+            self.file_.root.configuration.observation.observation_block.col("obs_id")
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
@@ -282,9 +285,9 @@ class HDF5EventSource(EventSource):
     def atmosphere_density_profile(self) -> AtmosphereDensityProfile:
         return read_atmosphere_density_profile(self.file_)
 
-    @lazyproperty
+    @property
     def obs_ids(self):
-        return list(np.unique(self.file_.root.dl1.event.subarray.trigger.col("obs_id")))
+        return self._obs_ids
 
     @property
     def scheduling_blocks(self) -> Dict[int, SchedulingBlockContainer]:

--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -120,7 +120,7 @@ class ApplyModels(Tool):
 
         shutil.copy(self.input_url, self.output_path)
 
-        self.h5file = tables.open_file(self.output_path, mode="r+")
+        self.h5file = self.enter_context(tables.open_file(self.output_path, mode="r+"))
         self.loader = TableLoader(
             parent=self,
             h5file=self.h5file,
@@ -157,7 +157,9 @@ class ApplyModels(Tool):
             # the table loader does not seem to see the newly written tables
             # we close and reopen the file and then table loader loads also the new tables
             self.h5file.close()
-            self.h5file = tables.open_file(self.output_path, mode="r+")
+            self.h5file = self.enter_context(
+                tables.open_file(self.output_path, mode="r+")
+            )
             self.loader.h5file = self.h5file
 
     def _apply(self, reconstructor):

--- a/ctapipe/tools/display_dl1.py
+++ b/ctapipe/tools/display_dl1.py
@@ -1,6 +1,7 @@
 """
 Calibrate dl0 data to dl1, and plot the photoelectron images.
 """
+from contextlib import ExitStack
 from copy import copy
 
 from matplotlib import pyplot as plt
@@ -8,6 +9,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 
 from ..calib import CameraCalibrator
 from ..core import Component, QualityQuery, Tool
+from ..core.tool import ToolConfigurationError
 from ..core.traits import Bool, Int, Path, classes_with_traits, flag
 from ..image.extractor import ImageExtractor
 from ..io import EventSource
@@ -57,6 +59,7 @@ class ImagePlotter(Component):
         self.cb_peak_time = None
         self.pdf = None
         self.subarray = subarray
+        self._exit_stack = ExitStack()
 
         self._init_figure()
 
@@ -66,7 +69,7 @@ class ImagePlotter(Component):
         self.ax_peak_time = self.fig.add_subplot(1, 2, 2)
         if self.output_path:
             self.log.info(f"Creating PDF: {self.output_path}")
-            self.pdf = PdfPages(self.output_path)
+            self.pdf = self._exit_stack.enter_context(PdfPages(self.output_path))
 
     def plot(self, event, tel_id):
         image = event.dl1.tel[tel_id].image
@@ -123,6 +126,13 @@ class ImagePlotter(Component):
         if self.pdf is not None:
             self.pdf.savefig(self.fig)
 
+    def __enter__(self):
+        self._exit_stack.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self._exit_stack.__exit__(exc_type, exc_value, traceback)
+
     def finish(self):
         if self.pdf is not None:
             self.log.info("Closing PDF")
@@ -163,20 +173,20 @@ class DisplayDL1Calib(Tool):
         self.plotter = None
 
     def setup(self):
-        self.eventsource = EventSource.from_config(parent=self)
+        self.eventsource = self.enter_context(EventSource.from_config(parent=self))
         self.quality_query = QualityQuery(parent=self)
 
         compatible_datalevels = [DataLevel.R1, DataLevel.DL0, DataLevel.DL1_IMAGES]
 
         if not self.eventsource.has_any_datalevel(compatible_datalevels):
-            raise Exception(
+            raise ToolConfigurationError(
                 "The input file contains no pixelwise information. "
                 "Images can not be constructed."
             )
         subarray = self.eventsource.subarray
 
         self.calibrator = CameraCalibrator(parent=self, subarray=subarray)
-        self.plotter = ImagePlotter(parent=self, subarray=subarray)
+        self.plotter = self.enter_context(ImagePlotter(parent=self, subarray=subarray))
 
     def start(self):
         for event in self.eventsource:

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -320,7 +320,6 @@ class ProcessorTool(Tool):
         Last steps after processing events.
         """
         self.write.write_simulation_histograms(self.event_source)
-        self.event_source.close()
         self._write_processing_statistics()
 
 

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -160,12 +160,14 @@ class ProcessorTool(Tool):
     def setup(self):
 
         # setup components:
-        self.event_source = EventSource(parent=self)
+        self.event_source = self.enter_context(EventSource(parent=self))
+
         if not self.event_source.has_any_datalevel(COMPATIBLE_DATALEVELS):
             self.log.critical(
-                "%s  needs the EventSource to provide either R1 or DL0 or DL1A data"
+                "%s  needs the EventSource to provide at least one of these datalevels: %s"
                 ", %s provides only %s",
                 self.name,
+                COMPATIBLE_DATALEVELS,
                 self.event_source,
                 self.event_source.datalevels,
             )
@@ -176,7 +178,9 @@ class ProcessorTool(Tool):
         self.calibrate = CameraCalibrator(parent=self, subarray=subarray)
         self.process_images = ImageProcessor(subarray=subarray, parent=self)
         self.process_shower = ShowerProcessor(subarray=subarray, parent=self)
-        self.write = DataWriter(event_source=self.event_source, parent=self)
+        self.write = self.enter_context(
+            DataWriter(event_source=self.event_source, parent=self)
+        )
 
         # add ml reco classes if model paths were supplied via cli and not already configured
         reco_aliases = {
@@ -316,7 +320,6 @@ class ProcessorTool(Tool):
         Last steps after processing events.
         """
         self.write.write_simulation_histograms(self.event_source)
-        self.write.finish()
         self.event_source.close()
         self._write_processing_statistics()
 

--- a/docs/changes/1926.feature.rst
+++ b/docs/changes/1926.feature.rst
@@ -1,0 +1,11 @@
+``Tool`` now comes with an ``ExitStack`` that enables proper
+handling of context-manager members inside ``Tool.run``.
+Things that require a cleanup step should be implemented
+as context managers and be added to the tool like this:
+
+.. code::
+
+    self.foo = self.enter_context(Foo())
+
+This will ensure that ``Foo.__exit__`` is called when the
+``Tool`` terminates, for whatever reason.


### PR DESCRIPTION
This adds an `ExitStack` to `Tool` which can be used to make sure that e.g. an `EventSource` or a `DataWriter` is properly closed when used by a tool.

Objects that provide context managers should now be used like this in a tool (e.g. `setup`) method:


```
def setup(self):
    self.event_source = self.enter_context(EventSource(parent=self))
```


Fixes #1184