### PR TITLE
Add coordinate overlay plotting to CameraDisplay

### DIFF
--- a/ctapipe/coordinates/__init__.py
+++ b/ctapipe/coordinates/__init__.py
@@ -42,6 +42,11 @@ class MissingFrameAttributeWarning(Warning):
     pass
 
 
+def get_representation_component_names(frame):
+    """Return the component names of a Frame (or SkyCoord)"""
+    return tuple(frame.get_representation_component_names().keys())
+
+
 # astropy requires all AltAz to have locations
 # and obstimes so they can be converted into true skycoords
 # Also it is required to transform one AltAz into another one

--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -15,7 +15,7 @@ from astropy.utils import lazyproperty
 from scipy.sparse import csr_matrix, lil_matrix
 from scipy.spatial import cKDTree
 
-from ctapipe.coordinates import CameraFrame
+from ctapipe.coordinates import CameraFrame, get_representation_component_names
 from ctapipe.utils import get_table_dataset
 from ctapipe.utils.linalg import rotation_matrix_2d
 
@@ -250,13 +250,11 @@ class CameraGeometry:
         )
         points_trans = points.transform_to(frame)
 
-        x_name, y_name = list(cam.frame.get_representation_component_names().keys())
+        x_name, y_name = get_representation_component_names(cam.frame)
         points_x = getattr(points, x_name)
         points_y = getattr(points, y_name)
 
-        trans_x_name, trans_y_name = list(
-            frame.get_representation_component_names().keys()
-        )
+        trans_x_name, trans_y_name = get_representation_component_names(frame)
         points_trans_x = getattr(points_trans, trans_x_name)
         points_trans_y = getattr(points_trans, trans_y_name)
 

--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -426,6 +426,23 @@ class CameraDisplay:
         return ellipse
 
     def overlay_coordinate(self, coord, keep_old=False, **kwargs):
+        """
+        Plot a coordinate into the ``CameraDisplay``
+
+        Parameters
+        ----------
+        coord : `~astropy.coordinates.SkyCoord`
+            The coordinate to plot. Must be able to be transformed into
+            the frame of the camera geometry of this display.
+            Most of the time, this means you need to add the telescope
+            pointing as a coordinate attribute like this:
+            ``SkyCoord(..., telescope_pointing=pointing)``
+        keep_old : bool
+            If False, any previously created overlays will be removed
+            before plotting the new one
+        kwargs :
+            All kwargs are passed to ``matplotlib.Axes.plot``
+        """
         if not keep_old:
             self.clear_overlays()
 

--- a/docs/changes/2203.feature.rst
+++ b/docs/changes/2203.feature.rst
@@ -1,0 +1,3 @@
+``CameraDisplay.overlay_coordinate`` can now be used to 
+plot coordinates into the camera display, e.g. to show 
+the source position or the position of stars in the FoV.


### PR DESCRIPTION
A follow-up to the old PR in #1138, I here add a new method `CameraDisplay.overlay_coordinate` that can plot any `SkyCoor` into the `CameraDisplay` by first transforming it into the frame of the display's camera geometry.

This is the result of the image produced in the unit test:

![coord_overlay](https://user-images.githubusercontent.com/5488440/211581289-293754bd-89ac-4623-9e55-569fdbc5e109.png)
