### PR TITLE
Implement part of common reconstructor API

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -515,7 +515,7 @@ def gamma_train_clf(model_tmp_path, energy_regressor_path):
         argv=[
             f"--input={inpath}",
             f"--output={outpath}",
-            f"--energy-regressor={energy_regressor_path}",
+            f"--reconstructor={energy_regressor_path}",
         ],
         raises=True,
     )
@@ -533,7 +533,7 @@ def proton_train_clf(model_tmp_path, energy_regressor_path):
         argv=[
             f"--input={inpath}",
             f"--output={outpath}",
-            f"--energy-regressor={energy_regressor_path}",
+            f"--reconstructor={energy_regressor_path}",
         ],
         raises=True,
     )

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -261,3 +261,10 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         lines.append("</table>")
         lines.append("</div>")
         return "\n".join(lines)
+
+    def __getstate__(self):
+        """Make Components pickle-able by removing non-pickleable members"""
+        state = self.__dict__.copy()
+        state["_trait_values"]["parent"] = None
+        state["_trait_notifiers"] = {}
+        return state

--- a/ctapipe/core/telescope_component.py
+++ b/ctapipe/core/telescope_component.py
@@ -34,6 +34,13 @@ class TelescopeComponent(Component):
         super().__init__(config, parent, **kwargs)
         self.subarray = subarray
 
+    @property
+    def subarray(self):
+        return self._subarray
+
+    @subarray.setter
+    def subarray(self, subarray):
+        self._subarray = subarray
         # configure all of the TelescopeParameters
         for attr, trait in self.class_traits().items():
             if not isinstance(trait, TelescopeParameter):

--- a/ctapipe/io/toymodel.py
+++ b/ctapipe/io/toymodel.py
@@ -23,7 +23,7 @@ from .eventsource import EventSource
 logger = logging.getLogger(__name__)
 
 
-class ToyEventSource(EventSource, TelescopeComponent):
+class ToyEventSource(TelescopeComponent, EventSource):
     # override input url from EventSource, we don't need one here
     input_url = traits.Path(allow_none=True, default_value=None).tag(config=True)
 
@@ -54,7 +54,6 @@ class ToyEventSource(EventSource, TelescopeComponent):
 
     def __init__(self, subarray, config=None, parent=None, rng=None, **kwargs):
         super().__init__(subarray=subarray, config=config, parent=parent, **kwargs)
-        self._subarray = subarray
         self._camera_radii = {}
 
         if rng is None:
@@ -65,10 +64,6 @@ class ToyEventSource(EventSource, TelescopeComponent):
     @staticmethod
     def calc_width(eccentricity, length):
         return length * np.sqrt(1 - eccentricity**2)
-
-    @property
-    def subarray(self):
-        return self._subarray
 
     @property
     def is_simulation(self):
@@ -87,10 +82,6 @@ class ToyEventSource(EventSource, TelescopeComponent):
     def observation_blocks(self) -> Dict[int, ObservationBlockContainer]:
         ob = ObservationBlockContainer(producer_id="ctapipe toymodel")
         return {ob.ob_id: ob}
-
-    @subarray.setter
-    def subarray(self, value):
-        self._subarray = value
 
     @staticmethod
     def is_compatible(file_path):

--- a/ctapipe/reco/__init__.py
+++ b/ctapipe/reco/__init__.py
@@ -5,7 +5,7 @@
 from .hillas_intersection import HillasIntersection
 from .hillas_reconstructor import HillasReconstructor
 from .impact import ImPACTReconstructor
