### PR TITLE
Rework h5 metadata

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -358,7 +358,6 @@ def dl1_parameters_file(dl1_tmp_path, prod5_gamma_simtel_path):
             f"--input={prod5_gamma_simtel_path}",
             f"--output={output}",
             "--write-parameters",
-            "--max-events=20",
             "--DataWriter.Contact.name=αℓℓ the äüöß",
         ]
         assert run_tool(ProcessorTool(), argv=argv, cwd=dl1_tmp_path) == 0

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -1,14 +1,13 @@
+import logging
+import warnings
 from collections import defaultdict
 from functools import partial
-from pprint import pformat
-from textwrap import wrap, dedent
-import warnings
-import numpy as np
-from astropy.units import UnitConversionError, Quantity, Unit
 from inspect import isclass
+from pprint import pformat
+from textwrap import dedent, wrap
 
-import logging
-
+import numpy as np
+from astropy.units import Quantity, Unit, UnitConversionError
 
 log = logging.getLogger(__name__)
 
@@ -254,6 +253,9 @@ class ContainerMeta(type):
 
         for k in field_names:
             dct["fields"][k] = dct.pop(k)
+
+        for field_name, field in dct["fields"].items():
+            field.name = field_name
 
         dct["__doc__"] = _build_docstring(dct.get("__doc__", ""), dct["fields"])
 

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -48,7 +48,9 @@ def _get_tel_index(event, tel_id):
 # - increase the patch number if there is a small bugfix to the model.
 DATA_MODEL_VERSION = "v4.0.0"
 DATA_MODEL_CHANGE_HISTORY = """
-- v4.0.0: - Container prefixes are now included for reconstruction algorithms
+- v4.0.0: - Changed how ctapipe-specific metadata is stored in hdf5 attributes.
+            This breaks backwards and forwards compatibility for almost everything.
+          - Container prefixes are now included for reconstruction algorithms
             and true parameters.
           - Telescope Impact Parameters were added.
           - Effective focal length and nominal focal length are both included

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -187,14 +187,6 @@ class HDF5EventSource(EventSource):
 
         with tables.open_file(path) as f:
             metadata = f.root._v_attrs
-            if "CTA PRODUCT DATA LEVELS" not in metadata._v_attrnames:
-                return False
-
-            datalevels = set(metadata["CTA PRODUCT DATA LEVELS"].split(","))
-            if not datalevels.intersection(
-                ("R1", "DL1_IMAGES", "DL1_PARAMETERS", "DL2")
-            ):
-                return False
 
             if "CTA PRODUCT DATA MODEL VERSION" not in metadata._v_attrnames:
                 return False
@@ -202,9 +194,21 @@ class HDF5EventSource(EventSource):
             version = metadata["CTA PRODUCT DATA MODEL VERSION"]
             if version not in COMPATIBLE_DATA_MODEL_VERSIONS:
                 logger.error(
-                    f"File is DL1 file but has unsupported version {version}"
-                    f", supported versions are {COMPATIBLE_DATA_MODEL_VERSIONS}"
+                    "File is a ctapipe HDF5 file but has unsupported data model"
+                    f" version {version}"
+                    f", supported versions are {COMPATIBLE_DATA_MODEL_VERSIONS}."
+                    " You may need to downgrade ctapipe (if the file version is older)"
+                    ", update ctapipe (if the file version is newer) or"
+                    " reproduce the file with your current ctapipe version."
                 )
+                return False
+
+            if "CTA PRODUCT DATA LEVELS" not in metadata._v_attrnames:
+                return False
+
+            # we can now read both R1 and DL1
+            datalevels = set(metadata["CTA PRODUCT DATA LEVELS"].split(","))
+            if not datalevels.intersection(("R1", "DL1_IMAGES", "DL1_PARAMETERS")):
                 return False
 
         return True

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -41,7 +41,7 @@ from ..instrument import SubarrayDescription
 from ..utils import IndexFinder
 from .datalevels import DataLevel
 from .eventsource import EventSource
-from .hdf5tableio import HDF5TableReader, read_column_attrs
+from .hdf5tableio import HDF5TableReader, get_column_attrs
 from .tableloader import DL2_SUBARRAY_GROUP, DL2_TELESCOPE_GROUP
 
 __all__ = ["HDF5EventSource"]
@@ -587,12 +587,12 @@ class HDF5EventSource(EventSource):
     @lazyproperty
     def _subarray_pointing_attrs(self):
         table = self.file_.root.dl1.monitoring.subarray.pointing
-        return read_column_attrs(table)
+        return get_column_attrs(table)
 
     @lru_cache(maxsize=1000)
     def _telescope_pointing_attrs(self, tel_id):
         pointing_group = self.file_.root.dl1.monitoring.telescope.pointing
-        return read_column_attrs(pointing_group[f"tel_{tel_id:03d}"])
+        return get_column_attrs(pointing_group[f"tel_{tel_id:03d}"])
 
     def _fill_array_pointing(self, data, array_pointing_finder):
         """

