### PR TITLE
Fix overwrite not working for ctapipe-apply-models

### DIFF
--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -111,6 +111,13 @@ class ApplyModels(Tool):
             "Include true images",
             "Exclude true images",
         ),
+        "overwrite": (
+            {
+                "H5Merger": {"overwrite": True},
+                "ApplyModels": {"overwrite": True},
+            },
+            "Overwrite output file if it exists",
+        ),
     }
 
     classes = [TableLoader] + classes_with_traits(Reconstructor)

--- a/docs/changes/2287.bugfix.rst
+++ b/docs/changes/2287.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--overwrite`` option not taking effect for ``ctapipe-apply-models``.


### PR DESCRIPTION
Because there was no alias defined for the `HDF5Merger` component the `--overwrite` option had no effect for `ctapipe-apply-models`.