### PR TITLE
Load observation info with TableLoader; standardize id fields in containers

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -71,6 +71,11 @@ NAN_TIME = Time(0, format="mjd", scale="tai")
 UNKNOWN_ID = np.uint64(np.iinfo(np.uint64).max)
 
 
+obs_id_field = partial(Field, UNKNOWN_ID, description="Observation Block ID")
+event_id_field = partial(Field, UNKNOWN_ID, description="Array Event ID")
+tel_id_field = partial(Field, UNKNOWN_ID, description="Telescope ID")
+
+
 class SchedulingBlockType(enum.Enum):
     """
     Types of Scheduling Block
@@ -161,8 +166,8 @@ class EventIndexContainer(Container):
     """index columns to include in event lists, common to all data levels"""
 
     default_prefix = ""  # don't want to prefix these
-    obs_id = Field(0, "observation identifier")
-    event_id = Field(0, "event identifier")
+    obs_id = obs_id_field()
+    event_id = event_id_field()
 
 
 class TelEventIndexContainer(Container):
@@ -172,9 +177,9 @@ class TelEventIndexContainer(Container):
     """
 
     default_prefix = ""  # don't want to prefix these
-    obs_id = Field(0, "observation identifier")
-    event_id = Field(0, "event identifier")
-    tel_id = Field(0, "telescope identifier")
+    obs_id = obs_id_field()
+    event_id = event_id_field()
+    tel_id = tel_id_field()
 
 
 class BaseHillasParametersContainer(Container):
@@ -1158,7 +1163,7 @@ class SimulatedShowerDistribution(Container):
 
     default_prefix = ""
 
-    obs_id = Field(-1, description="links to which events this corresponds to")
+    obs_id = obs_id_field()
     hist_id = Field(-1, description="Histogram ID")
     n_entries = Field(-1, description="Number of entries in the histogram")
     bins_energy = Field(
@@ -1243,7 +1248,7 @@ class ObservationBlockContainer(Container):
     """Stores information about the observation"""
 
     default_prefix = ""
-    obs_id = Field(UNKNOWN_ID, "Observation Block ID", type=np.uint64)
+    obs_id = obs_id_field()
     sb_id = Field(UNKNOWN_ID, "ID of the parent SchedulingBlock", type=np.uint64)
     producer_id = Field(
         "unknown",

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -69,11 +69,13 @@ NAN_TIME = Time(0, format="mjd", scale="tai")
 
 #: Used for unsigned integer obs_id or sb_id default values:
 UNKNOWN_ID = np.uint64(np.iinfo(np.uint64).max)
+#: Used for unsigned integer tel_id default value
+UNKNOWN_TEL_ID = np.uint16(np.iinfo(np.uint16).max)
 
 
 obs_id_field = partial(Field, UNKNOWN_ID, description="Observation Block ID")
 event_id_field = partial(Field, UNKNOWN_ID, description="Array Event ID")
-tel_id_field = partial(Field, UNKNOWN_ID, description="Telescope ID")
+tel_id_field = partial(Field, UNKNOWN_TEL_ID, description="Telescope ID")
 
 
 class SchedulingBlockType(enum.Enum):

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -589,7 +589,7 @@ class SimulatedShowerContainer(Container):
         nan * u.g / (u.cm**2), "Simulated Xmax value", unit=u.g / (u.cm**2)
     )
     shower_primary_id = Field(
-        -1,
+        np.int16(np.iinfo(np.int16).max),
         "Simulated shower primary ID 0 (gamma), 1(e-),"
         "2(mu-), 100*A+Z for nucleons and nuclei,"
         "negative for antimatter.",

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -28,6 +28,7 @@ TRUE_PARAMETERS_GROUP = "/simulation/event/telescope/parameters"
 TRUE_IMPACT_GROUP = "/simulation/event/telescope/impact"
 SIMULATION_CONFIG_TABLE = "/configuration/simulation/run"
 SHOWER_DISTRIBUTION_TABLE = "/simulation/service/shower_distribution"
+OBSERVATION_TABLE = "/configuration/observation/observation_block"
 
 DL2_SUBARRAY_GROUP = "/dl2/event/subarray"
 DL2_TELESCOPE_GROUP = "/dl2/event/telescope"
@@ -162,6 +163,10 @@ class TableLoader(Component):
         False, help="join subarray instrument information to each event"
     ).tag(config=True)
 
+    load_observation_info = traits.Bool(
+        False, help="join observation information to each event"
+    ).tag(config=True)
+
     focal_length_choice = traits.UseEnum(
         FocalLengthKind,
         default_value=FocalLengthKind.EFFECTIVE,
@@ -278,6 +283,19 @@ class TableLoader(Component):
         """
         return read_table(self.h5file, SHOWER_DISTRIBUTION_TABLE)
 
+    def read_observation_information(self, start=None, stop=None):
+        """
+        Read the observation information
+        """
+        return read_table(self.h5file, OBSERVATION_TABLE, start=start, stop=stop)
+
+    def _join_observation_info(self, table, start=None, stop=None):
+        observation_table = self.read_observation_information(start=start, stop=stop)
+        table = join_allow_empty(
+            table, observation_table, keys="obs_id", join_type="left"
+        )
+        return table
+
     def read_subarray_events(self, start=None, stop=None, keep_order=True):
         """Read subarray-based event information.
 
@@ -308,6 +326,9 @@ class TableLoader(Component):
                             stop=stop,
                         )
                         table = _join_subarray_events(table, dl2)
+
+        if self.load_observation_info:
+            table = self._join_observation_info(table, start=start, stop=stop)
 
         if keep_order:
             self._sort_to_original_order(table)

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -134,6 +134,15 @@ def test_true_parameters(dl1_file):
         assert "true_hillas_intensity" in table.colnames
 
 
+def test_observation_info(dl1_file):
+    """Test joining observation info onto telescope events"""
+    from ctapipe.io.tableloader import TableLoader
+
+    with TableLoader(dl1_file, load_observation_info=True) as table_loader:
+        table = table_loader.read_telescope_events()
+        assert "subarray_pointing_lat" in table.colnames
+
+
 def test_read_subarray_events(dl2_shower_geometry_file):
     """Test reading subarray events"""
     from ctapipe.io.tableloader import TableLoader


### PR DESCRIPTION
This adds an option to load the observation information from `/configuration/observation/observation_block` with TableLoader and join it to each event. 

This also standardizes the `obs_id`, `event_id` and `tel_id` fields used in some containers to remove mismatching descriptions which led to some warnings when merging different tables. 