### PR TITLE
Allow data model version 4 in HDFEventSource, actually check which frame is used for hillas parameters

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -296,6 +296,31 @@ def dl1_file(dl1_tmp_path, prod5_gamma_simtel_path):
 
 
 @pytest.fixture(scope="session")
+def dl1_camera_frame_file(dl1_tmp_path, prod5_gamma_simtel_path):
+    """
+    DL1 file containing both images and parameters from a gamma simulation set.
+    """
+    from ctapipe.core import run_tool
+    from ctapipe.tools.process import ProcessorTool
+
+    output = dl1_tmp_path / "gamma_camera_frame.dl1.h5"
+
+    # prevent running process multiple times in case of parallel tests
+    with FileLock(output.with_suffix(output.suffix + ".lock")):
+        if output.is_file():
+            return output
+
+        argv = [
+            f"--input={prod5_gamma_simtel_path}",
+            f"--output={output}",
+            "--camera-frame",
+            "--write-images",
+        ]
+        assert run_tool(ProcessorTool(), argv=argv, cwd=dl1_tmp_path) == 0
+        return output
+
+
+@pytest.fixture(scope="session")
 def dl2_only_file(dl2_tmp_path, prod5_gamma_simtel_path):
     """
     DL1 file containing both images and parameters from a gamma simulation set.

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -367,10 +367,10 @@ class HDF5EventSource(EventSource):
                 }
 
         if DataLevel.DL1_PARAMETERS in self.datalevels:
+            hillas_cls = HillasParametersContainer
+            timing_cls = TimingParametersContainer
+
             if self._is_hillas_in_camera_frame():
-                hillas_cls = HillasParametersContainer
-                timing_cls = TimingParametersContainer
-            else:
                 hillas_cls = CameraHillasParametersContainer
                 timing_cls = CameraTimingParametersContainer
 

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -369,10 +369,14 @@ class HDF5EventSource(EventSource):
         if DataLevel.DL1_PARAMETERS in self.datalevels:
             hillas_cls = HillasParametersContainer
             timing_cls = TimingParametersContainer
+            hillas_prefix = "hillas"
+            timing_prefix = "timing"
 
             if self._is_hillas_in_camera_frame():
                 hillas_cls = CameraHillasParametersContainer
                 timing_cls = CameraTimingParametersContainer
+                hillas_prefix = "camera_frame_hillas"
+                timing_prefix = "camera_frame_timing"
 
             param_readers = {
                 table.name: self.reader.read(
@@ -387,8 +391,8 @@ class HDF5EventSource(EventSource):
                         PeakTimeStatisticsContainer,
                     ),
                     prefixes=[
-                        "hillas",
-                        "timing",
+                        hillas_prefix,
+                        timing_prefix,
                         "leakage",
                         "concentration",
                         "morphology",
@@ -410,7 +414,7 @@ class HDF5EventSource(EventSource):
                             IntensityStatisticsContainer,
                         ],
                         prefixes=[
-                            "true_hillas",
+                            f"true_{hillas_prefix}",
                             "true_leakage",
                             "true_concentration",
                             "true_morphology",

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -20,6 +20,7 @@ def test_is_compatible(compatible_file, request):
 def test_metadata(dl1_file):
     with HDF5EventSource(input_url=dl1_file) as source:
         assert source.is_simulation
+        assert source.datamodel_version == (5, 0, 0)
         assert set(source.datalevels) == {
             DataLevel.DL1_IMAGES,
             DataLevel.DL1_PARAMETERS,

--- a/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/ctapipe/io/tests/test_hdf5eventsource.py
@@ -2,6 +2,10 @@ import astropy.units as u
 import numpy as np
 import pytest
 
+from ctapipe.containers import (
+    CameraHillasParametersContainer,
+    CameraTimingParametersContainer,
+)
 from ctapipe.io import DataLevel, EventSource, HDF5EventSource
 
 
@@ -188,3 +192,25 @@ def test_read_dl2(dl2_shower_geometry_file):
             impact = e.dl2.tel[tel_id].impact[algorithm]
             assert impact.prefix == algorithm + "_tel_impact"
             assert impact.distance is not None
+
+
+def test_dl1_camera_frame(dl1_camera_frame_file):
+    with HDF5EventSource(dl1_camera_frame_file) as s:
+        tel_id = None
+        for e in s:
+            for tel_id, dl1 in e.dl1.tel.items():
+                assert isinstance(
+                    dl1.parameters.hillas, CameraHillasParametersContainer
+                )
+                assert isinstance(
+                    dl1.parameters.timing, CameraTimingParametersContainer
+                )
+                assert dl1.parameters.hillas.intensity is not None
+
+            for tel_id, sim in e.simulation.tel.items():
+                assert isinstance(
+                    sim.true_parameters.hillas, CameraHillasParametersContainer
+                )
+                assert sim.true_parameters.hillas.intensity is not None
+
+        assert tel_id is not None, "did not test any events"


### PR DESCRIPTION
This makes to small changes to the HDFEventSource, one to add support for the data model version 4.0, which I think is important since the change was so small and we are planning a release of mc data. 

Second, we no actually check which kind of hillas parameters are in the input file instead of relying on the version in which telescope frame became the default.