### PR TITLE
Notify users about `test_plugin` install

### DIFF
--- a/ctapipe/io/tests/test_plugin.py
+++ b/ctapipe/io/tests/test_plugin.py
@@ -7,8 +7,10 @@ def test_plugin():
     from ctapipe.io import EventSource
 
     try:
-        EventSource("test.plugin").__class__.__name__ == "PluginEventSource"
+        es_name = EventSource("test.plugin").__class__.__name__
     except traitlets.traitlets.TraitError:
         pytest.fail(
             "plugin event source not found, did you run pip install -e ./test_plugin"
         )
+
+    assert es_name == "PluginEventSource"

--- a/ctapipe/io/tests/test_plugin.py
+++ b/ctapipe/io/tests/test_plugin.py
@@ -10,7 +10,7 @@ def test_plugin():
         es_name = EventSource("test.plugin").__class__.__name__
     except traitlets.traitlets.TraitError:
         pytest.fail(
-            "plugin event source not found, did you run pip install -e ./test_plugin"
+            "plugin event source not found, did you run `pip install -e ./test_plugin`?"
         )
 
     assert es_name == "PluginEventSource"

--- a/ctapipe/io/tests/test_plugin.py
+++ b/ctapipe/io/tests/test_plugin.py
@@ -1,5 +1,14 @@
+import pytest
+import traitlets
+
+
 def test_plugin():
     """Test we can use the dummy event source provided by the test plugin"""
     from ctapipe.io import EventSource
 
-    assert EventSource("test.plugin").__class__.__name__ == "PluginEventSource"
+    try:
+        EventSource("test.plugin").__class__.__name__ == "PluginEventSource"
+    except traitlets.traitlets.TraitError:
+        pytest.fail(
+            "plugin event source not found, did you run pip install -e ./test_plugin"
+        )

--- a/ctapipe/reco/tests/test_reconstructor.py
+++ b/ctapipe/reco/tests/test_reconstructor.py
@@ -1,12 +1,20 @@
 """
 Test for Reconstructor base class
 """
+import pytest
 
 
 def test_plugin(subarray_prod5_paranal):
     from ctapipe.reco import Reconstructor
 
     subarray = subarray_prod5_paranal
-    reconstructor = Reconstructor.from_name("PluginReconstructor", subarray)
+
+    try:
+        reconstructor = Reconstructor.from_name("PluginReconstructor", subarray)
+    except KeyError:
+        pytest.fail(
+            "plugin event source not found, did you run pip install -e ./test_plugin"
+        )
+
     assert reconstructor.__module__ == "ctapipe_test_plugin"
     assert reconstructor.__class__.__name__ == "PluginReconstructor"

--- a/ctapipe/reco/tests/test_reconstructor.py
+++ b/ctapipe/reco/tests/test_reconstructor.py
@@ -13,7 +13,7 @@ def test_plugin(subarray_prod5_paranal):
         reconstructor = Reconstructor.from_name("PluginReconstructor", subarray)
     except KeyError:
         pytest.fail(
-            "plugin event source not found, did you run pip install -e ./test_plugin"
+            "plugin event source not found, did you run `pip install -e ./test_plugin`?"
         )
 
     assert reconstructor.__module__ == "ctapipe_test_plugin"

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -474,7 +474,7 @@ def test_plugin_help(capsys):
     captured = capsys.readouterr()
     assert (
         "PluginEventSource.foo" in captured.out
-    ), "Tool help is missing plugin classes, did you run pip install -e ./test_plugin"
+    ), "Tool help is missing plugin classes, did you run `pip install -e ./test_plugin`?"
     assert (
         "PluginReconstructor.foo" in captured.out
-    ), "Tool help is missing plugin classes, did you run pip install -e ./test_plugin"
+    ), "Tool help is missing plugin classes, did you run `pip install -e ./test_plugin`?"

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -474,7 +474,7 @@ def test_plugin_help(capsys):
     captured = capsys.readouterr()
     assert (
         "PluginEventSource.foo" in captured.out
-    ), "Tool help is missing plugin classes"
+    ), "Tool help is missing plugin classes, did you run pip install -e ./test_plugin"
     assert (
         "PluginReconstructor.foo" in captured.out
-    ), "Tool help is missing plugin classes"
+    ), "Tool help is missing plugin classes, did you run pip install -e ./test_plugin"

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -112,6 +112,13 @@ usable from anywhere.
 
     $ pip install -e .
 
+ctapipe supports adding so-called event sources through plugins.
+In order for the respective tests to pass you have to install a 
+test plugin via
+
+.. code-block:: console
+
+    $ pip install -e ./test_plugin
 
 Run the tests to make sure everything is OK:
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -112,9 +112,9 @@ usable from anywhere.
 
     $ pip install -e .
 
-ctapipe supports adding so-called event sources through plugins.
-In order for the respective tests to pass you have to install a 
-test plugin via
+ctapipe supports adding so-called event sources and reconstructors 
+through plugins. In order for the respective tests to pass you have 
+to install the test plugin via
 
 .. code-block:: console
 


### PR DESCRIPTION
With the introduction of `test_plugin` and its tests local installations of ctapipe might have failing tests. This adds the needed install command to the getting-started instructions and changes the pytest failure messages from

```
FAILED ctapipe/io/tests/test_plugin.py::test_plugin - traitlets.traitlets.TraitError: input_url xyz/ctapipe/test.plugin is not an existing file  and no EventSource implementation claimed compatibility
FAILED ctapipe/reco/tests/test_reconstructor.py::test_plugin - KeyError: 'PluginReconstructor'
FAILED ctapipe/tools/tests/test_process.py::test_plugin_help - AssertionError: Tool help is missing plugin classes
```

to

```
FAILED ctapipe/io/tests/test_plugin.py::test_plugin - Failed: plugin event source not found, did you run pip install -e ./test_plugin
FAILED ctapipe/reco/tests/test_reconstructor.py::test_plugin - Failed: plugin event source not found, did you run pip install -e ./test_plugin
FAILED ctapipe/tools/tests/test_process.py::test_plugin_help - AssertionError: Tool help is missing plugin classes, did you run pip install -e ./test_plugin
```