### PR TITLE
Refactor apply tool to use HDF5Merger, read data only once

### DIFF
--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -344,18 +344,22 @@ class TableLoader(Component):
 
     def _join_observation_info(self, table):
         obs_table = self.read_observation_information()
-        # in v0.17, obs_id had inconsitent dtypes and joint
-        # get's messed up then because a join between int32 and uint64
+        # in v0.17, obs_id had inconsistent dtypes in different tables
+        # Joining then gets messed up then because a join between int32 and uint64
         # casts the obs_id in the joint result to float.
-        # fixing by casting here.
         obs_table["obs_id"] = obs_table["obs_id"].astype(table["obs_id"].dtype)
+
+        # to be able to sort to original table order
         self._add_index_if_needed(table)
+
         joint = join_allow_empty(
             table,
             obs_table,
             keys="obs_id",
             join_type="left",
         )
+
+        # sort back to original order and remove index col
         self._sort_to_original_order(joint)
         del table["__index__"]
         return joint

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -251,6 +251,19 @@ class TableLoader(Component):
         if self.load_instrument:
             self.instrument_table = self.subarray.to_table("joined")
 
+        groups = {
+            "load_dl1_parameters": PARAMETERS_GROUP,
+            "load_dl1_images": IMAGES_GROUP,
+            "load_true_parameters": TRUE_PARAMETERS_GROUP,
+            "load_true_images": TRUE_IMAGES_GROUP,
+        }
+        for attr, group in groups.items():
+            if getattr(self, attr) and group not in self.h5file.root:
+                self.log.info(
+                    "Setting %s to False, input file does not contain such data", attr
+                )
+                setattr(self, attr, False)
+
     def close(self):
         """Close the underlying hdf5 file"""
         if self._should_close:

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -345,7 +345,10 @@ class TableLoader(Component):
     def _join_observation_info(self, table):
         observation_table = self.read_observation_information()
         table = join_allow_empty(
-            table, observation_table, keys="obs_id", join_type="left"
+            table,
+            observation_table,
+            keys="obs_id",
+            join_type="left",
         )
         return table
 

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -410,7 +410,7 @@ def test_read_empty_table(dl2_shower_geometry_file):
 
 
 def test_order_merged():
-    """Reading an empty table should return an empty table."""
+    """Test reading functions return data in correct event order"""
     from ctapipe.io import TableLoader
 
     path = get_dataset_path("gamma_diffuse_dl2_train_small.dl2.h5")

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -427,3 +427,8 @@ def test_order_merged():
         for tel_id, table in tables.items():
             mask = tel_trigger["tel_id"] == tel_id
             check_equal_array_event_order(table, tel_trigger[mask])
+
+        tables = loader.read_telescope_events_by_type()
+        for tel, table in tables.items():
+            mask = np.isin(tel_trigger["tel_id"], loader.subarray.get_tel_ids(tel))
+            check_equal_array_event_order(table, tel_trigger[mask])

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 
 from ctapipe.instrument.subarray import SubarrayDescription
 from ctapipe.io.astropy_helpers import read_table
+from ctapipe.utils.datasets import get_dataset_path
 
 
 def check_equal_array_event_order(table1, table2):
@@ -406,3 +407,23 @@ def test_read_empty_table(dl2_shower_geometry_file):
     ) as loader:
         table = loader.read_telescope_events([6])
         assert len(table) == 0
+
+
+def test_order_merged():
+    """Reading an empty table should return an empty table."""
+    from ctapipe.io import TableLoader
+
+    path = get_dataset_path("gamma_diffuse_dl2_train_small.dl2.h5")
+
+    tel_trigger = read_table(path, "/dl1/event/telescope/trigger")
+    with TableLoader(
+        path,
+        load_dl1_parameters=False,
+        load_dl2=True,
+        load_observation_info=True,
+    ) as loader:
+        tables = loader.read_telescope_events_by_id()
+
+        for tel_id, table in tables.items():
+            mask = tel_trigger["tel_id"] == tel_id
+            check_equal_array_event_order(table, tel_trigger[mask])

