### PR TITLE
Fix docs build for traitlets 5.8 and array field defaults

### DIFF
--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -95,7 +95,9 @@ class Field:
                     func = repr(self.default_factory.func)
                 default = f"{func}({cls})"
             else:
-                default = str(self.default_factory())
+                # make sure numpy arrays are not dominating everything
+                with np.printoptions(threshold=4, precision=3, edgeitems=2):
+                    default = str(self.default_factory())
         else:
             default = str(self.default)
         cmps = [f"Field(default={default}"]

--- a/ctapipe/core/feature_generator.py
+++ b/ctapipe/core/feature_generator.py
@@ -5,6 +5,11 @@ from .component import Component
 from .expression_engine import ExpressionEngine
 from .traits import List, Tuple, Unicode
 
+__all__ = [
+    "FeatureGenerator",
+    "FeatureGeneratorException",
+]
+
 
 class FeatureGeneratorException(TypeError):
     """Signal a problem with a user-defined selection criteria function"""
@@ -23,9 +28,9 @@ class FeatureGenerator(Component):
         Tuple(Unicode(), Unicode()),
         help=(
             "List of 2-Tuples of Strings: ('new_feature_name', 'expression to generate feature'). "
-            "You can use `numpy` as `np` and `astropy.units` as `u`. "
-            "Several math functions are usable without the `np`-prefix. "
-            "Use `feature.quantity.to_value(unit)` to create features without units."
+            "You can use ``numpy`` as ``np`` and ``astropy.units`` as ``u``. "
+            "Several math functions are usable without the ``np``-prefix. "
+            "Use ``feature.quantity.to_value(unit)`` to create features without units."
         ),
     ).tag(config=True)
 

--- a/ctapipe/core/qualityquery.py
+++ b/ctapipe/core/qualityquery.py
@@ -28,9 +28,9 @@ class QualityQuery(Component):
         Tuple(Unicode(), Unicode()),
         help=(
             "list of tuples of ('<description', 'expression string') to accept "
-            "(select) a given data value.  E.g. `[('mycut', 'x > 3'),]. "
-            "You may use `numpy` as `np` and `astropy.units` as `u`, but no other"
-            " modules."
+            "(select) a given data value.  E.g. ``[('mycut', 'x > 3'),]``. "
+            "You may use ``numpy`` as ``np`` and ``astropy.units`` as ``u``,"
+            " but no other modules."
         ),
     ).tag(config=True)
 

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -315,3 +315,11 @@ def test_recursive_validation():
         cont.map[0] = ChildContainer(x=1 * u.m)
         cont.map[1] = ChildContainer(x=1 * u.s)
         cont.validate()
+
+
+def test_long_field_repr():
+    field = Field(default_factory=lambda: np.geomspace(1.0, 1e4, 5))
+    assert repr(field) == "Field(default=[1.e+00 1.e+01 ... 1.e+03 1.e+04])"
+
+    field = Field(default_factory=lambda: np.linspace(1.0, 2.0, 5))
+    assert repr(field) == "Field(default=[1.   1.25 ... 1.75 2.  ])"

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -165,7 +165,7 @@ class DataWriter(Component):
             "Additional metadata keywords and values that describe this data. "
             "This should be a dictionary where the keys will be appended to the "
             "CONTEXT section of the output file's attributes. Keys can be hierarchical "
-            "by using a space between each level, e.g. `SIMULATION PRODUCTION` "
+            "by using a space between each level, e.g. ``SIMULATION PRODUCTION`` "
             "would make a key PRODUCTION grouped under the key SIMULATION"
         )
     ).tag(config=True)

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -158,10 +158,11 @@ class HDF5EventSource(EventSource):
         default_value=FocalLengthKind.EFFECTIVE,
         help=(
             "If both nominal and effective focal lengths are available, "
-            " which one to use for the `CameraFrame` attached"
-            " to the `CameraGeometry` instances in the `SubarrayDescription`"
-            ", which will be used in CameraFrame to TelescopeFrame coordinate"
-            " transforms. The 'nominal' focal length is the one used during "
+            " which one to use for the `~ctapipe.coordinates.CameraFrame` attached"
+            " to the `~ctapipe.instrument.CameraGeometry` instances in the"
+            " `~ctapipe.instrument.SubarrayDescription` which will be used in"
+            " CameraFrame to TelescopeFrame coordinate transforms."
+            " The 'nominal' focal length is the one used during "
             " the simulation, the 'effective' focal length is computed using specialized "
             " ray-tracing from a point light source"
         ),

