### PR TITLE
Fix numba version to 0.56

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - joblib
   - jupyter
   - matplotlib
-  - numba
+  - numba=0.56
   - numpy>=1.17
   - numpydoc
   - pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires=
     importlib_resources ; python_version < "3.9"
     joblib
     matplotlib ~=3.0
-    numba >=0.43
+    numba ~=0.56.0
     numpy ~=1.16
     psutil
     pyyaml >=5.1


### PR DESCRIPTION
Creating the fresh env locally, mamba thought it could install numpy 1.24 with numba 0.53, which are incompatible, but that is not specified on the numba 0.53 package on conda-forge.

So here we explictly add the most recent numba version, which results in mamba correctly resolving it to the numpy 1.23 + numba 0.56 pair