### PR TITLE
Convert container input in validate

### DIFF
--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -190,18 +190,23 @@ class Field:
                     f"{errorstr} Should have dimensionality {self.ndim}"
                 )
             if value.dtype != self.dtype:
-                raise FieldValidationError(
-                    f"{errorstr} Has dtype "
-                    f"{value.dtype}, should have dtype"
-                    f" {self.dtype}"
-                )
-        else:
+                if np.can_cast(value, self.dtype, casting="safe"):
+                    value = value.astype(self.dtype)
+                else:
+                    raise FieldValidationError(
+                        f"{errorstr} Has dtype "
+                        f"{value.dtype}, should have dtype"
+                        f" {self.dtype}"
+                    )
             # not a numpy array
             if self.dtype is not None:
-                if not isinstance(value, self.dtype.type):
-                    raise FieldValidationError(
-                        f"{errorstr} Should have numpy dtype {self.dtype}"
-                    )
+                if np.can_cast(value, self.dtype, casting="safe"):
+                    value = value.astype(self.dtype)
+                else:
+                    if not isinstance(value, self.dtype.type):
+                        raise FieldValidationError(
+                            f"{errorstr} Should have numpy dtype {self.dtype}"
+                        )
 
 
 class DeprecatedField(Field):

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -190,20 +190,20 @@ class Field:
                     f"{errorstr} Should have dimensionality {self.ndim}"
                 )
             if value.dtype != self.dtype:
-                if np.can_cast(value, self.dtype, casting="safe"):
-                    value = value.astype(self.dtype)
-                else:
+                try:
+                    value = value.astype(self.dtype, casting="same_kind")
+                except TypeError:
                     raise FieldValidationError(
                         f"{errorstr} Has dtype "
                         f"{value.dtype}, should have dtype"
-                        f" {self.dtype}"
+                        f" {self.dtype} and could not cast it."
                     )
         else:
             # not a numpy array
             if self.dtype is not None:
                 # Workaround for string input
                 if np.issubdtype(type(value), np.number) and (
-                    np.can_cast(value, self.dtype, casting="safe")
+                    np.can_cast(value, self.dtype, casting="same_kind")
                 ):
                     value = self.dtype.type(value)
                 else:

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -198,10 +198,14 @@ class Field:
                         f"{value.dtype}, should have dtype"
                         f" {self.dtype}"
                     )
+        else:
             # not a numpy array
             if self.dtype is not None:
-                if np.can_cast(value, self.dtype, casting="safe"):
-                    value = value.astype(self.dtype)
+                # Workaround for string input
+                if np.issubdtype(type(value), np.number) and (
+                    np.can_cast(value, self.dtype, casting="safe")
+                ):
+                    value = self.dtype.type(value)
                 else:
                     if not isinstance(value, self.dtype.type):
                         raise FieldValidationError(

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -189,28 +189,19 @@ class Field:
                 raise FieldValidationError(
                     f"{errorstr} Should have dimensionality {self.ndim}"
                 )
-            if value.dtype != self.dtype:
-                try:
-                    value = value.astype(self.dtype, casting="same_kind")
-                except TypeError:
-                    raise FieldValidationError(
-                        f"{errorstr} Has dtype "
-                        f"{value.dtype}, should have dtype"
-                        f" {self.dtype} and could not cast it."
-                    )
+
         else:
-            # not a numpy array
             if self.dtype is not None:
-                # Workaround for string input
-                if np.issubdtype(type(value), np.number) and (
-                    np.can_cast(value, self.dtype, casting="same_kind")
-                ):
-                    value = self.dtype.type(value)
-                else:
-                    if not isinstance(value, self.dtype.type):
+                value = np.asanyarray(value)
+                if value.dtype != self.dtype:
+                    try:
+                        value = value.astype(self.dtype, casting="same_kind")
+                    except TypeError as err:
                         raise FieldValidationError(
-                            f"{errorstr} Should have numpy dtype {self.dtype}"
-                        )
+                            f"{errorstr} Has dtype "
+                            f"{value.dtype}, should have dtype"
+                            f" {self.dtype} and could not cast it."
+                        ) from err
 
 
 class DeprecatedField(Field):

