### PR TITLE
Use pre-commit/action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,13 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
-          pip install codecov pytest-cov flake8 restructuredtext-lint pytest-xdist 'coverage!=6.3.0'
+          pip install codecov pytest-cov restructuredtext-lint pytest-xdist 'coverage!=6.3.0'
           pip install .[all]
           pip install ./test_plugin
           pip freeze
 
       - name: Static codechecks
         run: |
-          flake8 ctapipe
           restructuredtext-lint README.rst
 
       - name: ctapipe-info

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --files $(git diff origin/main --name-only)


### PR DESCRIPTION
This PR adds a new CI workflow that uses [pre-commit/action](https://github.com/pre-commit/action).  It runs our pre-commit hooks on the changed files.

This really does no more than what happens locally.  My goal is that the CI and the local workflow should not differ (too much).  Developers should be able to locally debug errors caught by the CI without much hassle.

Partially supersedes #2267.