### PR TITLE
Remove support for datafiles from older versions of ctapipe

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -5,13 +5,12 @@ common pytest fixtures for tests in ctapipe
 from copy import deepcopy
 
 import pytest
+from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 
 from ctapipe.instrument import CameraGeometry
 from ctapipe.io import SimTelEventSource
 from ctapipe.utils import get_dataset_path
 from ctapipe.utils.filelock import FileLock
-
-from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 
 PYTEST_HEADER_MODULES.clear()
 PYTEST_HEADER_MODULES["eventio"] = "eventio"
@@ -54,7 +53,9 @@ def _global_example_event():
     print("******************** LOAD TEST EVENT ***********************")
 
     # FIXME: switch to prod5b+ file that contains effective focal length
-    with SimTelEventSource(input_url=filename, focal_length_choice="nominal") as reader:
+    with SimTelEventSource(
+        input_url=filename, focal_length_choice="EQUIVALENT"
+    ) as reader:
         event = next(iter(reader))
 
     return event
@@ -69,7 +70,9 @@ def example_subarray():
 
     print("******************** LOAD TEST EVENT ***********************")
 
-    with SimTelEventSource(input_url=filename, focal_length_choice="nominal") as reader:
+    with SimTelEventSource(
+        input_url=filename, focal_length_choice="EQUIVALENT"
+    ) as reader:
         return reader.subarray
 
 
@@ -94,7 +97,7 @@ def _subarray_and_event_gamma_off_axis_500_gev():
 
     path = get_dataset_path("lst_prod3_calibration_and_mcphotons.simtel.zst")
 
-    with SimTelEventSource(path, focal_length_choice="nominal") as source:
+    with SimTelEventSource(path, focal_length_choice="EQUIVALENT") as source:
         it = iter(source)
         # we want the second event, first event is a corner clipper
         next(it)
@@ -288,8 +291,8 @@ def dl1_by_type_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing both images and parameters from a gamma simulation set.
     """
-    from ctapipe.tools.process import ProcessorTool
     from ctapipe.core import run_tool
+    from ctapipe.tools.process import ProcessorTool
 
     output = dl1_tmp_path / "gamma_by_type.dl1.h5"
 
@@ -384,7 +387,7 @@ def dl1_muon_file(dl1_tmp_path):
             "--write-images",
             "--DataWriter.write_parameters=False",
             "--DataWriter.Contact.name=αℓℓ the äüöß",
-            "--SimTelEventSource.focal_length_choice=nominal",
+            "--SimTelEventSource.focal_length_choice=EQUIVALENT",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output
@@ -395,8 +398,8 @@ def dl1_proton_file(dl1_tmp_path, prod5_proton_simtel_path):
     """
     DL1 file containing images and parameters for a prod5 proton run
     """
-    from ctapipe.tools.process import ProcessorTool
     from ctapipe.core import run_tool
+    from ctapipe.tools.process import ProcessorTool
 
     output = dl1_tmp_path / "proton.dl1.h5"
 

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -210,33 +210,6 @@ def dl2_proton_geometry_file(dl2_tmp_path, prod5_proton_simtel_path):
 
 
 @pytest.fixture(scope="session")
-def dl2_shower_geometry_file_type(dl2_tmp_path, prod5_gamma_simtel_path):
-    """
-    File containing both parameters and shower geometry from a gamma simulation set.
-    """
-    from ctapipe.core import run_tool
-    from ctapipe.tools.process import ProcessorTool
-
-    output = dl2_tmp_path / "gamma_by_type.training.h5"
-
-    # prevent running process multiple times in case of parallel tests
-    with FileLock(output.with_suffix(output.suffix + ".lock")):
-        if output.is_file():
-            return output
-
-        argv = [
-            f"--input={prod5_gamma_simtel_path}",
-            f"--output={output}",
-            "--write-images",
-            "--write-showers",
-            "--max-events=20",
-            "--DataWriter.split_datasets_by=tel_type",
-        ]
-        assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
-        return output
-
-
-@pytest.fixture(scope="session")
 def dl2_merged_file(dl2_tmp_path, dl2_shower_geometry_file, dl2_proton_geometry_file):
     """
     File containing both parameters and shower geometry from a gamma simulation set.
@@ -281,32 +254,6 @@ def dl1_file(dl1_tmp_path, prod5_gamma_simtel_path):
             "--write-images",
             "--max-events=20",
             "--DataWriter.Contact.name=αℓℓ the äüöß",
-        ]
-        assert run_tool(ProcessorTool(), argv=argv, cwd=dl1_tmp_path) == 0
-        return output
-
-
-@pytest.fixture(scope="session")
-def dl1_by_type_file(dl1_tmp_path, prod5_gamma_simtel_path):
-    """
-    DL1 file containing both images and parameters from a gamma simulation set.
-    """
-    from ctapipe.core import run_tool
-    from ctapipe.tools.process import ProcessorTool
-
-    output = dl1_tmp_path / "gamma_by_type.dl1.h5"
-
-    # prevent running stage1 multiple times in case of parallel tests
-    with FileLock(output.with_suffix(output.suffix + ".lock")):
-        if output.is_file():
-            return output
-
-        argv = [
-            f"--input={prod5_gamma_simtel_path}",
-            f"--output={output}",
-            "--write-images",
-            "--max-events=20",
-            "--DataWriter.split_datasets_by=tel_type",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl1_tmp_path) == 0
         return output

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -57,7 +57,33 @@ __all__ = [
     "StatisticsContainer",
     "IntensityStatisticsContainer",
     "PeakTimeStatisticsContainer",
+    "DATA_MODEL_VERSION",
+    "DATA_MODEL_CHANGE_HISTORY",
 ]
+
+
+# define the version of the data model written here.
+# This should be updated when necessary:
+# - increase the major number if there is a breaking change to the model
+#   (meaning readers need to update scripts)
+# - increase the minor number if new columns or datasets are added
+# - increase the patch number if there is a small bugfix to the model.
+DATA_MODEL_VERSION = "v4.0.0"
+DATA_MODEL_CHANGE_HISTORY = """
+- v4.0.0: - Container prefixes are now included for reconstruction algorithms
+            and true parameters.
+          - Telescope Impact Parameters were added.
+          - Effective focal length and nominal focal length are both included
+            in the optics description now.
+- v3.0.0: reconstructed core uncertainties splitted in their X-Y components
+- v2.2.0: added R0 and R1 outputs
+- v2.1.0: hillas and timing parameters are per default saved in telescope frame (degree) as opposed to camera frame (m)
+- v2.0.0: Match optics and camera tables using indices instead of names
+- v1.2.0: change to more general data model, including also DL2 (DL1 unchanged)
+- v1.1.0: images and peak_times can be stored as scaled integers
+- v1.0.3: true_image dtype changed from float32 to int32
+"""
+
 
 
 # see https://github.com/astropy/astropy/issues/6509

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -4,10 +4,10 @@ Container structures for data that should be read or written to disk
 import enum
 from functools import partial
 
+import numpy as np
 from astropy import units as u
 from astropy.time import Time
 from numpy import nan
-import numpy as np
 
 from .core import Container, Field, Map
 
@@ -83,7 +83,6 @@ DATA_MODEL_CHANGE_HISTORY = """
 - v1.1.0: images and peak_times can be stored as scaled integers
 - v1.0.3: true_image dtype changed from float32 to int32
 """
-
 
 
 # see https://github.com/astropy/astropy/issues/6509

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -1,17 +1,17 @@
 """
 Traitlet implementations for ctapipe
 """
+import copy
+import os
+import pathlib
 from collections import UserList
 from fnmatch import fnmatch
 from typing import Optional
-import copy
-from astropy.time import Time
-import pathlib
 from urllib.parse import urlparse
-import os
 
 import traitlets
 import traitlets.config
+from astropy.time import Time
 from traitlets import Undefined
 
 from .component import non_abstract_children
@@ -65,6 +65,7 @@ List = traitlets.List
 Set = traitlets.Set
 CRegExp = traitlets.CRegExp
 CaselessStrEnum = traitlets.CaselessStrEnum
+UseEnum = traitlets.UseEnum
 TraitError = traitlets.TraitError
 TraitType = traitlets.TraitType
 observe = traitlets.observe
@@ -72,10 +73,10 @@ flag = traitlets.config.boolean_flag
 
 
 class AstroTime(TraitType):
-    """ A trait representing a point in Time, as understood by `astropy.time`"""
+    """A trait representing a point in Time, as understood by `astropy.time`"""
 
     def validate(self, obj, value):
-        """ try to parse and return an ISO time string """
+        """try to parse and return an ISO time string"""
         try:
             the_time = Time(value)
             the_time.format = "iso"