--- a/ctapipe/io/hdf5tableio.py
+++ b/ctapipe/io/hdf5tableio.py
@@ -594,6 +594,7 @@ class HDF5TableReader(TableReader):
                         raise IOError(
                             "Mapping of column names to container fields is not unique"
                             ", prefixes are required."
+                            f" Duplicated column: {col_name} / {field_name}"
                         )
 
                     if prefix is None:

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -278,7 +278,7 @@ class ColumnTransform(metaclass=ABCMeta):
     A Transformation to be applied before serialization / after deserialization.
 
     The ``TableWriter`` will call the transform on the data to be stored and
-    ``TableReader`` will call `.inverse`` the reverse the transformation
+    ``TableReader`` will call `.inverse`` to reverse the transformation
     when a transformation is detected in the file through metadata.
 
     Transformations implement ``get_meta`` to provide the necessary metadata
@@ -291,12 +291,16 @@ class ColumnTransform(metaclass=ABCMeta):
 
     @abstractmethod
     def inverse(self, value):
-        """No inverse transform by default"""
+        """Invert the transformation applied in ``__call__``"""
         return value
 
     @abstractmethod
     def get_meta(self, colname):
-        """Empty meta by default"""
+        """Metadata to be stored in the header information of the table
+
+        Needs to fully describe the transformation so upon reading, the
+        transformation can be inverted based on this metadata.
+        """
         return {}
 
 

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -9,9 +9,8 @@ import numpy as np
 from astropy.time import Time
 from astropy.units import Quantity
 
-from ..instrument import SubarrayDescription
 from ..core import Component
-
+from ..instrument import SubarrayDescription
 
 __all__ = ["TableReader", "TableWriter"]
 
@@ -187,7 +186,7 @@ class TableWriter(Component, metaclass=ABCMeta):
 
     @abstractmethod
     def close(self):
-        """ Close open writer """
+        """Close open writer"""
         pass
 
     def _apply_col_transform(self, table_name, col_name, value):
@@ -279,7 +278,7 @@ class ColumnTransform(metaclass=ABCMeta):
     A Transformation to be applied before serialization / after deserialization.
 
     The ``TableWriter`` will call the transform on the data to be stored and
-    ``TableReader`` will call `.inverse`` the reverse the transformation 
+    ``TableReader`` will call `.inverse`` the reverse the transformation
     when a transformation is detected in the file through metadata.
 
     Transformations implement ``get_meta`` to provide the necessary metadata
@@ -319,14 +318,14 @@ class TimeColumnTransform(ColumnTransform):
 
     def get_meta(self, colname):
         return {
-            f"{colname}_TRANSFORM": "time",
-            f"{colname}_TIME_FORMAT": self.format,
-            f"{colname}_TIME_SCALE": self.scale,
+            f"CTAFIELD_{colname}_TRANSFORM": "time",
+            f"CTAFIELD_{colname}_TIME_FORMAT": self.format,
+            f"CTAFIELD_{colname}_TIME_SCALE": self.scale,
         }
 
 
 class QuantityColumnTransform(ColumnTransform):
-    """ A Column Transform that transforms quantities to their values in the given unit"""
+    """A Column Transform that transforms quantities to their values in the given unit"""
 
     def __init__(self, unit):
         self.unit = unit
@@ -339,8 +338,8 @@ class QuantityColumnTransform(ColumnTransform):
 
     def get_meta(self, colname):
         return {
-            f"{colname}_TRANSFORM": "quantity",
-            f"{colname}_UNIT": self.unit.to_string("vounit"),
+            f"CTAFIELD_{colname}_TRANSFORM": "quantity",
+            f"CTAFIELD_{colname}_UNIT": self.unit.to_string("vounit"),
         }
 
 
@@ -443,13 +442,13 @@ class FixedPointColumnTransform(ColumnTransform):
 
     def get_meta(self, colname: str):
         return {
-            f"{colname}_TRANSFORM": "fixed_point",
-            f"{colname}_TRANSFORM_SCALE": self.scale,
-            f"{colname}_TRANSFORM_DTYPE": str(self.source_dtype),
-            f"{colname}_TRANSFORM_OFFSET": self.offset,
-            f"{colname}_NAN_VALUE": self.nan,
-            f"{colname}_POSINF_VALUE": self.posinf,
-            f"{colname}_NEGINF_VALUE": self.neginf,
+            f"CTAFIELD_{colname}_TRANSFORM": "fixed_point",
+            f"CTAFIELD_{colname}_TRANSFORM_SCALE": self.scale,
+            f"CTAFIELD_{colname}_TRANSFORM_DTYPE": str(self.source_dtype),
+            f"CTAFIELD_{colname}_TRANSFORM_OFFSET": self.offset,
+            f"CTAFIELD_{colname}_NAN_VALUE": self.nan,
+            f"CTAFIELD_{colname}_POSINF_VALUE": self.posinf,
+            f"CTAFIELD_{colname}_NEGINF_VALUE": self.neginf,
         }
 
 
