### PR TITLE
Speed up loader by using hstack instead of merge where possible

### DIFF
--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -2,6 +2,7 @@
 Class and related functions to read DL1 (a,b) and/or DL2 (a) data
 from an HDF5 file produced with ctapipe-process.
 """
+import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict
@@ -35,6 +36,10 @@ DL2_TELESCOPE_GROUP = "/dl2/event/telescope"
 
 SUBARRAY_EVENT_KEYS = ["obs_id", "event_id"]
 TELESCOPE_EVENT_KEYS = ["obs_id", "event_id", "tel_id"]
+
+
+class IndexNotMatching(UserWarning):
+    """Warning that is raised if the order of two tables is not matching as expected"""
 
 
 class ChunkIterator:
@@ -113,7 +118,7 @@ def _join_telescope_events(table1, table2):
     return join_allow_empty(table1, table2, TELESCOPE_EVENT_KEYS, how)
 
 
-def _merge_table_same_index(table1, table2, index_keys):
+def _merge_table_same_index(table1, table2, index_keys, fallback_join_type="left"):
     """Merge two tables assuming their primary keys are identical"""
     if len(table1) != len(table2):
         raise ValueError("Tables must have identical length")
@@ -122,7 +127,10 @@ def _merge_table_same_index(table1, table2, index_keys):
         return table1
 
     if not np.all(table1[index_keys] == table2[index_keys]):
-        raise ValueError(f"Tables primary keys ({index_keys}) do not match")
+        warnings.warn(
+            "Table order does not match, falling back to join", IndexNotMatching
+        )
+        return join_allow_empty(table1, table2, index_keys, fallback_join_type)
 
     columns = [col for col in table2.columns if col not in index_keys]
     return hstack((table1, table2[columns]), join_type="exact")
@@ -348,10 +356,7 @@ class TableLoader(Component):
                             start=start,
                             stop=stop,
                         )
-                        try:
-                            table = _merge_subarray_tables(table, dl2)
-                        except ValueError:
-                            table = _join_subarray_events(table, dl2)
+                        table = _merge_subarray_tables(table, dl2)
 
         if self.load_observation_info:
             table = self._join_observation_info(table, start=start, stop=stop)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -430,6 +430,9 @@ class TableLoader(Component):
                         dl2 = self._read_telescope_table(
                             path, tel_id, start=start, stop=stop
                         )
+                        if len(dl2) == 0:
+                            continue
+
                         table = _merge_telescope_tables(table, dl2)
 
         if self.load_true_images:

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 import numpy as np
 import tables
-from astropy.table import Table, vstack
+from astropy.table import Table, hstack, vstack
 from astropy.utils.decorators import lazyproperty
 
 from ctapipe.instrument.optics import FocalLengthKind
@@ -111,6 +111,29 @@ def _join_telescope_events(table1, table2):
     else:
         how = "left"
     return join_allow_empty(table1, table2, TELESCOPE_EVENT_KEYS, how)
+
+
+def _merge_table_same_index(table1, table2, index_keys):
+    """Merge two tables assuming their primary keys are identical"""
+    if len(table1) != len(table2):
+        raise ValueError("Tables must have identical length")
+
+    if len(table1) == 0:
+        return table1
+
+    if not np.all(table1[index_keys] == table2[index_keys]):
+        raise ValueError("Tables primary keys ({index_keys}) do not match")
+
+    columns = [col for col in table2.columns if col not in index_keys]
+    return hstack((table1, table2[columns]), join_type="exact")
+
+
+def _merge_subarray_tables(table1, table2):
+    return _merge_table_same_index(table1, table2, ["obs_id", "event_id"])
+
+
+def _merge_telescope_tables(table1, table2):
+    return _merge_table_same_index(table1, table2, ["obs_id", "event_id", "tel_id"])
 
 
 class TableLoader(Component):
@@ -310,7 +333,7 @@ class TableLoader(Component):
 
         if self.load_simulated and SHOWER_TABLE in self.h5file:
             showers = read_table(self.h5file, SHOWER_TABLE, start=start, stop=stop)
-            table = _join_subarray_events(table, showers)
+            table = _merge_subarray_tables(table, showers)
 
         if self.load_dl2:
             if DL2_SUBARRAY_GROUP in self.h5file:
@@ -325,7 +348,7 @@ class TableLoader(Component):
                             start=start,
                             stop=stop,
                         )
-                        table = _join_subarray_events(table, dl2)
+                        table = _merge_subarray_tables(table, dl2)
 
         if self.load_observation_info:
             table = self._join_observation_info(table, start=start, stop=stop)
@@ -371,19 +394,21 @@ class TableLoader(Component):
         if tel_id is None:
             raise ValueError("Please, specify a telescope ID.")
 
-        table = _empty_telescope_events_table()
+        table = read_table(self.h5file, "/dl1/event/telescope/trigger")
+        table = table[table["tel_id"] == tel_id]
+        table = table[slice(start, stop)]
 
         if self.load_dl1_parameters:
             parameters = self._read_telescope_table(
                 PARAMETERS_GROUP, tel_id, start=start, stop=stop
             )
-            table = _join_telescope_events(table, parameters)
+            table = _merge_telescope_tables(table, parameters)
 
         if self.load_dl1_images:
             images = self._read_telescope_table(
                 IMAGES_GROUP, tel_id, start=start, stop=stop
             )
-            table = _join_telescope_events(table, images)
+            table = _merge_telescope_tables(table, images)
 
         if self.load_dl2:
             if DL2_TELESCOPE_GROUP in self.h5file:
@@ -397,13 +422,13 @@ class TableLoader(Component):
                         dl2 = self._read_telescope_table(
                             path, tel_id, start=start, stop=stop
                         )
-                        table = _join_telescope_events(table, dl2)
+                        table = _merge_telescope_tables(table, dl2)
 
         if self.load_true_images:
             true_images = self._read_telescope_table(
                 TRUE_IMAGES_GROUP, tel_id, start=start, stop=stop
             )
-            table = _join_telescope_events(table, true_images)
+            table = _merge_telescope_tables(table, true_images)
 
         if self.load_true_parameters:
             true_parameters = self._read_telescope_table(

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -122,7 +122,7 @@ def _merge_table_same_index(table1, table2, index_keys):
         return table1
 
     if not np.all(table1[index_keys] == table2[index_keys]):
-        raise ValueError("Tables primary keys ({index_keys}) do not match")
+        raise ValueError(f"Tables primary keys ({index_keys}) do not match")
 
     columns = [col for col in table2.columns if col not in index_keys]
     return hstack((table1, table2[columns]), join_type="exact")
@@ -348,7 +348,10 @@ class TableLoader(Component):
                             start=start,
                             stop=stop,
                         )
-                        table = _merge_subarray_tables(table, dl2)
+                        try:
+                            table = _merge_subarray_tables(table, dl2)
+                        except ValueError:
+                            table = _join_subarray_events(table, dl2)
 
         if self.load_observation_info:
             table = self._join_observation_info(table, start=start, stop=stop)

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -137,11 +137,11 @@ def _merge_table_same_index(table1, table2, index_keys, fallback_join_type="left
 
 
 def _merge_subarray_tables(table1, table2):
-    return _merge_table_same_index(table1, table2, ["obs_id", "event_id"])
+    return _merge_table_same_index(table1, table2, SUBARRAY_EVENT_KEYS)
 
 
 def _merge_telescope_tables(table1, table2):
-    return _merge_table_same_index(table1, table2, ["obs_id", "event_id", "tel_id"])
+    return _merge_table_same_index(table1, table2, TELESCOPE_EVENT_KEYS)
 
 
 class TableLoader(Component):

--- a/ctapipe/tools/tests/test_apply_models.py
+++ b/ctapipe/tools/tests/test_apply_models.py
@@ -60,6 +60,12 @@ def test_apply_energy_regressor(
     assert f"{prefix}_tel_energy" in events.colnames
     assert f"{prefix}_tel_is_valid" in events.colnames
 
+    from ctapipe.io.tests.test_table_loader import check_equal_array_event_order
+
+    trigger = read_table(output_path, "/dl1/event/subarray/trigger")
+    energy = read_table(output_path, "/dl2/event/subarray/energy/ExtraTreesRegressor")
+    check_equal_array_event_order(trigger, energy)
+
 
 def test_apply_particle_classifier(
     particle_classifier_path,
@@ -141,3 +147,11 @@ def test_apply_both(
     events = loader.read_telescope_events()
     assert "ExtraTreesClassifier_prediction" in events.colnames
     assert "ExtraTreesRegressor_energy" in events.colnames
+
+    from ctapipe.io.tests.test_table_loader import check_equal_array_event_order
+
+    trigger = read_table(output_path, "/dl1/event/subarray/trigger")
+    particle_clf = read_table(
+        output_path, "/dl2/event/subarray/classification/ExtraTreesClassifier"
+    )
+    check_equal_array_event_order(trigger, particle_clf)


### PR DESCRIPTION
This speeds up the `TableLoader` quite a lot. In my quick test, loading the dl2 electron file I produced (96 MB only subarray data) went from 10s to 4.5 seconds although two of four dl2 columns are not ordered correctly, see #2125.