@@ -273,7 +274,7 @@ class TelescopePatternList(UserList):
 
     @property
     def tel(self):
-        """ access the value per telescope_id, e.g. `param.tel[2]`"""
+        """access the value per telescope_id, e.g. `param.tel[2]`"""
         if self._lookup:
             return self._lookup
         else:
@@ -511,7 +512,7 @@ class TelescopeParameter(List):
 
 
 class FloatTelescopeParameter(TelescopeParameter):
-    """ a `~ctapipe.core.traits.TelescopeParameter` with Float trait type"""
+    """a `~ctapipe.core.traits.TelescopeParameter` with Float trait type"""
 
     def __init__(self, **kwargs):
         """Create a new IntTelescopeParameter"""
@@ -519,7 +520,7 @@ class FloatTelescopeParameter(TelescopeParameter):
 
 
 class IntTelescopeParameter(TelescopeParameter):
-    """ a `~ctapipe.core.traits.TelescopeParameter` with Int trait type"""
+    """a `~ctapipe.core.traits.TelescopeParameter` with Int trait type"""
 
     def __init__(self, **kwargs):
         """Create a new IntTelescopeParameter"""
@@ -527,7 +528,7 @@ class IntTelescopeParameter(TelescopeParameter):
 
 
 class BoolTelescopeParameter(TelescopeParameter):
-    """ a `~ctapipe.core.traits.TelescopeParameter` with Bool trait type"""
+    """a `~ctapipe.core.traits.TelescopeParameter` with Bool trait type"""
 
     def __init__(self, **kwargs):
         """Create a new BoolTelescopeParameter"""

--- a/ctapipe/instrument/__init__.py
+++ b/ctapipe/instrument/__init__.py
@@ -1,10 +1,9 @@
-from .camera import CameraDescription, CameraGeometry, CameraReadout, PixelShape
 from .atmosphere import get_atmosphere_profile_functions
-from .telescope import TelescopeDescription
-from .optics import OpticsDescription
-from .subarray import SubarrayDescription, UnknownTelescopeID
+from .camera import CameraDescription, CameraGeometry, CameraReadout, PixelShape
 from .guess import guess_telescope
-
+from .optics import FocalLengthKind, OpticsDescription
+from .subarray import SubarrayDescription, UnknownTelescopeID
+from .telescope import TelescopeDescription
 
 __all__ = [
     "CameraDescription",
@@ -17,4 +16,5 @@ __all__ = [
     "SubarrayDescription",
     "TelescopeDescription",
     "UnknownTelescopeID",
+    "FocalLengthKind",
 ]

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -60,8 +60,8 @@ class OpticsDescription:
         num_mirrors,
         equivalent_focal_length,
         effective_focal_length,
-        mirror_area=None,
-        num_mirror_tiles=None,
+        mirror_area,
+        num_mirror_tiles,
     ):
 
         self.name = name
@@ -84,7 +84,7 @@ class OpticsDescription:
             (
                 round(self.equivalent_focal_length.to_value(u.m), 4),
                 round(effective_focal_length, 4),
-                self.mirror_area,
+                round(self.mirror_area.to_value(u.m**2)),
                 self.num_mirrors,
                 self.num_mirror_tiles,
             )

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -3,6 +3,7 @@ Classes and functions related to telescope Optics
 """
 
 import logging
+from enum import Enum, auto, unique
 
 import astropy.units as u
 import numpy as np
@@ -10,6 +11,23 @@ import numpy as np
 from ..utils import get_table_dataset
 
 logger = logging.getLogger(__name__)
+
+
+@unique
+class FocalLengthKind(Enum):
+    """
+    Enumeration for the different kinds.
+    """
+
+    #: Effective focal length computed from ray tracing a point source
+    #: and calculating the off-axis center of mass of the light distribution.
+    #: This focal length should be used in coordinate transforms between camera
+    #: frame and telescope frame to correct for the mean effect of coma abberation.
+    EFFECTIVE = auto()
+    #: Equivalent focal length is the nominal focal length of the main reflector
+    #: for single mirror telescopes and the thin-lens equivalent for dual mirror
+    #: telescopes.
+    EQUIVALENT = auto()
 
 
 class OpticsDescription:
@@ -31,8 +49,8 @@ class OpticsDescription:
         mirror telescopes.
     effective_focal_length : astropy.units.Quantity[length]
         The effective_focal_length is the focal length estimated from
-        ray tracing to correct for koma aberration. It is thus not automatically
-        available for all simulations, but only if it was set before hand
+        ray tracing to correct for coma aberration. It is thus not automatically
+        available for all simulations, but only if it was set beforehand
         in the simtel configuration. This is the focal length that should be
         used for transforming from camera frame to telescope frame for all
         reconstruction tasks to correct for the mean aberration.

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -24,10 +24,19 @@ class OpticsDescription:
     ----------
     num_mirrors: int
         Number of mirrors, i. e. 2 for Schwarzschild-Couder else 1
-    equivalent_focal_length: Quantity(float)
-        effective focal-length of telescope, independent of which type of
-        optics (as in the Monte-Carlo)
-    mirror_area: float
+    equivalent_focal_length : astropy.units.Quantity[length]
+        Equivalent focal-length of telescope, independent of which type of
+        optics (as in the Monte-Carlo). This is the nominal focal length
+        for single mirror telescopes and the equivalent focal length for dual
+        mirror telescopes.
+    effective_focal_length : astropy.units.Quantity[length]
+        The effective_focal_length is the focal length estimated from
+        ray tracing to correct for koma aberration. It is thus not automatically
+        available for all simulations, but only if it was set before hand
+        in the simtel configuration. This is the focal length that should be
+        used for transforming from camera frame to telescope frame for all
+        reconstruction tasks to correct for the mean aberration.
+    mirror_area: astropy.units.Quantity[area]
         total reflective surface area of the optical system (in m^2)
     num_mirror_tiles: int
         number of mirror facets

--- a/ctapipe/instrument/optics.py
+++ b/ctapipe/instrument/optics.py
@@ -12,11 +12,16 @@ from ..utils import get_table_dataset
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "OpticsDescription",
+    "FocalLengthKind",
+]
+
 
 @unique
 class FocalLengthKind(Enum):
     """
