### PR TITLE
Remove defaultdict behavior from map, check type of value

### DIFF
--- a/ctapipe/calib/camera/tests/test_flatfield.py
+++ b/ctapipe/calib/camera/tests/test_flatfield.py
@@ -6,7 +6,11 @@ from astropy.time import Time
 from traitlets.config import Config
 
 from ctapipe.calib.camera.flatfield import FlasherFlatFieldCalculator
-from ctapipe.containers import ArrayEventContainer
+from ctapipe.containers import (
+    ArrayEventContainer,
+    MonitoringCameraContainer,
+    R1CameraContainer,
+)
 from ctapipe.instrument import SubarrayDescription
 
 
@@ -42,17 +46,15 @@ def test_flasherflatfieldcalculator(prod5_sst):
     data.trigger.time = Time.now()
 
     # initialize mon and r1 data
-    data.mon.tel[tel_id].pixel_status.hardware_failing_pixels = np.zeros(
-        (n_gain, n_pixels), dtype=bool
+    mon = MonitoringCameraContainer()
+    mon.pixel_status.hardware_failing_pixels = np.zeros((n_gain, n_pixels), dtype=bool)
+    mon.pixel_status.pedestal_failing_pixels = np.zeros((n_gain, n_pixels), dtype=bool)
+    mon.pixel_status.flatfield_failing_pixels = np.zeros((n_gain, n_pixels), dtype=bool)
+    data.mon.tel[tel_id] = mon
+    data.r1.tel[tel_id] = R1CameraContainer(
+        waveform=np.zeros((n_gain, n_pixels, 40)),
+        selected_gain_channel=np.zeros(n_pixels, dtype=np.uint8),
     )
-    data.mon.tel[tel_id].pixel_status.pedestal_failing_pixels = np.zeros(
-        (n_gain, n_pixels), dtype=bool
-    )
-    data.mon.tel[tel_id].pixel_status.flatfield_failing_pixels = np.zeros(
-        (n_gain, n_pixels), dtype=bool
-    )
-    data.r1.tel[tel_id].waveform = np.zeros((n_gain, n_pixels, 40))
-    data.r1.tel[tel_id].selected_gain_channel = np.zeros(n_pixels, dtype=np.uint8)
 
     # flat-field signal put == delta function of height ff_level at sample 20
     data.r1.tel[tel_id].waveform[:, :, 20] = ff_level

--- a/ctapipe/calib/camera/tests/test_pedestals.py
+++ b/ctapipe/calib/camera/tests/test_pedestals.py
@@ -11,7 +11,11 @@ from ctapipe.calib.camera.pedestals import (
     PedestalIntegrator,
     calc_pedestals_from_traces,
 )
-from ctapipe.containers import ArrayEventContainer
+from ctapipe.containers import (
+    ArrayEventContainer,
+    MonitoringCameraContainer,
+    R1CameraContainer,
+)
 from ctapipe.instrument import SubarrayDescription
 
 
@@ -44,11 +48,13 @@ def test_pedestal_integrator(prod5_sst):
     data.trigger.time = Time.now()
 
     # fill the values necessary for the pedestal calculation
-    data.mon.tel[tel_id].pixel_status.hardware_failing_pixels = np.zeros(
-        (n_gain, n_pixels), dtype=bool
+    mon = MonitoringCameraContainer()
+    mon.pixel_status.hardware_failing_pixels = np.zeros((n_gain, n_pixels), dtype=bool)
+    data.mon.tel[tel_id] = mon
+    data.r1.tel[tel_id] = R1CameraContainer(
+        waveform=np.full((2, n_pixels, 40), ped_level),
+        selected_gain_channel=np.zeros(n_pixels, dtype=np.uint8),
     )
-    data.r1.tel[tel_id].waveform = np.full((2, n_pixels, 40), ped_level)
-    data.r1.tel[tel_id].selected_gain_channel = np.zeros(n_pixels, dtype=np.uint8)
 
     while ped_calculator.n_events_seen < n_events:
         if ped_calculator.calculate_pedestals(data):

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -442,7 +442,7 @@ class DL1Container(Container):
     """DL1 Calibrated Camera Images and associated data"""
 
     tel = Field(
-        default_factory=partial(Map, DL1CameraContainer),
+        default_factory=partial(Map, int, DL1CameraContainer),
         description="map of tel_id to DL1CameraContainer",
     )
 
@@ -492,7 +492,7 @@ class R0Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, R0CameraContainer),
+        default_factory=partial(Map, int, R0CameraContainer),
         description="map of tel_id to R0CameraContainer",
     )
 
