### PR TITLE
Add option to configure ml prefixes

### DIFF
--- a/ctapipe/reco/sklearn.py
+++ b/ctapipe/reco/sklearn.py
@@ -84,7 +84,9 @@ class SKLearnReconstructor(Reconstructor):
     target: str = None
 
     prefix = Unicode(
-        default_value=None, allow_none=True, help="Prefix for output of this model"
+        default_value=None,
+        allow_none=True,
+        help="Prefix for the output of this model. If None, ``model_cls`` is used.",
     ).tag(config=True)
     features = List(Unicode(), help="Features to use for this model").tag(config=True)
     model_config = Dict({}, help="kwargs for the sklearn model").tag(config=True)

--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -163,7 +163,7 @@ class ApplyModels(Tool):
             self.loader.h5file = self.h5file
 
     def _apply(self, reconstructor):
-        prefix = reconstructor.model_cls
+        prefix = reconstructor.prefix
         property = reconstructor.property
 
         desc = f"Applying {reconstructor.__class__.__name__}"

--- a/docs/changes/2217.feature.rst
+++ b/docs/changes/2217.feature.rst
@@ -1,0 +1,1 @@
+Add option to configure prefixes of ml models keeping the model class as default prefix.


### PR DESCRIPTION
This adds the option to configure the prefixes of the ml models, while still using the model class as the default.
Related: https://github.com/cta-observatory/ctapipe/pull/2138#discussion_r1032774404