### PR TITLE
Fix tables.Node.__del__ throwing exceptions on interpreter exit when writing index tables, fixes #2067

### DIFF
--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -256,7 +256,6 @@ class DataWriter(Component):
         self._subarray: SubarrayDescription = event_source.subarray
 
         self._hdf5_filters = None
-        self._writer: HDF5TableWriter = None
 
         self._setup_output_path()
         self._setup_compression()
@@ -326,24 +325,23 @@ class DataWriter(Component):
         self.log.info("Finishing output")
         if not self._at_least_one_event:
             self.log.warning("No events have been written to the output file")
-        if self._writer:
-            if self.write_index_tables:
-                self._generate_indices()
 
-            write_reference_metadata_headers(
-                subarray=self._subarray,
-                obs_ids=self.event_source.obs_ids,
-                writer=self._writer,
-                is_simulation=self._is_simulation,
-                data_levels=self.datalevels,
-                contact_info=self.contact_info,
-                instrument_info=self.instrument_info,
-            )
+        if self.write_index_tables:
+            self._generate_indices()
 
-            self._write_context_metadata_headers()
+        write_reference_metadata_headers(
+            subarray=self._subarray,
+            obs_ids=self.event_source.obs_ids,
+            writer=self._writer,
+            is_simulation=self._is_simulation,
+            data_levels=self.datalevels,
+            contact_info=self.contact_info,
+            instrument_info=self.instrument_info,
+        )
 
-            self._writer.close()
-            self._writer = None
+        self._write_context_metadata_headers()
+
+        self._writer.close()
 
     @property
     def datalevels(self):


### PR DESCRIPTION
…