### PR TITLE
Add rng attribute back to TrainEnergyRegressor

### DIFF
--- a/ctapipe/tools/tests/test_train.py
+++ b/ctapipe/tools/tests/test_train.py
@@ -42,6 +42,26 @@ def test_too_few_events(tmp_path, dl2_shower_geometry_file):
         )
 
 
+def test_sampling(tmp_path, dl2_shower_geometry_file):
+    from ctapipe.tools.train_energy_regressor import TrainEnergyRegressor
+
+    tool = TrainEnergyRegressor()
+    config = resource_file("train_energy_regressor.yaml")
+    out_file = tmp_path / "energy.pkl"
+
+    run_tool(
+        tool,
+        argv=[
+            "--input=dataset://gamma_diffuse_dl2_train_small.dl2.h5",
+            f"--output={out_file}",
+            f"--config={config}",
+            "--log-level=INFO",
+            "--n-events=100",
+        ],
+        raises=True,
+    )
+
+
 def test_cross_validation_results(tmp_path, gamma_train_clf, proton_train_clf):
     from ctapipe.tools.train_disp_reconstructor import TrainDispReconstructor
     from ctapipe.tools.train_energy_regressor import TrainEnergyRegressor

--- a/ctapipe/tools/train_energy_regressor.py
+++ b/ctapipe/tools/train_energy_regressor.py
@@ -97,6 +97,7 @@ class TrainEnergyRegressor(Tool):
         self.cross_validate = CrossValidator(
             parent=self, model_component=self.regressor
         )
+        self.rng = np.random.default_rng(self.random_seed)
         self.check_output(self.output_path, self.cross_validate.output_path)
 
     def start(self):


### PR DESCRIPTION
fixes #2246

Bisecting, I found that this was removed by accident during #2213 and not caught by the tests or review.