### PR TITLE
Change recommendation on reusing ArrayEvent in EventSources

### DIFF
--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -70,11 +70,8 @@ class EventSource(Component):
     0
     1
 
-    **NOTE**: For effiency reasons, most sources only use a single ``ArrayEvent`` instance
-    and update it with new data on iteration, which might lead to surprising
-    behaviour if you want to access multiple events at the same time.
-    To keep an event and prevent its data from being overwritten with the next event's data,
-    perform a deepcopy: ``some_special_event = copy.deepcopy(event)``.
+    **NOTE**: EventSource implementations should not reuse the same ArrayEventContainer,
+    as these are mutable and may lead to errors when analyzing multiple events.
 
 
     Attributes

--- a/ctapipe/io/tests/test_event_source.py
+++ b/ctapipe/io/tests/test_event_source.py
@@ -16,7 +16,7 @@ def test_construct():
         EventSource()
 
 
-class DummyReader(EventSource):
+class DummyEventSource(EventSource):
     """
     Simple working EventSource
     """
@@ -54,13 +54,13 @@ class DummyReader(EventSource):
 
 def test_can_be_implemented():
     dataset = get_dataset_path(prod5_path)
-    test_reader = DummyReader(input_url=dataset)
+    test_reader = DummyEventSource(input_url=dataset)
     assert test_reader is not None
 
 
 def test_is_iterable():
     dataset = get_dataset_path(prod5_path)
-    test_reader = DummyReader(input_url=dataset)
+    test_reader = DummyEventSource(input_url=dataset)
     for _ in test_reader:
         pass
 
@@ -98,7 +98,7 @@ def test_from_config(tmp_path):
 
     config = Config({"EventSource": {"input_url": dataset}})
     reader = EventSource(config=config)
-    assert isinstance(reader, DummyReader)
+    assert isinstance(reader, DummyEventSource)
     assert reader.input_url == dataset
 
 

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -11,7 +11,8 @@ import tables
 
 from ctapipe.core import run_tool
 from ctapipe.instrument.subarray import SubarrayDescription
-from ctapipe.io import DataLevel, EventSource, read_table
+from ctapipe.io import read_table
+from ctapipe.io.tests.test_event_source import DummyEventSource
 from ctapipe.tools.process import ProcessorTool
 from ctapipe.tools.quickstart import CONFIGS_TO_WRITE, QuickStartTool
 from ctapipe.utils import get_dataset_path
@@ -151,43 +152,10 @@ def test_stage_1_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
 def test_stage1_datalevels(tmp_path):
     """test the dl1 tool on a file not providing r1, dl0 or dl1a"""
 
-    class DummyEventSource(EventSource):
-        """for testing"""
-
-        @staticmethod
-        def is_compatible(file_path):
-            with open(file_path, "rb") as infile:
-                dummy = infile.read(5)
-                return dummy == b"dummy"
-
-        @property
-        def datalevels(self):
-            return (DataLevel.R0,)
-
-        @property
-        def is_simulation(self):
-            return True
-
-        @property
-        def scheduling_blocks(self):
-            return dict()
-
-        @property
-        def observation_blocks(self):
-            return dict()
-
-        @property
-        def subarray(self):
-            return None
-
-        def _generator(self):
-            return None
-
     dummy_file = tmp_path / "datalevels_dummy.h5"
     out_file = tmp_path / "datalevels_dummy_stage1_output.h5"
-    with open(dummy_file, "wb") as infile:
+    with dummy_file.open("wb") as infile:
         infile.write(b"dummy")
-        infile.flush()
 
     config = resource_file("stage1_config.json")
     tool = ProcessorTool()


### PR DESCRIPTION
After #1970  and #1952 we should update the event source docstring accordingly