@@ -467,7 +466,10 @@ class EnumColumnTransform(ColumnTransform):
         return self.enum(value)
 
     def get_meta(self, colname):
-        return {f"{colname}_TRANSFORM": "enum", f"{colname}_ENUM": self.enum}
+        return {
+            f"CTAFIELD_{colname}_TRANSFORM": "enum",
+            f"CTAFIELD_{colname}_ENUM": self.enum,
+        }
 
 
 def encode_utf8_max_len(string, max_length):
@@ -530,11 +532,14 @@ class StringTransform(ColumnTransform):
         return np.array([v.decode("utf-8") for v in value])
 
     def get_meta(self, colname):
-        return {f"{colname}_TRANSFORM": "string", f"{colname}_MAXLEN": self.max_length}
+        return {
+            f"CTAFIELD_{colname}_TRANSFORM": "string",
+            f"CTAFIELD_{colname}_MAXLEN": self.max_length,
+        }
 
 
 class TelListToMaskTransform(ColumnTransform):
-    """ convert variable-length list of tel_ids to a fixed-length mask """
+    """convert variable-length list of tel_ids to a fixed-length mask"""
 
     def __init__(self, subarray: SubarrayDescription):
         self._forward = subarray.tel_ids_to_mask
@@ -552,4 +557,4 @@ class TelListToMaskTransform(ColumnTransform):
         return self._inverse(value)
 
     def get_meta(self, colname):
-        return {f"{colname}_TRANSFORM": "tel_list_to_mask"}
+        return {f"CTAFIELD_{colname}_TRANSFORM": "tel_list_to_mask"}

--- a/ctapipe/io/tests/test_astropy_helpers.py
+++ b/ctapipe/io/tests/test_astropy_helpers.py
@@ -1,32 +1,31 @@
 #!/usr/bin/env python3
 import warnings
-import numpy as np
-from astropy import units as u
-import tables
-import pytest
-from astropy.time import Time
-from astropy.table import Table
-from astropy.utils.diff import report_diff_values
-
-from astropy.io.fits.verify import VerifyWarning
-
-from ctapipe.core import Container, Field
-from ctapipe.containers import ReconstructedEnergyContainer, TelescopeTriggerContainer
-from ctapipe.io import HDF5TableWriter
-from ctapipe.io.astropy_helpers import read_table
 from io import StringIO
 
+import numpy as np
+import pytest
+import tables
+from astropy import units as u
+from astropy.io.fits.verify import VerifyWarning
+from astropy.table import Table
+from astropy.time import Time
+from astropy.utils.diff import report_diff_values
+
+from ctapipe.containers import ReconstructedEnergyContainer, TelescopeTriggerContainer
+from ctapipe.core import Container, Field
+from ctapipe.io import HDF5TableWriter
+from ctapipe.io.astropy_helpers import read_table
 
 
 def assert_table_equal(a, b):
