### PR TITLE
Upade codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
           ctapipe-info --version
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         if: matrix.codecov
 
   docs:


### PR DESCRIPTION
Github CI warns about node actions being run with node16 instead of node12 and our offending action was codecov, which has a new major release since june 2022