### PR TITLE
Make ExpressionEngine be no Component. Fixes #2065.

### DIFF
--- a/ctapipe/core/expression_engine.py
+++ b/ctapipe/core/expression_engine.py
@@ -4,9 +4,6 @@ Expression Engine
 import astropy.units as u  # for use in selection functions
 import numpy as np  # for use in selection functions
 
-from .component import Component
-from .traits import List, Tuple, Unicode
-
 # the following are what are allowed to be used
 # in selection functions (passed to eval())
 ALLOWED_GLOBALS = {"u": u, "np": np}  # astropy units  # numpy
@@ -19,21 +16,14 @@ class ExpressionError(TypeError):
     """Signal a problem with a user-defined selection criteria function"""
 
 
-class ExpressionEngine(Component):
+class ExpressionEngine:
     """
     Compile expressions on init, evaluate on call.
     """
 
-    expressions = List(
-        Tuple(Unicode(), Unicode()),
-        help="List of 2-Tuples of Strings: ('name', 'expression').",
-    ).tag(config=True)
-
-    def __init__(self, config=None, parent=None, **kwargs):
-        super().__init__(config=config, parent=parent, **kwargs)
-
+    def __init__(self, expressions):
         self.compiled = []
-        for name, expression in self.expressions:
+        for name, expression in expressions:
             try:
                 self.compiled.append(compile(expression, __name__, mode="eval"))
             except Exception:

--- a/ctapipe/core/feature_generator.py
+++ b/ctapipe/core/feature_generator.py
@@ -31,7 +31,7 @@ class FeatureGenerator(Component):
 
     def __init__(self, config=None, parent=None, **kwargs):
         super().__init__(config=config, parent=parent, **kwargs)
-        self.engine = ExpressionEngine(parent=self, expressions=self.features)
+        self.engine = ExpressionEngine(expressions=self.features)
         self._feature_names = [name for name, _ in self.features]
 
     def __call__(self, table):

--- a/ctapipe/core/qualityquery.py
+++ b/ctapipe/core/qualityquery.py
@@ -41,10 +41,7 @@ class QualityQuery(Component):
         self.criteria_names = [n for (n, _) in self.quality_criteria]
         self.expressions = [e for (_, e) in self.quality_criteria]
 
-        self.engine = ExpressionEngine(
-            parent=self,
-            expressions=self.quality_criteria,
-        )
+        self.engine = ExpressionEngine(self.quality_criteria)
         for _, expr in self.quality_criteria:
             if "lambda" in expr:
                 raise ValueError(


### PR DESCRIPTION
This removes the (before duplicated) expressions from the provenance log. QualityQuery and FeatureGeneration 'expressions' are still available via their configs and provenance log.