--- a/ctapipe/core/container.py
+++ b/ctapipe/core/container.py
@@ -190,18 +190,17 @@ class Field:
                     f"{errorstr} Should have dimensionality {self.ndim}"
                 )
 
-        else:
-            if self.dtype is not None:
-                value = np.asanyarray(value)
-                if value.dtype != self.dtype:
-                    try:
-                        value = value.astype(self.dtype, casting="same_kind")
-                    except TypeError as err:
-                        raise FieldValidationError(
-                            f"{errorstr} Has dtype "
-                            f"{value.dtype}, should have dtype"
-                            f" {self.dtype} and could not cast it."
-                        ) from err
+        if self.dtype is not None:
+            value = np.asanyarray(value)
+            if value.dtype != self.dtype:
+                try:
+                    value = value.astype(self.dtype, casting="same_kind")
+                except TypeError as err:
+                    raise FieldValidationError(
+                        f"{errorstr} Has dtype "
+                        f"{value.dtype}, should have dtype"
+                        f" {self.dtype} and could not cast it."
+                    ) from err
 
 
 class DeprecatedField(Field):

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -239,7 +239,7 @@ def test_field_validation():
     field_f.validate(np.ones((2, 2), dtype=np.float32))
     field_f.validate(np.ones((2, 2), dtype=np.int32))
     with pytest.raises(FieldValidationError):
-        field_f.validate(np.ones((2), dtype=np.str_))
+        field_f.validate(np.ones((2, 2), dtype=np.str_))
 
     #   test ndims
     with pytest.raises(FieldValidationError):

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -236,11 +236,10 @@ def test_field_validation():
     field_f.validate(np.ones((2, 2), dtype=np.float64))
 
     #   test dtype
-    # Not castable
-    with pytest.raises(FieldValidationError):
-        field_f.validate(np.ones((2, 2), dtype=np.str_))
-    # This is castable without loss of precision
     field_f.validate(np.ones((2, 2), dtype=np.float32))
+    field_f.validate(np.ones((2, 2), dtype=np.int32))
+    with pytest.raises(FieldValidationError):
+        field_f.validate(np.ones((2), dtype=np.str_))
 
     #   test ndims
     with pytest.raises(FieldValidationError):
@@ -250,6 +249,7 @@ def test_field_validation():
     with pytest.raises(FieldValidationError):
         field_f.validate(7.0)
 
+    # test scalar dtypes
     field_s = Field(None, "scalar with type", dtype="int32")
     field_s.validate(np.int32(3))
     with pytest.raises(FieldValidationError):
@@ -257,15 +257,11 @@ def test_field_validation():
 
     field_s2 = Field(None, "scalar with type", dtype="float32")
     field_s2.validate(np.float32(3.3))
-    # python float is 64-bit, but 3.3 does not exceed 32 bit precision
     field_s2.validate(3.3)
     field_s2.validate(3)
     with pytest.raises(FieldValidationError):
         field_s2.validate("3.3")
-    with pytest.raises(FieldValidationError):
-        field_s2.validate(np.finfo(np.float32).max + 1)
 
-    # test scalars with units and dtypes:
     field_s3 = Field(1.0, "scalar with dtype and unit", dtype="float32", unit="m")
     field_s3.validate(np.float32(6) * u.m)
 

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -227,39 +227,38 @@ def test_field_validation():
     field_u = Field(None, "float with units", unit="m")
     field_u.validate(3.0 * u.m)
     field_u.validate(3.0 * u.km)
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="unit"):
         field_u.validate(3.0)
 
     # test numpy arrays
-
     field_f = Field(None, "float array", dtype=np.float64, ndim=2)
     field_f.validate(np.ones((2, 2), dtype=np.float64))
 
-    #   test dtype
+    # test dtype
     field_f.validate(np.ones((2, 2), dtype=np.float32))
     field_f.validate(np.ones((2, 2), dtype=np.int32))
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="dtype"):
         field_f.validate(np.ones((2, 2), dtype=np.str_))
 
