### PR TITLE
Allow feature generator to overwrite already defined columns

### DIFF
--- a/ctapipe/core/tests/test_feature_generator.py
+++ b/ctapipe/core/tests/test_feature_generator.py
@@ -35,12 +35,17 @@ def test_feature_generator():
 
 def test_existing_feature():
     """If the feature already exists, fail"""
-    expressions = [("foo", "bar")]
+    expressions = [("foo", "2"), ("bar", "3")]
     generator = FeatureGenerator(features=expressions)
     table = Table({"foo": [1], "bar": [1]})
 
     with pytest.raises(FeatureGeneratorException):
         generator(table)
+
+    generator.overwrite = True
+    generator(table)
+    assert (table["foo"] == 2).all()
+    assert (table["bar"] == 3).all()
 
 
 def test_missing_colname():

--- a/docs/changes/2240.feature.rst
+++ b/docs/changes/2240.feature.rst
@@ -1,0 +1,1 @@
+Allow that the ``FeatureGenerator`` overwrites existing columns.


### PR DESCRIPTION
This is needed to implement the improvements for the apply tool to only read the data once and to use the merger tool for writing to the output.

As the reconstructors are applied in order, any feature the feature generators might already be defined and filled into the table, so subsequent reconstructors need to be able to overwrite the already present feature with the one they define.