### PR TITLE
Load all dl2 available groups in TableLoader

### DIFF
--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -119,7 +119,7 @@ def test_read_subarray_events(test_file_dl2):
     _, dl2_file = test_file_dl2
 
     with TableLoader(
-        dl2_file, load_dl2_geometry=True, load_simulated=True, load_trigger=True
+        dl2_file, load_dl2=True, load_simulated=True, load_trigger=True
     ) as table_loader:
         table = table_loader.read_subarray_events()
         assert "HillasReconstructor_alt" in table.colnames
@@ -138,7 +138,7 @@ def test_read_telescope_events_type(test_file_dl2):
         dl2_file,
         load_dl1_images=False,
         load_dl1_parameters=False,
-        load_dl2_geometry=True,
+        load_dl2=True,
         load_simulated=True,
         load_true_images=True,
         load_trigger=False,
@@ -165,7 +165,7 @@ def test_read_telescope_events_by_type(test_file_dl2):
         dl2_file,
         load_dl1_images=False,
         load_dl1_parameters=False,
-        load_dl2_geometry=True,
+        load_dl2=True,
         load_simulated=True,
         load_true_images=True,
         load_trigger=False,

--- a/docs/tutorials/ctapipe_overview.ipynb
+++ b/docs/tutorials/ctapipe_overview.ipynb
@@ -740,7 +740,7 @@
     "\n",
     "from ctapipe.io import TableLoader\n",
     "\n",
-    "loader = TableLoader(f.name, load_dl2_geometry=True, load_simulated=True)\n",
+    "loader = TableLoader(f.name, load_dl2=True, load_simulated=True)\n",
     "\n",
     "events = loader.read_subarray_events()"
    ]


### PR DESCRIPTION
This replaces the hard coded `geometry` group with loading all groups that are in the `/dl2/event/subarray/<attribute>/<algorithm>` and `/dl2/event/telescope/<attribute>/<algorithm>/tel_<tel_id:03d>` structure.