-    #   test ndims
-    with pytest.raises(FieldValidationError):
+    # test ndims
+    with pytest.raises(FieldValidationError, match="dimension"):
         field_f.validate(np.ones((2), dtype=np.float64))
 
     # test scalars
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="array"):
         field_f.validate(7.0)
 
     # test scalar dtypes
     field_s = Field(None, "scalar with type", dtype="int32")
     field_s.validate(np.int32(3))
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="dtype"):
         field_s.validate(3.3)
 
     field_s2 = Field(None, "scalar with type", dtype="float32")
     field_s2.validate(np.float32(3.3))
     field_s2.validate(3.3)
     field_s2.validate(3)
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="dtype"):
         field_s2.validate("3.3")
 
     field_s3 = Field(1.0, "scalar with dtype and unit", dtype="float32", unit="m")
@@ -276,12 +275,12 @@ def test_field_validation():
     field_n.validate(None)
 
     field_n2 = Field(None, "test", allow_none=False, dtype="float32")
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="dtype"):
         field_n2.validate(None)
 
     field_type = Field(None, "foo", type=str)
     field_type.validate("foo")
-    with pytest.raises(FieldValidationError):
+    with pytest.raises(FieldValidationError, match="instance"):
         field_type.validate(5)
 
 

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -236,14 +236,15 @@ def test_field_validation():
     field_f.validate(np.ones((2, 2), dtype=np.float64))
 
     #   test dtype
+    # Not castable
     with pytest.raises(FieldValidationError):
-        field_f.validate(np.ones((2, 2), dtype=np.int32))
+        field_f.validate(np.ones((2, 2), dtype=np.str_))
     # This is castable without loss of precision
     field_f.validate(np.ones((2, 2), dtype=np.float32))
 
     #   test ndims
     with pytest.raises(FieldValidationError):
-        field_f.validate(np.ones((2), dtype=np.float32))
+        field_f.validate(np.ones((2), dtype=np.float64))
 
     # test scalars
     with pytest.raises(FieldValidationError):
@@ -251,11 +252,18 @@ def test_field_validation():
 
     field_s = Field(None, "scalar with type", dtype="int32")
     field_s.validate(np.int32(3))
+    with pytest.raises(FieldValidationError):
+        field_s.validate(3.3)
 
     field_s2 = Field(None, "scalar with type", dtype="float32")
-    field_s2.validate(np.float32(3.2))
+    field_s2.validate(np.float32(3.3))
+    # python float is 64-bit, but 3.3 does not exceed 32 bit precision
+    field_s2.validate(3.3)
+    field_s2.validate(3)
     with pytest.raises(FieldValidationError):
-        field_s2.validate(3.3)
+        field_s2.validate("3.3")
+    with pytest.raises(FieldValidationError):
+        field_s2.validate(np.finfo(np.float32).max + 1)
 
     # test scalars with units and dtypes:
     field_s3 = Field(1.0, "scalar with dtype and unit", dtype="float32", unit="m")

--- a/ctapipe/core/tests/test_container.py
+++ b/ctapipe/core/tests/test_container.py
@@ -238,6 +238,8 @@ def test_field_validation():
     #   test dtype
     with pytest.raises(FieldValidationError):
         field_f.validate(np.ones((2, 2), dtype=np.int32))
+    # This is castable without loss of precision
+    field_f.validate(np.ones((2, 2), dtype=np.float32))
 
     #   test ndims
     with pytest.raises(FieldValidationError):

--- a/docs/changes/2199.maintenance.rst
+++ b/docs/changes/2199.maintenance.rst
@@ -1,0 +1,1 @@
+Fields now convert input to their dtype if possible

--- a/docs/changes/2199.maintenance.rst
+++ b/docs/changes/2199.maintenance.rst
@@ -1,1 +1,1 @@
-Fields now convert input to their dtype if possible
+Fields now convert input to their dtype if possible during the validate step


### PR DESCRIPTION
Fixes #2147 

Noteworthy things:
- I used `np.can_cast` to check if the conversion is possible. I hope to avoid most `np.nan` issues this way. 
- Converting and then checking for equal values would be insufficient in the nan case. One would need to compare only the non-nan values (which is possible, I just decided against it).
- `can_cast` fails for scalar strings, which is why I only check numbers in the scalar case