@@ -524,7 +524,7 @@ class R1Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, R1CameraContainer),
+        default_factory=partial(Map, int, R1CameraContainer),
         description="map of tel_id to R1CameraContainer",
     )
 
@@ -559,7 +559,7 @@ class DL0Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, DL0CameraContainer),
+        default_factory=partial(Map, int, DL0CameraContainer),
         description="map of tel_id to DL0CameraContainer",
     )
 
@@ -632,7 +632,7 @@ class SimulatedEventContainer(Container):
         default_factory=SimulatedShowerContainer,
         description="True event information",
     )
-    tel = Field(default_factory=partial(Map, SimulatedCameraContainer))
+    tel = Field(default_factory=partial(Map, int, SimulatedCameraContainer))
 
 
 class SimulationConfigContainer(Container):
@@ -738,7 +738,7 @@ class TriggerContainer(Container):
     )
     event_type = Field(EventType.SUBARRAY, description="Event type")
     tel = Field(
-        default_factory=partial(Map, TelescopeTriggerContainer),
+        default_factory=partial(Map, int, TelescopeTriggerContainer),
         description="telescope-wise trigger information",
     )
 
@@ -855,15 +855,15 @@ class ReconstructedContainer(Container):
     # but most will compute only fill or two of these sub-Contaiers:
 
     geometry = Field(
-        default_factory=partial(Map, ReconstructedGeometryContainer),
+        default_factory=partial(Map, str, ReconstructedGeometryContainer),
         description="map of algorithm to reconstructed shower parameters",
     )
     energy = Field(
-        default_factory=partial(Map, ReconstructedEnergyContainer),
+        default_factory=partial(Map, str, ReconstructedEnergyContainer),
         description="map of algorithm to reconstructed energy parameters",
     )
     classification = Field(
-        default_factory=partial(Map, ParticleClassificationContainer),
+        default_factory=partial(Map, str, ParticleClassificationContainer),
         description="map of algorithm to classification parameters",
     )
 
@@ -872,7 +872,7 @@ class TelescopeReconstructedContainer(ReconstructedContainer):
     """Telescope-wise reconstructed quantities"""
 
     impact = Field(
-        default_factory=partial(Map, TelescopeImpactParameterContainer),
+        default_factory=partial(Map, str, TelescopeImpactParameterContainer),
         description="map of algorithm to impact parameter info",
     )
 
