### PR TITLE
ML: fix issue where if one specified a config file, input_url would fail

### DIFF
--- a/ctapipe/ml/tools/apply_energy_regressor.py
+++ b/ctapipe/ml/tools/apply_energy_regressor.py
@@ -1,6 +1,6 @@
 from astropy.table.operations import vstack
 import tables
-from ctapipe.core.tool import Tool
+from ctapipe.core.tool import Tool, ToolConfigurationError
 from ctapipe.core.traits import Bool, Path, flag, create_class_enum_trait
 from ctapipe.io import TableLoader, write_table
 from tqdm.auto import tqdm
@@ -18,7 +18,7 @@ class ApplyEnergyRegressor(Tool):
 
     input_url = Path(
         default_value=None,
-        allow_none=False,
+        allow_none=True,
         directory_ok=False,
         exists=True,
     ).tag(config=True)
@@ -57,6 +57,12 @@ class ApplyEnergyRegressor(Tool):
 
     def setup(self):
         """"""
+
+        if self.input_url is None:
+            raise ToolConfigurationError(
+                "You must specify an input_url (--input / -i <URL>) !"
+            )
+
         self.h5file = tables.open_file(self.input_url, mode="r+")
         self.loader = TableLoader(
             parent=self,


### PR DESCRIPTION
This was due to a subtle bug that happens when the Path traitlet's
allow_none=False option is used.  The problem was that validate() is
called when loading the config file, at whkch point input_url is None
temporarily.


To reproduce:
```
ctapipe-ml-apply-energy-regressor -i some_input_file.h5  # works
ctapipe-ml-apply-energy-regressor -i some_input_file.h5  --config some_other_config.yaml # fails with strange message
```
Adding a config like this failed with a message like "input_url" cannot be None