### PR TITLE
Raise error if run_tool encounters non-zero exit code and raises is True

### DIFF
--- a/ctapipe/core/tests/test_run_tool.py
+++ b/ctapipe/core/tests/test_run_tool.py
@@ -1,0 +1,19 @@
+from subprocess import CalledProcessError
+
+import pytest
+
+from ctapipe.core.tool import Tool, run_tool
+
+
+def test_run_tool_raises_exit_code():
+    class ErrorTool(Tool):
+        def setup(self):
+            pass
+
+        def start(self):
+            pass
+
+    ret = run_tool(ErrorTool(), ["--non-existing-alias"], raises=False)
+    assert ret == 2
+    with pytest.raises(CalledProcessError):
+        run_tool(ErrorTool(), ["--non-existing-alias"], raises=True)

--- a/ctapipe/core/tests/test_tool.py
+++ b/ctapipe/core/tests/test_tool.py
@@ -3,14 +3,17 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from subprocess import CalledProcessError
 
 import pytest
 from traitlets import Dict, Float, Int, TraitError
 from traitlets.config import Config
 
 from .. import Component, Tool
-from ..tool import export_tool_config_to_commented_yaml, run_tool
+from ..tool import (
+    ToolConfigurationError,
+    export_tool_config_to_commented_yaml,
+    run_tool,
+)
 
 
 def test_tool_simple():
@@ -337,7 +340,7 @@ def test_invalid_traits(tmp_path, caplog):
     # 2 means trait error
     assert run_tool(MyTool(), ["--MyTool.foo=5"], raises=False) == 2
 
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ToolConfigurationError):
         run_tool(MyTool(), ["--MyTool.foo=5"], raises=True)
 
     # test that it also works for config files
@@ -346,7 +349,7 @@ def test_invalid_traits(tmp_path, caplog):
         json.dump({"MyTool": {"foo": 5}}, f)
 
     assert run_tool(MyTool(), [f"--config={config}"], raises=False) == 2
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(ToolConfigurationError):
         assert run_tool(MyTool(), [f"--config={config}"], raises=True)
 
 

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -369,6 +369,8 @@ class Tool(Application):
             self.log.error("%s", err)
             self.log.error("Use --help for more info")
             exit_status = 2  # wrong cmd line parameter
+            if raises:
+                raise
         except KeyboardInterrupt:
             self.log.warning("WAS INTERRUPTED BY CTRL-C")
             Provenance().finish_activity(activity_name=self.name, status="interrupted")
@@ -378,7 +380,7 @@ class Tool(Application):
             Provenance().finish_activity(activity_name=self.name, status="error")
             exit_status = 1  # any other error
             if raises:
-                raise err
+                raise
         finally:
             if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                 self.write_provenance()

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -4,6 +4,8 @@
 Test ctapipe-process on a few different use cases
 """
 
+from subprocess import CalledProcessError
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -152,7 +154,7 @@ def test_stage1_datalevels(tmp_path):
     config = resource_file("stage1_config.json")
     tool = ProcessorTool()
 
-    assert (
+    with pytest.raises(CalledProcessError):
         run_tool(
             tool,
             argv=[
@@ -164,8 +166,7 @@ def test_stage1_datalevels(tmp_path):
             ],
             cwd=tmp_path,
         )
-        == 1
-    )
+
     # make sure the dummy event source was really used
     assert isinstance(tool.event_source, DummyEventSource)
 


### PR DESCRIPTION
A tool could return 2 for e.g. an unknown command line argument and not raise in `raises=True` mode, resulting in the failure to go unnoticed.