### PR TITLE
Fix wrong overwrite config in train_* tools

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -525,6 +525,7 @@ def energy_regressor_path(model_tmp_path):
                 f"--output={out_file}",
                 f"--config={config}",
                 "--log-level=INFO",
+                "--overwrite",
             ],
         )
         assert ret == 0
@@ -586,6 +587,7 @@ def particle_classifier_path(model_tmp_path, gamma_train_clf, proton_train_clf):
                 f"--output={out_file}",
                 f"--config={config}",
                 "--log-level=INFO",
+                "--overwrite",
             ],
         )
         assert ret == 0

--- a/ctapipe/tools/train_disp_reconstructor.py
+++ b/ctapipe/tools/train_disp_reconstructor.py
@@ -60,16 +60,6 @@ class TrainDispReconstructor(Tool):
         ),
     ).tag(config=True)
 
-    flags = {
-        "overwrite": (
-            {
-                "TrainDispReconstructor": {"overwrite": True},
-                "CrossValidator": {"overwrite": True},
-            },
-            "Overwrite existing output",
-        ),
-    }
-
     aliases = {
         ("i", "input"): "TableLoader.input_url",
         ("o", "output"): "TrainDispReconstructor.output_path",

--- a/ctapipe/tools/train_energy_regressor.py
+++ b/ctapipe/tools/train_energy_regressor.py
@@ -56,16 +56,6 @@ class TrainEnergyRegressor(Tool):
         default_value=0, help="Random seed for sampling and cross validation"
     ).tag(config=True)
 
-    flags = {
-        "overwrite": (
-            {
-                "TrainEnergyReconstructor": {"overwrite": True},
-                "CrossValidator": {"overwrite": True},
-            },
-            "Overwrite existing output",
-        ),
-    }
-
     aliases = {
         ("i", "input"): "TableLoader.input_url",
         ("o", "output"): "TrainEnergyRegressor.output_path",

--- a/ctapipe/tools/train_particle_classifier.py
+++ b/ctapipe/tools/train_particle_classifier.py
@@ -82,16 +82,6 @@ class TrainParticleClassifier(Tool):
         help="Random number seed for sampling and the cross validation splitting",
     ).tag(config=True)
 
-    flags = {
-        "overwrite": (
-            {
-                "TrainParticleClassifier": {"overwrite": True},
-                "CrossValidator": {"overwrite": True},
-            },
-            "Overwrite existing output",
-        ),
-    }
-
     aliases = {
         "signal": "TrainParticleClassifier.input_url_signal",
         "background": "TrainParticleClassifier.input_url_background",


### PR DESCRIPTION
Fixes #2242 

PR #2213 assumed wrongly that `CrossValidator` has an `overwrite` trait, but it just takes it as a keyword argument in its write method, making the extra config in the train tools an error.