### PR TITLE
Improve likelihood muon intensity fitter

### DIFF
--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -18,6 +18,8 @@ from numba import double, vectorize
 from scipy.constants import alpha
 from scipy.ndimage import correlate1d
 
+from ctapipe.image.pixel_likelihood import neg_log_likelihood_approx
+
 from ...containers import MuonEfficiencyContainer
 from ...coordinates import CameraFrame, TelescopeFrame
 from ...core import TelescopeComponent
@@ -411,16 +413,7 @@ def build_negative_log_likelihood(
         # scale prediction by optical efficiency of the telescope
         prediction *= optical_efficiency_muon
 
-        # A gaussian approximation is used here, where the total
-        # standard deviation is the pedestal standard deviation (e.g. by NSB) and
-        # the single photon resolution times the image magnitude.
-        sigma2 = pedestal**2 + prediction * (1 + spe_width**2)
-
-        # gaussian negative log-likelihood, analytically simplified and
-        # constant terms discarded
-        neg_log_l = np.log(sigma2) + (image - prediction) ** 2 / sigma2
-
-        return neg_log_l.sum()
+        return neg_log_likelihood_approx(image, prediction, spe_width, pedestal)
 
     return negative_log_likelihood
 

--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -41,6 +41,8 @@ __all__ = [
     "chi_squared",
 ]
 
+EPSILON = 5.0e-324
+
 
 class PixelLikelihoodError(RuntimeError):
     pass
@@ -91,9 +93,9 @@ def neg_log_likelihood_approx(image, prediction, spe_width, pedestal):
     -------
     float
     """
-    theta = pedestal ** 2 + prediction * (1 + spe_width ** 2)
+    theta = pedestal**2 + prediction * (1 + spe_width**2)
 
-    neg_log_l = np.log(theta) + (image - prediction) ** 2 / theta
+    neg_log_l = np.log(theta + EPSILON) + (image - prediction) ** 2 / theta
 
     return np.sum(neg_log_l)
 
@@ -134,16 +136,16 @@ def neg_log_likelihood_numeric(
     ns = ns[ns >= 0]
 
     for n in ns:
-        theta = pedestal ** 2 + n * spe_width ** 2
+        theta = pedestal**2 + n * spe_width**2
         _l = (
-            prediction ** n
+            prediction**n
             * np.exp(-prediction)
             / theta
             * np.exp(-((image - n) ** 2) / (2 * theta))
         )
         likelihood += _l
 
-    return -np.sum(np.log(likelihood))
+    return -np.sum(np.log(likelihood + EPSILON))
 
 
 def neg_log_likelihood(image, prediction, spe_width, pedestal, prediction_safety=20.0):
@@ -206,8 +208,8 @@ def mean_poisson_likelihood_gaussian(prediction, spe_width, pedestal):
     -------
     float
     """
-    theta = pedestal ** 2 + prediction * (1 + spe_width ** 2)
-    mean_log_likelihood = 1 + np.log(2 * np.pi) + np.log(theta)
+    theta = pedestal**2 + prediction * (1 + spe_width**2)
+    mean_log_likelihood = 1 + np.log(2 * np.pi) + np.log(theta + EPSILON)
 
     return np.sum(mean_log_likelihood)
 
@@ -253,7 +255,7 @@ def mean_poisson_likelihood_full(prediction, spe_width, ped):
 
     mean_like = 0
 
-    width = ped ** 2 + prediction * spe_width ** 2
+    width = ped**2 + prediction * spe_width**2
     width = np.sqrt(width)
 
     for pred, w, spe, p in zip(prediction, width, spe_width, ped):


### PR DESCRIPTION
Use already implemented likelihood for muon intensity fit and catch `np.log(0)` case in likelihood