### PR TITLE
Fix multiplied metadata when reading multiple containers from a single table (#1785)

### DIFF
--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -473,11 +473,12 @@ class HDF5TableReader(TableReader):
 
     def _handle_metadata(self, table_name, containers, prefixes, ignore_columns):
         tab = self._tables[table_name]
+        self._meta[table_name] = {}
         for container, prefix in zip(containers, prefixes):
-            # store the meta
-            self._meta[table_name] = {}
+            container_name = container.__name__
+            self._meta[table_name][container_name] = {}
             for key in tab.attrs._f_list():
-                self._meta[table_name][key] = tab.attrs[key]
+                self._meta[table_name][container_name][key] = tab.attrs[key]
 
     def _map_table_to_containers(
         self, table_name, containers, prefixes, ignore_columns
@@ -612,7 +613,7 @@ class HDF5TableReader(TableReader):
                     kwargs[fieldname] = None
 
                 container = cls(**kwargs, prefix=prefix)
-                container.meta = self._meta[table_name]
+                container.meta = self._meta[table_name][container.__class__.__name__]
                 ret.append(container)
 
             if return_iterable:


### PR DESCRIPTION
When reading multiple containers from a single table, table metadata
gets multiplied to all containers. This has impacts for e.g. the
_TRANSFORM metadata, due to columns not found (on containers that have
now those wrong metadata).

This fix introduces a new (temporary) level while reading, that
separates (different) container metadata from table-metadata.

This way the correct metadata gets assigned to the corresponding
containers.

General metadata (e.g. version number) are assigned to all containers.