### PR TITLE
Rework container prefix handling

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -95,7 +95,7 @@ class EventType(enum.Enum):
 class EventIndexContainer(Container):
     """index columns to include in event lists, common to all data levels"""
 
-    container_prefix = ""  # don't want to prefix these
+    default_prefix = ""  # don't want to prefix these
     obs_id = Field(0, "observation identifier")
     event_id = Field(0, "event identifier")
 
@@ -106,7 +106,7 @@ class TelEventIndexContainer(Container):
     levels that have telescope-wise information
     """
 
-    container_prefix = ""  # don't want to prefix these
+    default_prefix = ""  # don't want to prefix these
     obs_id = Field(0, "observation identifier")
     event_id = Field(0, "event identifier")
     tel_id = Field(0, "telescope identifier")
@@ -130,7 +130,7 @@ class CameraHillasParametersContainer(BaseHillasParametersContainer):
     is given in meter from the camera center.
     """
 
-    container_prefix = "camera_frame_hillas"
+    default_prefix = "camera_frame_hillas"
     x = Field(nan * u.m, "centroid x coordinate", unit=u.m)
     y = Field(nan * u.m, "centroid x coordinate", unit=u.m)
     r = Field(nan * u.m, "radial coordinate of centroid", unit=u.m)
@@ -150,7 +150,7 @@ class HillasParametersContainer(BaseHillasParametersContainer):
     longitude and latitude in degree.
     """
 
-    container_prefix = "hillas"
+    default_prefix = "hillas"
     fov_lon = Field(
         nan * u.deg,
         "longitude angle in a spherical system centered on the pointing position",
@@ -177,7 +177,7 @@ class LeakageContainer(Container):
     camera, measured in number of signal pixels or in intensity.
     """
 
