### PR TITLE
Fix cv split for StratifiedKFold

### DIFF
--- a/ctapipe/ml/apply.py
+++ b/ctapipe/ml/apply.py
@@ -348,7 +348,7 @@ class CrossValidator(Component):
             cv_values = np.array(cv_values)
             with np.printoptions(precision=4):
                 self.log.info(
-                    "Mean % score from CV: %.4f ± %.4f",
+                    "Mean %s score from CV: %.4f ± %.4f",
                     metric,
                     cv_values.mean(),
                     cv_values.std(),

--- a/ctapipe/ml/apply.py
+++ b/ctapipe/ml/apply.py
@@ -324,7 +324,7 @@ class CrossValidator(Component):
         )
 
         for fold, (train_indices, test_indices) in enumerate(
-            tqdm(kfold.split(table), total=self.n_cross_validations)
+            tqdm(kfold.split(table, table[self.model_component.target]), total=self.n_cross_validations)
         ):
             train = table[train_indices]
             test = table[test_indices]


### PR DESCRIPTION
`sklearn.model_selection.StratifiedKFold.split()` needs an argument `y`:
https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.StratifiedKFold.html
`sklearn.model_selection.KFold.split()` can also take an argument `y`, so no case differentiation is necessary:
https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.KFold.html