### PR TITLE
Allow lookup of telescope parameters by type

### DIFF
--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -298,6 +298,13 @@ def test_telescope_parameter_lookup_by_type(mock_subarray):
     assert lookup["LST_LST_LSTCam"] == 100
     assert lookup["MST_MST_MSTCam"] == 10
 
+    # no global default
+    lookup = TelescopeParameterLookup([("type", "LST*", 100)])
+    lookup.attach_subarray(mock_subarray)
+    assert lookup["LST_LST_LSTCam"] == 100
+    with pytest.raises(KeyError):
+        assert lookup["MST_MST_MSTCam"] == 10
+
 
 def test_telescope_parameter_patterns(mock_subarray):
     """Test validation of TelescopeParameters"""

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -291,6 +291,14 @@ def test_telescope_parameter_lookup(mock_subarray):
         telparam_list2[None]
 
 
+def test_telescope_parameter_lookup_by_type(mock_subarray):
+    lookup = TelescopeParameterLookup([("type", "*", 10), ("type", "LST*", 100)])
+
+    lookup.attach_subarray(mock_subarray)
+    assert lookup["LST_LST_LSTCam"] == 100
+    assert lookup["MST_MST_MSTCam"] == 10
+
+
 def test_telescope_parameter_patterns(mock_subarray):
     """Test validation of TelescopeParameters"""
 

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -291,16 +291,20 @@ def test_telescope_parameter_lookup(mock_subarray):
         telparam_list2[None]
 
 
-def test_telescope_parameter_lookup_by_type(mock_subarray):
-    lookup = TelescopeParameterLookup([("type", "*", 10), ("type", "LST*", 100)])
+def test_telescope_parameter_lookup_by_type(subarray_prod5_paranal):
+    subarray = subarray_prod5_paranal.select_subarray([1, 2, 3, 4, 100, 101])
 
-    lookup.attach_subarray(mock_subarray)
+    lookup = TelescopeParameterLookup([("type", "*", 10), ("type", "LST*", 100)])
+    lookup.attach_subarray(subarray)
+
     assert lookup["LST_LST_LSTCam"] == 100
     assert lookup["MST_MST_NectarCam"] == 10
+    assert lookup[subarray.tel[1]] == 100
+    assert lookup[subarray.tel[100]] == 10
 
     # no global default
     lookup = TelescopeParameterLookup([("type", "LST*", 100)])
-    lookup.attach_subarray(mock_subarray)
+    lookup.attach_subarray(subarray)
     assert lookup["LST_LST_LSTCam"] == 100
 
     with pytest.raises(KeyError, match="no parameter value"):
@@ -308,6 +312,10 @@ def test_telescope_parameter_lookup_by_type(mock_subarray):
 
     with pytest.raises(ValueError, match="Unknown telescope"):
         assert lookup["Foo"]
+
+    with pytest.raises(ValueError, match="Unknown telescope"):
+        # sst
+        assert lookup[subarray_prod5_paranal.tel[30]]
 
 
 def test_telescope_parameter_patterns(mock_subarray):

--- a/ctapipe/core/tests/test_traits.py
+++ b/ctapipe/core/tests/test_traits.py
@@ -296,14 +296,18 @@ def test_telescope_parameter_lookup_by_type(mock_subarray):
 
     lookup.attach_subarray(mock_subarray)
     assert lookup["LST_LST_LSTCam"] == 100
-    assert lookup["MST_MST_MSTCam"] == 10
+    assert lookup["MST_MST_NectarCam"] == 10
 
     # no global default
     lookup = TelescopeParameterLookup([("type", "LST*", 100)])
     lookup.attach_subarray(mock_subarray)
     assert lookup["LST_LST_LSTCam"] == 100
-    with pytest.raises(KeyError):
-        assert lookup["MST_MST_MSTCam"] == 10
+
+    with pytest.raises(KeyError, match="no parameter value"):
+        assert lookup["MST_MST_NectarCam"]
+
+    with pytest.raises(ValueError, match="Unknown telescope"):
+        assert lookup["Foo"]
 
 
 def test_telescope_parameter_patterns(mock_subarray):

--- a/ctapipe/core/traits.py
+++ b/ctapipe/core/traits.py
@@ -393,12 +393,10 @@ class TelescopeParameterLookup:
         self._value_for_tel_id = None
         self._value_for_type = None
         self._subarray = None
-        self._subarray_global_value = None
-        self._subarray_global_value_set = False
+        self._subarray_global_value = Undefined
         for param in telescope_parameter_list:
             if param[1] == "*":
                 self._subarray_global_value = param[2]
-                self._subarray_global_value_set = True
 
     def attach_subarray(self, subarray):
         """
@@ -440,7 +438,7 @@ class TelescopeParameterLookup:
         Returns the resolved parameter for the given telescope id
         """
         if tel is None:
-            if self._subarray_global_value_set:
+            if self._subarray_global_value is not Undefined:
                 return self._subarray_global_value
 
             raise KeyError("No subarray global value set for TelescopeParameter")
@@ -464,7 +462,7 @@ class TelescopeParameterLookup:
 
         if isinstance(tel, str):
             try:
-                if self._subarray_global_value_set:
+                if self._subarray_global_value is not Undefined:
                     return self._value_for_type.get(tel, self._subarray_global_value)
                 return self._value_for_type[tel]
             except KeyError:

--- a/ctapipe/io/metadata.py
+++ b/ctapipe/io/metadata.py
@@ -52,9 +52,9 @@ __all__ = [
 
 
 CONVERSIONS = {
-    Time: lambda t: t.utc.iso,
-    list: lambda l: ",".join([convert(elem) for elem in l]),
-    DataLevel: lambda d: d.name,
+    Time: lambda value: value.utc.iso,
+    list: lambda value: ",".join([convert(elem) for elem in value]),
+    DataLevel: lambda value: value.name,
 }
 
 


### PR DESCRIPTION
This allows also using the `TelescopeParameter` to be used like this:

```
self.param.tel["LST_LST_LSTCam"]
```

instead of just by telescope id.


This is needed for solving https://github.com/cta-observatory/ctapipe/issues/2119