### PR TITLE
Simplify ChunkIterator, return start, stop, table

### DIFF
--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -303,9 +303,18 @@ def test_chunked(dl2_shower_geometry_file):
         iters = (event_it, tel_event_it, by_type_it, by_id_it)
 
         for chunk, (events, tel_events, by_type, by_id) in enumerate(zip(*iters)):
+
+            expected_start = chunk * chunk_size
+            expected_stop = min(n_events, (chunk + 1) * chunk_size)
+
+            start, stop, events = events
+            tel_events = tel_events.data
+            by_type = by_type.data
+            by_id = by_id.data
+            assert expected_start == start
+            assert expected_stop == stop
+
             n_read += len(events)
-            start = chunk * chunk_size
-            stop = min(n_events, (chunk + 1) * chunk_size)
 
             # last chunk might be smaller
             if chunk == (n_chunks - 1):

--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -178,7 +178,7 @@ class ApplyModels(Tool):
         chunk_iterator = self.loader.read_telescope_events_by_id_chunked(
             self.chunk_size
         )
-        for chunk in tqdm(chunk_iterator, desc=desc, unit=unit):
+        for start, stop, chunk in tqdm(chunk_iterator, desc=desc, unit=unit):
             tel_tables = []
 
             for tel_id, table in chunk.items():
@@ -249,8 +249,8 @@ class ApplyModels(Tool):
             self._combine(
                 reconstructor.stereo_combiner,
                 vstack(tel_tables),
-                start=chunk_iterator.start,
-                stop=chunk_iterator.stop,
+                start=start,
+                stop=stop,
             )
 
     def _combine(self, combiner, mono_predictions, start=None, stop=None):

--- a/docs/changes/2241.api.rst
+++ b/docs/changes/2241.api.rst
@@ -1,0 +1,2 @@
+The ``_chunked`` methods of the ``TableLoader`` now return
+an Iterator over namedtuples with start, stop, data.


### PR DESCRIPTION
* Instead of the iterator protocol, it now uses the sequence protocol. This allows random access and simplifies the internal book-keeping.

* Instead of storing start, stop on the Iterator, they are returned together with the table(s).

This made the implementation of the apply tool reading the data only once much easier.