-from .reconstructor import GeometryReconstructor, Reconstructor
+from .reconstructor import GeometryReconstructor, ReconstructionProperty, Reconstructor
 from .shower_processor import ShowerProcessor
 from .sklearn import (
     CrossValidator,
@@ -18,6 +18,7 @@ from .stereo_combination import StereoCombiner, StereoMeanCombiner
 __all__ = [
     "Reconstructor",
     "GeometryReconstructor",
+    "ReconstructionProperty",
     "ShowerProcessor",
     "HillasReconstructor",
     "ImPACTReconstructor",

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -91,7 +91,27 @@ class Reconstructor(TelescopeComponent):
         """
 
     @classmethod
-    def read(cls, path, **kwargs):
+    def read(cls, path, parent=None, subarray=None, **kwargs):
+        """Read a joblib-pickled reconstructor from ``path``
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Path to a Reconstructor instance pickled using joblib
+        parent : None or Component or Tool
+            Attach a new parent to the loaded class, this will properly
+        subarray : SubarrayDescription
+            Attach a new subarray to the loaded reconstructor
+            A warning will be raised if the telescope types of the
+            subarray stored in the pickled class do not match with the
+            provided subarray.
+
+        **kwargs are set on the loaded instance
+
+        Returns
+        -------
+        Reconstructor instance loaded from file
+        """
         with open(path, "rb") as f:
             instance = joblib.load(f)
 
@@ -101,11 +121,11 @@ class Reconstructor(TelescopeComponent):
             )
 
         # first deal with kwargs that would need "special" treatmet, parent and subarray
-        if parent := kwargs.pop("parent", None):
+        if parent is not None:
             instance.parent = weakref.proxy(parent)
             instance.log = parent.log.getChild(instance.__class__.__name__)
 
-        if subarray := kwargs.pop("subarray", None):
+        if subarray is not None:
             if instance.subarray.telescope_types != subarray.telescope_types:
                 instance.log.warning(
                     "Supplied subarray has different telescopes than subarray loaded from file"

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -95,15 +95,25 @@ class Reconstructor(TelescopeComponent):
         with open(path, "rb") as f:
             instance = joblib.load(f)
 
-        for attr, value in kwargs.items():
-            if attr == "parent":
-                value = weakref.proxy(value)
-            setattr(instance, attr, value)
-
         if not isinstance(instance, cls):
             raise TypeError(
                 f"{path} did not contain an instance of {cls}, got {instance}"
             )
+
+        # first deal with kwargs that would need "special" treatmet, parent and subarray
+        if parent := kwargs.pop("parent", None):
+            instance.parent = weakref.proxy(parent)
+            instance.log = parent.log.getChild(instance.__class__.__name__)
+
+        if subarray := kwargs.pop("subarray", None):
+            if instance.subarray.telescope_types != subarray.telescope_types:
+                instance.log.warning(
+                    "Supplied subarray has different telescopes than subarray loaded from file"
+                )
+            instance.subarray = subarray
+
+        for attr, value in kwargs.items():
+            setattr(instance, attr, value)
 
         Provenance().add_input_file(path, role="reconstructor")
         return instance

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -17,6 +17,7 @@ __all__ = [
     "GeometryReconstructor",
     "TooFewTelescopesException",
     "InvalidWidthException",
+    "ReconstructionProperty",
 ]
 
 

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -77,7 +77,7 @@ class Reconstructor(TelescopeComponent):
 
     #: The properties this Reconstructor is able to predict
     #: To be defined in subclasses
-    properties: Tuple[ReconstructionProperty] = NotImplemented
+    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
 
     @abstractmethod
     def __call__(self, event: ArrayEventContainer):

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -1,7 +1,6 @@
 import weakref
 from abc import abstractmethod
 from enum import Enum
-from typing import Tuple
 
 import astropy.units as u
 import joblib
@@ -75,10 +74,6 @@ class Reconstructor(TelescopeComponent):
         super().__init__(subarray=subarray, **kwargs)
         self.quality_query = StereoQualityQuery(parent=self)
 
-    #: The properties this Reconstructor is able to predict
-    #: To be defined in subclasses
-    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
-
     @abstractmethod
     def __call__(self, event: ArrayEventContainer):
         """
@@ -118,8 +113,6 @@ class GeometryReconstructor(Reconstructor):
     """
     Base class for algorithms predicting only the shower geometry
     """
-
-    properties = (ReconstructionProperty.GEOMETRY,)
 
     def _create_hillas_dict(self, event):
         hillas_dict = {

--- a/ctapipe/reco/shower_processor.py
+++ b/ctapipe/reco/shower_processor.py
@@ -39,15 +39,6 @@ class ShowerProcessor(Component):
         ),
     ).tag(config=True)
 
-    reconstructor_paths = traits.List(
-        traits.Path(exists=True, directory_ok=False),
-        help=(
-            "Trained stereo reconstructors to be read from path."
-            " These are loaded and applied after the ones configured"
-            " through ``reconstructor_types``"
-        ),
-    ).tag(config=True)
-
     def __init__(
         self, subarray: SubarrayDescription, config=None, parent=None, **kwargs
     ):
@@ -77,11 +68,6 @@ class ShowerProcessor(Component):
             )
             for reco_type in self.reconstructor_types
         ]
-
-        for path in self.reconstructor_paths:
-            self.reconstructors.append(
-                Reconstructor.read(path, subarray=self.subarray, parent=self)
-            )
 
     def __call__(self, event: ArrayEventContainer):
         """

--- a/ctapipe/reco/sklearn.py
+++ b/ctapipe/reco/sklearn.py
@@ -5,7 +5,7 @@ import pathlib
 import weakref
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Tuple
+from typing import Dict
 
 import astropy.units as u
 import joblib
@@ -26,22 +26,10 @@ from ..containers import (
     ReconstructedGeometryContainer,
 )
 from ..coordinates import TelescopeFrame
-from ..core import Component, FeatureGenerator, Provenance, QualityQuery
-from ..core.traits import (
-    Bool,
-    ComponentName,
-    Dict,
-    Enum,
-    Int,
-    Integer,
-    List,
-    Path,
-    TraitError,
-    Unicode,
-)
+from ..core import Component, FeatureGenerator, Provenance, QualityQuery, traits
 from ..io import write_table
 from .preprocessing import collect_features, table_to_X, telescope_to_horizontal
-from .reconstructor import Reconstructor
+from .reconstructor import ReconstructionProperty, Reconstructor
 from .stereo_combination import StereoCombiner
 from .utils import add_defaults_and_meta
 
@@ -64,7 +52,7 @@ SUPPORTED_MODELS = {**SUPPORTED_CLASSIFIERS, **SUPPORTED_REGRESSORS}
 class MLQualityQuery(QualityQuery):
     """Quality criteria for machine learning models with different defaults"""
 
-    quality_criteria = List(
+    quality_criteria = traits.List(
         default_value=[
             ("> 50 phe", "hillas_intensity > 50"),
             ("Positive width", "hillas_width > 0"),
@@ -85,29 +73,29 @@ class SKLearnReconstructor(Reconstructor):
     from a pickled file if the ``load_path`` traitlet is given.
     """
 
-    #: What particle property is being predicted, one of "energy", "geometry", "classification"
-    property = None
     #: Name of the target column in training table
-    target: str = None
+    target: str = ""
 
