### PR TITLE
Import all ctapipe_ plugins, not just IO. Add test with dummy plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
           python --version
           pip install codecov pytest-cov pyflakes pytest-xdist 'coverage!=6.3.0'
           pip install .[all]
+          pip install ./test_plugin
           pip freeze
 
       - name: Static codechecks

--- a/ctapipe/__init__.py
+++ b/ctapipe/__init__.py
@@ -3,6 +3,10 @@ ctapipe - CTA Python pipeline experimental version
 
 Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
+from .core.plugins import IMPORTED_PLUGINS, detect_and_import_plugins
 from .version import __version__
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "IMPORTED_PLUGINS"]
+
+
+detect_and_import_plugins()

--- a/ctapipe/core/plugins.py
+++ b/ctapipe/core/plugins.py
@@ -1,17 +1,28 @@
 """ Functions for dealing with IO plugins """
-
 import importlib
+import logging
 import pkgutil
 
-
-def detect_and_import_plugins(prefix):
-    """ detect and import  plugin modules with given prefix, """
-    return {
-        name: importlib.import_module(name)
-        for finder, name, ispkg in pkgutil.iter_modules()
-        if name.startswith(prefix)
-    }
+__all__ = [
+    "detect_and_import_plugins",
+    "IMPORTED_PLUGINS",
+]
 
 
-def detect_and_import_io_plugins():
-    return detect_and_import_plugins(prefix="ctapipe_io_")
+log = logging.getLogger(__name__)
+
+IMPORTED_PLUGINS = {}
+
+
+def detect_and_import_plugins(prefix="ctapipe_"):
+    """detect and import  plugin modules with given prefix,"""
+
+    for _, name, _ in pkgutil.iter_modules():
+        if not name.startswith(prefix):
+            continue
+
+        try:
+            IMPORTED_PLUGINS[name] = importlib.import_module(name)
+            log.info("Imported plugin %s", name)
+        except Exception as e:
+            log.error("Failed to import pluging %s: %s", name, e)

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -6,10 +6,11 @@ import pathlib
 import re
 import textwrap
 from abc import abstractmethod
+from inspect import cleandoc
 from typing import Union
+
 import yaml
 from docutils.core import publish_parts
-from inspect import cleandoc
 
 try:
     import tomli as toml
@@ -18,10 +19,9 @@ try:
 except ImportError:
     HAS_TOML = False
 
-from traitlets import default, List
+from traitlets import List, default
 from traitlets.config import Application, Config, Configurable
 
-from .. import __version__ as version
 from . import Provenance
 from .component import Component
 from .logging import ColoredFormatter, create_logging_config
@@ -168,6 +168,9 @@ class Tool(Application):
         return self.name + ".provenance.log"
 
     def __init__(self, **kwargs):
