### PR TITLE
Fix loading of monoscopic dl2 data in the tableloader

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -2,6 +2,8 @@
 common pytest fixtures for tests in ctapipe
 """
 
+from astropy.table import Table
+import astropy.units as u
 from copy import deepcopy
 
 import pytest
@@ -10,6 +12,7 @@ from ctapipe.instrument import CameraGeometry
 from ctapipe.io import SimTelEventSource
 from ctapipe.utils import get_dataset_path
 from ctapipe.utils.filelock import FileLock
+from ctapipe.io import write_table
 
 from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 
@@ -180,6 +183,21 @@ def dl2_shower_geometry_file(dl2_tmp_path, prod5_gamma_simtel_path):
             "--max-events=20",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
+        # TODO: Remove once #1767 is merged
+        # We do not have mono dl2 data in the file yet, so we add a dummy table
+        dl2_telescope_table = Table(
+            {
+                "obs_id": [1, 1, 2],
+                "event_id": [1, 2, 1],
+                "tel_id": [25, 25, 25],
+                "energy": u.Quantity([100, 120, 90], u.GeV),
+            }
+        )
+        write_table(
+            dl2_telescope_table,
+            output,
+            "/dl2/event/telescope/energy/dummy/tel_025",
+        )
         return output
 
 
@@ -206,6 +224,22 @@ def dl2_proton_geometry_file(dl2_tmp_path, prod5_proton_simtel_path):
             "--max-events=20",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
+        # TODO: Remove once #1767 is merged
+        # We do not have mono dl2 data in the file yet, so we add a dummy table
+        dl2_telescope_table = Table(
+            {
+                "obs_id": [1, 1, 2],
+                "event_id": [1, 2, 1],
+                "tel_id": [25, 25, 25],
+                "energy": u.Quantity([100, 120, 90], u.GeV),
+            }
+        )
+        write_table(
+            dl2_telescope_table,
+            output,
+            "/dl2/event/telescope/energy/dummy/tel_025",
+        )
+
         return output
 
 
@@ -233,6 +267,22 @@ def dl2_shower_geometry_file_type(dl2_tmp_path, prod5_gamma_simtel_path):
             "--DataWriter.split_datasets_by=tel_type",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
+        # TODO: Remove once #1767 is merged
+        # We do not have mono dl2 data in the file yet, so we add a dummy table
+        dl2_telescope_table = Table(
+            {
+                "obs_id": [1, 1, 2],
+                "event_id": [1, 2, 1],
+                "tel_id": [25, 25, 25],
+                "energy": u.Quantity([100, 120, 90], u.GeV),
+            }
+        )
+        write_table(
+            dl2_telescope_table,
+            output,
+            "/dl2/event/telescope/energy/dummy/MST_MST_FlashCam",
+        )
+
         return output
 
 

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -40,6 +40,15 @@ camera_names = [
     "Whipple490",
 ]
 
+dl2_telescope_dummy_table = Table(
+    {
+        "obs_id": [1, 1, 2],
+        "event_id": [1, 2, 1],
+        "tel_id": [25, 25, 25],
+        "energy": u.Quantity([100, 120, 90], u.GeV),
+    }
+)
+
 
 @pytest.fixture(scope="function", params=camera_names)
 def camera_geometry(request):
@@ -185,16 +194,8 @@ def dl2_shower_geometry_file(dl2_tmp_path, prod5_gamma_simtel_path):
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
         # TODO: Remove once #1767 is merged
         # We do not have mono dl2 data in the file yet, so we add a dummy table
-        dl2_telescope_table = Table(
-            {
-                "obs_id": [1, 1, 2],
-                "event_id": [1, 2, 1],
-                "tel_id": [25, 25, 25],
-                "energy": u.Quantity([100, 120, 90], u.GeV),
-            }
-        )
         write_table(
-            dl2_telescope_table,
+            dl2_telescope_dummy_table,
             output,
             "/dl2/event/telescope/energy/dummy/tel_025",
         )
@@ -226,20 +227,11 @@ def dl2_proton_geometry_file(dl2_tmp_path, prod5_proton_simtel_path):
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
         # TODO: Remove once #1767 is merged
         # We do not have mono dl2 data in the file yet, so we add a dummy table
-        dl2_telescope_table = Table(
-            {
-                "obs_id": [1, 1, 2],
-                "event_id": [1, 2, 1],
-                "tel_id": [25, 25, 25],
-                "energy": u.Quantity([100, 120, 90], u.GeV),
-            }
-        )
         write_table(
-            dl2_telescope_table,
+            dl2_telescope_dummy_table,
             output,
             "/dl2/event/telescope/energy/dummy/tel_025",
         )
-
         return output
 
 
@@ -269,20 +261,11 @@ def dl2_shower_geometry_file_type(dl2_tmp_path, prod5_gamma_simtel_path):
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
         # TODO: Remove once #1767 is merged
         # We do not have mono dl2 data in the file yet, so we add a dummy table
-        dl2_telescope_table = Table(
-            {
-                "obs_id": [1, 1, 2],
-                "event_id": [1, 2, 1],
-                "tel_id": [25, 25, 25],
-                "energy": u.Quantity([100, 120, 90], u.GeV),
-            }
-        )
         write_table(
-            dl2_telescope_table,
+            dl2_telescope_dummy_table,
             output,
             "/dl2/event/telescope/energy/dummy/MST_MST_FlashCam",
         )
-
         return output
 
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -283,7 +283,7 @@ class TableLoader(Component):
 
         if self.load_dl2:
             if DL2_TELESCOPE_GROUP in self.h5file:
-                for group_name in self.h5file[DL2_TELESCOPE_GROUP]._v_children:
+                for group_name in self.h5file.root[DL2_TELESCOPE_GROUP]._v_children:
                     group_path = f"{DL2_TELESCOPE_GROUP}/{group_name}"
                     group = self.h5file.root[group_path]
 


### PR DESCRIPTION
There is a small bug in the tableloader, which prevents it from reading monoscopic dl2 data.
Since we do not produce any so far, the tests did not spot it.

For now, I added a dummy table for the test files. We should be able to remove it soon (once the ML module is ready).
(tel 25 and FlashCam, because thats what the tableloader unit tests looks for).