--- a/ctapipe/io/simteleventsource.py
+++ b/ctapipe/io/simteleventsource.py
@@ -439,10 +439,11 @@ class SimTelEventSource(EventSource):
         default_value=FocalLengthKind.EFFECTIVE,
         help=(
             "If both nominal and effective focal lengths are available in the"
-            " SimTelArray file, which one to use for the `CameraFrame` attached"
-            " to the `CameraGeometry` instances in the `SubarrayDescription`"
-            ", which will be used in CameraFrame to TelescopeFrame coordinate"
-            " transforms. The 'nominal' focal length is the one used during "
+            " SimTelArray file, which one to use for the `~ctapipe.coordinates.CameraFrame`"
+            " attached to the `~ctapipe.instrument.CameraGeometry` instances in"
+            " the `~ctapipe.instrument.SubarrayDescription`, which will be used in"
+            " CameraFrame to TelescopeFrame coordinate transforms. "
+            " The 'nominal' focal length is the one used during "
             " the simulation, the 'effective' focal length is computed using specialized "
             " ray-tracing from a point light source"
         ),

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -205,10 +205,11 @@ class TableLoader(Component):
         default_value=FocalLengthKind.EFFECTIVE,
         help=(
             "If both nominal and effective focal lengths are available, "
-            " which one to use for the `CameraFrame` attached"
-            " to the `CameraGeometry` instances in the `SubarrayDescription`"
-            ", which will be used in CameraFrame to TelescopeFrame coordinate"
-            " transforms. The 'nominal' focal length is the one used during "
+            " which one to use for the `~ctapipe.coordinates.CameraFrame` attached"
+            " to the `~ctapipe.instrument.CameraGeometry` instances in the"
+            " `ctapipe.instrument.SubarrayDescription`, which will be used in"
+            " CameraFrame to TelescopeFrame coordinate transforms."
+            " The 'nominal' focal length is the one used during "
             " the simulation, the 'effective' focal length is computed using specialized "
             " ray-tracing from a point light source"
         ),

--- a/ctapipe/tools/train_energy_regressor.py
+++ b/ctapipe/tools/train_energy_regressor.py
@@ -1,3 +1,6 @@
+"""
+Tool for training the EnergyRegressor
+"""
 import numpy as np
 
 from ctapipe.core import Tool
@@ -35,8 +38,8 @@ class TrainEnergyRegressor(Tool):
         allow_none=False,
         directory_ok=False,
         help=(
-            "Ouput path for the trained reconstructor."
-            " At the moment, pickle is the only supported format.",
+            "Output path for the trained reconstructor."
+            " At the moment, pickle is the only supported format."
         ),
     ).tag(config=True)
 

--- a/ctapipe/tools/train_particle_classifier.py
+++ b/ctapipe/tools/train_particle_classifier.py
@@ -1,3 +1,6 @@
+"""
+Tool for training the ParticleClassifier
+"""
 import numpy as np
 from astropy.table import vstack
 
@@ -52,7 +55,7 @@ class TrainParticleClassifier(Tool):
         directory_ok=False,
         help=(
             "Output file for the trained reconstructor."
-            " At the moment, pickle is the only supported format.",
+            " At the moment, pickle is the only supported format."
         ),
     ).tag(config=True)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,13 +8,19 @@ SPHINXPROJ    = ctapipe
 SOURCEDIR     = .
 BUILDDIR      = _build
 
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-.PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf api
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+
+.PHONY: all help clean Makefile


### PR DESCRIPTION
This fixes an issue we found when building the lstchain docs. Arrays were included with all numbers spanning multiple lines which made the sphinx build fail.