-    prefix = Unicode(
+    prefix = traits.Unicode(
         default_value=None,
         allow_none=True,
         help="Prefix for the output of this model. If None, ``model_cls`` is used.",
     ).tag(config=True)
-    features = List(Unicode(), help="Features to use for this model").tag(config=True)
-    model_config = Dict({}, help="kwargs for the sklearn model").tag(config=True)
-    model_cls = Enum(SUPPORTED_MODELS.keys(), default_value=None, allow_none=True).tag(
+    features = traits.List(traits.Unicode(), help="Features to use for this model").tag(
         config=True
     )
+    model_config = traits.Dict({}, help="kwargs for the sklearn model").tag(config=True)
+    model_cls = traits.Enum(
+        SUPPORTED_MODELS.keys(), default_value=None, allow_none=True
+    ).tag(config=True)
 
-    stereo_combiner_cls = ComponentName(
+    stereo_combiner_cls = traits.ComponentName(
         StereoCombiner,
         default_value="StereoMeanCombiner",
         help="Which stereo combination method to use",
     ).tag(config=True)
 
-    load_path = Path(
+    load_path = traits.Path(
         default_value=None,
         allow_none=True,
         help="If given, load serialized model from this path",
@@ -120,7 +108,7 @@ class SKLearnReconstructor(Reconstructor):
 
         if self.load_path is None:
             if self.model_cls is None:
-                raise TraitError(
+                raise traits.TraitError(
                     "Must provide `model_cls` if not loading model from file"
                 )
 
@@ -145,7 +133,7 @@ class SKLearnReconstructor(Reconstructor):
             self.stereo_combiner = StereoCombiner.from_name(
                 self.stereo_combiner_cls,
                 prefix=self.prefix,
-                property=self.property,
+                property=self.properties[0],
                 parent=self,
             )
         else:
@@ -262,14 +250,14 @@ class SKLearnRegressionReconstructor(SKLearnReconstructor):
     Base class for regression tasks
     """
 
-    model_cls = Enum(
+    model_cls = traits.Enum(
         SUPPORTED_REGRESSORS.keys(),
         default_value=None,
         allow_none=True,
         help="Which scikit-learn regression model to use.",
     ).tag(config=True)
 
-    log_target = Bool(
+    log_target = traits.Bool(
         default_value=False,
         help="If True, the model is trained to predict the natural logarithm.",
     ).tag(config=True)
@@ -318,18 +306,18 @@ class SKLearnClassificationReconstructor(SKLearnReconstructor):
     Base class for classification tasks
     """
 
-    model_cls = Enum(
+    model_cls = traits.Enum(
         SUPPORTED_CLASSIFIERS.keys(),
         default_value=None,
         allow_none=True,
         help="Which scikit-learn classification model to use.",
     ).tag(config=True)
 
-    invalid_class = Integer(
+    invalid_class = traits.Integer(
         default_value=-1, help="The label to fill in case no prediction could be made"
     ).tag(config=True)
 
-    positive_class = Integer(
+    positive_class = traits.Integer(
         default_value=1,
         help=(
             "The label value of the positive class in case of binary classification."
@@ -396,7 +384,7 @@ class EnergyRegressor(SKLearnRegressionReconstructor):
 
     #: Name of the target table column for training
     target = "true_energy"
-    property = "energy"
+    properties = (ReconstructionProperty.ENERGY,)
 
     def __call__(self, event: ArrayEventContainer) -> None:
         """
@@ -429,7 +417,7 @@ class EnergyRegressor(SKLearnRegressionReconstructor):
 
         self.stereo_combiner(event)
 
-    def predict_table(self, key, table: Table) -> Table:
+    def predict_table(self, key, table: Table) -> Dict[ReconstructionProperty, Table]:
         """Predict on a table of events"""
         table = self.feature_generator(table)
 
@@ -452,7 +440,7 @@ class EnergyRegressor(SKLearnRegressionReconstructor):
             prefix=self.prefix,
             stereo=False,
         )
-        return result
+        return {ReconstructionProperty.ENERGY: result}
 
 
 class ParticleClassifier(SKLearnClassificationReconstructor):
@@ -462,12 +450,13 @@ class ParticleClassifier(SKLearnClassificationReconstructor):
 
     #: Name of the target table column for training
     target = "true_shower_primary_id"
-    property = "classification"
 
-    positive_class = Integer(
+    positive_class = traits.Integer(
         default_value=0,
         help="Particle id (in simtel system) of the positive class. Default is 0 for gammas.",
     ).tag(config=True)
+
+    properties = (ReconstructionProperty.PARTICLE_TYPE,)
 
     def __call__(self, event: ArrayEventContainer) -> None:
         for tel_id in event.trigger.tels_with_trigger:
@@ -495,7 +484,7 @@ class ParticleClassifier(SKLearnClassificationReconstructor):
 
         self.stereo_combiner(event)
 
-    def predict_table(self, key, table: Table) -> Table:
+    def predict_table(self, key, table: Table) -> Dict[ReconstructionProperty, Table]:
         """Predict on a table of events"""
         table = self.feature_generator(table)
 
@@ -515,7 +504,7 @@ class ParticleClassifier(SKLearnClassificationReconstructor):
         add_defaults_and_meta(
             result, ParticleClassificationContainer, prefix=self.prefix, stereo=False
         )
-        return result
+        return {ReconstructionProperty.PARTICLE_TYPE: result}
 
 
 class DispReconstructor(Reconstructor):
@@ -523,38 +512,45 @@ class DispReconstructor(Reconstructor):
     Predict absolute value and sign for disp origin reconstruction for each telescope.
     """
 
-    property = "geometry"
-    prefix = Unicode(default_value="disp", allow_none=False).tag(config=True)
-    features = List(Unicode(), help="Features to use for both models").tag(config=True)
     target = "true_norm"
-    log_target = Bool(
+    properties = (ReconstructionProperty.GEOMETRY, ReconstructionProperty.DISP)
+
+    prefix = traits.Unicode(default_value="disp", allow_none=False).tag(config=True)
+    features = traits.List(
+        traits.Unicode(), help="Features to use for both models"
+    ).tag(config=True)
+    log_target = traits.Bool(
         default_value=False,
         help="If True, the model is trained to predict the natural logarithm of the absolute value.",
     ).tag(config=True)
 
-    norm_config = Dict({}, help="kwargs for the sklearn regressor").tag(config=True)
-    norm_cls = Enum(
+    norm_config = traits.Dict({}, help="kwargs for the sklearn regressor").tag(
+        config=True
+    )
+    norm_cls = traits.Enum(
         SUPPORTED_REGRESSORS.keys(),
         default_value=None,
         allow_none=True,
         help="Which scikit-learn regression model to use.",
     ).tag(config=True)
 
-    sign_config = Dict({}, help="kwargs for the sklearn classifier").tag(config=True)
-    sign_cls = Enum(
+    sign_config = traits.Dict({}, help="kwargs for the sklearn classifier").tag(
+        config=True
+    )
+    sign_cls = traits.Enum(
         SUPPORTED_CLASSIFIERS.keys(),
         default_value=None,
         allow_none=True,
         help="Which scikit-learn classification model to use.",
     ).tag(config=True)
 
-    stereo_combiner_cls = ComponentName(
+    stereo_combiner_cls = traits.ComponentName(
         StereoCombiner,
         default_value="StereoMeanCombiner",
         help="Which stereo combination method to use",
     ).tag(config=True)
 
-    load_path = Path(
+    load_path = traits.Path(
         default_value=None,
         allow_none=True,
         help="If given, load serialized model from this path",
@@ -567,7 +563,7 @@ class DispReconstructor(Reconstructor):
 
         if self.load_path is None:
             if self.norm_cls is None or self.sign_cls is None:
-                raise TraitError(
+                raise traits.TraitError(
                     "Must provide `norm_cls` and `sign_cls` if not loading from file"
                 )
 
@@ -588,7 +584,7 @@ class DispReconstructor(Reconstructor):
             self.stereo_combiner = StereoCombiner.from_name(
                 self.stereo_combiner_cls,
                 prefix=self.prefix,
-                property=self.property,
+                property=ReconstructionProperty.GEOMETRY,
                 parent=self,
             )
         else:
@@ -758,7 +754,7 @@ class DispReconstructor(Reconstructor):
 
         self.stereo_combiner(event)
 
-    def predict_table(self, key, table: Table) -> Tuple[Table, Table]:
+    def predict_table(self, key, table: Table) -> Dict[ReconstructionProperty, Table]:
         """Predict on a table of events
 
         Parameters
@@ -823,7 +819,10 @@ class DispReconstructor(Reconstructor):
             stereo=False,
         )
 
-        return disp_result, altaz_result
+        return {
+            ReconstructionProperty.DISP: disp_result,
+            ReconstructionProperty.GEOMETRY: altaz_result,
+        }
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -835,9 +834,9 @@ class DispReconstructor(Reconstructor):
 class CrossValidator(Component):
     """Class to train sklearn based reconstructors in a cross validation"""
 
-    n_cross_validations = Int(5).tag(config=True)
+    n_cross_validations = traits.Int(5).tag(config=True)
 
-    output_path = Path(
+    output_path = traits.Path(
         default_value=None,
         allow_none=True,
         directory_ok=False,
@@ -849,9 +848,9 @@ class CrossValidator(Component):
         ),
     ).tag(config=True)
 
-    rng_seed = Int(default_value=1337, help="Seed for the random number generator").tag(
-        config=True
-    )
+    rng_seed = traits.Int(
+        default_value=1337, help="Seed for the random number generator"
+    ).tag(config=True)
 
     def __init__(self, model_component, **kwargs):
         super().__init__(**kwargs)

--- a/ctapipe/reco/sklearn.py
+++ b/ctapipe/reco/sklearn.py
@@ -4,7 +4,7 @@ Component Wrappers around sklearn models
 import pathlib
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Tuple
 
 import astropy.units as u
 import joblib
@@ -74,6 +74,10 @@ class SKLearnReconstructor(Reconstructor):
 
     #: Name of the target column in training table
     target: str = ""
+
+    #: The properties this Reconstructor is able to predict
+    #: To be defined in subclasses
+    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
 
     prefix = traits.Unicode(
         default_value=None,
@@ -231,6 +235,10 @@ class SKLearnRegressionReconstructor(SKLearnReconstructor):
     Base class for regression tasks
     """
 
+    #: The properties this Reconstructor is able to predict
+    #: To be defined in subclasses
+    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
+
     model_cls = traits.Enum(
         SUPPORTED_REGRESSORS.keys(),
         default_value=None,
@@ -286,6 +294,10 @@ class SKLearnClassificationReconstructor(SKLearnReconstructor):
     """
     Base class for classification tasks
     """
+
+    #: The properties this Reconstructor is able to predict
+    #: To be defined in subclasses
+    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
 
     model_cls = traits.Enum(
         SUPPORTED_CLASSIFIERS.keys(),
@@ -365,6 +377,7 @@ class EnergyRegressor(SKLearnRegressionReconstructor):
 
     #: Name of the target table column for training
     target = "true_energy"
+    #: The properties this reconstructor is able to predict, only energy
     properties = (ReconstructionProperty.ENERGY,)
 
     def __call__(self, event: ArrayEventContainer) -> None:
@@ -437,6 +450,7 @@ class ParticleClassifier(SKLearnClassificationReconstructor):
         help="Particle id (in simtel system) of the positive class. Default is 0 for gammas.",
     ).tag(config=True)
 
+    #: The properties this reconstructor is able to predict, only particle type
     properties = (ReconstructionProperty.PARTICLE_TYPE,)
 
     def __call__(self, event: ArrayEventContainer) -> None:
@@ -494,12 +508,16 @@ class DispReconstructor(Reconstructor):
     """
 
     target = "true_norm"
+
+    #: The properties this reconstructor is able to predict, geometry (altaz part) and disp
     properties = (ReconstructionProperty.GEOMETRY, ReconstructionProperty.DISP)
 
     prefix = traits.Unicode(default_value="disp", allow_none=False).tag(config=True)
+
     features = traits.List(
         traits.Unicode(), help="Features to use for both models"
     ).tag(config=True)
+
     log_target = traits.Bool(
         default_value=False,
         help="If True, the model is trained to predict the natural logarithm of the absolute value.",
@@ -508,6 +526,7 @@ class DispReconstructor(Reconstructor):
     norm_config = traits.Dict({}, help="kwargs for the sklearn regressor").tag(
         config=True
     )
+
     norm_cls = traits.Enum(
         SUPPORTED_REGRESSORS.keys(),
         default_value=None,
@@ -518,6 +537,7 @@ class DispReconstructor(Reconstructor):
     sign_config = traits.Dict({}, help="kwargs for the sklearn classifier").tag(
         config=True
     )
+
     sign_cls = traits.Enum(
         SUPPORTED_CLASSIFIERS.keys(),
         default_value=None,

--- a/ctapipe/reco/sklearn.py
+++ b/ctapipe/reco/sklearn.py
@@ -2,7 +2,6 @@
 Component Wrappers around sklearn models
 """
 import pathlib
-import weakref
 from abc import abstractmethod
 from collections import defaultdict
 from typing import Dict
@@ -191,24 +190,6 @@ class SKLearnReconstructor(Reconstructor):
         with path.open("wb") as f:
             Provenance().add_output_file(path, role="ml-models")
             joblib.dump(self, f, compress=True)
-
-    @classmethod
-    def read(cls, path, **kwargs):
-        with open(path, "rb") as f:
-            instance = joblib.load(f)
-
-        for attr, value in kwargs.items():
-            if attr == "parent":
-                value = weakref.proxy(value)
-            setattr(instance, attr, value)
-
-        if not isinstance(instance, cls):
-            raise TypeError(
-                f"{path} did not contain an instance of {cls}, got {instance}"
-            )
-
-        Provenance().add_input_file(path, role="ml-model")
-        return instance
 
     @lazyproperty
     def instrument_table(self):

--- a/ctapipe/reco/sklearn.py
+++ b/ctapipe/reco/sklearn.py
@@ -4,7 +4,7 @@ Component Wrappers around sklearn models
 import pathlib
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Dict, Tuple
+from typing import Dict
 
 import astropy.units as u
 import joblib
@@ -75,9 +75,8 @@ class SKLearnReconstructor(Reconstructor):
     #: Name of the target column in training table
     target: str = ""
 
-    #: The properties this Reconstructor is able to predict
-    #: To be defined in subclasses
-    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
+    #: property predicted, overridden in baseclass
+    property = None
 
     prefix = traits.Unicode(
         default_value=None,
@@ -136,7 +135,7 @@ class SKLearnReconstructor(Reconstructor):
             self.stereo_combiner = StereoCombiner.from_name(
                 self.stereo_combiner_cls,
                 prefix=self.prefix,
-                property=self.properties[0],
+                property=self.property,
                 parent=self,
             )
         else:
@@ -235,10 +234,6 @@ class SKLearnRegressionReconstructor(SKLearnReconstructor):
     Base class for regression tasks
     """
 
-    #: The properties this Reconstructor is able to predict
-    #: To be defined in subclasses
-    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
-
     model_cls = traits.Enum(
         SUPPORTED_REGRESSORS.keys(),
         default_value=None,
@@ -294,10 +289,6 @@ class SKLearnClassificationReconstructor(SKLearnReconstructor):
     """
     Base class for classification tasks
     """
-
-    #: The properties this Reconstructor is able to predict
-    #: To be defined in subclasses
-    properties: Tuple[ReconstructionProperty, ...] = NotImplemented
 
     model_cls = traits.Enum(
         SUPPORTED_CLASSIFIERS.keys(),
@@ -377,8 +368,7 @@ class EnergyRegressor(SKLearnRegressionReconstructor):
 
     #: Name of the target table column for training
     target = "true_energy"
-    #: The properties this reconstructor is able to predict, only energy
-    properties = (ReconstructionProperty.ENERGY,)
+    property = ReconstructionProperty.ENERGY
 
     def __call__(self, event: ArrayEventContainer) -> None:
         """
@@ -450,8 +440,7 @@ class ParticleClassifier(SKLearnClassificationReconstructor):
         help="Particle id (in simtel system) of the positive class. Default is 0 for gammas.",
     ).tag(config=True)
 
-    #: The properties this reconstructor is able to predict, only particle type
-    properties = (ReconstructionProperty.PARTICLE_TYPE,)
+    property = ReconstructionProperty.PARTICLE_TYPE
 
     def __call__(self, event: ArrayEventContainer) -> None:
         for tel_id in event.trigger.tels_with_trigger:
@@ -508,9 +497,6 @@ class DispReconstructor(Reconstructor):
     """
 
     target = "true_norm"
-
-    #: The properties this reconstructor is able to predict, geometry (altaz part) and disp
-    properties = (ReconstructionProperty.GEOMETRY, ReconstructionProperty.DISP)
 
     prefix = traits.Unicode(default_value="disp", allow_none=False).tag(config=True)
 

--- a/ctapipe/reco/stereo_combination.py
+++ b/ctapipe/reco/stereo_combination.py
@@ -4,9 +4,11 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import AltAz, CartesianRepresentation, SphericalRepresentation
 from astropy.table import Table
+from traitlets import UseEnum
 
 from ctapipe.core import Component, Container
 from ctapipe.core.traits import Bool, CaselessStrEnum, Unicode
+from ctapipe.reco.reconstructor import ReconstructionProperty
 
 from ..containers import (
     ArrayEventContainer,
@@ -68,8 +70,8 @@ class StereoCombiner(Component):
         help="Prefix to be added to the output container / column names",
     ).tag(config=True)
 
-    property = CaselessStrEnum(
-        ["energy", "classification", "geometry"],
+    property = UseEnum(
+        ReconstructionProperty,
         help="Which property is being combined",
     ).tag(config=True)
 
@@ -105,10 +107,14 @@ class StereoMeanCombiner(StereoCombiner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.property not in {"energy", "classification", "geometry"}:
+        supported = {
+            ReconstructionProperty.ENERGY,
+            ReconstructionProperty.GEOMETRY,
+            ReconstructionProperty.PARTICLE_TYPE,
+        }
+        if self.property not in supported:
             raise NotImplementedError(
-                f"Cannot combine {self.property}."
-                "Implemented are: energy, classification, geometry"
+                f"Combination of {self.property} not implemented in {self.__class__.__name__}"
             )
 
     def _calculate_weights(self, data):
@@ -208,7 +214,7 @@ class StereoMeanCombiner(StereoCombiner):
         )
         event.dl2.stereo.classification[self.prefix] = container
 
-    def _combine_disp(self, event):
+    def _combine_altaz(self, event):
         ids = []
         alt_values = []
         az_values = []
@@ -261,14 +267,14 @@ class StereoMeanCombiner(StereoCombiner):
         """
         Calculate the mean prediction for a single array event.
         """
-        if self.property == "energy":
+        if self.property is ReconstructionProperty.ENERGY:
             self._combine_energy(event)
 
-        elif self.property == "classification":
+        elif self.property is ReconstructionProperty.PARTICLE_TYPE:
             self._combine_classification(event)
 
-        elif self.property == "geometry":
-            self._combine_disp(event)
+        elif self.property is ReconstructionProperty.GEOMETRY:
+            self._combine_altaz(event)
 
     def predict_table(self, mono_predictions: Table) -> Table:
         """
@@ -296,7 +302,7 @@ class StereoMeanCombiner(StereoCombiner):
         n_array_events = len(array_events)
         weights = self._calculate_weights(valid_predictions)
 
-        if self.property == "classification":
+        if self.property is ReconstructionProperty.PARTICLE_TYPE:
             if len(valid_predictions) > 0:
                 mono_predictions = valid_predictions[f"{prefix}_prediction"]
                 stereo_predictions = _weighted_mean_ufunc(
@@ -309,7 +315,7 @@ class StereoMeanCombiner(StereoCombiner):
             stereo_table[f"{self.prefix}_is_valid"] = np.isfinite(stereo_predictions)
             stereo_table[f"{self.prefix}_goodness_of_fit"] = np.nan
 
-        elif self.property == "energy":
+        elif self.property is ReconstructionProperty.ENERGY:
             if len(valid_predictions) > 0:
                 mono_energies = valid_predictions[f"{prefix}_energy"].quantity.to_value(
                     u.TeV
@@ -350,7 +356,7 @@ class StereoMeanCombiner(StereoCombiner):
             stereo_table[f"{self.prefix}_is_valid"] = np.isfinite(stereo_energy)
             stereo_table[f"{self.prefix}_goodness_of_fit"] = np.nan
 
-        elif self.property == "geometry":
+        elif self.property is ReconstructionProperty.GEOMETRY:
             if len(valid_predictions) > 0:
                 coord = AltAz(
                     alt=valid_predictions[f"{prefix}_alt"],

--- a/ctapipe/reco/tests/test_sklearn.py
+++ b/ctapipe/reco/tests/test_sklearn.py
@@ -237,7 +237,7 @@ def test_io_with_parent(example_table, tmp_path, example_subarray):
     path = tmp_path / "classifier.pkl"
 
     parent.classifier.write(path)
-    loaded = ParticleClassifier(load_path=path)
+    loaded = ParticleClassifier.read(path)
     assert loaded.features == parent.classifier.features
     assert_array_equal(
         loaded._models[KEY].feature_importances_,

--- a/ctapipe/reco/tests/test_stereo_combination.py
+++ b/ctapipe/reco/tests/test_stereo_combination.py
@@ -13,6 +13,7 @@ from ctapipe.containers import (
     ReconstructedEnergyContainer,
     ReconstructedGeometryContainer,
 )
+from ctapipe.reco.reconstructor import ReconstructionProperty
 from ctapipe.reco.stereo_combination import StereoMeanCombiner
 
 
@@ -66,7 +67,7 @@ def mono_table():
 def test_predict_mean_energy(weights, mono_table):
     combine = StereoMeanCombiner(
         prefix="dummy",
-        property="energy",
+        property=ReconstructionProperty.ENERGY,
         weights=weights,
     )
     stereo = combine.predict_table(mono_table)
@@ -93,7 +94,7 @@ def test_predict_mean_energy(weights, mono_table):
 def test_predict_mean_classification(mono_table):
     combine = StereoMeanCombiner(
         prefix="classifier",
-        property="classification",
+        property=ReconstructionProperty.PARTICLE_TYPE,
     )
     stereo = combine.predict_table(mono_table)
     assert stereo.colnames == [
@@ -119,7 +120,7 @@ def test_predict_mean_classification(mono_table):
 def test_predict_mean_disp(mono_table):
     combine = StereoMeanCombiner(
         prefix="disp",
-        property="geometry",
+        property=ReconstructionProperty.GEOMETRY,
     )
     stereo = combine.predict_table(mono_table)
 
@@ -204,17 +205,17 @@ def test_mean_prediction_single_event(weights):
 
     combine_energy = StereoMeanCombiner(
         prefix="dummy",
-        property="energy",
+        property=ReconstructionProperty.ENERGY,
         weights=weights,
     )
     combine_classification = StereoMeanCombiner(
         prefix="dummy",
-        property="classification",
+        property=ReconstructionProperty.PARTICLE_TYPE,
         weights=weights,
     )
     combine_geometry = StereoMeanCombiner(
         prefix="dummy",
-        property="geometry",
+        property=ReconstructionProperty.GEOMETRY,
         weights=weights,
     )
     combine_energy(event)

--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -9,18 +9,12 @@ from astropy.table.operations import vstack
 from tqdm.auto import tqdm
 
 from ctapipe.core.tool import Tool
-from ctapipe.core.traits import Integer, List, Path
+from ctapipe.core.traits import Integer, List, Path, classes_with_traits
 from ctapipe.io import TableLoader, write_table
 from ctapipe.io.astropy_helpers import read_table
 from ctapipe.io.tableio import TelListToMaskTransform
 from ctapipe.io.tableloader import _join_subarray_events
-from ctapipe.reco import (
-    DispReconstructor,
-    EnergyRegressor,
-    ParticleClassifier,
-    StereoCombiner,
-)
-from ctapipe.reco.reconstructor import Reconstructor
+from ctapipe.reco import Reconstructor
 
 __all__ = [
     "ApplyModels",
@@ -83,13 +77,7 @@ class ApplyModels(Tool):
         "chunk-size": "ApplyModels.chunk_size",
     }
 
-    classes = [
-        TableLoader,
-        EnergyRegressor,
-        ParticleClassifier,
-        DispReconstructor,
-        StereoCombiner,
-    ]
+    classes = [TableLoader] + classes_with_traits(Reconstructor)
 
     def setup(self):
         """

--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -38,8 +38,8 @@ class ApplyModels(Tool):
     examples = """
     ctapipe-apply-models \\
         --input gamma.dl2.h5 \\
-        --energy-regressor energy_regressor.pkl \\
-        --particle-classifier particle-classifier.pkl \\
+        --reconstructor energy_regressor.pkl \\
+        --reconstructor particle-classifier.pkl \\
         --output gamma_applied.dl2.h5
     """
 

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -74,7 +74,7 @@ class ProcessorTool(Tool):
         ("o", "output"): "DataWriter.output_path",
         ("t", "allowed-tels"): "EventSource.allowed_tels",
         ("m", "max-events"): "EventSource.max_events",
-        "reconstructor": "ShowerProcessor.reconstructor_paths",
+        "reconstructor": "ShowerProcessor.reconstructor_types",
         "image-cleaner-type": "ImageProcessor.image_cleaner_type",
     }
 

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -74,9 +74,7 @@ class ProcessorTool(Tool):
         ("o", "output"): "DataWriter.output_path",
         ("t", "allowed-tels"): "EventSource.allowed_tels",
         ("m", "max-events"): "EventSource.max_events",
-        "energy-regressor": "ShowerProcessor.EnergyRegressor.load_path",
-        "particle-classifier": "ShowerProcessor.ParticleClassifier.load_path",
-        "disp-reconstructor": "ShowerProcessor.DispReconstructor.load_path",
+        "reconstructor": "ShowerProcessor.reconstructor_paths",
         "image-cleaner-type": "ImageProcessor.image_cleaner_type",
     }
 
@@ -177,26 +175,9 @@ class ProcessorTool(Tool):
             DataWriter(event_source=self.event_source, parent=self)
         )
 
-        # add ml reco classes if model paths were supplied via cli and not already configured
-        reco_aliases = {
-            "--energy-regressor": "EnergyRegressor",
-            "--particle-classifier": "ParticleClassifier",
-            "--disp-reconstructor": "DispReconstructor",
-        }
-        for alias, name in reco_aliases.items():
-            has_alias = any(arg.startswith(alias) for arg in self.argv)
-            if has_alias and name not in self.process_shower.reconstructor_types:
-                self.log.info(
-                    "Adding %s to ShowerProcesser because path was given on cli", name
-                )
-                reconstructor = Reconstructor.from_name(
-                    name,
-                    parent=self.process_shower,
-                    subarray=subarray,
-                )
-                self.process_shower.reconstructors.append(reconstructor)
-                self.process_shower.reconstructor_types.append(name)
-                self.write.write_showers = True
+        # Assume that if someone configured a stereo reconstructor, they want it written out
+        if len(self.process_shower.reconstructors) > 0:
+            self.write.write_showers = True
 
         self.event_type_filter = EventTypeFilter(parent=self)
 

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -175,10 +175,6 @@ class ProcessorTool(Tool):
             DataWriter(event_source=self.event_source, parent=self)
         )
 
-        # Assume that if someone configured a stereo reconstructor, they want it written out
-        if len(self.process_shower.reconstructors) > 0:
-            self.write.write_showers = True
-
         self.event_type_filter = EventTypeFilter(parent=self)
 
         # warn if max_events prevents writing the histograms

--- a/ctapipe/tools/tests/test_apply_models.py
+++ b/ctapipe/tools/tests/test_apply_models.py
@@ -25,7 +25,7 @@ def test_apply_energy_regressor(
         argv=[
             f"--input={input_path}",
             f"--output={output_path}",
-            f"--energy-regressor={energy_regressor_path}",
+            f"--reconstructor={energy_regressor_path}",
             "--StereoMeanCombiner.weights=konrad",
             "--chunk-size=5",  # small chunksize so we test multiple chunks for the test file
         ],
@@ -86,9 +86,9 @@ def test_apply_all(
         argv=[
             f"--input={input_path}",
             f"--output={output_path}",
-            f"--energy-regressor={energy_regressor_path}",
-            f"--particle-classifier={particle_classifier_path}",
-            f"--disp-reconstructor={disp_reconstructor_path}",
+            f"--reconstructor={energy_regressor_path}",
+            f"--reconstructor={particle_classifier_path}",
+            f"--reconstructor={disp_reconstructor_path}",
             "--StereoMeanCombiner.weights=konrad",
             "--chunk-size=5",  # small chunksize so we test multiple chunks for the test file
         ],

--- a/ctapipe/tools/tests/test_process_ml.py
+++ b/ctapipe/tools/tests/test_process_ml.py
@@ -27,11 +27,10 @@ def test_process_apply_energy(
             "ShowerProcessor": {
                 "reconstructor_types": [
                     "HillasReconstructor",
-                    "EnergyRegressor",
                 ],
-                "EnergyRegressor": {
-                    "load_path": str(energy_regressor_path),
-                },
+                "reconstructor_paths": [
+                    str(energy_regressor_path),
+                ],
             },
         }
     }
@@ -79,8 +78,6 @@ def test_process_apply_classification(
             "ShowerProcessor": {
                 "reconstructor_types": [
                     "HillasReconstructor",
-                    "EnergyRegressor",
-                    "ParticleClassifier",
                 ]
             },
         }
@@ -94,8 +91,8 @@ def test_process_apply_classification(
         f"--output={output}",
         "--write-images",
         "--write-showers",
-        f"--energy-regressor={energy_regressor_path}",
-        f"--particle-classifier={particle_classifier_path}",
+        f"--reconstructor={energy_regressor_path}",
+        f"--reconstructor={particle_classifier_path}",
         f"--config={config_path}",
     ]
     assert run_tool(ProcessorTool(), argv=argv, cwd=tmp_path, raises=True) == 0
@@ -140,8 +137,6 @@ def test_process_apply_disp(
             "ShowerProcessor": {
                 "reconstructor_types": [
                     "HillasReconstructor",
-                    "EnergyRegressor",
-                    "DispReconstructor",
                 ]
             },
         }
@@ -155,8 +150,8 @@ def test_process_apply_disp(
         f"--output={output}",
         "--write-images",
         "--write-showers",
-        f"--energy-regressor={energy_regressor_path}",
-        f"--disp-reconstructor={disp_reconstructor_path}",
+        f"--reconstructor={energy_regressor_path}",
+        f"--reconstructor={disp_reconstructor_path}",
         f"--config={config_path}",
     ]
     assert run_tool(ProcessorTool(), argv=argv, cwd=tmp_path, raises=True) == 0

--- a/ctapipe/tools/tests/test_process_ml.py
+++ b/ctapipe/tools/tests/test_process_ml.py
@@ -27,12 +27,13 @@ def test_process_apply_energy(
             "ShowerProcessor": {
                 "reconstructor_types": [
                     "HillasReconstructor",
+                    "EnergyRegressor",
                 ],
-                "reconstructor_paths": [
-                    str(energy_regressor_path),
-                ],
+                "EnergyRegressor": {
+                    "load_path": str(energy_regressor_path),
+                },
             },
-        }
+        },
     }
 
     with config_path.open("w") as f:
@@ -75,11 +76,6 @@ def test_process_apply_classification(
             "EventSource": {
                 "allowed_tels": allowed_tels,
             },
-            "ShowerProcessor": {
-                "reconstructor_types": [
-                    "HillasReconstructor",
-                ]
-            },
         }
     }
 
@@ -89,13 +85,17 @@ def test_process_apply_classification(
     argv = [
         f"--input={input_url}",
         f"--output={output}",
+        f"--config={config_path}",
         "--write-images",
         "--write-showers",
-        f"--reconstructor={energy_regressor_path}",
-        f"--reconstructor={particle_classifier_path}",
-        f"--config={config_path}",
+        "--reconstructor=HillasReconstructor",
+        "--reconstructor=EnergyRegressor",
+        "--reconstructor=ParticleClassifier",
+        f"--EnergyRegressor.load_path={energy_regressor_path}",
+        f"--ParticleClassifier.load_path={particle_classifier_path}",
     ]
-    assert run_tool(ProcessorTool(), argv=argv, cwd=tmp_path, raises=True) == 0
+    tool = ProcessorTool()
+    run_tool(tool, argv=argv, cwd=tmp_path, raises=True)
 
     tel_events = read_table(
         output, "/dl2/event/telescope/classification/ExtraTreesClassifier/tel_004"
@@ -137,6 +137,8 @@ def test_process_apply_disp(
             "ShowerProcessor": {
                 "reconstructor_types": [
                     "HillasReconstructor",
+                    "EnergyRegressor",
+                    "DispReconstructor",
                 ]
             },
         }
@@ -150,11 +152,13 @@ def test_process_apply_disp(
         f"--output={output}",
         "--write-images",
         "--write-showers",
-        f"--reconstructor={energy_regressor_path}",
-        f"--reconstructor={disp_reconstructor_path}",
         f"--config={config_path}",
+        f"--EnergyRegressor.load_path={energy_regressor_path}",
+        f"--DispReconstructor.load_path={disp_reconstructor_path}",
     ]
-    assert run_tool(ProcessorTool(), argv=argv, cwd=tmp_path, raises=True) == 0
+
+    tool = ProcessorTool()
+    run_tool(tool, argv=argv, cwd=tmp_path, raises=True)
 
     tel_events = read_table(output, "/dl2/event/telescope/disp/disp/tel_004")
     assert "disp_parameter_norm" in tel_events.colnames

--- a/docs/changes/2229.api.rst
+++ b/docs/changes/2229.api.rst
@@ -1,0 +1,7 @@
+Change how ML reconstructors are given to the ``ctapipe-process`` tool,
+the ``ShowerProcessor`` and the ``ctapipe-apply-models`` tool.
+The tools now take ``--reconstructor`` options, which might repeated,
+and results in a list of reconstructors that are applied in the given order.
+
+SKLearn reconstructors now return a dict mapping the new ``ReconstructionProperty`` enum
+to tables to enable reconstructors that predict multiple properties at once.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.mathjax",
     "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.smart_resolver",
     "nbsphinx",
     "matplotlib.sphinxext.plot_directive",
     "numpydoc",


### PR DESCRIPTION
* Move `.read` to `Reconstructor`
* Introduce `ReconstructionProperty` enum
* Let `predict_telescope_table` return a `dict[Property, Table]`
* Unify cli arguments of `ctapipe-process` and `ctapipe-apply-models` to have `--reconstructor` for each `Reconstructor` subclass to apply.

* Remove the aliases for the reconstructor load paths in `ctapipe-process` and the hacky workaround to make it not necessary to specify reconstructor types for them in the config.


Associated issues: #2116 