### PR TITLE
Report HDF5EventSource as compatible for dl2 only files, fixes #2058

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -296,6 +296,33 @@ def dl1_file(dl1_tmp_path, prod5_gamma_simtel_path):
 
 
 @pytest.fixture(scope="session")
+def dl2_only_file(dl2_tmp_path, prod5_gamma_simtel_path):
+    """
+    DL1 file containing both images and parameters from a gamma simulation set.
+    """
+    from ctapipe.core import run_tool
+    from ctapipe.tools.process import ProcessorTool
+
+    output = dl2_tmp_path / "gamma_no_dl1.dl2.h5"
+
+    # prevent running process multiple times in case of parallel tests
+    with FileLock(output.with_suffix(output.suffix + ".lock")):
+        if output.is_file():
+            return output
+
+        argv = [
+            f"--input={prod5_gamma_simtel_path}",
+            f"--output={output}",
+            "--write-showers",
+            "--no-write-images",
+            "--no-write-parameters",
+            "--max-events=20",
+        ]
+        assert run_tool(ProcessorTool(), argv=argv, cwd=dl2_tmp_path) == 0
+        return output
+
+
+@pytest.fixture(scope="session")
 def dl1_image_file(dl1_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing only images (DL1A) from a gamma simulation set.

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -215,7 +215,9 @@ class HDF5EventSource(EventSource):
 
             # we can now read both R1 and DL1
             datalevels = set(metadata["CTA PRODUCT DATA LEVELS"].split(","))
-            if not datalevels.intersection(("R1", "DL1_IMAGES", "DL1_PARAMETERS")):
+            if not datalevels.intersection(
+                ("R1", "DL1_IMAGES", "DL1_PARAMETERS", "DL2")
+            ):
                 return False
 
         return True

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -1,18 +1,19 @@
 import astropy.units as u
 import numpy as np
+import pytest
 
 from ctapipe.io import DataLevel, EventSource, HDF5EventSource
-from ctapipe.utils import get_dataset_path
 
 
-def test_is_compatible(dl1_file, dl2_only_file):
-    simtel_path = get_dataset_path("gamma_test_large.simtel.gz")
-    assert not HDF5EventSource.is_compatible(simtel_path)
-    assert HDF5EventSource.is_compatible(dl1_file)
-    with EventSource(input_url=dl1_file) as source:
-        assert isinstance(source, HDF5EventSource)
-    assert HDF5EventSource.is_compatible(dl2_only_file)
-    with EventSource(input_url=dl2_only_file) as source:
+def test_is_not_compatible(prod5_gamma_simtel_path):
+    assert not HDF5EventSource.is_compatible(prod5_gamma_simtel_path)
+
+
+@pytest.mark.parametrize("compatible_file", ["dl1_file", "dl2_only_file"])
+def test_is_compatible(compatible_file, request):
+    file = request.getfixturevalue(compatible_file)
+    assert HDF5EventSource.is_compatible(file)
+    with EventSource(input_url=file) as source:
         assert isinstance(source, HDF5EventSource)
 
 

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -5,11 +5,14 @@ from ctapipe.io import DataLevel, EventSource, HDF5EventSource
 from ctapipe.utils import get_dataset_path
 
 
-def test_is_compatible(dl1_file):
+def test_is_compatible(dl1_file, dl2_only_file):
     simtel_path = get_dataset_path("gamma_test_large.simtel.gz")
     assert not HDF5EventSource.is_compatible(simtel_path)
     assert HDF5EventSource.is_compatible(dl1_file)
     with EventSource(input_url=dl1_file) as source:
+        assert isinstance(source, HDF5EventSource)
+    assert HDF5EventSource.is_compatible(dl2_only_file)
+    with EventSource(input_url=dl2_only_file) as source:
         assert isinstance(source, HDF5EventSource)
 
 


### PR DESCRIPTION
- Files with no dl1 information are now compatible if there is dl2
  information in the file. This matters for the case of
  --no-write-images and no-write-parameters or if they are skipped during
  the merge step
- Adds dl2 only file to conftest and checks compatibility