--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -88,16 +88,16 @@ class ApplyModels(Tool):
             "don't show a progress bar during event processing",
         ),
         **flag(
+            "dl1-parameters",
+            "HDF5Merger.dl1_parameters",
+            "Include dl1 parameters",
+            "Exclude dl1 parameters",
+        ),
+        **flag(
             "dl1-images",
             "HDF5Merger.dl1_images",
             "Include dl1 images",
             "Exclude dl1 images",
-        ),
-        **flag(
-            "true-images",
-            "HDF5Merger.true_images",
-            "Include true images",
-            "Exclude true images",
         ),
         **flag(
             "true-parameters",
@@ -106,10 +106,10 @@ class ApplyModels(Tool):
             "Exclude true parameters",
         ),
         **flag(
-            "dl1-parameters",
-            "HDF5Merger.dl1_parameters",
-            "Include dl1 parameters",
-            "Exclude dl1 parameters",
+            "true-images",
+            "HDF5Merger.true_images",
+            "Include true images",
+            "Exclude true images",
         ),
     }
 

--- a/ctapipe/tools/tests/test_apply_models.py
+++ b/ctapipe/tools/tests/test_apply_models.py
@@ -8,6 +8,7 @@ from ctapipe.containers import (
 )
 from ctapipe.core import run_tool
 from ctapipe.io import TableLoader, read_table