@@ -884,7 +884,7 @@ class DL2Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, TelescopeReconstructedContainer),
+        default_factory=partial(Map, int, TelescopeReconstructedContainer),
         description="map of tel_id to single-telescope reconstruction (DL2a)",
     )
     stereo = Field(
@@ -907,7 +907,7 @@ class TelescopePointingContainer(Container):
 
 class PointingContainer(Container):
     tel = Field(
-        default_factory=partial(Map, TelescopePointingContainer),
+        default_factory=partial(Map, int, TelescopePointingContainer),
         description="Telescope pointing positions",
     )
     array_azimuth = Field(nan * u.rad, "Array pointing azimuth", unit=u.rad)
@@ -934,7 +934,7 @@ class EventCalibrationContainer(Container):
 
     # create the camera container
     tel = Field(
-        default_factory=partial(Map, EventCameraCalibrationContainer),
+        default_factory=partial(Map, int, EventCameraCalibrationContainer),
         description="map of tel_id to EventCameraCalibrationContainer",
     )
 
@@ -1148,7 +1148,7 @@ class MonitoringContainer(Container):
 
     # create the camera container
     tel = Field(
-        default_factory=partial(Map, MonitoringCameraContainer),
+        default_factory=partial(Map, int, MonitoringCameraContainer),
         description="map of tel_id to MonitoringCameraContainer",
     )
 

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -11,6 +11,9 @@ from numpy import nan
 
 from .core import Container, Field, Map
 
+INT_TYPES = (int, np.integer)
+
+
 __all__ = [
     "ArrayEventContainer",
     "ConcentrationContainer",
@@ -442,7 +445,7 @@ class DL1Container(Container):
     """DL1 Calibrated Camera Images and associated data"""
 
     tel = Field(
-        default_factory=partial(Map, int, DL1CameraContainer),
+        default_factory=partial(Map, INT_TYPES, DL1CameraContainer),
         description="map of tel_id to DL1CameraContainer",
     )
 
@@ -492,7 +495,7 @@ class R0Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, int, R0CameraContainer),
+        default_factory=partial(Map, INT_TYPES, R0CameraContainer),
         description="map of tel_id to R0CameraContainer",
     )
 
@@ -524,7 +527,7 @@ class R1Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, int, R1CameraContainer),
+        default_factory=partial(Map, INT_TYPES, R1CameraContainer),
         description="map of tel_id to R1CameraContainer",
     )
 
@@ -559,7 +562,7 @@ class DL0Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, int, DL0CameraContainer),
+        default_factory=partial(Map, INT_TYPES, DL0CameraContainer),
         description="map of tel_id to DL0CameraContainer",
     )
 
@@ -632,7 +635,7 @@ class SimulatedEventContainer(Container):
         default_factory=SimulatedShowerContainer,
         description="True event information",
     )
-    tel = Field(default_factory=partial(Map, int, SimulatedCameraContainer))
+    tel = Field(default_factory=partial(Map, INT_TYPES, SimulatedCameraContainer))
 
 
 class SimulationConfigContainer(Container):
@@ -738,7 +741,7 @@ class TriggerContainer(Container):
     )
     event_type = Field(EventType.SUBARRAY, description="Event type")
     tel = Field(
-        default_factory=partial(Map, int, TelescopeTriggerContainer),
+        default_factory=partial(Map, INT_TYPES, TelescopeTriggerContainer),
         description="telescope-wise trigger information",
     )
 