+        # here to prevent circular import
+        from .. import __version__ as version
+
         # make sure there are some default aliases in all Tools:
         super().__init__(**kwargs)
         aliases = {
@@ -379,7 +382,7 @@ class Tool(Application):
     @property
     def version_string(self):
         """a formatted version string with version, release, and git hash"""
-        return f"{version}"
+        return self.version
 
     def get_current_config(self):
         """return the current configuration as a dict (e.g. the values

--- a/ctapipe/io/__init__.py
+++ b/ctapipe/io/__init__.py
@@ -1,21 +1,15 @@
+from .astropy_helpers import read_table, write_table
+from .datalevels import DataLevel
+from .datawriter import DATA_MODEL_VERSION, DataWriter
 from .eventseeker import EventSeeker
 from .eventsource import EventSource
+from .hdf5eventsource import HDF5EventSource, get_hdf5_datalevels
 from .hdf5tableio import HDF5TableReader, HDF5TableWriter
-from .tableio import TableWriter, TableReader
-from .tableloader import TableLoader
-from .datalevels import DataLevel
-from .astropy_helpers import read_table, write_table
-from .datawriter import DataWriter, DATA_MODEL_VERSION
-
-from ..core.plugins import detect_and_import_io_plugins
 
 # import event sources to make them visible to EventSource.from_url
 from .simteleventsource import SimTelEventSource
-from .hdf5eventsource import HDF5EventSource, get_hdf5_datalevels
-
-# import IO plugins with their event sources
-detect_and_import_io_plugins()
-
+from .tableio import TableReader, TableWriter
+from .tableloader import TableLoader
 
 __all__ = [
     "HDF5TableWriter",

--- a/ctapipe/io/tests/test_event_source.py
+++ b/ctapipe/io/tests/test_event_source.py
@@ -1,10 +1,10 @@
 import pytest
-from ctapipe.utils import get_dataset_path
-from ctapipe.io import EventSource, SimTelEventSource, DataLevel
-from traitlets.config.loader import Config
 from traitlets import TraitError
+from traitlets.config.loader import Config
 
 from ctapipe.core import Component
+from ctapipe.io import DataLevel, EventSource, SimTelEventSource
+from ctapipe.utils import get_dataset_path
 
 prod5_path = "gamma_20deg_0deg_run2___cta-prod5-paranal_desert-2147m-Paranal-dark_cone10-100evts.simtel.zst"
 
@@ -169,3 +169,19 @@ def test_allowed_tels_from_config():
     config = Config({"EventSource": {"input_url": dataset, "allowed_tels": {1, 3}}})
     reader = EventSource(config=config, parent=None)
     assert reader.allowed_tels == {1, 3}
+
+
+def test_plugin():
+    """Test that the test plugin is detected and its eventsource is available
+
+    Requires running `pip install [-e] test_plugin`
+    """
+    from ctapipe.core.plugins import IMPORTED_PLUGINS
+
+    assert (
+        "ctapipe_test_plugin" in IMPORTED_PLUGINS
+    ), "Did you run `pip install -e test_plugin`?"
+
+    source = EventSource("test.dummy")
+    assert source.__class__.__name__ == "PluginEventSource"
+    assert len(list(source)) == 10

--- a/test_plugin/ctapipe_test_plugin/__init__.py
+++ b/test_plugin/ctapipe_test_plugin/__init__.py
@@ -1,0 +1,67 @@
+import astropy.units as u
+import numpy as np
+
+from ctapipe.instrument import (
+    CameraDescription,
+    CameraGeometry,
+    CameraReadout,
+    OpticsDescription,
+    SubarrayDescription,
+    TelescopeDescription,
+)
+from ctapipe.io import DataLevel, EventSource
+from ctapipe.io.datawriter import ArrayEventContainer
+
+optics = OpticsDescription(
+    "dummy",
+    num_mirrors=1,
+    equivalent_focal_length=28 * u.m,
+    effective_focal_length=29 * u.m,
+    mirror_area=400 * u.m**2,
+    num_mirror_tiles=250,
+)
+
+step = 0.1
+t = np.arange(0, 40, step)
+camera = CameraDescription(
+    camera_name="dummy",
+    geometry=CameraGeometry.make_rectangular(),
+    readout=CameraReadout(
+        camera_name="dummy",
+        sampling_rate=1 * u.GHz,
+        reference_pulse_shape=np.exp(-0.5 * (t - 10) ** 2 / 4),
+        reference_pulse_sample_width=step * u.ns,
+    ),
+)
+
+
+telescope = TelescopeDescription(
+    "dummy",
+    "LST",
+    optics=optics,
+    camera=camera,
+)
+
+
+subarray = SubarrayDescription(
+    name="Dummy",
+    tel_descriptions={1: telescope},
+    tel_positions={1: [0, 0, 0] * u.m},
+)
+
+
+class PluginEventSource(EventSource):
+    """A minimal dummy event source"""
+
+    is_simulation = False
+    datalevels = (DataLevel.DL1_IMAGES,)
+    obs_ids = (1,)
+    subarray = subarray
+
+    @classmethod
+    def is_compatible(cls, path):
+        return str(path).endswith(".dummy")
+
+    def _generator(self):
+        for i in range(10):
+            yield ArrayEventContainer(count=i)

--- a/test_plugin/pyproject.toml
+++ b/test_plugin/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "ctapipe_test_plugin"
+version = "0.1.0"
+dependencies = [
+	"ctapipe",
+]
+
+
+[build-system]
+requires = ["setuptools >= 61.0.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages]
+find = {}  # Scan the project directory with the default parameters

--- a/test_plugin/setup.py
+++ b/test_plugin/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
* Import all plugin packages (moved to __init__.py, removed restriction on `ctapipe_io` to `ctapipe_` prefix
* Test a dummy plugin for unit tests


TODO:

- [ ] Add hooks in ctapipe process to call reconstructor plugins?
- [ ] Add hooks in `DataWriter` so that plugins can store additional information in output files?