-    Enumeration for the different kinds.
+    Enumeration for the different kinds of focal lengths.
     """
 
     #: Effective focal length computed from ray tracing a point source

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -6,12 +6,12 @@ from contextlib import ExitStack
 from copy import copy
 from itertools import groupby
 from typing import Dict, List, Union
-from astropy.coordinates.earth import EarthLocation
 
 import numpy as np
 import tables
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.coordinates.earth import EarthLocation
 from astropy.table import QTable, Table, join
 from astropy.utils import lazyproperty
 
@@ -380,9 +380,10 @@ class SubarrayDescription:
         """
         Draw a quick matplotlib plot of the array
         """
+        from matplotlib import pyplot as plt
+
         from ctapipe.coordinates.ground_frames import EastingNorthingFrame
         from ctapipe.visualization import ArrayDisplay
-        from matplotlib import pyplot as plt
 
         plt.figure(figsize=(8, 8))
         ad = ArrayDisplay(subarray=self, frame=EastingNorthingFrame(), tel_scale=0.75)
@@ -594,12 +595,15 @@ class SubarrayDescription:
                     " Reprocessing the data with ctapipe >= 0.12 will fix this problem."
                 )
 
+        has_eff = "effective_focal_length" in optics_table.colnames
         optic_descriptions = [
             OpticsDescription(
                 row["name"],
                 num_mirrors=row["num_mirrors"],
                 equivalent_focal_length=row["equivalent_focal_length"],
-                effective_focal_length=row["effective_focal_length"],
+                effective_focal_length=(
+                    row["effective_focal_length"] if has_eff else np.nan * u.m
+                ),
                 mirror_area=row["mirror_area"],
                 num_mirror_tiles=row["num_mirror_tiles"],
             )

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -320,17 +320,25 @@ class SubarrayDescription:
                 [t.optics.equivalent_focal_length.to_value(u.m) for t in unique_types],
                 u.m,
             )
-            cols = {
-                "description": [str(t) for t in unique_types],
-                "name": [t.name for t in unique_types],
-                "type": [t.type for t in unique_types],
-                "mirror_area": mirror_area,
-                "num_mirrors": [t.optics.num_mirrors for t in unique_types],
-                "num_mirror_tiles": [t.optics.num_mirror_tiles for t in unique_types],
-                "equivalent_focal_length": focal_length,
-            }
-            tab = Table(cols)
-            tab.meta["TAB_VER"] = "2.0"
+            effective_focal_length = u.Quantity(
+                [t.optics.effective_focal_length.to_value(u.m) for t in unique_types],
+                u.m,
+            )
+            tab = Table(
+                {
+                    "description": [str(t) for t in unique_types],
+                    "name": [t.name for t in unique_types],
+                    "type": [t.type for t in unique_types],
+                    "mirror_area": mirror_area,
+                    "num_mirrors": [t.optics.num_mirrors for t in unique_types],
+                    "num_mirror_tiles": [
+                        t.optics.num_mirror_tiles for t in unique_types
+                    ],
+                    "equivalent_focal_length": focal_length,
+                    "effective_focal_length": effective_focal_length,
+                }
+            )
+            tab.meta["TAB_VER"] = "3.0"
         else:
             raise ValueError(f"Table type '{kind}' not known")
 
@@ -591,6 +599,7 @@ class SubarrayDescription:
                 row["name"],
                 num_mirrors=row["num_mirrors"],
                 equivalent_focal_length=row["equivalent_focal_length"],
+                effective_focal_length=row["effective_focal_length"],
                 mirror_area=row["mirror_area"],
                 num_mirror_tiles=row["num_mirror_tiles"],
             )

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -560,10 +560,6 @@ class SubarrayDescription:
 
         cameras = {}
 
-        # backwards compatibility for older tables, index is the name
-        if "camera_index" not in layout.colnames:
-            layout["camera_index"] = layout["camera_type"]
-
         for idx in set(layout["camera_index"]):
             geometry = CameraGeometry.from_table(
                 read_table(
@@ -582,6 +578,13 @@ class SubarrayDescription:
         optics_table = read_table(
             path, "/configuration/instrument/telescope/optics", table_cls=QTable
         )
+        optics_version = optics_table.meta["TAB_VER"]
+        if optics_version != "3.0":
+            raise IOError(
+                "Inputfile contains unsupported optics table version."
+                f"Supported: 3.0, got {optics_version}"
+            )
+
         # for backwards compatibility
         # if optics_index not in table, guess via telescope_description string
         # might not result in correct array when there are duplicated telescope_description

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -547,7 +547,7 @@ class SubarrayDescription:
                 meta["reference_itrs_z"] = itrs.z.to_value(u.m)
 
     @classmethod
-    def from_hdf(cls, path):
+    def from_hdf(cls, path, focal_length_choice="effective"):
         # here to prevent circular import
         from ..io import read_table
 
@@ -616,9 +616,20 @@ class SubarrayDescription:
             # copy to support different telescopes with same camera geom
             camera = copy(cameras[row["camera_index"]])
             optics = optic_descriptions[row["optics_index"]]
-            focal_length = optics.equivalent_focal_length
-            camera.geometry.frame = CameraFrame(focal_length=focal_length)
 
+            if focal_length_choice == "effective":
+                focal_length = optics.effective_focal_length
+                if np.isnan(focal_length.value):
+                    raise RuntimeError(
+                        "`focal_length_choice` was set to 'effective', but the"
+                        " effective focal length was not present in the file. "
+                        " Use nominal focal length or adapt configuration"
+                        " to include the effective focal length"
+                    )
+            else:
+                focal_length = optics.equivalent_focal_length
+
+            camera.geometry.frame = CameraFrame(focal_length=focal_length)
             telescope_descriptions[row["tel_id"]] = TelescopeDescription(
                 name=row["name"], tel_type=row["type"], optics=optics, camera=camera
             )

--- a/ctapipe/instrument/tests/test_optics.py
+++ b/ctapipe/instrument/tests/test_optics.py
@@ -13,7 +13,7 @@ from ctapipe.utils.datasets import get_dataset_path
 
 
 def test_guess_optics():
-    """ make sure we can guess an optics type from metadata"""
+    """make sure we can guess an optics type from metadata"""
     from ctapipe.instrument import guess_telescope
 
     answer = guess_telescope(1855, 28.0 * u.m)
@@ -31,8 +31,9 @@ def test_construct_optics():
         name="test",
         num_mirrors=1,
         num_mirror_tiles=100,
-        mirror_area=u.Quantity(550, u.m ** 2),
+        mirror_area=u.Quantity(550, u.m**2),
         equivalent_focal_length=u.Quantity(10, u.m),
+        effective_focal_length=u.Quantity(11, u.m),
     )
 
     with pytest.raises(TypeError):
@@ -42,12 +43,13 @@ def test_construct_optics():
             num_mirror_tiles=100,
             mirror_area=550,
             equivalent_focal_length=10,
+            effective_focal_length=11,
         )
 
 
 @pytest.mark.parametrize("optics_name", OpticsDescription.get_known_optics_names())
 def test_optics_from_name(optics_name):
-    """ try constructing all by name """
+    """try constructing all by name"""
     optics = OpticsDescription.from_name(optics_name)
     assert optics.equivalent_focal_length > 0
     # make sure the string rep gives back the name:
@@ -58,7 +60,7 @@ def test_optics_from_name_user_supplied_table():
     table = get_table_dataset("optics", role="")
     optics = OpticsDescription.from_name("SST-GCT", optics_table=table)
     assert optics.name == "SST-GCT"
-    assert optics.mirror_area > 1.0 * u.m ** 2
+    assert optics.mirror_area > 1.0 * u.m**2
 
 
 def test_optics_from_dump_instrument():

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -128,7 +128,7 @@ def test_hdf(example_subarray, tmp_path):
     path = tmp_path / "subarray.h5"
 
     example_subarray.to_hdf(path)
-    read = SubarrayDescription.from_hdf(path)
+    read = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
 
     assert example_subarray == read
 
@@ -147,7 +147,7 @@ def test_hdf(example_subarray, tmp_path):
     with tables.open_file(path, "r+") as hdf:
         del hdf.root.configuration.instrument.subarray._v_attrs.name
 
-    no_name = SubarrayDescription.from_hdf(path)
+    no_name = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
     assert no_name.name == "Unknown"
 
     # Test we can also write and read to an already opened h5file
@@ -155,7 +155,8 @@ def test_hdf(example_subarray, tmp_path):
         example_subarray.to_hdf(h5file)
 
     with tables.open_file(path, "r") as h5file:
-        assert SubarrayDescription.from_hdf(h5file) == example_subarray
+        read = SubarrayDescription.from_hdf(h5file, focal_length_choice="nominal")
+        assert read == example_subarray
 
 
 def test_hdf_same_camera(tmp_path):
@@ -172,7 +173,7 @@ def test_hdf_same_camera(tmp_path):
 
     path = tmp_path / "subarray.h5"
     array.to_hdf(path)
-    read = SubarrayDescription.from_hdf(path)
+    read = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
     assert array == read
 
 
@@ -202,7 +203,7 @@ def test_hdf_duplicate_string_repr(tmp_path):
 
     path = tmp_path / "subarray.h5"
     array.to_hdf(path)
-    read = SubarrayDescription.from_hdf(path)
+    read = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
     assert array == read
     assert (
         read.tel[1].optics.num_mirror_tiles == read.tel[2].optics.num_mirror_tiles + 1

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -1,11 +1,11 @@
 """ Tests for SubarrayDescriptions """
 from copy import deepcopy
-from astropy.coordinates.earth import EarthLocation
 
 import numpy as np
+import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-import pytest
+from astropy.coordinates.earth import EarthLocation
 
 from ctapipe.coordinates import TelescopeFrame
 from ctapipe.instrument import (
@@ -128,7 +128,7 @@ def test_hdf(example_subarray, tmp_path):
     path = tmp_path / "subarray.h5"
 
     example_subarray.to_hdf(path)
-    read = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
+    read = SubarrayDescription.from_hdf(path, focal_length_choice="EQUIVALENT")
 
     assert example_subarray == read
 
@@ -147,7 +147,7 @@ def test_hdf(example_subarray, tmp_path):
     with tables.open_file(path, "r+") as hdf:
         del hdf.root.configuration.instrument.subarray._v_attrs.name
 
-    no_name = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
+    no_name = SubarrayDescription.from_hdf(path, focal_length_choice="EQUIVALENT")
     assert no_name.name == "Unknown"
 
     # Test we can also write and read to an already opened h5file
@@ -155,7 +155,7 @@ def test_hdf(example_subarray, tmp_path):
         example_subarray.to_hdf(h5file)
 
     with tables.open_file(path, "r") as h5file:
-        read = SubarrayDescription.from_hdf(h5file, focal_length_choice="nominal")
+        read = SubarrayDescription.from_hdf(h5file, focal_length_choice="EQUIVALENT")
         assert read == example_subarray
 
 
@@ -173,7 +173,7 @@ def test_hdf_same_camera(tmp_path):
 
     path = tmp_path / "subarray.h5"
     array.to_hdf(path)
-    read = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
+    read = SubarrayDescription.from_hdf(path, focal_length_choice="EQUIVALENT")
     assert array == read
 
 
@@ -203,7 +203,7 @@ def test_hdf_duplicate_string_repr(tmp_path):
 
     path = tmp_path / "subarray.h5"
     array.to_hdf(path)
-    read = SubarrayDescription.from_hdf(path, focal_length_choice="nominal")
+    read = SubarrayDescription.from_hdf(path, focal_length_choice="EQUIVALENT")
     assert array == read
     assert (
         read.tel[1].optics.num_mirror_tiles == read.tel[2].optics.num_mirror_tiles + 1

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -168,12 +168,6 @@ class DataWriter(Component):
         help="compression level, 0=None, 9=maximum", default_value=5, min=0, max=9
     ).tag(config=True)
 
-    split_datasets_by = CaselessStrEnum(
-        values=["tel_id", "tel_type"],
-        default_value="tel_id",
-        help="Splitting level for the DL1 parameters and images datasets",
-    ).tag(config=True)
-
     compression_type = CaselessStrEnum(
         values=["blosc:zstd", "zlib"],
         help="compressor algorithm to use. ",
@@ -278,7 +272,7 @@ class DataWriter(Component):
             )
 
             for tel_id, sim in event.simulation.tel.items():
-                table_name = self.table_name(tel_id, self._subarray.tel[tel_id])
+                table_name = self.table_name(tel_id)
                 tel_index = _get_tel_index(event, tel_id)
                 self._writer.write(
                     f"simulation/event/telescope/impact/{table_name}",
@@ -557,9 +551,9 @@ class DataWriter(Component):
                         containers=hist_container,
                     )
 
-    def table_name(self, tel_id, tel_type):
+    def table_name(self, tel_id):
         """construct dataset table names depending on chosen split method"""
-        return f"tel_{tel_id:03d}" if self.split_datasets_by == "tel_id" else tel_type
+        return f"tel_{tel_id:03d}"
 
     def _write_r1_telescope_events(
         self, writer: TableWriter, event: ArrayEventContainer
@@ -567,8 +561,7 @@ class DataWriter(Component):
         for tel_id, r1_tel in event.r1.tel.items():
 
             tel_index = _get_tel_index(event, tel_id)
-            telescope = self._subarray.tel[tel_id]
-            table_name = self.table_name(tel_id, str(telescope))
+            table_name = self.table_name(tel_id)
 
             r1_tel.prefix = ""
             writer.write(f"r1/event/telescope/{table_name}", [tel_index, r1_tel])
@@ -579,8 +572,7 @@ class DataWriter(Component):
         for tel_id, r0_tel in event.r0.tel.items():
 
             tel_index = _get_tel_index(event, tel_id)
-            telescope = self._subarray.tel[tel_id]
-            table_name = self.table_name(tel_id, str(telescope))
+            table_name = self.table_name(tel_id)
 
             r0_tel.prefix = ""
             writer.write(f"r0/event/telescope/{table_name}", [tel_index, r0_tel])
@@ -619,7 +611,7 @@ class DataWriter(Component):
             telescope = self._subarray.tel[tel_id]
             self.log.debug("WRITING TELESCOPE %s: %s", tel_id, telescope)
 
-            table_name = self.table_name(tel_id, str(telescope))
+            table_name = self.table_name(tel_id)
 
             if self.write_parameters:
                 writer.write(
@@ -676,9 +668,7 @@ class DataWriter(Component):
         """
 
         for tel_id, dl2_tel in event.dl2.tel.items():
