### PR TITLE
Fix error message for missing effective focal length

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -628,10 +628,10 @@ class SubarrayDescription:
                 focal_length = optics.effective_focal_length
                 if np.isnan(focal_length.value):
                     raise RuntimeError(
-                        "`focal_length_choice` was set to 'effective', but the"
+                        "`focal_length_choice` was set to 'EFFECTIVE', but the"
                         " effective focal length was not present in the file. "
-                        " Use nominal focal length or adapt configuration"
-                        " to include the effective focal length"
+                        " Set `focal_length_choice='EQUIVALENT'` or make sure"
+                        " input files contain the effective focal length"
                     )
             elif focal_length_choice is FocalLengthKind.EQUIVALENT:
                 focal_length = optics.equivalent_focal_length

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -338,11 +338,10 @@ class SimTelEventSource(EventSource):
             if self.focal_length_choice is FocalLengthKind.EFFECTIVE:
                 if np.isnan(effective_focal_length):
                     raise RuntimeError(
-                        f"`SimTelEventSource.focal_length_choice` was set to"
-                        f" {self.focal_length_choice!r}, but the effective focal length"
-                        f" was not present in the file. "
-                        " Use nominal focal length or adapt your simulation configuration"
-                        " to include the effective focal length"
+                        "`SimTelEventSource.focal_length_choice` was set to 'EFFECTIVE'"
+                        ", but the effective focal length was not present in the file."
+                        " Set `focal_length_choice='EQUIVALENT'` or make sure"
+                        " input files contain the effective focal length"
                     )
                 focal_length = effective_focal_length
             elif self.focal_length_choice is FocalLengthKind.EQUIVALENT:


### PR DESCRIPTION
After the switch to the enum in #1923, the error messages were not updated.