### PR TITLE
Ignore unknown column metadata in read_table

### DIFF
--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -89,9 +89,15 @@ def read_table(
 
         astropy_table = table_cls(array, meta=meta, copy=False)
         for column, tr in transforms.items():
+            if column not in astropy_table.colnames:
+                continue
+
             astropy_table[column] = tr.inverse(astropy_table[column])
 
         for column, desc in descriptions.items():
+            if column not in astropy_table.colnames:
+                continue
+
             astropy_table[column].description = desc
 
         return astropy_table


### PR DESCRIPTION
This does not fully address #1785, but it makes the resulting tables at least readable using `read_table`.