### PR TITLE
Fix deprecation warning due to pkg_resources

### DIFF
--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -17,14 +17,17 @@ from importlib import import_module
 from os.path import abspath
 from pathlib import Path
 
-import pkg_resources
 import psutil
 from astropy.time import Time
-from pkg_resources import get_distribution
 
 import ctapipe
 
 from .support import Singleton
+
+if sys.version_info < (3, 9):
+    from importlib_metadata import distributions, version
+else:
+    from importlib.metadata import distributions, version
 
 log = logging.getLogger(__name__)
 
@@ -52,7 +55,7 @@ def get_module_version(name):
         return module.__version__
     except AttributeError:
         try:
-            return get_distribution(name).version
+            return version(name)
         except Exception:
             return "unknown"
     except ImportError:
@@ -286,8 +289,8 @@ class _ActivityProvenance:
 
 def _get_python_packages():
     return [
-        {"name": p.project_name, "version": p.version, "path": p.module_path}
-        for p in sorted(pkg_resources.working_set, key=lambda p: p.project_name)
+        {"name": p.name, "version": p.version}
+        for p in sorted(distributions(), key=lambda d: d.name)
     ]
 
 

--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -4,12 +4,15 @@ import logging
 import os
 import sys
 
-from pkg_resources import resource_filename
-
 from ..core import Provenance, get_module_version
 from ..core.plugins import detect_and_import_plugins
 from ..utils import datasets
 from .utils import get_parser
+
+if sys.version_info < (3, 9):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
 __all__ = ["info"]
 
@@ -189,7 +192,7 @@ def _info_resources():
     all_resources = sorted(datasets.find_all_matching_datasets(r"\w.*"))
     home = os.path.expanduser("~")
     try:
-        resource_dir = resource_filename("ctapipe_resources", "")
+        resource_dir = files("ctapipe_resources")
     except ImportError:
         resource_dir = None
 

--- a/ctapipe/tools/utils.py
+++ b/ctapipe/tools/utils.py
@@ -2,7 +2,13 @@
 """Utils to create scripts and command-line tools"""
 import argparse
 import importlib
+import sys
 from collections import OrderedDict
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import distribution
+else:
+    from importlib.metadata import distribution
 
 __all__ = [
     "ArgparseFormatter",
@@ -38,9 +44,11 @@ def get_installed_tools():
     TODO: not sure if this will be useful ... maybe to check if the list
     of installed packages matches the available scripts somehow?
     """
-    from pkg_resources import get_entry_map
-
-    console_tools = get_entry_map("ctapipe")["console_scripts"]
+    console_tools = {
+        ep.name: ep.value
+        for ep in distribution("ctapipe").entry_points
+        if ep.group == "console_scripts"
+    }
     return console_tools
 
 
@@ -49,8 +57,9 @@ def get_all_descriptions():
     tools = get_installed_tools()
 
     descriptions = OrderedDict()
-    for name, info in tools.items():
-        module = importlib.import_module(info.module_name)
+    for name, value in tools.items():
+        module_name, attr = value.split(":")
+        module = importlib.import_module(module_name)
         if hasattr(module, "__doc__") and module.__doc__ is not None:
             try:
                 descrip = module.__doc__

--- a/ctapipe/utils/datasets.py
+++ b/ctapipe/utils/datasets.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import yaml
 from astropy.table import Table
-from pkg_resources import resource_listdir
 from requests.exceptions import HTTPError
 
 from .download import download_file_cached, get_cache_path
@@ -31,8 +30,11 @@ from ..core import Provenance
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    "get_dataset_path", "find_in_path", "find_all_matching_datasets",
-    "get_default_url", "DEFAULT_URL"
+    "get_dataset_path",
+    "find_in_path",
+    "find_all_matching_datasets",
+    "get_default_url",
+    "DEFAULT_URL",
 ]
 
 
@@ -66,7 +68,10 @@ def get_searchpath_dirs(searchpath=None, url=None):
 
 
 def find_all_matching_datasets(
-    pattern, searchpath=None, regexp_group=None, url=None,
+    pattern,
+    searchpath=None,
+    regexp_group=None,
+    url=None,
 ):
     """
     Returns a list of resource names (or substrings) matching the given
@@ -111,13 +116,13 @@ def find_all_matching_datasets(
 
     # then check resources module
     if has_resources:
-        for resource in resource_listdir("ctapipe_resources", ""):
-            match = re.match(pattern, resource)
+        for resource in files("ctapipe_resources").iterdir():
+            match = re.match(pattern, resource.name)
             if match:
                 if regexp_group is not None:
                     results.add(match.group(regexp_group))
                 else:
-                    results.add(Path(resource))
+                    results.add(resource)
 
     return list(results)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ exclude = '''
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error::DeprecationWarning",
-    "error::PendingDeprecationWarning",
     "error::astropy.utils.exceptions.AstropyDeprecationWarning",
     "error::ctapipe.utils.deprecation.CTAPipeDeprecationWarning",
 ]


### PR DESCRIPTION
pkg_resources is deprecated in general and importlib.{resources,metadata} designed to replace it.

Recently, just importing pkg_resources raises a `DeprecationWarning`.

This also replaces an external dependency with using python's stdlib (or a backport for older versions that do not yet have everything we need)