-
-            telescope = self._subarray.tel[tel_id]
-            table_name = self.table_name(tel_id, str(telescope))
+            table_name = self.table_name(tel_id)
 
             tel_index = _get_tel_index(event, tel_id)
             for container_name, algorithm_map in dl2_tel.items():

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -48,9 +48,11 @@ def _get_tel_index(event, tel_id):
 # - increase the patch number if there is a small bugfix to the model.
 DATA_MODEL_VERSION = "v4.0.0"
 DATA_MODEL_CHANGE_HISTORY = """
-- v4.0.0: Container prefixes are now included for reconstruction algorithms
-          and true parameters.
-          Telescope Impact Parameters were added.
+- v4.0.0: - Container prefixes are now included for reconstruction algorithms
+            and true parameters.
+          - Telescope Impact Parameters were added.
+          - Effective focal length and nominal focal length are both included
+            in the optics description now.
 - v3.0.0: reconstructed core uncertainties splitted in their X-Y components
 - v2.2.0: added R0 and R1 outputs
 - v2.1.0: hillas and timing parameters are per default saved in telescope frame (degree) as opposed to camera frame (m)
@@ -102,7 +104,7 @@ def write_reference_metadata_headers(
         product=meta.Product(
             description="ctapipe Data Product",
             data_category=category,
-            data_level=[l.name for l in data_levels],
+            data_level=[level.name for level in data_levels],
             data_association="Subarray",
             data_model_name="ASWG",
             data_model_version=DATA_MODEL_VERSION,

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -14,6 +14,7 @@ from astropy import units as u
 from traitlets import Dict, Instance
 
 from ..containers import (
+    DATA_MODEL_VERSION,
     ArrayEventContainer,
     SimulatedShowerDistribution,
     TelEventIndexContainer,
@@ -27,7 +28,10 @@ from .datalevels import DataLevel
 from .simteleventsource import SimTelEventSource
 from .tableio import FixedPointColumnTransform, TelListToMaskTransform
 
-__all__ = ["DataWriter", "DATA_MODEL_VERSION", "write_reference_metadata_headers"]
+__all__ = [
+    "DataWriter",
+    "write_reference_metadata_headers",
+]
 
 tables.parameters.NODE_CACHE_SLOTS = 3000  # fixes problem with too many datasets
 
@@ -39,28 +43,6 @@ def _get_tel_index(event, tel_id):
         tel_id=np.int16(tel_id),
     )
 
-
-# define the version of the DL1 data model written here. This should be updated
-# when necessary:
-# - increase the major number if there is a breaking change to the model
-#   (meaning readers need to update scripts)
-# - increase the minor number if new columns or datasets are added
-# - increase the patch number if there is a small bugfix to the model.
-DATA_MODEL_VERSION = "v4.0.0"
-DATA_MODEL_CHANGE_HISTORY = """
-- v4.0.0: - Container prefixes are now included for reconstruction algorithms
-            and true parameters.
-          - Telescope Impact Parameters were added.
-          - Effective focal length and nominal focal length are both included
-            in the optics description now.
-- v3.0.0: reconstructed core uncertainties splitted in their X-Y components
-- v2.2.0: added R0 and R1 outputs
-- v2.1.0: hillas and timing parameters are per default saved in telescope frame (degree) as opposed to camera frame (m)
-- v2.0.0: Match optics and camera tables using indices instead of names
-- v1.2.0: change to more general data model, including also DL2 (DL1 unchanged)
-- v1.1.0: images and peak_times can be stored as scaled integers
-- v1.0.3: true_image dtype changed from float32 to int32
-"""
 
 PROV = Provenance()
 

--- a/ctapipe/io/eventseeker.py
+++ b/ctapipe/io/eventseeker.py
@@ -2,6 +2,7 @@
 Handles seeking to a particular event in a `ctapipe.io.EventSource`
 """
 from copy import deepcopy
+
 from ctapipe.core import Component
 
 __all__ = ["EventSeeker"]
@@ -28,7 +29,7 @@ class EventSeeker(Component):
     To obtain a particular event in a simtel file:
 
     >>> from ctapipe.io import SimTelEventSource
-    >>> event_source = SimTelEventSource(input_url="dataset://gamma_test_large.simtel.gz", focal_length_choice="nominal")
+    >>> event_source = SimTelEventSource(input_url="dataset://gamma_test_large.simtel.gz", focal_length_choice="EQUIVALENT")
     >>> seeker = EventSeeker(event_source=event_source)
     >>> event = seeker.get_event_index(2)
     >>> print(event.count)
@@ -37,7 +38,7 @@ class EventSeeker(Component):
     To obtain a particular event in a simtel file from its event_id:
 
     >>> from ctapipe.io import SimTelEventSource
-    >>> event_source = SimTelEventSource(input_url="dataset://gamma_test_large.simtel.gz", back_seekable=True, focal_length_choice="nominal")
+    >>> event_source = SimTelEventSource(input_url="dataset://gamma_test_large.simtel.gz", back_seekable=True, focal_length_choice="EQUIVALENT")
     >>> seeker = EventSeeker(event_source=event_source)
     >>> event = seeker.get_event_id(31007)
     >>> print(event.count)

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -1,44 +1,46 @@
-import astropy.units as u
-from astropy.utils.decorators import lazyproperty
 import logging
