### PR TITLE
Use ruff instead of isort/flake8 in pre-commit, add pre-commit CI workflow

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,9 +1,0 @@
----
-engines:
- pylint:
-   enabled: true
-   python_version: 3
- pyflakes:
-   disable:
-     - F999
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Static codechecks
         run: |
-          flake8 ctapipe
+          ruff .
           restructuredtext-lint README.rst
 
       - name: ctapipe-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
-          pip install codecov pytest-cov flake8 restructuredtext-lint pytest-xdist 'coverage!=6.3.0'
           pip install .[all]
           pip install ./test_plugin
           pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
 
       - name: Static codechecks
         run: |
-          ruff .
           restructuredtext-lint README.rst
 
       - name: ctapipe-info

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install pre-commit
+          pre-commit install
+      - name: Lint
+        run: |
+          pre-commit run --files $(git diff origin/main --name-only)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,20 +13,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pre-commit
-            ~/.cache/pip
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Setup python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          pip install pre-commit
-          pre-commit install
-      - name: Lint
-        run: |
-          pre-commit run --files $(git diff origin/main --name-only)
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --files $(git diff origin/main --name-only)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,10 @@
 repos:
-  # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.252'
     hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black-jupyter
-  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        args: [--max-line-length=88, "--extend-ignore=E203,E712"]

--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """
+
 Functions to help adapt internal ctapipe data to astropy formats and conventions
 """
 import os
@@ -65,7 +66,6 @@ def read_table(
     """
 
     with ExitStack() as stack:
-
         if not isinstance(h5file, tables.File):
             h5file = stack.enter_context(tables.open_file(h5file))
 

--- a/docs/changes/2267.maintenance.rst
+++ b/docs/changes/2267.maintenance.rst
@@ -1,0 +1,6 @@
+We now use ``ruff``, a fast linter and formatter.
+``ruff`` Replaces ``isort``, ``flake8``, ``pylint``, and the codacy CI.
+
+- ``ruff`` is used as a pre-commit
+- ``pre-commit`` is used in a separate CI workflow,
+  that way, the linting CI does not diverge from the local pre-commit hooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,7 @@ filterwarnings = [
         path = ""
 
 [tool.ruff]
- # F: pyflakes, E/W: pycodestyle, I: isort, N: pep8-naming, PL: pylint
- select = ["F", "E", "W", "I", "N", "PL"]
+# F: pyflakes, E/W: pycodestyle, I: isort, N: pep8-naming, PL: pylint
+select = ["F", "E", "W", "I", "N", "PL"]
+[tool.ruff.per-file-ignores]
+"test_*.py" = ["PLR2004"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,7 @@ filterwarnings = [
     [[tool.towncrier.section]]
         name = ""
         path = ""
+
+[tool.ruff]
+ # F: pyflakes, E/W: pycodestyle, I: isort, N: pep8-naming, PL: pylint
+ select = ["F", "E", "W", "I", "N", "PL"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,9 @@ install_requires=
 [options.extras_require]
 tests =
     pytest
+    pytest-cov
+    pytest-xdist
+    coverage != 6.3.0
     pandas ~=1.0
     tomli
     pytest_astropy_header
@@ -67,6 +70,7 @@ docs =
     graphviz
     pandas
     ipython
+    restructuredtext-lint
 
 dev =
     setuptools_scm[toml]


### PR DESCRIPTION
A few weeks ago I found [ruff](https://github.com/charliermarsh/ruff), which is a python linter and fixer. According to [testimonials](https://github.com/charliermarsh/ruff#testimonials) and personal experience it is super-fast.  It checks everything from `flake8` to `isort` to `pylint` (and `black` is currently being implemented) in a single run:
```
$ hyperfine 'ruff .' 'flake8 .' -i -r 100
Benchmark 1: ruff .
  Time (mean ± σ):      58.0 ms ±   4.6 ms    [User: 32.9 ms, System: 83.4 ms]
  Range (min … max):    43.2 ms …  66.8 ms    100 runs

  Warning: Ignoring non-zero exit code.

Benchmark 2: flake8 .
  Time (mean ± σ):     706.4 ms ±  18.0 ms    [User: 12423.5 ms, System: 782.9 ms]
  Range (min … max):   677.1 ms … 767.5 ms    100 runs

  Warning: Ignoring non-zero exit code.

Summary
  'ruff .' ran
   12.19 ± 1.01 times faster than 'flake8 .'
```

* This PR uses ruff instead of isort/flake8 in the pre-commit config and adds a new CI workflow that runs `pre-commit` on the changed files. Additionally pylint-checks are done by ruff. 
* Ruff ignores `PLR2004 Magic value used in comparison, consider replacing 2 with a constant variable` in test files.
* This PR removes the codacy configuration, which had only pylint configured, because that is taken care of by pre-commit and the CI
* I added a commit that changes a file with errors, for debugging the CI and displaying how it works. That one must be reverted before merging.

I also moved some `pip installs` from the workflow files into the `setup.cfg`, to clean up a little.