### PR TITLE
Get reference_location and optics/camera name from simtel metadata if available

### DIFF
--- a/ctapipe/instrument/guess.py
+++ b/ctapipe/instrument/guess.py
@@ -9,6 +9,14 @@ from collections import namedtuple
 import astropy.units as u
 import numpy as np
 
+__all__ = [
+    "GuessingKey",
+    "GuessingResult",
+    "guess_telescope",
+    "unknown_telescope",
+    "type_from_mirror_area",
+]
+
 GuessingKey = namedtuple(
     "GuessingKey",
     ["n_pixels", "focal_length", "num_mirror_tiles"],

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -458,8 +458,9 @@ class SimTelEventSource(EventSource):
             self.telescope_indices_original[tel_id] = tel_idx
             tel_positions[tel_id] = header["tel_pos"][tel_idx] * u.m
 
+        name = self.file_.global_meta.get(b"ARRAY_CONFIG_NAME", b"MonteCarloArray")
         subarray = SubarrayDescription(
-            name="MonteCarloArray",
+            name=name.decode(),
             tel_positions=tel_positions,
             tel_descriptions=tel_descriptions,
             reference_location=_location_from_meta(self.file_.global_meta),

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -225,22 +225,23 @@ class SimTelEventSource(EventSource):
     Make sure you set this parameters in the simulation configuration to fully
     make use of ctapipe. In future, ctapipe might require these metadata parameters.
 
-    This includes
+    This includes:
+
     * Reference Point of the telescope coordinates. Make sure to include the
-      user-defined parameters ``LONGITUDE`` and ``LATITUDE`` with the geodetic
-      coordinates of the array reference point. Also make sure the ``ALTITUDE``
-      config parameter is included in the global metadata.
+        user-defined parameters ``LONGITUDE`` and ``LATITUDE`` with the geodetic
+        coordinates of the array reference point. Also make sure the ``ALTITUDE``
+        config parameter is included in the global metadata.
 
     * Names of the optical structures and the cameras are read from
-      ``OPTICS_CONFIG_NAME`` and ``CAMERA_CONFIG_NAME``, make sure to include
-      these in the telescope meta.
+        ``OPTICS_CONFIG_NAME`` and ``CAMERA_CONFIG_NAME``, make sure to include
+        these in the telescope meta.
 
     * The ``MIRROR_CLASS`` should also be included in the telescope meta
-      to correctly setup coordinate transforms.
+        to correctly setup coordinate transforms.
 
     If these parameters are not included in the input data, ctapipe will
     fallback guesses these based on avaible data and the list of known telescopes
-    in `ctapipe.instrument.guess`.
+    for `ctapipe.instrument.guess_telescope`.
     """
 
     skip_calibration_events = Bool(True, help="Skip calibration events").tag(

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -450,3 +450,26 @@ def test_extracted_calibevents():
             assert e.simulation is not None
             assert e.simulation.shower is None
         assert i == 4
+
+
+def test_simtel_metadata(monkeypatch):
+    from ctapipe.instrument import guess
+
+    path = "dataset://gamma_prod6_preliminary.simtel.zst"
+
+    with monkeypatch.context() as m:
+        # remove all guessing keys so we cannot use guessing
+        m.setattr(guess, "TELESCOPE_NAMES", [])
+
+        with SimTelEventSource(path) as source:
+            subarray = source.subarray
+
+    assert subarray.name == "Paranal-prod6"
+    assert subarray.tel[1].camera.camera_name == "LSTcam"
+    assert subarray.tel[1].optics.name == "LST"
+
+    assert subarray.tel[5].camera.camera_name == "FlashCam"
+    assert subarray.tel[5].optics.name == "MST"
+
+    assert subarray.tel[50].camera.camera_name == "SST-Camera"
+    assert subarray.tel[50].optics.name == "SST"


### PR DESCRIPTION
This completely removes the guessing if the metadata first included in the current prod6 iterations is present.

* We take the reference location from the `ALTITUDE`, `*LATITUDE`, `*LONGITUDE` attributes.
* Optics and camera names from `OPTICS_CONFIG_NAME` and `CAMERA_CONFIG_NAME`
* subarray name from `ARRAY_CONFIG_NAME`
* number of mirrors from `MIRROR_CLASS`