-import numpy as np
-import tables
 from ast import literal_eval
 
-from ..core import Container, Field
-from ..core.traits import CaselessStrEnum
-from ..instrument import SubarrayDescription
+import astropy.units as u
+import numpy as np
+import tables
+from astropy.utils.decorators import lazyproperty
+
+from ctapipe.instrument.optics import FocalLengthKind
+
 from ..containers import (
-    ConcentrationContainer,
     ArrayEventContainer,
+    CameraHillasParametersContainer,
+    CameraTimingParametersContainer,
+    ConcentrationContainer,
     DL1CameraContainer,
     EventIndexContainer,
-    CameraHillasParametersContainer,
     HillasParametersContainer,
+    ImageParametersContainer,
     IntensityStatisticsContainer,
     LeakageContainer,
     MorphologyContainer,
     ParticleClassificationContainer,
-    ReconstructedEnergyContainer,
-    SimulationConfigContainer,
-    SimulatedShowerContainer,
-    SimulatedEventContainer,
     PeakTimeStatisticsContainer,
-    CameraTimingParametersContainer,
+    R1CameraContainer,
+    ReconstructedEnergyContainer,
+    ReconstructedGeometryContainer,
+    SimulatedEventContainer,
+    SimulatedShowerContainer,
+    SimulationConfigContainer,
+    TelescopeImpactParameterContainer,
+    TelescopeTriggerContainer,
+    TelEventIndexContainer,
     TimingParametersContainer,
     TriggerContainer,
-    ImageParametersContainer,
-    TelEventIndexContainer,
-    TelescopeTriggerContainer,
-    R1CameraContainer,
-    TelescopeImpactParameterContainer,
-    ReconstructedGeometryContainer,
 )
+from ..core import Container, Field
+from ..core.traits import UseEnum
+from ..instrument import SubarrayDescription
+from ..utils import IndexFinder
+from .datalevels import DataLevel
 from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader
-from .datalevels import DataLevel
-from ..utils import IndexFinder
-
 from .tableloader import DL2_SUBARRAY_GROUP, DL2_TELESCOPE_GROUP
 
 __all__ = ["HDF5EventSource"]
@@ -124,9 +126,9 @@ class HDF5EventSource(EventSource):
         image parameters evaluated on these.
     """
 
-    focal_length_choice = CaselessStrEnum(
-        ["nominal", "effective"],
-        default_value="effective",
+    focal_length_choice = UseEnum(
+        FocalLengthKind,
+        default_value=FocalLengthKind.EFFECTIVE,
         help=(
             "If both nominal and effective focal lengths are available, "
             " which one to use for the `CameraFrame` attached"

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -183,9 +183,22 @@ class TableLoader(Component):
         False, help="join subarray instrument information to each event"
     ).tag(config=True)
 
+    focal_length_choice = traits.CaselessStrEnum(
+        ["nominal", "effective"],
+        default_value="effective",
+        help=(
+            "If both nominal and effective focal lengths are available, "
+            " which one to use for the `CameraFrame` attached"
+            " to the `CameraGeometry` instances in the `SubarrayDescription`"
+            ", which will be used in CameraFrame to TelescopeFrame coordinate"
+            " transforms. The 'nominal' focal length is the one used during "
+            " the simulation, the 'effective' focal length is computed using specialized "
+            " ray-tracing from a point light source"
+        ),
+    ).tag(config=True)
+
     def __init__(self, input_url=None, h5file=None, **kwargs):
         self._should_close = False
-
         # enable using input_url as posarg
         if input_url not in {None, traits.Undefined}:
             kwargs["input_url"] = input_url
@@ -203,7 +216,10 @@ class TableLoader(Component):
             self.input_url = Path(h5file.filename)
             self.h5file = h5file
 
-        self.subarray = SubarrayDescription.from_hdf(self.h5file)
+        self.subarray = SubarrayDescription.from_hdf(
+            self.h5file,
+            focal_length_choice=self.focal_length_choice,
+        )
 
         Provenance().add_input_file(self.input_url, role="Event data")
 

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -3,19 +3,21 @@ Class and related functions to read DL1 (a,b) and/or DL2 (a) data
 from an HDF5 file produced with ctapipe-process.
 """
 
-from pathlib import Path
 import re
 from collections import defaultdict
+from pathlib import Path
 from typing import Dict
-from astropy.utils.decorators import lazyproperty
 
 import numpy as np
-from astropy.table import vstack, Table
 import tables
+from astropy.table import Table, vstack
+from astropy.utils.decorators import lazyproperty
 
-from ..core import Component, traits, Provenance
+from ctapipe.instrument.optics import FocalLengthKind
+
+from ..core import Component, Provenance, traits
 from ..instrument import SubarrayDescription
-from .astropy_helpers import read_table, join_allow_empty
+from .astropy_helpers import join_allow_empty, read_table
 
 __all__ = ["TableLoader"]
 
@@ -183,9 +185,9 @@ class TableLoader(Component):
         False, help="join subarray instrument information to each event"
     ).tag(config=True)
 
