### PR TITLE
Fix comparison of timestamps in calibration code

### DIFF
--- a/ctapipe/calib/camera/flatfield.py
+++ b/ctapipe/calib/camera/flatfield.py
@@ -115,18 +115,18 @@ class FlatFieldCalculator(Component):
 
 class FlasherFlatFieldCalculator(FlatFieldCalculator):
     """Calculates flat-field parameters from flasher data
-       based on the best algorithm described by S. Fegan in MST-CAM-TN-0060 (eq. 19)
-       Pixels are defined as outliers on the base of a cut on the pixel charge median
-       over the full sample distribution and the pixel signal time inside the
-       waveform time
+      based on the best algorithm described by S. Fegan in MST-CAM-TN-0060 (eq. 19)
+      Pixels are defined as outliers on the base of a cut on the pixel charge median
+      over the full sample distribution and the pixel signal time inside the
+      waveform time
 
 
-     Parameters
-     ----------
-     charge_cut_outliers : List[2]
-         Interval of accepted charge values (fraction with respect to camera median value)
-     time_cut_outliers : List[2]
-         Interval (in waveform samples) of accepted time values
+    Parameters
+    ----------
+    charge_cut_outliers : List[2]
+        Interval of accepted charge values (fraction with respect to camera median value)
+    time_cut_outliers : List[2]
+        Interval (in waveform samples) of accepted time values
 
     """
 
@@ -140,18 +140,18 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
 
     def __init__(self, **kwargs):
         """Calculates flat-field parameters from flasher data
-           based on the best algorithm described by S. Fegan in MST-CAM-TN-0060 (eq. 19)
-           Pixels are defined as outliers on the base of a cut on the pixel charge median
-           over the full sample distribution and the pixel signal time inside the
-           waveform time
+          based on the best algorithm described by S. Fegan in MST-CAM-TN-0060 (eq. 19)
+          Pixels are defined as outliers on the base of a cut on the pixel charge median
+          over the full sample distribution and the pixel signal time inside the
+          waveform time
 
 
-         Parameters:
-         ----------
-         charge_cut_outliers : List[2]
-             Interval of accepted charge values (fraction with respect to camera median value)
-         time_cut_outliers : List[2]
-             Interval (in waveform samples) of accepted time values
+        Parameters:
+        ----------
+        charge_cut_outliers : List[2]
+            Interval of accepted charge values (fraction with respect to camera median value)
+        time_cut_outliers : List[2]
+            Interval (in waveform samples) of accepted time values
 
         """
         super().__init__(**kwargs)
@@ -190,14 +190,14 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
 
     def calculate_relative_gain(self, event):
         """
-         calculate the flatfield statistical values
-         and fill mon.tel[tel_id].flatfield container
+        calculate the flatfield statistical values
+        and fill mon.tel[tel_id].flatfield container
 
-         Parameters
-         ----------
-         event : general event container
+        Parameters
+        ----------
+        event : general event container
 
-         """
+        """
 
         # initialize the np array at each cycle
         waveform = event.r1.tel[self.tel_id].waveform
@@ -235,7 +235,7 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
 
         self.collect_sample(dl1.image, pixel_mask, dl1.peak_time)
 
-        sample_age = trigger_time - self.time_start
+        sample_age = (trigger_time - self.time_start).to_value(u.s)
 
         # check if to create a calibration event
         if (
@@ -296,7 +296,7 @@ class FlasherFlatFieldCalculator(FlatFieldCalculator):
     def calculate_time_results(
         self, trace_time, masked_pixels_of_sample, time_start, trigger_time
     ):
-        """Calculate and return the time results """
+        """Calculate and return the time results"""
         masked_trace_time = np.ma.array(trace_time, mask=masked_pixels_of_sample)
 
         # median over the sample per pixel

--- a/ctapipe/calib/camera/pedestals.py
+++ b/ctapipe/calib/camera/pedestals.py
@@ -72,8 +72,7 @@ class PedestalCalculator(Component):
         Set to None if no configuration to pass.
 
     kwargs
-
-"""
+    """
 
     tel_id = Int(0, help="id of the telescope to calculate the pedestal values").tag(
         config=True
@@ -115,7 +114,7 @@ class PedestalCalculator(Component):
 
         kwargs
 
-    """
+        """
 
         super().__init__(**kwargs)
 
@@ -143,21 +142,21 @@ class PedestalCalculator(Component):
 
 class PedestalIntegrator(PedestalCalculator):
     """Calculates pedestal parameters integrating the charge of pedestal events:
-       the pedestal value corresponds to the charge estimated with the selected
-       charge extractor
-       The pixels are set as outliers on the base of a cut on the pixel charge median
-       over the pedestal sample and the pixel charge standard deviation over
-       the pedestal sample with respect to the camera median values
+      the pedestal value corresponds to the charge estimated with the selected
+      charge extractor
+      The pixels are set as outliers on the base of a cut on the pixel charge median
+      over the pedestal sample and the pixel charge standard deviation over
+      the pedestal sample with respect to the camera median values
 
 
-     Parameters:
-     ----------
-     charge_median_cut_outliers : List[2]
-         Interval (number of std) of accepted charge values around camera median value
-     charge_std_cut_outliers : List[2]
-         Interval (number of std) of accepted charge standard deviation around camera median value
+    Parameters:
+    ----------
+    charge_median_cut_outliers : List[2]
+        Interval (number of std) of accepted charge values around camera median value
+    charge_std_cut_outliers : List[2]
+        Interval (number of std) of accepted charge standard deviation around camera median value
 
-     """
+    """
 
     charge_median_cut_outliers = List(
         [-3, 3],
@@ -170,19 +169,19 @@ class PedestalIntegrator(PedestalCalculator):
 
     def __init__(self, **kwargs):
         """Calculates pedestal parameters integrating the charge of pedestal events:
-           the pedestal value corresponds to the charge estimated with the selected
-           charge extractor
-           The pixels are set as outliers on the base of a cut on the pixel charge median
-           over the pedestal sample and the pixel charge standard deviation over
-           the pedestal sample with respect to the camera median values
+          the pedestal value corresponds to the charge estimated with the selected
+          charge extractor
+          The pixels are set as outliers on the base of a cut on the pixel charge median
+          over the pedestal sample and the pixel charge standard deviation over
+          the pedestal sample with respect to the camera median values
 
 
-         Parameters:
-         ----------
-         charge_median_cut_outliers : List[2]
-             Interval (number of std) of accepted charge values around camera median value
-         charge_std_cut_outliers : List[2]
-             Interval (number of std) of accepted charge standard deviation around camera median value
+        Parameters:
+        ----------
+        charge_median_cut_outliers : List[2]
+            Interval (number of std) of accepted charge values around camera median value
+        charge_std_cut_outliers : List[2]
+            Interval (number of std) of accepted charge standard deviation around camera median value
         """
 
         super().__init__(**kwargs)
@@ -257,7 +256,7 @@ class PedestalIntegrator(PedestalCalculator):
 
         self.collect_sample(dl1.image, pixel_mask)
 
-        sample_age = trigger_time - self.time_start
+        sample_age = (trigger_time - self.time_start).to_value(u.s)
 
         # check if to create a calibration event
         if (


### PR DESCRIPTION
This code was comparing an astropy `TimeDelta` object to a plain number,
which was supposed to be in seconds. However, astropy treats plain
numbers as days, not seconds. Since astropy 5.1, this creates a warning
and made me find this bug. See
https://github.com/astropy/astropy/issues/12887.