@@ -884,7 +887,7 @@ class DL2Container(Container):
     """
 
     tel = Field(
-        default_factory=partial(Map, int, TelescopeReconstructedContainer),
+        default_factory=partial(Map, INT_TYPES, TelescopeReconstructedContainer),
         description="map of tel_id to single-telescope reconstruction (DL2a)",
     )
     stereo = Field(
@@ -907,7 +910,7 @@ class TelescopePointingContainer(Container):
 
 class PointingContainer(Container):
     tel = Field(
-        default_factory=partial(Map, int, TelescopePointingContainer),
+        default_factory=partial(Map, INT_TYPES, TelescopePointingContainer),
         description="Telescope pointing positions",
     )
     array_azimuth = Field(nan * u.rad, "Array pointing azimuth", unit=u.rad)
@@ -934,7 +937,7 @@ class EventCalibrationContainer(Container):
 
     # create the camera container
     tel = Field(
-        default_factory=partial(Map, int, EventCameraCalibrationContainer),
+        default_factory=partial(Map, INT_TYPES, EventCameraCalibrationContainer),
         description="map of tel_id to EventCameraCalibrationContainer",
     )
 
@@ -1148,7 +1151,7 @@ class MonitoringContainer(Container):
 
     # create the camera container
     tel = Field(
-        default_factory=partial(Map, int, MonitoringCameraContainer),
+        default_factory=partial(Map, INT_TYPES, MonitoringCameraContainer),
         description="map of tel_id to MonitoringCameraContainer",
     )
 

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -86,8 +86,8 @@ class Field:
             if isclass(self.default_factory):
                 default = _fqdn(self.default_factory)
             elif isinstance(self.default_factory, partial):
-                # case for `partial(Map, Container)`
-                cls = _fqdn(self.default_factory.args[0])
+                # case for `partial(Map, key_type, Container)`
+                cls = _fqdn(self.default_factory.args[1])
                 if self.default_factory.func is Map:
                     func = "Map"
                 else:

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -36,6 +36,7 @@ from ..containers import (
     SimulationConfigContainer,
     TelescopeImpactParameterContainer,
     TelescopePointingContainer,
+    TelescopeReconstructedContainer,
     TelescopeTriggerContainer,
     TelEventIndexContainer,
     TimingParametersContainer,
@@ -661,8 +662,10 @@ class HDF5EventSource(EventSource):
                             intensity_statistics=simulated_params[4],
                         )
 
+                data.dl2.tel[tel_id] = TelescopeReconstructedContainer()
                 for kind, algorithms in dl2_tel_readers.items():
                     c = getattr(data.dl2.tel[tel_id], kind)
+
                     for algorithm, readers in algorithms.items():
                         c[algorithm] = next(readers[key])
 

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -30,10 +30,12 @@ from ..containers import (
     ReconstructedEnergyContainer,
     ReconstructedGeometryContainer,
     SchedulingBlockContainer,
+    SimulatedCameraContainer,
     SimulatedEventContainer,
     SimulatedShowerContainer,
     SimulationConfigContainer,
     TelescopeImpactParameterContainer,
+    TelescopePointingContainer,
     TelescopeTriggerContainer,
     TelEventIndexContainer,
     TimingParametersContainer,
@@ -588,6 +590,8 @@ class HDF5EventSource(EventSource):
                 if self.allowed_tels and tel_id not in self.allowed_tels:
                     continue
 
+                data.simulation.tel[tel_id] = SimulatedCameraContainer()
+
                 if key in true_impact_readers:
                     data.simulation.tel[tel_id].impact = next(true_impact_readers[key])
 
@@ -729,11 +733,14 @@ class HDF5EventSource(EventSource):
 
             pointing_telescope = tel_pointing_table[closest_time_index]
             attrs = self._telescope_pointing_attrs(tel_id)
-            data.pointing.tel[tel_id].azimuth = u.Quantity(
-                pointing_telescope["azimuth"],
-                attrs["azimuth"]["UNIT"],
-            )
-            data.pointing.tel[tel_id].altitude = u.Quantity(
-                pointing_telescope["altitude"],
-                attrs["altitude"]["UNIT"],
+
+            data.pointing.tel[tel_id] = TelescopePointingContainer(
+                azimuth=u.Quantity(
+                    pointing_telescope["azimuth"],
+                    attrs["azimuth"]["UNIT"],
+                ),
+                altitude=u.Quantity(
+                    pointing_telescope["altitude"],
+                    attrs["altitude"]["UNIT"],
+                ),
             )

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -24,8 +24,11 @@ from ..calib.camera.gainselection import GainSelector
 from ..containers import (
     ArrayEventContainer,
     CoordinateFrameType,
+    DL1CameraCalibrationContainer,
+    EventCameraCalibrationContainer,
     EventIndexContainer,
     EventType,
+    MonitoringCameraContainer,
     ObservationBlockContainer,
     ObservationBlockState,
     ObservingMode,
@@ -805,10 +808,11 @@ class SimTelEventSource(EventSource):
 
                 # fill dc_to_pe and pedestal_per_sample info into monitoring
                 # container
-                mon = data.mon.tel[tel_id]
+                mon = MonitoringCameraContainer()
                 mon.calibration.dc_to_pe = dc_to_pe
                 mon.calibration.pedestal_per_sample = pedestal
                 mon.pixel_status = self._get_pixels_status(tel_id)
+                data.mon.tel[tel_id] = mon
 
                 r1_waveform, selected_gain_channel = apply_simtel_r1_calibration(
                     adc_samples,
@@ -827,8 +831,12 @@ class SimTelEventSource(EventSource):
                 time_calib = array_event["laser_calibrations"][tel_id]["tm_calib"]
                 pix_index = np.arange(n_pixels)
 
-                dl1_calib = data.calibration.tel[tel_id].dl1
-                dl1_calib.time_shift = time_calib[selected_gain_channel, pix_index]
+                calib = EventCameraCalibrationContainer(
+                    dl1=DL1CameraCalibrationContainer(
+                        time_shift=time_calib[selected_gain_channel, pix_index]
+                    )
+                )
+                data.calibration.tel[tel_id] = calib
 
             yield data
 

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -906,7 +906,7 @@ class SimTelEventSource(EventSource):
 
         central_time = parse_simtel_time(trigger["gps_time"])
 
-        tel = Map(TelescopeTriggerContainer)
+        tel = Map((int, np.integer), TelescopeTriggerContainer)
         for tel_id, time in zip(
             trigger["triggered_telescopes"], trigger["trigger_times"]
         ):

--- a/ctapipe/io/tests/test_datawriter.py
+++ b/ctapipe/io/tests/test_datawriter.py
@@ -14,6 +14,7 @@ from ctapipe.containers import (
     ParticleClassificationContainer,
     ReconstructedEnergyContainer,
     ReconstructedGeometryContainer,
+    TelescopeReconstructedContainer,
 )
 from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import DataLevel, EventSource
@@ -27,8 +28,10 @@ def generate_dummy_dl2(event):
 
     algos = ["HillasReconstructor", "ImPACTReconstructor"]
 
-    for algo in algos:
-        for tel_id in event.dl1.tel:
+    for tel_id in event.dl1.tel:
+        event.dl2.tel[tel_id] = TelescopeReconstructedContainer()
+
+        for algo in algos:
             event.dl2.tel[tel_id].geometry[algo] = ReconstructedGeometryContainer(
                 alt=70 * u.deg,
                 az=120 * u.deg,
@@ -46,13 +49,13 @@ def generate_dummy_dl2(event):
                 prefix=f"{algo}_tel",
             )
 
+    for algo in algos:
         event.dl2.stereo.geometry[algo] = ReconstructedGeometryContainer(
             alt=72 * u.deg,
             az=121 * u.deg,
             telescopes=[1, 2, 4],
             prefix=algo,
         )
-
         event.dl2.stereo.energy[algo] = ReconstructedEnergyContainer(
             energy=10 * u.TeV,
             telescopes=[1, 2, 4],

--- a/ctapipe/visualization/tests/test_bokeh.py
+++ b/ctapipe/visualization/tests/test_bokeh.py
@@ -7,12 +7,16 @@ from ctapipe.coordinates import TelescopeFrame
 
 def test_create_display_without_geometry(example_event, example_subarray):
     """Test we can create a display without giving the geometry to init"""
+    from ctapipe.calib import CameraCalibrator
     from ctapipe.visualization.bokeh import CameraDisplay
 
     # test we can create it without geometry, and then set all the stuff
     display = CameraDisplay()
 
-    tel_id = next(iter(example_event.r0.tel.keys()))
+    calib = CameraCalibrator(example_subarray)
+    calib(example_event)
+
+    tel_id = example_event.trigger.tels_with_trigger[0]
     display.geometry = example_subarray.tel[tel_id].camera.geometry
     display.image = example_event.dl1.tel[tel_id].image
 


### PR DESCRIPTION
This is a draft to see if we can remove the `defaultdict` behavior from map and see what breaks.


There are a lot of places, where we rely on the default being created automatically, but at least the ones I checked until now are entirely unnecessary and even expensive. E.g. the `CameraCalibrator` checked:

```
if event.r1.tel[tel_id].waveform is None
```

which for an event not having a waveform for tel_id would result in creating the default container and then checking if the waveform is None and as a side effect, inserting the default container into the event.

Instead, doing:

```
if tel_id in event.r1.tel:
```

Only does the simple check if the key is in the dict, no side effects.

So I think it might be worthwhile to pursue this, but it will be some work (and make some test setup code harder, which creates `ArrayEvent` by hand.