-    focal_length_choice = traits.CaselessStrEnum(
-        ["nominal", "effective"],
-        default_value="effective",
+    focal_length_choice = traits.UseEnum(
+        FocalLengthKind,
+        default_value=FocalLengthKind.EFFECTIVE,
         help=(
             "If both nominal and effective focal lengths are available, "
             " which one to use for the `CameraFrame` attached"

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -6,13 +6,14 @@ from pathlib import Path
 
 import numpy as np
 import tables
-from traitlets.config import Config
 from astropy import units as u
+from traitlets.config import Config
+
 from ctapipe.calib import CameraCalibrator
 from ctapipe.containers import (
     ParticleClassificationContainer,
-    ReconstructedGeometryContainer,
     ReconstructedEnergyContainer,
+    ReconstructedGeometryContainer,
 )
 from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import DataLevel, EventSource
@@ -66,18 +67,11 @@ def generate_dummy_dl2(event):
 def test_write(tmpdir: Path):
     """
     Check that we can write and read data from R0-DL2 to files
-
-    Parameters
-    ----------
-    tmpdir :
-        temp directory fixture
     """
 
     output_path = Path(tmpdir / "events.dl1.h5")
     source = EventSource(
-        get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"),
-        max_events=20,
-        allowed_tels=[1, 2, 3, 4],
+        get_dataset_path("gamma_prod5.simtel.zst"),
         focal_length_choice="nominal",
     )
     calibrate = CameraCalibrator(subarray=source.subarray)
@@ -108,15 +102,15 @@ def test_write(tmpdir: Path):
     # full test of the data model, a verify tool should be created.
     with tables.open_file(output_path) as h5file:
         # check R0:
-        r0tel = h5file.get_node("/r0/event/telescope/tel_001")
+        r0tel = h5file.get_node("/r0/event/telescope/tel_004")
         assert r0tel.col("waveform").max() > 0
 
         # check R1:
-        r1tel = h5file.get_node("/r1/event/telescope/tel_001")
+        r1tel = h5file.get_node("/r1/event/telescope/tel_004")
         assert r1tel.col("waveform").max() > 0
 
         # check DL1:
-        images = h5file.get_node("/dl1/event/telescope/images/tel_001")
+        images = h5file.get_node("/dl1/event/telescope/images/tel_004")
         assert images.col("image").max() > 0.0
         assert (
             h5file.root._v_attrs[
@@ -138,7 +132,7 @@ def test_write(tmpdir: Path):
             assert np.count_nonzero(dl2_energy.col(f"{prefix}_tel_ids")[0]) == 3
 
             dl2_tel_energy = h5file.get_node(
-                f"/dl2/event/telescope/energy/{prefix}/tel_002"
+                f"/dl2/event/telescope/energy/{prefix}/tel_004"
             )
             assert np.allclose(dl2_tel_energy.col(f"{prefix}_tel_energy"), 10)
             assert "tel_ids" not in dl2_tel_energy
@@ -156,9 +150,7 @@ def test_roundtrip(tmpdir: Path):
 
     output_path = Path(tmpdir / "events.DL1DL2.h5")
     source = EventSource(
-        get_dataset_path("gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"),
-        max_events=20,
-        allowed_tels=[1, 2, 3, 4],
+        get_dataset_path("gamma_prod5.simtel.zst"),
         focal_length_choice="nominal",
     )
     calibrate = CameraCalibrator(subarray=source.subarray)
@@ -198,7 +190,7 @@ def test_roundtrip(tmpdir: Path):
     # check a few things in the output just to make sure there is output. For a
     # full test of the data model, a verify tool should be created.
     with tables.open_file(output_path) as h5file:
-        images = h5file.get_node("/dl1/event/telescope/images/tel_001")
+        images = h5file.get_node("/dl1/event/telescope/images/tel_004")
 
         assert len(images) > 0
         assert images.col("image").dtype == np.int32
@@ -230,10 +222,7 @@ def test_dl1writer_no_events(tmpdir: Path):
     """
 
     output_path = Path(tmpdir / "no_events.dl1.h5")
-    dataset = "lst_prod3_calibration_and_mcphotons.simtel.zst"
-    with EventSource(
-        get_dataset_path(dataset), focal_length_choice="nominal"
-    ) as source:
+    with EventSource("dataset://gamma_prod5.simtel.zst") as source:
         # exhaust source
         for _ in source:
             pass

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -72,7 +72,7 @@ def test_write(tmpdir: Path):
     output_path = Path(tmpdir / "events.dl1.h5")
     source = EventSource(
         get_dataset_path("gamma_prod5.simtel.zst"),
-        focal_length_choice="nominal",
+        focal_length_choice="EQUIVALENT",
     )
     calibrate = CameraCalibrator(subarray=source.subarray)
 
@@ -151,7 +151,7 @@ def test_roundtrip(tmpdir: Path):
     output_path = Path(tmpdir / "events.DL1DL2.h5")
     source = EventSource(
         get_dataset_path("gamma_prod5.simtel.zst"),
-        focal_length_choice="nominal",
+        focal_length_choice="EQUIVALENT",
     )
     calibrate = CameraCalibrator(subarray=source.subarray)
 

--- a/ctapipe/io/tests/test_eventseeker.py
+++ b/ctapipe/io/tests/test_eventseeker.py
@@ -1,7 +1,8 @@
-from ctapipe.utils import get_dataset_path
+import pytest
+
 from ctapipe.io import SimTelEventSource
 from ctapipe.io.eventseeker import EventSeeker
-import pytest
+from ctapipe.utils import get_dataset_path
 
 dataset = get_dataset_path("gamma_test_large.simtel.gz")
 
@@ -11,7 +12,7 @@ def test_eventseeker():
     with SimTelEventSource(
         input_url=dataset,
         back_seekable=True,
-        focal_length_choice='nominal',
+        focal_length_choice="EQUIVALENT",
     ) as reader:
 
         seeker = EventSeeker(event_source=reader)
@@ -37,8 +38,10 @@ def test_eventseeker():
             seeker.get_event_index(dict())
 
     with SimTelEventSource(
-        input_url=dataset, max_events=5, back_seekable=True,
-        focal_length_choice='nominal',
+        input_url=dataset,
+        max_events=5,
+        back_seekable=True,
+        focal_length_choice="EQUIVALENT",
     ) as reader:
         seeker = EventSeeker(event_source=reader)
         with pytest.raises(IndexError):
@@ -48,8 +51,9 @@ def test_eventseeker():
 
 def test_eventseeker_edit():
     with SimTelEventSource(
-        input_url=dataset, back_seekable=True,
-        focal_length_choice='nominal',
+        input_url=dataset,
+        back_seekable=True,
+        focal_length_choice="EQUIVALENT",
     ) as reader:
         seeker = EventSeeker(event_source=reader)
         event = seeker.get_event_index(1)
@@ -63,8 +67,9 @@ def test_eventseeker_edit():
 def test_eventseeker_simtel():
     # Ensure the EventSeeker can forward seek even if back-seeking is not possible
     with SimTelEventSource(
-        input_url=dataset, back_seekable=False,
-        focal_length_choice='nominal',
+        input_url=dataset,
+        back_seekable=False,
+        focal_length_choice="EQUIVALENT",
     ) as reader:
         seeker = EventSeeker(event_source=reader)
         event = seeker.get_event_index(1)

--- a/ctapipe/io/tests/test_prod2.py
+++ b/ctapipe/io/tests/test_prod2.py
@@ -11,7 +11,7 @@ def test_eventio_prod2():
     with pytest.warns(UnknownPixelShapeWarning):
         with SimTelEventSource(
             input_url=dataset,
-            focal_length_choice='nominal',
+            focal_length_choice="EQUIVALENT",
         ) as reader:
             for event in reader:
                 if event.count == 2:

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -322,8 +322,10 @@ def test_focal_length_choice():
         SimTelEventSource(gamma_test_large_path, focal_length_choice="effective")
 
     s = SimTelEventSource(gamma_test_large_path, focal_length_choice="nominal")
-    assert s.subarray.tel[1].camera.geometry.frame.focal_length == 28 * u.m
-    assert np.isnan(s.subarray.tel[1].camera.geometry.frame.focal_length)
+    tel = s.subarray.tel[1]
+    assert tel.camera.geometry.frame.focal_length == 28 * u.m
+    assert u.isclose(tel.optics.equivalent_focal_length, 28.0 * u.m, atol=0.05 * u.m)
+    assert np.isnan(tel.optics.effective_focal_length)
 
     # this file does
     s = SimTelEventSource(prod5b_path, focal_length_choice="effective")

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -322,12 +322,26 @@ def test_focal_length_choice():
         SimTelEventSource(gamma_test_large_path, focal_length_choice="effective")
 
     s = SimTelEventSource(gamma_test_large_path, focal_length_choice="nominal")
-    assert s.subarray.tel[1].optics.equivalent_focal_length == 28 * u.m
+    assert s.subarray.tel[1].camera.geometry.frame.focal_length == 28 * u.m
+    assert np.isnan(s.subarray.tel[1].camera.geometry.frame.focal_length)
 
     # this file does
     s = SimTelEventSource(prod5b_path, focal_length_choice="effective")
     assert u.isclose(
-        s.subarray.tel[1].optics.equivalent_focal_length, 29.3 * u.m, atol=0.05 * u.m
+        s.subarray.tel[1].optics.equivalent_focal_length, 28.0 * u.m, atol=0.05 * u.m
+    )
+    assert u.isclose(
+        s.subarray.tel[1].optics.effective_focal_length, 29.3 * u.m, atol=0.05 * u.m
+    )
+    assert u.isclose(
+        s.subarray.tel[1].camera.geometry.frame.focal_length,
+        29.3 * u.m,
+        atol=0.05 * u.m,
+    )
+
+    s = SimTelEventSource(prod5b_path, focal_length_choice="nominal")
+    assert u.isclose(
+        s.subarray.tel[1].optics.equivalent_focal_length, 28.0 * u.m, atol=0.05 * u.m
     )
     # check guessing of the name is not affected by focal length choice
     assert str(s.subarray.tel[1]) == "LST_LST_LSTCam"
@@ -335,6 +349,14 @@ def test_focal_length_choice():
     s = SimTelEventSource(prod5b_path, focal_length_choice="nominal")
     assert u.isclose(
         s.subarray.tel[1].optics.equivalent_focal_length, 28.0 * u.m, atol=0.05 * u.m
+    )
+    assert u.isclose(
+        s.subarray.tel[1].optics.effective_focal_length, 29.3 * u.m, atol=0.05 * u.m
+    )
+    assert u.isclose(
+        s.subarray.tel[1].camera.geometry.frame.focal_length,
+        28.0 * u.m,
+        atol=0.05 * u.m,
     )
     # check guessing of the name is not affected by focal length choice
     assert str(s.subarray.tel[1]) == "LST_LST_LSTCam"

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -66,43 +66,9 @@ def test_check_order():
 from ctapipe.instrument.subarray import SubarrayDescription
 
 
-@pytest.fixture(params=["by_type", "by_id"])
-def test_file(request, dl1_file, dl1_by_type_file):
-    """Test dl1 files in both structures"""
-    if request.param == "by_type":
-        f = dl1_by_type_file
-    else:
-        f = dl1_file
-
-    return request.param, f
-
-
-@pytest.fixture(params=["by_type", "by_id"])
-def test_file_dl2(request, dl2_shower_geometry_file, dl2_shower_geometry_file_type):
-    """Test dl2 files in both structures"""
-    if request.param == "by_type":
-        f = dl2_shower_geometry_file
-    else:
-        f = dl2_shower_geometry_file_type
-
-    return request.param, f
-
-
-def test_get_structure(test_file):
-    """Test _get_structure"""
-    from ctapipe.io.tableloader import _get_structure
-
-    expected, path = test_file
-
-    with tables.open_file(path, "r") as f:
-        assert _get_structure(f) == expected
-
-
-def test_telescope_events_for_tel_id(test_file):
+def test_telescope_events_for_tel_id(dl1_file):
     """Test loading data for a single telescope"""
     from ctapipe.io.tableloader import TableLoader
-
-    _, dl1_file = test_file
 
     loader = TableLoader(dl1_file, load_dl1_parameters=True)
 
@@ -122,11 +88,9 @@ def test_telescope_events_for_tel_id(test_file):
     assert not table_loader.h5file.isopen
 
 
-def test_load_instrument(test_file):
+def test_load_instrument(dl1_file):
     """Test joining instrument data onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
-
-    _, dl1_file = test_file
 
     with TableLoader(dl1_file, load_instrument=True) as table_loader:
         expected = table_loader.subarray.tel[8].optics.equivalent_focal_length
@@ -135,11 +99,9 @@ def test_load_instrument(test_file):
         assert np.all(table["equivalent_focal_length"] == expected)
 
 
-def test_load_simulated(test_file):
+def test_load_simulated(dl1_file):
     """Test joining simulation info onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
-
-    _, dl1_file = test_file
 
     with TableLoader(dl1_file, load_simulated=True) as table_loader:
         table = table_loader.read_subarray_events()
@@ -151,11 +113,9 @@ def test_load_simulated(test_file):
         assert "true_impact_distance" in table.colnames
 
 
-def test_true_images(test_file):
+def test_true_images(dl1_file):
     """Test joining true images onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
-
-    _, dl1_file = test_file
 
     with TableLoader(
         dl1_file, load_dl1_parameters=False, load_true_images=True
@@ -164,11 +124,9 @@ def test_true_images(test_file):
         assert "true_image" in table.colnames
 
 
-def test_true_parameters(test_file):
+def test_true_parameters(dl1_file):
     """Test joining true parameters onto telescope events"""
     from ctapipe.io.tableloader import TableLoader
-
-    _, dl1_file = test_file
 
     with TableLoader(
         dl1_file, load_dl1_parameters=False, load_true_parameters=True
@@ -177,13 +135,15 @@ def test_true_parameters(test_file):
         assert "true_hillas_intensity" in table.colnames
 
 
-def test_read_subarray_events(test_file_dl2):
+def test_read_subarray_events(dl2_shower_geometry_file):
     """Test reading subarray events"""
     from ctapipe.io.tableloader import TableLoader
 
-    _, dl2_file = test_file_dl2
-
-    with TableLoader(dl2_file, load_dl2=True, load_simulated=True) as table_loader:
+    with TableLoader(
+        dl2_shower_geometry_file,
+        load_dl2=True,
+        load_simulated=True,
+    ) as table_loader:
         table = table_loader.read_subarray_events()
         assert "HillasReconstructor_alt" in table.colnames
         assert "true_energy" in table.colnames
@@ -209,17 +169,15 @@ def test_table_loader_keeps_original_order(dl2_merged_file):
     check_equal_array_event_order(events, tel_events)
 
 
-def test_read_telescope_events_type(test_file_dl2):
+def test_read_telescope_events_type(dl2_shower_geometry_file):
     """Test reading telescope events for a given telescope type"""
 
     from ctapipe.io.tableloader import TableLoader
 
-    _, dl2_file = test_file_dl2
-
-    subarray = SubarrayDescription.from_hdf(dl2_file)
+    subarray = SubarrayDescription.from_hdf(dl2_shower_geometry_file)
 
     with TableLoader(
-        dl2_file,
+        dl2_shower_geometry_file,
         load_dl1_images=False,
         load_dl1_parameters=False,
         load_dl2=True,
@@ -239,16 +197,15 @@ def test_read_telescope_events_type(test_file_dl2):
         assert "HillasReconstructor_tel_distance" in table.colnames
 
 
-def test_read_telescope_events_by_type(test_file_dl2):
+def test_read_telescope_events_by_type(dl2_shower_geometry_file):
     """Test reading telescope events for by types"""
 
     from ctapipe.io.tableloader import TableLoader
 
-    _, dl2_file = test_file_dl2
-    subarray = SubarrayDescription.from_hdf(dl2_file)
+    subarray = SubarrayDescription.from_hdf(dl2_shower_geometry_file)
 
     with TableLoader(
-        dl2_file,
+        dl2_shower_geometry_file,
         load_dl1_images=False,
         load_dl1_parameters=False,
         load_dl2=True,
@@ -271,11 +228,9 @@ def test_read_telescope_events_by_type(test_file_dl2):
             assert "equivalent_focal_length" in table.colnames
 
 
-def test_h5file(test_file_dl2):
+def test_h5file(dl2_shower_geometry_file):
     """Test we can also pass an already open h5file"""
     from ctapipe.io.tableloader import TableLoader
-
-    _, dl2_file = test_file_dl2
 
     # no input raises error
     with pytest.raises(ValueError):
@@ -283,7 +238,7 @@ def test_h5file(test_file_dl2):
             pass
 
     # test we can use an already open file
-    with tables.open_file(dl2_file, mode="r+") as h5file:
+    with tables.open_file(dl2_shower_geometry_file, mode="r+") as h5file:
         with TableLoader(h5file=h5file) as loader:
             assert 25 in loader.subarray.tel
             loader.read_subarray_events()

--- a/ctapipe/reco/tests/test_HillasReconstructor.py
+++ b/ctapipe/reco/tests/test_HillasReconstructor.py
@@ -1,24 +1,25 @@
 from copy import deepcopy
-import numpy as np
-from astropy import units as u
-import pytest
 
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.coordinates import AltAz, SkyCoord
 from traitlets.config import Config
+
+from ctapipe.calib import CameraCalibrator
 from ctapipe.containers import HillasParametersContainer
 from ctapipe.image.image_processor import ImageProcessor
 from ctapipe.instrument import SubarrayDescription, TelescopeDescription
 from ctapipe.io import SimTelEventSource
-from ctapipe.reco.hillas_reconstructor import HillasReconstructor, HillasPlane
+from ctapipe.reco.hillas_reconstructor import HillasPlane, HillasReconstructor
 from ctapipe.utils import get_dataset_path
-from astropy.coordinates import SkyCoord, AltAz
-from ctapipe.calib import CameraCalibrator
 
 
 def test_estimator_results():
     """
     creating some planes pointing in different directions (two
     north-south, two east-west) and that have a slight position errors (+-
-    0.1 m in one of the four cardinal directions """
+    0.1 m in one of the four cardinal directions"""
     horizon_frame = AltAz()
 
     p1 = SkyCoord(alt=43 * u.deg, az=45 * u.deg, frame=horizon_frame)
@@ -63,7 +64,7 @@ def test_h_max_results(example_subarray):
     """
     creating some planes pointing in different directions (two
     north-south, two east-west) and that have a slight position errors (+-
-    0.1 m in one of the four cardinal directions """
+    0.1 m in one of the four cardinal directions"""
     horizon_frame = AltAz()
 
     p1 = SkyCoord(alt=0 * u.deg, az=45 * u.deg, frame=horizon_frame)
@@ -121,11 +122,13 @@ def test_invalid_events(subarray_and_event_gamma_off_axis_500_gev):
 
     # perform no quality cuts, so we can see if our additional checks on valid
     # input work
-    config = Config({
-        "StereoQualityQuery": {
-            "quality_criteria": [],
+    config = Config(
+        {
+            "StereoQualityQuery": {
+                "quality_criteria": [],
+            }
         }
-    })
+    )
     hillas_reconstructor = HillasReconstructor(subarray, config=config)
 
     calib(event)
@@ -192,26 +195,30 @@ def test_reconstruction_against_simulation(subarray_and_event_gamma_off_axis_500
     "filename",
     [
         "gamma_divergent_LaPalma_baseline_20Zd_180Az_prod3_test.simtel.gz",
-        "gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"
-    ]
+        "gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz",
+    ],
 )
 def test_CameraFrame_against_TelescopeFrame(filename):
 
     input_file = get_dataset_path(filename)
-        # "gamma_divergent_LaPalma_baseline_20Zd_180Az_prod3_test.simtel.gz"
+    # "gamma_divergent_LaPalma_baseline_20Zd_180Az_prod3_test.simtel.gz"
     # )
 
-    source = SimTelEventSource(input_file, max_events=10, focal_length_choice="nominal")
+    source = SimTelEventSource(
+        input_file, max_events=10, focal_length_choice="EQUIVALENT"
+    )
 
     # too few events survive for this test with the defautl quality criteria,
     # use less restrictive ones
-    config = Config({
-        "StereoQualityQuery": {
-            "quality_criteria": [
-                ("valid_width", "parameters.hillas.width.value > 0"),
-            ]
+    config = Config(
+        {
+            "StereoQualityQuery": {
+                "quality_criteria": [
+                    ("valid_width", "parameters.hillas.width.value > 0"),
+                ]
+            }
         }
-    })
+    )
 
     calib = CameraCalibrator(subarray=source.subarray)
     reconstructor = HillasReconstructor(source.subarray, config=config)
@@ -247,10 +254,12 @@ def test_CameraFrame_against_TelescopeFrame(filename):
                 tel = getattr(result_telescope_frame, field)
 
                 if hasattr(cam, "unit"):
-                    assert u.isclose(cam, tel, rtol=1e-3, atol=1e-3 * tel.unit, equal_nan=True)
+                    assert u.isclose(
+                        cam, tel, rtol=1e-3, atol=1e-3 * tel.unit, equal_nan=True
+                    )
                 elif isinstance(cam, list):
                     assert cam == tel
                 else:
                     assert np.isclose(cam, tel, rtol=1e-3, atol=1e-3, equal_nan=True)
 
-    assert reconstructed_events > 0 # check that we reconstruct at least 1 event
+    assert reconstructed_events > 0  # check that we reconstruct at least 1 event

--- a/ctapipe/reco/tests/test_reconstruction_methods.py
+++ b/ctapipe/reco/tests/test_reconstruction_methods.py
@@ -1,13 +1,11 @@
+import pytest
 from astropy import units as u
 
+from ctapipe.calib import CameraCalibrator
 from ctapipe.image import ImageProcessor
 from ctapipe.io import EventSource
-from ctapipe.reco import HillasReconstructor, HillasIntersection
-
+from ctapipe.reco import HillasIntersection, HillasReconstructor
 from ctapipe.utils import get_dataset_path
-from ctapipe.calib import CameraCalibrator
-
-import pytest
 
 
 @pytest.fixture
@@ -30,7 +28,7 @@ def test_reconstructors(reconstructors):
         "gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"
     )
 
-    source = EventSource(filename, max_events=10, focal_length_choice="nominal")
+    source = EventSource(filename, max_events=10, focal_length_choice="EQUIVALENT")
     subarray = source.subarray
     calib = CameraCalibrator(source.subarray)
     image_processor = ImageProcessor(source.subarray)

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -303,7 +303,7 @@ def test_training_from_simtel(tmp_path):
                 f"--output={output}",
                 "--max-events=5",
                 "--overwrite",
-                "--SimTelEventSource.focal_length_choice=nominal",
+                "--SimTelEventSource.focal_length_choice=EQUIVALENT",
             ],
             cwd=tmp_path,
         )

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import tables
+
 from ctapipe.core import run_tool
 from ctapipe.instrument.subarray import SubarrayDescription
 from ctapipe.io import DataLevel, EventSource, read_table
@@ -215,11 +216,9 @@ def test_stage_2_from_simtel(tmp_path):
             ProcessorTool(),
             argv=[
                 f"--config={config}",
-                f"--input={GAMMA_TEST_LARGE}",
+                "--input=dataset://gamma_prod5.simtel.zst",
                 f"--output={output}",
-                "--max-events=5",
                 "--overwrite",
-                "--SimTelEventSource.focal_length_choice=nominal",
             ],
             cwd=tmp_path,
         )

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -13,7 +13,9 @@ from ctapipe.utils import get_dataset_path
 
 GAMMA_TEST_LARGE = get_dataset_path("gamma_test_large.simtel.gz")
 LST_MUONS = get_dataset_path("lst_muons.simtel.zst")
-PROD5B_PATH = get_dataset_path("gamma_20deg_0deg_run2___cta-prod5-paranal_desert-2147m-Paranal-dark_cone10-100evts.simtel.zst")
+PROD5B_PATH = get_dataset_path(
+    "gamma_20deg_0deg_run2___cta-prod5-paranal_desert-2147m-Paranal-dark_cone10-100evts.simtel.zst"
+)
 
 
 def test_muon_reconstruction_simtel(tmp_path):
@@ -50,6 +52,7 @@ def test_muon_reconstruction_dl1(tmp_path, dl1_muon_file):
             argv=[
                 f"--input={dl1_muon_file}",
                 f"--output={muon_dl1_output_file}",
+                "--HDF5EventSource.focal_length_choice=nominal",
                 "--overwrite",
             ],
             cwd=tmp_path,
@@ -75,10 +78,11 @@ def test_display_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
         run_tool(
             DisplayDL1Calib(),
             argv=[
-                "--max-events=1", "--telescope=11",
+                "--max-events=1",
+                "--telescope=11",
                 "--SimTelEventSource.focal_length_choice=nominal",
             ],
-            cwd=tmp_path
+            cwd=tmp_path,
         )
         == 0
     )
@@ -106,7 +110,7 @@ def test_info():
 
 
 def test_fileinfo(tmp_path, dl1_image_file):
-    """ check we can run ctapipe-fileinfo and get results """
+    """check we can run ctapipe-fileinfo and get results"""
     import yaml
     from astropy.table import Table
 
@@ -150,15 +154,13 @@ def test_dump_instrument(tmp_path):
     assert (tmp_path / "FlashCam.camgeom.fits.gz").exists()
 
     assert (
-        run_tool(tool, [f"--input={PROD5B_PATH}", "--format=ecsv"], cwd=tmp_path)
-        == 0
+        run_tool(tool, [f"--input={PROD5B_PATH}", "--format=ecsv"], cwd=tmp_path) == 0
     )
 
     assert (tmp_path / "MonteCarloArray.optics.ecsv").exists()
 
     assert (
-        run_tool(tool, [f"--input={PROD5B_PATH}", "--format=hdf5"], cwd=tmp_path)
-        == 0
+        run_tool(tool, [f"--input={PROD5B_PATH}", "--format=hdf5"], cwd=tmp_path) == 0
     )
     assert (tmp_path / "subarray.h5").exists()
 

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -8,6 +8,7 @@ import sys
 import matplotlib as mpl
 import numpy as np
 import tables
+
 from ctapipe.core import run_tool
 from ctapipe.utils import get_dataset_path
 
@@ -28,7 +29,7 @@ def test_muon_reconstruction_simtel(tmp_path):
             argv=[
                 f"--input={LST_MUONS}",
                 f"--output={muon_simtel_output_file}",
-                "--SimTelEventSource.focal_length_choice=nominal",
+                "--SimTelEventSource.focal_length_choice=EQUIVALENT",
                 "--overwrite",
             ],
             cwd=tmp_path,
@@ -52,7 +53,7 @@ def test_muon_reconstruction_dl1(tmp_path, dl1_muon_file):
             argv=[
                 f"--input={dl1_muon_file}",
                 f"--output={muon_dl1_output_file}",
-                "--HDF5EventSource.focal_length_choice=nominal",
+                "--HDF5EventSource.focal_length_choice=EQUIVALENT",
                 "--overwrite",
             ],
             cwd=tmp_path,
@@ -80,7 +81,7 @@ def test_display_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
             argv=[
                 "--max-events=1",
                 "--telescope=11",
-                "--SimTelEventSource.focal_length_choice=nominal",
+                "--SimTelEventSource.focal_length_choice=EQUIVALENT",
             ],
             cwd=tmp_path,
         )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,7 @@ def setup(app):
         "Set",
         "TraitError",
         "Unicode",
+        "UseEnum",
     ]
     for alias in aliases:
         getattr(traits, alias).__name__ = alias

--- a/examples/load_one_event.py
+++ b/examples/load_one_event.py
@@ -5,10 +5,10 @@ purposes
 import sys
 
 from ctapipe.calib import CameraCalibrator
-from ctapipe.io import EventSource
-from ctapipe.utils import get_dataset_path
 from ctapipe.image import ImageProcessor
+from ctapipe.io import EventSource
 from ctapipe.reco import ShowerProcessor
+from ctapipe.utils import get_dataset_path
 
 if __name__ == "__main__":
 
@@ -19,7 +19,9 @@ if __name__ == "__main__":
             "gamma_LaPalma_baseline_20Zd_180Az_prod3b_test.simtel.gz"
         )
 
-    with EventSource(filename, max_events=1, focal_length_choice="nominal") as source:
+    with EventSource(
+        filename, max_events=1, focal_length_choice="EQUIVALENT"
+    ) as source:
         calib = CameraCalibrator(subarray=source.subarray)
         process_images = ImageProcessor(subarray=source.subarray)
         process_shower = ShowerProcessor(subarray=source.subarray)


### PR DESCRIPTION
* Remove optics version < 3 (without effective_focal_length)
* Remove support for files split by telescope type instead of telescope id


More to come.