### PR TITLE
Improve output of Tool in case of TraitError

### DIFF
--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -11,6 +11,7 @@ from typing import Union
 
 import yaml
 from docutils.core import publish_parts
+from traitlets import TraitError
 
 try:
     import tomli as toml
@@ -359,8 +360,9 @@ class Tool(Application):
             self.finish()
             self.log.info(f"Finished: {self.name}")
             Provenance().finish_activity(activity_name=self.name)
-        except ToolConfigurationError as err:
-            self.log.error(f"{err}.  Use --help for more info")
+        except (ToolConfigurationError, TraitError) as err:
+            self.log.error("%s", err)
+            self.log.error("Use --help for more info")
             exit_status = 2  # wrong cmd line parameter
         except KeyboardInterrupt:
             self.log.warning("WAS INTERRUPTED BY CTRL-C")


### PR DESCRIPTION
Fixes a not-so-helpful error message with a full traceback reported by @tobychev


Now:
```
❯ ctapipe-merge
2022-12-16 13:00:55,286 ERROR [ctapipe.ctapipe-merge] (tool.run): The 'output_path' trait of a MergeTool instance expected a pathlib.Path or non-empty str for a file, not the Sentinel traitlets.Undefined.
2022-12-16 13:00:55,286 ERROR [ctapipe.ctapipe-merge] (tool.run): Use --help for more info
```


Before:
```
2022-12-16 12:56:33,241 ERROR [ctapipe.ctapipe-merge] (tool.run): Caught unexpected exception: The 'output_path' trait of a MergeTool instance expected a pathlib.Path or non-empty str for a file, not the Sentinel traitlets.Undefined.
Traceback (most recent call last):
  File "/home/mnoethe/.local/conda/envs/cta-dev/lib/python3.9/site-packages/traitlets/traitlets.py", line 653, in get
    value = obj._trait_values[self.name]
KeyError: 'output_path'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mnoethe/Uni/CTA/ctapipe/ctapipe/core/tool.py", line 346, in run
    self.setup()
  File "/home/mnoethe/Uni/CTA/ctapipe/ctapipe/tools/merge.py", line 219, in setup
    if not self.output_path:
  File "/home/mnoethe/.local/conda/envs/cta-dev/lib/python3.9/site-packages/traitlets/traitlets.py", line 700, in __get__
    return self.get(obj, cls)
  File "/home/mnoethe/.local/conda/envs/cta-dev/lib/python3.9/site-packages/traitlets/traitlets.py", line 670, in get
    value = self._validate(obj, default)
  File "/home/mnoethe/.local/conda/envs/cta-dev/lib/python3.9/site-packages/traitlets/traitlets.py", line 735, in _validate
    value = self.validate(obj, value)
  File "/home/mnoethe/Uni/CTA/ctapipe/ctapipe/core/traits.py", line 153, in validate
    self.error(obj, value)
  File "/home/mnoethe/.local/conda/envs/cta-dev/lib/python3.9/site-packages/traitlets/traitlets.py", line 841, in error
    raise TraitError(e)
traitlets.traitlets.TraitError: The 'output_path' trait of a MergeTool instance expected a pathlib.Path or non-empty str for a file, not the Sentinel traitlets.Undefined.
```