-    '''
+    """
     Assert that two astropy tables are the same.
 
     Compares two tables using the astropy diff utility
     and use the report as error message in case they don't match
-    '''
+    """
     msg = StringIO()
-    msg.write('\n')
+    msg.write("\n")
     valid = report_diff_values(a, b, fileobj=msg)
     msg.seek(0)
     assert valid, msg.read()
@@ -132,9 +131,9 @@ def test_transforms(tmp_path):
 
     with tables.open_file(path, "w") as f:
         f.create_table("/data", "test", obj=data, createparents=True)
-        f.root.data.test.attrs["waveform_TRANSFORM_SCALE"] = 100.0
-        f.root.data.test.attrs["waveform_TRANSFORM_OFFSET"] = 200
-        f.root.data.test.attrs["waveform_TRANSFORM_DTYPE"] = "float64"
+        f.root.data.test.attrs["CTAFIELD_0_TRANSFORM_SCALE"] = 100.0
+        f.root.data.test.attrs["CTAFIELD_0_TRANSFORM_OFFSET"] = 200
+        f.root.data.test.attrs["CTAFIELD_0_TRANSFORM_DTYPE"] = "float64"
 
     table = read_table(path, "/data/test")
 

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -18,7 +18,7 @@ from ctapipe.containers import (
 from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import DataLevel, EventSource
 from ctapipe.io.datawriter import DATA_MODEL_VERSION, DataWriter
-from ctapipe.io.hdf5tableio import read_column_attrs
+from ctapipe.io.hdf5tableio import get_column_attrs
 from ctapipe.utils import get_dataset_path
 
 
@@ -120,7 +120,7 @@ def test_write(tmpdir: Path):
             == DATA_MODEL_VERSION
         )
         shower = h5file.get_node("/simulation/event/subarray/shower")
-        shower_attrs = read_column_attrs(shower)
+        shower_attrs = get_column_attrs(shower)
         assert len(shower) > 0
         assert shower.col("true_alt").mean() > 0.0
         assert shower_attrs["true_alt"]["UNIT"] == "deg"

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -18,6 +18,7 @@ from ctapipe.containers import (
 from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import DataLevel, EventSource
 from ctapipe.io.datawriter import DATA_MODEL_VERSION, DataWriter
+from ctapipe.io.hdf5tableio import read_column_attrs
 from ctapipe.utils import get_dataset_path
 
 
@@ -119,11 +120,10 @@ def test_write(tmpdir: Path):
             == DATA_MODEL_VERSION
         )
         shower = h5file.get_node("/simulation/event/subarray/shower")
+        shower_attrs = read_column_attrs(shower)
         assert len(shower) > 0
         assert shower.col("true_alt").mean() > 0.0
-        assert (
-            shower._v_attrs["true_alt_UNIT"] == "deg"
-        )  # pylint: disable=protected-access
+        assert shower_attrs["true_alt"]["UNIT"] == "deg"
 
         # check DL2
         for prefix in ("ImPACTReconstructor", "HillasReconstructor"):

--- a/ctapipe/io/tests/test_hdf5.py
+++ b/ctapipe/io/tests/test_hdf5.py
@@ -1,22 +1,23 @@
 import enum
+
 import numpy as np
+import pandas as pd
 import pytest
 import tables
-import pandas as pd
 from astropy import units as u
 from astropy.time import Time
 
-from ctapipe.core.container import Container, Field
 from ctapipe import containers
 from ctapipe.containers import (
+    HillasParametersContainer,
+    LeakageContainer,
     R0CameraContainer,
     SimulatedShowerContainer,
-    HillasParametersContainer,
     TelEventIndexContainer,
-    LeakageContainer,
 )
-from ctapipe.io.hdf5tableio import HDF5TableWriter, HDF5TableReader
+from ctapipe.core.container import Container, Field
 from ctapipe.io import read_table
+from ctapipe.io.hdf5tableio import HDF5TableReader, HDF5TableWriter
 
 
 @pytest.fixture(scope="session")
@@ -270,9 +271,9 @@ def test_units(tmp_path):
         writer.write("units", c)
 
     with tables.open_file(path, "r") as f:
-        assert f.root.data.units.attrs["inverse_length_UNIT"] == "m**-1"
-        assert f.root.data.units.attrs["time_UNIT"] == "s"
-        assert f.root.data.units.attrs["grammage_UNIT"] == "cm**-2.g"
+        assert f.root.data.units.attrs["CTAFIELD_0_UNIT"] == "m**-1"
+        assert f.root.data.units.attrs["CTAFIELD_1_UNIT"] == "s"
+        assert f.root.data.units.attrs["CTAFIELD_2_UNIT"] == "cm**-2.g"
 
 
 def test_write_containers(tmp_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ exclude=
 max-line-length=90
 #ignore=W291,E303,W391,F403,F401,W503,W1202
 select = C,E,F,W,B,B950
-ignore = E501,W503,E203,W201
+ignore = E501,W503,E203,W201,E731
 per-file-ignores =
     */__init__.py: F401, F403
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,8 @@ minversion=3.0
 norecursedirs=build docs/_build
 addopts = -v
 astropy_header = true
-
+filterwarnings =
+    ignore:`np.MachAr` is deprecated:DeprecationWarning
 
 [aliases]
 test=pytest


### PR DESCRIPTION
This is a draft reworking how we deal with the hdf5 metadata.

* To easily identify the "special" metadata fields, these now have a common `CTAFIELD` prefix
* To follow the same style as the hdf5 table convention, the code now uses the integer position instead of the column name
* As the prefix is stored in the metadata, the `HDF5TableReader` can now get it from the file metadata and does not have to be provided with prefixes if the mapping from Container field names to column names is unique, an error is raised otherwise.
* The code creating the mapping from column names to container fields was simplified a lot, although it is now more powerful.

I still have to check performance and file size implications of this, and I would want to also address #1944.

This should fix #1971 and #1785

This breaks reading every file produced previously