-    container_prefix = "leakage"
+    default_prefix = "leakage"
 
     pixels_width_1 = Field(
         nan, "fraction of pixels after cleaning that are in camera border of width=1"
@@ -203,7 +203,7 @@ class ConcentrationContainer(Container):
     in certain areas of the image and the full image.
     """
 
-    container_prefix = "concentration"
+    default_prefix = "concentration"
     cog = Field(
         nan, "Percentage of photo-electrons inside one pixel diameter of the cog"
     )
@@ -232,7 +232,7 @@ class CameraTimingParametersContainer(BaseTimingParametersContainer):
     along the shower main axis in the camera frame.
     """
 
-    container_prefix = "camera_frame_timing"
+    default_prefix = "camera_frame_timing"
     slope = Field(
         nan / u.m, "Slope of arrival times along main shower axis", unit=1 / u.m
     )
@@ -245,7 +245,7 @@ class TimingParametersContainer(BaseTimingParametersContainer):
     spherical system centered on the pointing position (TelescopeFrame)
     """
 
-    container_prefix = "timing"
+    default_prefix = "timing"
     slope = Field(
         nan / u.deg, "Slope of arrival times along main shower axis", unit=1 / u.deg
     )
@@ -273,24 +273,24 @@ class StatisticsContainer(Container):
 
 
 class IntensityStatisticsContainer(StatisticsContainer):
-    container_prefix = "intensity"
+    default_prefix = "intensity"
 
 
 class PeakTimeStatisticsContainer(StatisticsContainer):
-    container_prefix = "peak_time"
+    default_prefix = "peak_time"
 
 
 class CoreParametersContainer(Container):
     """Telescope-wise shower's direction in the Tilted/Ground Frame"""
 
-    container_prefix = "core"
+    default_prefix = "core"
     psi = Field(nan * u.deg, "Image direction in the Tilted/Ground Frame", unit="deg")
 
 
 class ImageParametersContainer(Container):
     """Collection of image parameters"""
 
-    container_prefix = "params"
+    default_prefix = "params"
     hillas = Field(
         default_factory=HillasParametersContainer,
         description="Hillas Parameters",
@@ -497,7 +497,7 @@ class TelescopeImpactParameterContainer(Container):
     Impact Parameter computed from reconstructed shower geometry
     """
 
-    container_prefix = "impact"
+    default_prefix = "impact"
 
     distance = Field(
         nan * u.m, "distance of the telescope to the shower axis", unit=u.m
@@ -506,7 +506,7 @@ class TelescopeImpactParameterContainer(Container):
 
 
 class SimulatedShowerContainer(Container):
-    container_prefix = "true"
+    default_prefix = "true"
     energy = Field(nan * u.TeV, "Simulated Energy", unit=u.TeV)
     alt = Field(nan * u.deg, "Simulated altitude", unit=u.deg)
     az = Field(nan * u.deg, "Simulated azimuth", unit=u.deg)
@@ -530,7 +530,7 @@ class SimulatedCameraContainer(Container):
     but for simulated data.
     """
 
-    container_prefix = ""
+    default_prefix = ""
 
     true_image_sum = Field(
         np.int32(-1), "Total number of detected Cherenkov photons in the camera"
@@ -650,7 +650,7 @@ class SimulationConfigContainer(Container):
 
 
 class TelescopeTriggerContainer(Container):
-    container_prefix = ""
+    default_prefix = ""
     time = Field(NAN_TIME, description="Telescope trigger time")
     n_trigger_pixels = Field(
         -1, description="Number of trigger groups (sectors) listed"
@@ -659,7 +659,7 @@ class TelescopeTriggerContainer(Container):
 
 
 class TriggerContainer(Container):
-    container_prefix = ""
+    default_prefix = ""
     time = Field(NAN_TIME, description="central average time stamp")
     tels_with_trigger = Field(
         None, description="List of telescope ids that triggered the array event"
@@ -676,7 +676,7 @@ class ReconstructedGeometryContainer(Container):
     Standard output of algorithms reconstructing shower geometry
     """
 
-    container_prefix = ""
+    default_prefix = ""
 
     alt = Field(nan * u.deg, "reconstructed altitude", unit=u.deg)
     alt_uncert = Field(nan * u.deg, "reconstructed altitude uncertainty", unit=u.deg)
@@ -735,7 +735,7 @@ class ReconstructedEnergyContainer(Container):
     Standard output of algorithms estimating energy
     """
 
-    container_prefix = ""
+    default_prefix = ""
 
     energy = Field(nan * u.TeV, "reconstructed energy", unit=u.TeV)
     energy_uncert = Field(nan * u.TeV, "reconstructed energy uncertainty", unit=u.TeV)
@@ -756,7 +756,7 @@ class ParticleClassificationContainer(Container):
     Standard output of gamma/hadron classification algorithms
     """
 
-    container_prefix = ""
+    default_prefix = ""
 
     # TODO: Do people agree on this? This is very MAGIC-like.
     # TODO: Perhaps an integer classification to support different classes?
@@ -1091,7 +1091,7 @@ class SimulatedShowerDistribution(Container):
     core distance.
     """
 
-    container_prefix = ""
+    default_prefix = ""
 
     obs_id = Field(-1, description="links to which events this corresponds to")
     hist_id = Field(-1, description="Histogram ID")

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -260,8 +260,8 @@ class ContainerMeta(type):
         new_cls = type.__new__(cls, name, bases, dct)
 
         # if prefix was not set as a class variable, build a default one
-        if "container_prefix" not in dct:
-            new_cls.container_prefix = name.lower().replace("container", "")
+        if "default_prefix" not in dct:
+            new_cls.default_prefix = name.lower().replace("container", "")
 
         return new_cls
 
@@ -317,12 +317,12 @@ class Container(metaclass=ContainerMeta):
 
     """
 
-    def __init__(self, **fields):
+    def __init__(self, prefix=None, **fields):
         self.meta = {}
         # __slots__ cannot be provided with defaults
-        # via class variables, so we use a `container_prefix` class variable
+        # via class variables, so we use a `default_prefix` class variable
         # and an instance variable `prefix` in `__slots__`
-        self.prefix = self.container_prefix
+        self.prefix = prefix if prefix is not None else self.default_prefix
 
         for k in set(self.fields).difference(fields):
 

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -34,7 +34,7 @@ def test_prefix():
     c3 = ReallyAwesomeContainer(prefix="c3")
     c2.prefix = "c2"
 
-    assert c1.prefix == "foo"
+    assert c1.prefix == "test2"
     assert c2.prefix == "c2"
     assert c3.prefix == "c3"
 

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -11,34 +11,36 @@ def test_prefix():
         pass
 
     # make sure the default prefix is class name without container
-    assert AwesomeContainer.container_prefix == "awesome"
+    assert AwesomeContainer.default_prefix == "awesome"
     assert AwesomeContainer().prefix == "awesome"
 
     # make sure we can set the class level prefix at definition time
     class ReallyAwesomeContainer(Container):
-        container_prefix = "test"
+        default_prefix = "test"
 
-    assert ReallyAwesomeContainer.container_prefix == "test"
+    assert ReallyAwesomeContainer.default_prefix == "test"
     r = ReallyAwesomeContainer()
     assert r.prefix == "test"
 
-    ReallyAwesomeContainer.container_prefix = "test2"
+    ReallyAwesomeContainer.default_prefix = "test2"
     # new instance should have the old prefix, old instance
     # the one it was created with
     assert ReallyAwesomeContainer().prefix == "test2"
     assert r.prefix == "test"
 
     # Make sure we can set the class level prefix at runtime
-    ReallyAwesomeContainer.container_prefix = "foo"
+    ReallyAwesomeContainer.default_prefix = "foo"
     assert ReallyAwesomeContainer().prefix == "foo"
 
     # make sure we can assign instance level prefixes
     c1 = ReallyAwesomeContainer()
     c2 = ReallyAwesomeContainer()
+    c3 = ReallyAwesomeContainer(prefix="c3")
     c2.prefix = "c2"
 
     assert c1.prefix == "foo"
     assert c2.prefix == "c2"
+    assert c3.prefix == "c3"
 
 
 def test_inheritance():

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -22,15 +22,11 @@ def test_prefix():
     r = ReallyAwesomeContainer()
     assert r.prefix == "test"
 
+    # new instance should have the new prefix,
+    # old instance the one it was created with
     ReallyAwesomeContainer.default_prefix = "test2"
-    # new instance should have the old prefix, old instance
-    # the one it was created with
     assert ReallyAwesomeContainer().prefix == "test2"
     assert r.prefix == "test"
-
-    # Make sure we can set the class level prefix at runtime
-    ReallyAwesomeContainer.default_prefix = "foo"
-    assert ReallyAwesomeContainer().prefix == "foo"
 
     # make sure we can assign instance level prefixes
     c1 = ReallyAwesomeContainer()

--- a/ctapipe/image/image_processor.py
+++ b/ctapipe/image/image_processor.py
@@ -234,7 +234,8 @@ class ImageProcessor(TelescopeComponent):
                     default=DEFAULT_TRUE_IMAGE_PARAMETERS,
                 )
                 for container in sim_camera.true_parameters.values():
-                    container.prefix = "true_" + container.prefix
+                    if not container.prefix.startswith("true_"):
+                        container.prefix = f"true_{container.prefix}"
 
                 self.log.debug(
                     "sim params: %s",

--- a/ctapipe/image/image_processor.py
+++ b/ctapipe/image/image_processor.py
@@ -42,12 +42,10 @@ DEFAULT_PEAKTIME_STATISTICS = PeakTimeStatisticsContainer()
 
 
 class ImageQualityQuery(QualityQuery):
-    """ for configuring image-wise data checks """
+    """for configuring image-wise data checks"""
 
     quality_criteria = List(
-        default_value=[
-            ("size_greater_0", "image.sum() > 0")
-        ],
+        default_value=[("size_greater_0", "image.sum() > 0")],
         help=QualityQuery.quality_criteria.help,
     ).tag(config=True)
 
@@ -68,8 +66,7 @@ class ImageProcessor(TelescopeComponent):
     ).tag(config=True)
 
     apply_image_modifier = BoolTelescopeParameter(
-        default_value=False,
-        help="If true, apply ImageModifier to dl1 images"
+        default_value=False, help="If true, apply ImageModifier to dl1 images"
     ).tag(config=True)
 
     def __init__(
@@ -236,6 +233,9 @@ class ImageProcessor(TelescopeComponent):
                     peak_time=None,  # true image from simulation has no peak time
                     default=DEFAULT_TRUE_IMAGE_PARAMETERS,
                 )
+                for container in sim_camera.true_parameters.values():
+                    container.prefix = "true_" + container.prefix
+
                 self.log.debug(
                     "sim params: %s",
                     event.simulation.tel[tel_id].true_parameters.as_dict(

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -432,11 +432,6 @@ class DataWriter(Component):
         if not self.write_parameters:
             writer.exclude("/dl1/event/telescope/images/.*", "image_mask")
 
-        if self._is_simulation:
-            # no timing information yet for true images
-            writer.exclude("/simulation/event/telescope/parameters/.*", r".*_peak_time_.*")
-            writer.exclude("/simulation/event/telescope/parameters/.*", r".*_timing_.*")
-
         # Set up transforms
         if self.transform_image:
             transform = FixedPointColumnTransform(
@@ -668,11 +663,18 @@ class DataWriter(Component):
                     and event.simulation.tel[tel_id].true_image is not None
                 )
                 if self.write_parameters and has_sim_image:
+                    true_parameters = event.simulation.tel[tel_id].true_parameters
+                    # only write the available containers, no peak time related
+                    # features for true image available.
                     writer.write(
                         f"simulation/event/telescope/parameters/{table_name}",
                         [
                             tel_index,
-                            *event.simulation.tel[tel_id].true_parameters.values(),
+                            true_parameters.hillas,
+                            true_parameters.leakage,
+                            true_parameters.concentration,
+                            true_parameters.morphology,
+                            true_parameters.intensity_statistics,
                         ],
                     )
 

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -46,8 +46,11 @@ def _get_tel_index(event, tel_id):
 #   (meaning readers need to update scripts)
 # - increase the minor number if new columns or datasets are added
 # - increase the patch number if there is a small bugfix to the model.
-DATA_MODEL_VERSION = "v3.0.0"
+DATA_MODEL_VERSION = "v4.0.0"
 DATA_MODEL_CHANGE_HISTORY = """
+- v4.0.0: Container prefixes are now included for reconstruction algorithms
+          and true parameters.
+          Telescope Impact Parameters were added.
 - v3.0.0: reconstructed core uncertainties splitted in their X-Y components
 - v2.2.0: added R0 and R1 outputs
 - v2.1.0: hillas and timing parameters are per default saved in telescope frame (degree) as opposed to camera frame (m)

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -432,8 +432,8 @@ class DataWriter(Component):
 
         if self._is_simulation:
             # no timing information yet for true images
-            writer.exclude("/simulation/event/telescope/parameters/.*", r"peak_time_.*")
-            writer.exclude("/simulation/event/telescope/parameters/.*", "timing_.*")
+            writer.exclude("/simulation/event/telescope/parameters/.*", r".*_peak_time_.*")
+            writer.exclude("/simulation/event/telescope/parameters/.*", r".*_timing_.*")
 
         # Set up transforms
         if self.transform_image:

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -423,6 +423,8 @@ class DataWriter(Component):
         writer.exclude("/dl1/monitoring/telescope/pointing/.*", "n_trigger_pixels")
         writer.exclude("/dl1/monitoring/telescope/pointing/.*", "trigger_pixels")
         writer.exclude("/dl1/monitoring/event/pointing/.*", "event_type")
+        writer.exclude("/dl1/event/telescope/images/.*", "parameters")
+        writer.exclude("/simulation/event/telescope/images/.*", "true_parameters")
 
         if not self.write_images:
             writer.exclude("/simulation/event/telescope/images/.*", "true_image")

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -504,7 +504,7 @@ class DataWriter(Component):
         class ExtraSimInfo(Container):
             """just to contain obs_id"""
 
-            container_prefix = ""
+            default_prefix = ""
             obs_id = Field(0, "Simulation Run Identifier")
 
         for obs_id, config in self.event_source.simulation_config.items():
@@ -670,10 +670,9 @@ class DataWriter(Component):
                         f"simulation/event/telescope/parameters/{table_name}",
                         [
                             tel_index,
-                            *event.simulation.tel[tel_id].true_parameters.values()
-                        ]
+                            *event.simulation.tel[tel_id].true_parameters.values(),
+                        ],
                     )
-
 
     def _write_dl2_telescope_events(
         self, writer: TableWriter, event: ArrayEventContainer

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -475,7 +475,7 @@ class DataWriter(Component):
         writer.exclude("dl2/event/telescope/.*", "tel_ids")
         writer.add_column_transform_regexp(
             table_regexp="dl2/event/subarray/.*",
-            col_regexp="tel_ids",
+            col_regexp=".*_tel_ids",
             transform=tr_tel_list_to_mask,
         )
 

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -472,7 +472,7 @@ class DataWriter(Component):
         # set up DL2 transforms:
         # - the single-tel output has no list of tel_ids
         # - the stereo output tel_ids list needs to be transformed to a pattern
-        writer.exclude("dl2/event/telescope/.*", "tel_ids")
+        writer.exclude("dl2/event/telescope/.*", ".*_tel_ids")
         writer.add_column_transform_regexp(
             table_regexp="dl2/event/subarray/.*",
             col_regexp=".*_tel_ids",

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -356,6 +356,7 @@ class HDF5EventSource(EventSource):
                     algorithm: HDF5TableReader(self.file_).read(
                         table._v_pathname,
                         containers=container,
+                        prefixes=(algorithm,),
                     )
                     for algorithm, table in group._v_children.items()
                 }
@@ -372,12 +373,12 @@ class HDF5EventSource(EventSource):
                     continue
 
                 dl2_tel_readers[kind] = {}
-                for name, algorithm_group in group._v_children.items():
-                    dl2_tel_readers[kind][name] = {
+                for algorithm, algorithm_group in group._v_children.items():
+                    dl2_tel_readers[kind][algorithm] = {
                         key: HDF5TableReader(self.file_).read(
                             table._v_pathname,
                             containers=container,
-                            prefixes=True,
+                            prefixes=(f"{algorithm}_tel",),
                         )
                         for key, table in algorithm_group._v_children.items()
                     }

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -246,7 +246,7 @@ class HDF5EventSource(EventSource):
         # Alternatively this becomes a flat list
         # and the obs_id matching part needs to be done in _generate_events()
         class ObsIdContainer(Container):
-            container_prefix = ""
+            default_prefix = ""
             obs_id = Field(-1)
 
         simulation_configs = {}

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -508,7 +508,7 @@ class HDF5EventSource(EventSource):
                         simulated.true_image = simulated_image_row["true_image"]
 
                 if DataLevel.DL1_PARAMETERS in self.datalevels:
-                    if f"tel_{tel_id:03d}" not in param_readers.keys():
+                    if f"tel_{tel_id:03d}" not in param_readers:
                         logger.debug(
                             f"Triggered telescope {tel_id} is missing "
                             "from the parameters table."
@@ -528,7 +528,7 @@ class HDF5EventSource(EventSource):
                         peak_time_statistics=params[6],
                     )
                     if self.has_simulated_dl1:
-                        if f"tel_{tel_id:03d}" not in param_readers.keys():
+                        if f"tel_{tel_id:03d}" not in simulated_param_readers:
                             logger.debug(
                                 f"Triggered telescope {tel_id} is missing "
                                 "from the simulated parameters table, but was "

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -54,7 +54,7 @@ DL2_CONTAINERS = {
 }
 
 
-COMPATIBLE_DL1_VERSIONS = [
+COMPATIBLE_DATA_MODEL_VERSIONS = [
     "v1.0.0",
     "v1.0.1",
     "v1.0.2",
@@ -65,6 +65,7 @@ COMPATIBLE_DL1_VERSIONS = [
     "v2.1.0",
     "v2.2.0",
     "v3.0.0",
+    "v4.0.0",
 ]
 
 
@@ -181,10 +182,10 @@ class HDF5EventSource(EventSource):
                 return False
 
             version = metadata["CTA PRODUCT DATA MODEL VERSION"]
-            if version not in COMPATIBLE_DL1_VERSIONS:
+            if version not in COMPATIBLE_DATA_MODEL_VERSIONS:
                 logger.error(
                     f"File is DL1 file but has unsupported version {version}"
-                    f", supported versions are {COMPATIBLE_DL1_VERSIONS}"
+                    f", supported versions are {COMPATIBLE_DATA_MODEL_VERSIONS}"
                 )
                 return False
 

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -335,7 +335,13 @@ class HDF5EventSource(EventSource):
                             MorphologyContainer,
                             IntensityStatisticsContainer,
                         ],
-                        prefixes=True,
+                        prefixes=[
+                            "true_hillas",
+                            "true_leakage",
+                            "true_concentration",
+                            "true_morphology",
+                            "true_intensity",
+                        ],
                     )
                     for tel in self.file_.root.dl1.event.telescope.parameters
                 }

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -566,7 +566,7 @@ class HDF5TableReader(TableReader):
         if prefixes is False:
             prefixes = ["" for _ in containers]
         elif prefixes is True:
-            prefixes = [container.container_prefix for container in containers]
+            prefixes = [container.default_prefix for container in containers]
         elif isinstance(prefixes, str):
             prefixes = [prefixes for _ in containers]
 

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -606,7 +606,7 @@ class HDF5TableReader(TableReader):
                 for fieldname in missing_cols:
                     kwargs[fieldname] = None
 
-                container = cls(**kwargs)
+                container = cls(**kwargs, prefix=prefix)
                 container.meta = self._meta[table_name]
                 ret.append(container)
 

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -468,11 +468,12 @@ class SimTelEventSource(EventSource):
                                 self.subarray.tel_index_array[tel_id]
                             ],
                             distance_uncert=0 * u.m,
+                            prefix="true_impact",
                         )
                     else:
-                        impact_container = TelescopeImpactParameterContainer()
-
-                    impact_container.prefix = "true_impact"
+                        impact_container = TelescopeImpactParameterContainer(
+                            prefix="true_impact",
+                        )
 
                     data.simulation.tel[tel_id] = SimulatedCameraContainer(
                         true_image_sum=true_image_sums[

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -117,14 +117,6 @@ def _get_structure(h5file):
     return "by_type"
 
 
-def _add_column_prefix(table, prefix, ignore=()):
-    """
-    Add a prefix to all columns in table besides columns in ``ignore``.
-    """
-    for col in set(table.colnames) - set(ignore):
-        table.rename_column(col, f"{prefix}_{col}")
-
-
 def _join_subarray_events(table1, table2):
     """Outer join two tables on the telescope subarray keys"""
     return join_allow_empty(table1, table2, SUBARRAY_EVENT_KEYS, "left")
@@ -318,12 +310,6 @@ class TableLoader(Component):
                             start=start,
                             stop=stop,
                         )
-
-                        # add the algorithm as prefix to distinguish multiple
-                        # algorithms predicting the same quantities
-                        _add_column_prefix(
-                            dl2, prefix=algorithm, ignore=SUBARRAY_EVENT_KEYS
-                        )
                         table = _join_subarray_events(table, dl2)
 
         if keep_order:
@@ -393,12 +379,6 @@ class TableLoader(Component):
                         dl2 = self._read_telescope_table(
                             path, tel_id, start=start, stop=stop
                         )
-
-                        # add the algorithm as prefix to distinguish multiple
-                        # algorithms predicting the same quantities
-                        _add_column_prefix(
-                            dl2, prefix=algorithm, ignore=TELESCOPE_EVENT_KEYS
-                        )
                         table = _join_telescope_events(table, dl2)
 
         if self.load_true_images:
@@ -411,7 +391,6 @@ class TableLoader(Component):
             true_parameters = self._read_telescope_table(
                 TRUE_PARAMETERS_GROUP, tel_id, start=start, stop=stop
             )
-            _add_column_prefix(true_parameters, "true", ignore=TELESCOPE_EVENT_KEYS)
             table = _join_telescope_events(table, true_parameters)
 
         if self.load_instrument:

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -571,7 +571,7 @@ def test_column_exclusions(tmp_path):
     tmp_file = tmp_path / "test_column_exclusions.hdf5"
 
     class SomeContainer(Container):
-        container_prefix = ""
+        default_prefix = ""
         hillas_x = Field(None)
         hillas_y = Field(None)
         impact_x = Field(None)
@@ -615,7 +615,7 @@ def test_column_transforms(tmp_path):
     tmp_file = tmp_path / "test_column_transforms.hdf5"
 
     class SomeContainer(Container):
-        container_prefix = ""
+        default_prefix = ""
 
         current = Field(1 * u.A, unit=u.uA)
         time = Field(NAN_TIME)
@@ -648,7 +648,7 @@ def test_fixed_point_column_transform(tmp_path):
     tmp_file = tmp_path / "test_column_transforms.hdf5"
 
     class SomeContainer(Container):
-        container_prefix = ""
+        default_prefix = ""
         image = Field(np.array([np.nan, np.inf, -np.inf]))
 
     cont = SomeContainer()
@@ -686,7 +686,7 @@ def test_column_transforms_regexps(tmp_path):
         return x * 10
 
     class SomeContainer(Container):
-        container_prefix = ""
+        default_prefix = ""
         hillas_x = Field(1)
         hillas_y = Field(1)
 
@@ -847,7 +847,7 @@ def test_strings(tmp_path):
 
     # when not giving a max_len, should be taken from the first container
     class Container1(Container):
-        container_prefix = ""
+        default_prefix = ""
         string = Field("", "test string")
 
     path = tmp_path / "test.h5"
@@ -864,7 +864,7 @@ def test_strings(tmp_path):
     assert table["string"].tolist() == ["Hello", "öä"]
 
     class Container2(Container):
-        container_prefix = ""
+        default_prefix = ""
         string = Field("", "test string", max_length=10)
 
     path = tmp_path / "test.h5"

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -887,3 +887,24 @@ def test_strings(tmp_path):
         for string in expected:
             c = next(generator)
             assert c.string == string
+
+
+def test_prefix_in_output_container(tmp_path):
+    """Test that output containers retain the used prefix"""
+
+    class Container1(Container):
+        default_prefix = ""
+        value = Field(-1, "value")
+
+    path = tmp_path / "prefix.h5"
+    with HDF5TableWriter(path, mode="w", add_prefix=True) as writer:
+        for value in (1, 2, 3):
+            writer.write("values", Container1(value=value, prefix="custom_prefix"))
+
+    with HDF5TableReader(path) as reader:
+        generator = reader.read("/values", Container1, prefixes="custom_prefix")
+
+        for value in (1, 2, 3):
+            c = next(generator)
+            assert c.prefix == "custom_prefix"
+            assert c.value == value

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -172,4 +172,3 @@ def test_read_dl2(dl2_shower_geometry_file):
             impact = e.dl2.tel[tel_id].impact[algorithm]
             assert impact.prefix == algorithm + "_tel"
             assert impact.distance is not None
-            assert impact.tel_ids is None

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -161,6 +161,7 @@ def test_read_dl2(dl2_shower_geometry_file):
         assert algorithm in e.dl2.stereo.geometry
         assert e.dl2.stereo.geometry[algorithm].alt is not None
         assert e.dl2.stereo.geometry[algorithm].az is not None
+        assert e.dl2.stereo.geometry[algorithm].tel_ids is not None
         assert e.dl2.stereo.geometry[algorithm].prefix == algorithm
 
         tel_mask = e.dl2.stereo.geometry[algorithm].tel_ids

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -159,8 +159,13 @@ def test_read_dl2(dl2_shower_geometry_file):
     with HDF5EventSource(dl2_shower_geometry_file) as s:
         e = next(iter(s))
         assert algorithm in e.dl2.stereo.geometry
+        assert e.dl2.stereo.geometry[algorithm].alt is not None
+        assert e.dl2.stereo.geometry[algorithm].az is not None
+        assert e.dl2.stereo.geometry[algorithm].prefix == algorithm
+
         tel_mask = e.dl2.stereo.geometry[algorithm].tel_ids
         tel_ids = s.subarray.tel_mask_to_tel_ids(tel_mask)
         for tel_id in tel_ids:
             assert algorithm in e.dl2.tel[tel_id].impact
+            assert e.dl2.tel[tel_id].impact[algorithm].prefix == algorithm + "_tel"
             assert e.dl2.tel[tel_id].impact[algorithm].distance is not None

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -167,6 +167,9 @@ def test_read_dl2(dl2_shower_geometry_file):
         tel_mask = e.dl2.stereo.geometry[algorithm].tel_ids
         tel_ids = s.subarray.tel_mask_to_tel_ids(tel_mask)
         for tel_id in tel_ids:
+            assert tel_id in e.dl2.tel
             assert algorithm in e.dl2.tel[tel_id].impact
-            assert e.dl2.tel[tel_id].impact[algorithm].prefix == algorithm + "_tel"
-            assert e.dl2.tel[tel_id].impact[algorithm].distance is not None
+            impact = e.dl2.tel[tel_id].impact[algorithm]
+            assert impact.prefix == algorithm + "_tel"
+            assert impact.distance is not None
+            assert impact.tel_ids is None

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -236,7 +236,7 @@ def test_read_telescope_events_type(test_file_dl2):
         expected_ids = subarray.get_tel_ids_for_type("MST_MST_FlashCam")
         assert set(table["tel_id"].data).issubset(expected_ids)
         assert "equivalent_focal_length" in table.colnames
-        assert "HillasReconstructor_impact_distance" in table.colnames
+        assert "HillasReconstructor_tel_distance" in table.colnames
 
 
 def test_read_telescope_events_by_type(test_file_dl2):

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -40,6 +40,7 @@ __all__ = ["HillasIntersection"]
 
 
 INVALID = ReconstructedGeometryContainer(tel_ids=[])
+INVALID.prefix = 'HillasIntersection'
 
 
 class HillasIntersection(Reconstructor):
@@ -258,6 +259,7 @@ class HillasIntersection(Reconstructor):
             h_max_uncert=u.Quantity(np.nan * x_max.unit),
             goodness_of_fit=np.nan,
         )
+        result.prefix = self.__class__.__name__
         return result
 
     def reconstruct_nominal(self, hillas_parameters):

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -39,8 +39,10 @@ from ctapipe.core import traits
 __all__ = ["HillasIntersection"]
 
 
-INVALID = ReconstructedGeometryContainer(tel_ids=[])
-INVALID.prefix = 'HillasIntersection'
+INVALID = ReconstructedGeometryContainer(
+    tel_ids=[],
+    prefix="HillasIntersection",
+)
 
 
 class HillasIntersection(Reconstructor):

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -243,7 +243,7 @@ class HillasIntersection(Reconstructor):
 
         src_error = np.sqrt(err_fov_lon**2 + err_fov_lat**2)
 
-        result = ReconstructedGeometryContainer(
+        return ReconstructedGeometryContainer(
             alt=sky_pos.altaz.alt.to(u.rad),
             az=sky_pos.altaz.az.to(u.rad),
             core_x=grd.x,
@@ -260,9 +260,8 @@ class HillasIntersection(Reconstructor):
             h_max=x_max,
             h_max_uncert=u.Quantity(np.nan * x_max.unit),
             goodness_of_fit=np.nan,
+            prefix=self.__class__.__name__,
         )
-        result.prefix = self.__class__.__name__
-        return result
 
     def reconstruct_nominal(self, hillas_parameters):
         """

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -38,6 +38,7 @@ __all__ = ["HillasPlane", "HillasReconstructor"]
 
 
 INVALID = ReconstructedGeometryContainer(tel_ids=[])
+INVALID.prefix = 'HillasReconstructor'
 
 
 def angle(v1, v2):
@@ -282,7 +283,7 @@ class HillasReconstructor(Reconstructor):
             az_uncert=err_est_dir,
             h_max=h_max,
         )
-
+        result.prefix = self.__class__.__name__
         return result
 
     def initialize_hillas_planes(

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -37,8 +37,10 @@ from astropy import units as u
 __all__ = ["HillasPlane", "HillasReconstructor"]
 
 
-INVALID = ReconstructedGeometryContainer(tel_ids=[])
-INVALID.prefix = 'HillasReconstructor'
+INVALID = ReconstructedGeometryContainer(
+    tel_ids=[],
+    prefix="HillasReconstructor",
+)
 
 
 def angle(v1, v2):

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -268,25 +268,21 @@ class HillasReconstructor(Reconstructor):
         # estimate max height of shower
         h_max = self.estimate_h_max(hillas_planes)
 
-        # astropy's coordinates system rotates counter-clockwise.
-        # Apparently we assume it to be clockwise.
-        # that's why lon get's a sign
-        result = ReconstructedGeometryContainer(
+        return ReconstructedGeometryContainer(
             alt=lat,
-            az=-lon,
+            az=-lon,  # az is clockwise, lon counter-clockwise
             core_x=core_pos_ground.x,
             core_y=core_pos_ground.y,
             core_tilted_x=core_pos_tilted.x,
             core_tilted_y=core_pos_tilted.y,
-            tel_ids=[h for h in hillas_dict.keys()],
+            tel_ids=[tel_id for tel_id in hillas_dict.keys()],
             average_intensity=np.mean([h.intensity for h in hillas_dict.values()]),
             is_valid=True,
             alt_uncert=err_est_dir,
             az_uncert=err_est_dir,
             h_max=h_max,
+            prefix=self.__class__.__name__,
         )
-        result.prefix = self.__class__.__name__
-        return result
 
     def initialize_hillas_planes(
         self, hillas_dict, subarray, telescopes_pointings, array_pointing

--- a/ctapipe/reco/impact.py
+++ b/ctapipe/reco/impact.py
@@ -757,11 +757,12 @@ class ImPACTReconstructor(Component):
 
         shower_result.h_max *= np.cos(zenith)
         shower_result.h_max_uncert = errors[5] * shower_result.h_max
-
         shower_result.goodness_of_fit = like
+        shower_result.prefix = self.__class__.__name__
 
         # Create a container class for reconstructed energy
         energy_result = ReconstructedEnergyContainer()
+        energy_result.prefix = self.__class__.__name__
         # Fill with results
         energy_result.energy = fit_params[4] * u.TeV
         energy_result.energy_uncert = errors[4] * u.TeV

--- a/ctapipe/reco/impact.py
+++ b/ctapipe/reco/impact.py
@@ -395,7 +395,7 @@ class ImPACTReconstructor(Component):
         # everything in the correct units when loading in the class
         # and ignore them from then on
 
-        zenith = (np.pi / 2) - self.array_direction.alt.to(u.rad).value
+        zenith = self.array_direction.zen.to_value(u.rad)
 
         # Geometrically calculate the depth of maximum given this test position
         x_max = self.get_shower_max(source_x, source_y, core_x, core_y, zenith)
@@ -693,7 +693,7 @@ class ImPACTReconstructor(Component):
         )
         tilt_x = tilted.x.to(u.m).value
         tilt_y = tilted.y.to(u.m).value
-        zenith = 90 * u.deg - self.array_direction.alt
+        zenith = self.array_direction.zen
 
         seeds = spread_line_seed(
             self.hillas_parameters,
@@ -716,9 +716,6 @@ class ImPACTReconstructor(Component):
         )
 
         # Create a container class for reconstructed shower
-        shower_result = ReconstructedGeometryContainer(
-            prefix=self.__class__.__name__,
-        )
 
         # Convert the best fits direction and core to Horizon and ground systems and
         # copy to the shower container
@@ -729,7 +726,6 @@ class ImPACTReconstructor(Component):
         )
         horizon = nominal.transform_to(AltAz())
 
-        shower_result.alt, shower_result.az = horizon.alt, horizon.az
         tilted = TiltedGroundFrame(
             x=fit_params[2] * u.m,
             y=fit_params[3] * u.m,
@@ -738,28 +734,33 @@ class ImPACTReconstructor(Component):
         )
         ground = project_to_ground(tilted)
 
-        shower_result.core_x = ground.x
-        shower_result.core_y = ground.y
-
-        shower_result.is_valid = True
-
-        # Currently no errors not available to copy NaN
-        shower_result.alt_uncert = np.nan
-        shower_result.az_uncert = np.nan
-        shower_result.core_uncert = np.nan
-
-        # Copy reconstructed Xmax
-        shower_result.h_max = fit_params[5] * self.get_shower_max(
-            fit_params[0],
-            fit_params[1],
-            fit_params[2],
-            fit_params[3],
-            zenith.to(u.rad).value,
+        h_max = (
+            fit_params[5]
+            * np.cos(zenith)
+            * self.get_shower_max(
+                fit_params[0],
+                fit_params[1],
+                fit_params[2],
+                fit_params[3],
+                zenith.to(u.rad).value,
+            )
         )
 
-        shower_result.h_max *= np.cos(zenith)
-        shower_result.h_max_uncert = errors[5] * shower_result.h_max
-        shower_result.goodness_of_fit = like
+        shower_result = ReconstructedGeometryContainer(
+            alt=horizon.alt,
+            az=horizon.az,
+            core_x=ground.x,
+            core_y=ground.y,
+            is_valid=True,
+            alt_uncert=np.nan,
+            az_uncert=np.nan,
+            core_uncert=np.nan,
+            # Copy reconstructed hmax
+            h_max=h_max,
+            h_max_uncert=errors[5] * h_max,
+            goodness_of_fit=like,
+            prefix=self.__class__.__name__,
+        )
 
         # Create a container class for reconstructed energy
         energy_result = ReconstructedEnergyContainer(

--- a/ctapipe/reco/impact.py
+++ b/ctapipe/reco/impact.py
@@ -716,7 +716,9 @@ class ImPACTReconstructor(Component):
         )
 
         # Create a container class for reconstructed shower
-        shower_result = ReconstructedGeometryContainer()
+        shower_result = ReconstructedGeometryContainer(
+            prefix=self.__class__.__name__,
+        )
 
         # Convert the best fits direction and core to Horizon and ground systems and
         # copy to the shower container
@@ -758,15 +760,14 @@ class ImPACTReconstructor(Component):
         shower_result.h_max *= np.cos(zenith)
         shower_result.h_max_uncert = errors[5] * shower_result.h_max
         shower_result.goodness_of_fit = like
-        shower_result.prefix = self.__class__.__name__
 
         # Create a container class for reconstructed energy
-        energy_result = ReconstructedEnergyContainer()
-        energy_result.prefix = self.__class__.__name__
-        # Fill with results
-        energy_result.energy = fit_params[4] * u.TeV
-        energy_result.energy_uncert = errors[4] * u.TeV
-        energy_result.is_valid = True
+        energy_result = ReconstructedEnergyContainer(
+            prefix=self.__class__.__name__,
+            energy=fit_params[4] * u.TeV,
+            energy_uncert=errors[4] * u.TeV,
+            is_valid=True,
+        )
 
         return shower_result, energy_result
 

--- a/ctapipe/reco/shower_processor.py
+++ b/ctapipe/reco/shower_processor.py
@@ -85,5 +85,6 @@ class ShowerProcessor(Component):
         for tel_id in event.trigger.tels_with_trigger:
             tel_index = self.subarray.tel_indices[tel_id]
             event.dl2.tel[tel_id].impact[k] = TelescopeImpactParameterContainer(
-                distance=impact_distances[tel_index]
+                distance=impact_distances[tel_index],
+                prefix=f"{self.reconstructor_type}_impact",
             )

--- a/ctapipe/reco/shower_processor.py
+++ b/ctapipe/reco/shower_processor.py
@@ -86,5 +86,5 @@ class ShowerProcessor(Component):
             tel_index = self.subarray.tel_indices[tel_id]
             event.dl2.tel[tel_id].impact[k] = TelescopeImpactParameterContainer(
                 distance=impact_distances[tel_index],
-                prefix=f"{self.reconstructor_type}_impact",
+                prefix=f"{self.reconstructor_type}_tel",
             )

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -126,21 +126,25 @@ def test_stage_1_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
     for feature in features:
         assert feature in dl1_features.columns
 
-    # DL1B file as input
-    assert (
-        run_tool(
-            ProcessorTool(),
-            argv=[
-                f"--config={config}",
-                f"--input={dl1_parameters_file}",
-                f"--output={tmp_path}/dl1b_from_dl1b.dl1.h5",
-                "--write-parameters",
-                "--overwrite",
-            ],
-            cwd=tmp_path,
-        )
-        == 1
+    true_impact = read_table(
+        dl1b_from_dl1a_file,
+        "/simulation/event/telescope/impact/tel_025",
     )
+    assert "true_impact_distance" in true_impact.colnames
+
+    # DL1B file as input
+    ret = run_tool(
+        ProcessorTool(),
+        argv=[
+            f"--config={config}",
+            f"--input={dl1_parameters_file}",
+            f"--output={tmp_path}/dl1b_from_dl1b.dl1.h5",
+            "--write-parameters",
+            "--overwrite",
+        ],
+        cwd=tmp_path,
+    )
+    assert ret == 1
 
 
 def test_stage1_datalevels(tmp_path):


### PR DESCRIPTION
This PR changes our prefix handling to make it consistent over the different IO methods. 

Instead of attaching the algorithm name in the TableLoader to avoid duplicated column names, the container prefixes are already set by the algorithms themselves.

This means the prefixed column names are written into the  file and the loader can just read them.

Also, as the columns include the prefix now, so do the metadata entries.

I use the the algorithm name as prefix for stereo features and `f"{algorithm}_tel"` as prefix for telescope-wise features. In a first iteration I used `mono`, but this is misleading at least in the case of the impact, as it is a information per telescope but derived from a stereo method.

The Container class attribute `container_prefix` was also renamed to the more fitting `default_prefix` and the prefix can now be passed to `Container.__init__`.