+from ctapipe.io.tests.test_table_loader import check_equal_array_event_order
 
 
 def test_apply_energy_regressor(
@@ -43,29 +44,31 @@ def test_apply_energy_regressor(
         assert colname in table.colnames
         assert table[colname].description == field.description
 
-    loader = TableLoader(output_path, load_dl2=True)
-    events = loader.read_subarray_events()
+    with TableLoader(output_path, load_dl2=True) as loader:
 
-    assert f"{prefix}_energy" in events.colnames
-    assert f"{prefix}_energy_uncert" in events.colnames
-    assert f"{prefix}_is_valid" in events.colnames
-    assert f"{prefix}_telescopes" in events.colnames
-    assert np.any(events[f"{prefix}_is_valid"])
-    assert np.all(np.isfinite(events[f"{prefix}_energy"][events[f"{prefix}_is_valid"]]))
+        events = loader.read_subarray_events()
+        assert f"{prefix}_energy" in events.colnames
+        assert f"{prefix}_energy_uncert" in events.colnames
+        assert f"{prefix}_is_valid" in events.colnames
+        assert f"{prefix}_telescopes" in events.colnames
+        assert np.any(events[f"{prefix}_is_valid"])
+        assert np.all(
+            np.isfinite(events[f"{prefix}_energy"][events[f"{prefix}_is_valid"]])
+        )
 
-    events = loader.read_telescope_events()
-    assert f"{prefix}_energy" in events.colnames
-    assert f"{prefix}_energy_uncert" in events.colnames
-    assert f"{prefix}_is_valid" in events.colnames
-    assert f"{prefix}_telescopes" in events.colnames
+        tel_events = loader.read_telescope_events()
+        assert f"{prefix}_energy" in tel_events.colnames
+        assert f"{prefix}_energy_uncert" in tel_events.colnames
+        assert f"{prefix}_is_valid" in tel_events.colnames
+        assert f"{prefix}_telescopes" in events.colnames
 
-    assert f"{prefix}_tel_energy" in events.colnames
-    assert f"{prefix}_tel_is_valid" in events.colnames
-
-    from ctapipe.io.tests.test_table_loader import check_equal_array_event_order
+        assert f"{prefix}_tel_energy" in tel_events.colnames
+        assert f"{prefix}_tel_is_valid" in tel_events.colnames
+        assert "hillas_intensity" in tel_events.colnames
 
     trigger = read_table(output_path, "/dl1/event/subarray/trigger")
     energy = read_table(output_path, "/dl2/event/subarray/energy/ExtraTreesRegressor")
+
     check_equal_array_event_order(trigger, energy)
 
 
@@ -89,6 +92,8 @@ def test_apply_all(
             f"--reconstructor={energy_regressor_path}",
             f"--reconstructor={particle_classifier_path}",
             f"--reconstructor={disp_reconstructor_path}",
+            "--no-dl1-parameters",
+            "--no-true-parameters",
             "--StereoMeanCombiner.weights=konrad",
             "--chunk-size=5",  # small chunksize so we test multiple chunks for the test file
         ],
@@ -116,40 +121,40 @@ def test_apply_all(
         assert colname in table.colnames
         assert table[colname].description == field.description
 
-    loader = TableLoader(output_path, load_dl2=True)
-    events = loader.read_subarray_events()
-    assert f"{prefix_clf}_prediction" in events.colnames
-    assert f"{prefix_clf}_telescopes" in events.colnames
-    assert f"{prefix_clf}_is_valid" in events.colnames
-    assert f"{prefix_clf}_goodness_of_fit" in events.colnames
-    assert f"{prefix_disp}_alt" in events.colnames
-    assert f"{prefix_disp}_az" in events.colnames
-    assert f"{prefix_disp}_ang_distance_uncert" in events.colnames
-    assert f"{prefix_disp}_is_valid" in events.colnames
-    assert f"{prefix_disp}_goodness_of_fit" in events.colnames
+    with TableLoader(output_path, load_dl2=True) as loader:
+        events = loader.read_subarray_events()
+        assert f"{prefix_clf}_prediction" in events.colnames
+        assert f"{prefix_clf}_telescopes" in events.colnames
+        assert f"{prefix_clf}_is_valid" in events.colnames
+        assert f"{prefix_clf}_goodness_of_fit" in events.colnames
+        assert f"{prefix_disp}_alt" in events.colnames
+        assert f"{prefix_disp}_az" in events.colnames
+        assert f"{prefix_disp}_ang_distance_uncert" in events.colnames
+        assert f"{prefix_disp}_is_valid" in events.colnames
+        assert f"{prefix_disp}_goodness_of_fit" in events.colnames
 
-    events = loader.read_telescope_events()
-    assert f"{prefix_clf}_prediction" in events.colnames
-    assert f"{prefix_clf}_telescopes" in events.colnames
-    assert f"{prefix_clf}_is_valid" in events.colnames
-    assert f"{prefix_clf}_goodness_of_fit" in events.colnames
-    assert f"{prefix_disp}_alt" in events.colnames
-    assert f"{prefix_disp}_az" in events.colnames
-    assert f"{prefix_disp}_ang_distance_uncert" in events.colnames
-    assert f"{prefix_disp}_is_valid" in events.colnames
-    assert f"{prefix_disp}_goodness_of_fit" in events.colnames
+        tel_events = loader.read_telescope_events()
+        assert f"{prefix_clf}_prediction" in tel_events.colnames
+        assert f"{prefix_clf}_telescopes" in tel_events.colnames
+        assert f"{prefix_clf}_is_valid" in tel_events.colnames
+        assert f"{prefix_clf}_goodness_of_fit" in tel_events.colnames
+        assert f"{prefix_disp}_alt" in tel_events.colnames
+        assert f"{prefix_disp}_az" in tel_events.colnames
+        assert f"{prefix_disp}_ang_distance_uncert" in tel_events.colnames
+        assert f"{prefix_disp}_is_valid" in tel_events.colnames
+        assert f"{prefix_disp}_goodness_of_fit" in tel_events.colnames
 
-    assert f"{prefix_clf}_tel_prediction" in events.colnames
-    assert f"{prefix_clf}_tel_is_valid" in events.colnames
-    assert f"{prefix_disp}_tel_alt" in events.colnames
-    assert f"{prefix_disp}_tel_az" in events.colnames
-    assert f"{prefix_disp}_tel_is_valid" in events.colnames
-    assert f"{prefix_disp}_parameter_norm" in events.colnames
-    assert f"{prefix_disp}_parameter_is_valid" in events.colnames
+        assert f"{prefix_clf}_tel_prediction" in tel_events.colnames
+        assert f"{prefix_clf}_tel_is_valid" in tel_events.colnames
+        assert f"{prefix_disp}_tel_alt" in tel_events.colnames
+        assert f"{prefix_disp}_tel_az" in tel_events.colnames
+        assert f"{prefix_disp}_tel_is_valid" in tel_events.colnames
+        assert f"{prefix_disp}_parameter_norm" in tel_events.colnames
+        assert f"{prefix_disp}_parameter_is_valid" in tel_events.colnames
 
-    assert "ExtraTreesRegressor_energy" in events.colnames
-
-    from ctapipe.io.tests.test_table_loader import check_equal_array_event_order
+        # check that the "--no-dl1-parameters" option worked
+        assert "hillas_intensity" not in tel_events.colnames
+        assert "ExtraTreesRegressor_energy" in events.colnames
 
     trigger = read_table(output_path, "/dl1/event/subarray/trigger")
     particle_clf = read_table(


### PR DESCRIPTION
Refactor ctapipe-apply models
    
* The tool now uses the HDF5Merger component for copying data from
the input file, which makes it possible to select what data should
be copied.

* Data is only read once in chunks from the input files and all
reconstructors are applied in order to each of the chunks.

For this, it was needed to not modify the input table in the feature generator, which I opted to do by the shallow copy approach as discussed here: #2248 

Fixes #2248 
Fixes #2130
Fixes #2250