### PR TITLE
Fix warnings from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           python -m build
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ test=pytest
 name = ctapipe
 description = CTA Python pipeline experimental version
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = ctapipe developers
 author_email = karl.kosack@cea.fr
 license = BSD 3-Clause License


### PR DESCRIPTION
This fixes two warnings I found in the CI log of the deploy workflow:

```
 Warning:  You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.
Checking dist/ctapipe-0.17.0-py3-none-any.whl: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking dist/ctapipe-0.17.0.tar.gz: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`. 
```