### PR TITLE
Add overwrite option to write_table

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -467,24 +467,19 @@ class SubarrayDescription:
                         "File already contains a SubarrayDescription and overwrite=False"
                     )
 
-                h5file.remove_node(
-                    "/configuration/instrument/", "subarray", recursive=True
-                )
-                h5file.remove_node(
-                    "/configuration/instrument/", "telescope", recursive=True
-                )
-
             write_table(
                 self.to_table(),
                 h5file,
                 path="/configuration/instrument/subarray/layout",
                 mode="a",
+                overwrite=overwrite,
             )
             write_table(
                 self.to_table(kind="optics"),
                 h5file,
                 path="/configuration/instrument/telescope/optics",
                 mode="a",
+                overwrite=overwrite,
             )
             for i, camera in enumerate(self.camera_types):
                 write_table(

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -461,24 +461,21 @@ class SubarrayDescription:
             if not isinstance(h5file, tables.File):
                 h5file = stack.enter_context(tables.open_file(h5file, mode=mode))
 
-            if "/configuration/instrument/subarray" in h5file.root:
-                if overwrite is False:
-                    raise IOError(
-                        "File already contains a SubarrayDescription and overwrite=False"
-                    )
+            if "/configuration/instrument/subarray" in h5file.root and not overwrite:
+                raise IOError(
+                    "File already contains a SubarrayDescription and overwrite=False"
+                )
 
             write_table(
                 self.to_table(),
                 h5file,
                 path="/configuration/instrument/subarray/layout",
-                mode="a",
                 overwrite=overwrite,
             )
             write_table(
                 self.to_table(kind="optics"),
                 h5file,
                 path="/configuration/instrument/telescope/optics",
-                mode="a",
                 overwrite=overwrite,
             )
             for i, camera in enumerate(self.camera_types):
@@ -486,13 +483,13 @@ class SubarrayDescription:
                     camera.geometry.to_table(),
                     h5file,
                     path=f"/configuration/instrument/telescope/camera/geometry_{i}",
-                    mode="a",
+                    overwrite=overwrite,
                 )
                 write_table(
                     camera.readout.to_table(),
                     h5file,
                     path=f"/configuration/instrument/telescope/camera/readout_{i}",
-                    mode="a",
+                    overwrite=overwrite,
                 )
 
             h5file.root.configuration.instrument.subarray._v_attrs.name = self.name

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -131,6 +131,9 @@ def write_table(
     copied = False
     parent, table_name = os.path.split(path)
 
+    if append and overwrite:
+        raise ValueError("overwrite and append are mutually exclusive")
+
     with ExitStack() as stack:
         if not isinstance(h5file, tables.File):
             h5file = stack.enter_context(tables.open_file(h5file, mode=mode))

--- a/ctapipe/io/tests/test_write_table.py
+++ b/ctapipe/io/tests/test_write_table.py
@@ -45,13 +45,17 @@ def test_write_table(tmp_path):
     assert read.meta["FOO"] == "bar"
     assert read["speed"].description == "Speed of stuff"
 
+    # test error for already existing table
+    with pytest.raises(IOError):
+        write_table(table, output_path, table_path)
+
     # test we can append
     write_table(table, output_path, table_path, append=True)
     read = read_table(output_path, table_path)
     assert len(read) == 2 * len(table)
 
     # test we can overwrite
-    write_table(table, output_path, table_path, append=False)
+    write_table(table, output_path, table_path, overwrite=True)
     assert len(read_table(output_path, table_path)) == len(table)
 
 


### PR DESCRIPTION
`write_table` always overwrote an existing table for `append=False`.

To bring this inline with our other IO methods, which by default don't perform potentially destructive actions, I add the overwrite option here which is by default False.