### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_call:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-issue-stale: 30
+          days-before-issue-close: 5
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-pr-stale: 45
+          days-before-pr-close: 10
+          exempt-all-pr-milestones: true  # don't stale PRs that have a milestone attached
+          debug-only: true


### PR DESCRIPTION
This adds the [stale action](https://github.com/actions/stale) from github.

to be discussed: the number of days before issues/pr get labeled as `stale` and how long after that before it gets closed.

Currently this does not label PRs that have a milestone.

I could not find a way to include the number of comments as a filter, but anyways I think it is ok to mark long discussions as stale, when they are old. In any case, one can just remove the `stale`-label and the counter starts again.