### PR TITLE
Fix unreachable assertion in Provenance unit test

### DIFF
--- a/ctapipe/core/tests/test_provenance.py
+++ b/ctapipe/core/tests/test_provenance.py
@@ -19,7 +19,8 @@ def provenance():
     prov.finish_activity("test1")
     return prov
 
-    assert set(prov.finished_activity_names) == {"test2", "test1"}
+def test_provenance_activity_names(provenance):
+    assert set(provenance.finished_activity_names) == {"test2", "test1"}
 
 
 def test_ActivityProvenance():


### PR DESCRIPTION
The assertion was inside a fixture after a return statement, so it was never called.

I created a new unit-test that uses the fixture and calls that assertion.