### PR TITLE
Fix invalid case in HillasReconstructor and HillasIntersection

### DIFF
--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -103,7 +103,9 @@ class HillasIntersection(Reconstructor):
         try:
             hillas_dict = self._create_hillas_dict(event)
         except (TooFewTelescopesException, InvalidWidthException):
-            return INVALID
+            event.dl2.stereo.geometry[self.__class__.__name__] = INVALID
+            self._store_impact_parameter(event)
+            return
 
         # Due to tracking the pointing of the array will never be a constant
         array_pointing = SkyCoord(

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -149,7 +149,9 @@ class HillasReconstructor(Reconstructor):
         try:
             hillas_dict = self._create_hillas_dict(event)
         except (TooFewTelescopesException, InvalidWidthException):
-            return INVALID
+            event.dl2.stereo.geometry[self.__class__.__name__] = INVALID
+            self._store_impact_parameter(event)
+            return
 
         # Here we perform some basic quality checks BEFORE applying reconstruction
         # This should be substituted by a DL1 QualityQuery specific to this

--- a/ctapipe/reco/reco_algorithms.py
+++ b/ctapipe/reco/reco_algorithms.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 
+import astropy.units as u
 import numpy as np
 from astropy.coordinates import AltAz, SkyCoord
 
@@ -97,10 +98,17 @@ class Reconstructor(Component):
 
     def _store_impact_parameter(self, event):
         """Compute and store the impact parameter for each reconstruction."""
-        impact_distances = shower_impact_distance(
-            shower_geom=event.dl2.stereo.geometry[self.__class__.__name__],
-            subarray=self.subarray,
-        )
+        geometry = event.dl2.stereo.geometry[self.__class__.__name__]
+
+        if geometry.is_valid:
+            impact_distances = shower_impact_distance(
+                shower_geom=geometry,
+                subarray=self.subarray,
+            )
+        else:
+            n_tels = len(self.subarray)
+            impact_distances = u.Quantity(np.full(n_tels, np.nan), u.m)
+
         default_prefix = TelescopeImpactParameterContainer.default_prefix
         prefix = f"{self.__class__.__name__}_tel_{default_prefix}"
         for tel_id in event.trigger.tels_with_trigger:


### PR DESCRIPTION
The PR #2073 did only change the "happy path" not  the invalid case, leading to the invalid container not being filled into the event.