### PR TITLE
Make ReconstructionProperties into a Flag enum to support same reconstructor providing many properties

### DIFF
--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -32,6 +32,7 @@ from ..core import traits
 from .reconstructor import (
     GeometryReconstructor,
     InvalidWidthException,
+    ReconstructionProperty,
     TooFewTelescopesException,
 )
 
@@ -73,6 +74,8 @@ class HillasIntersection(GeometryReconstructor):
     weighting = traits.CaselessStrEnum(
         ["Konrad", "hess"], default_value="Konrad", help="Weighting Method name"
     ).tag(config=True)
+
+    property = ReconstructionProperty.GEOMETRY
 
     def __init__(self, subarray, **kwargs):
         """

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -22,6 +22,7 @@ from ..coordinates import (
 from .reconstructor import (
     GeometryReconstructor,
     InvalidWidthException,
+    ReconstructionProperty,
     TooFewTelescopesException,
 )
 
@@ -105,6 +106,8 @@ class HillasReconstructor(GeometryReconstructor):
     uncertainty on the reconstructed parameters
 
     """
+
+    property = ReconstructionProperty.GEOMETRY
 
     def __init__(self, subarray, **kwargs):
         super().__init__(subarray=subarray, **kwargs)

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -42,7 +42,7 @@ class ReconstructionProperty(Flag):
     DISP = auto()
 
     def __str__(self):
-        return f"{self.name}"
+        return f"{self.name.lower()}"
 
 
 class TooFewTelescopesException(Exception):

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -1,6 +1,6 @@
 import weakref
 from abc import abstractmethod
-from enum import Enum
+from enum import Flag, auto
 
 import astropy.units as u
 import joblib
@@ -22,22 +22,27 @@ __all__ = [
 ]
 
 
-class ReconstructionProperty(str, Enum):
+class ReconstructionProperty(Flag):
     """
     Primary particle properties estimated by a `Reconstructor`
 
-    The str values of this enum are used for data storage.
+    These properties are of enum.Flag type and can thus be
+    combined using bitwise operators to indicate a reconstructor
+    provides several properties at once.
     """
 
     #: Energy if the primary particle
-    ENERGY = "energy"
+    ENERGY = auto()
     #: Geometric properties of the primary particle,
     #: direction and impact point
-    GEOMETRY = "geometry"
+    GEOMETRY = auto()
     #: Prediction score that a particle belongs to a certain class
-    PARTICLE_TYPE = "classification"
+    PARTICLE_TYPE = auto()
     #: Disp, distance of the source position from the Hillas COG along the main axis
-    DISP = "disp"
+    DISP = auto()
+
+    def __str__(self):
+        return f"{self.name}"
 
 
 class TooFewTelescopesException(Exception):

--- a/ctapipe/reco/stereo_combination.py
+++ b/ctapipe/reco/stereo_combination.py
@@ -19,9 +19,9 @@ from ..containers import (
 from .utils import add_defaults_and_meta
 
 _containers = {
-    "energy": ReconstructedEnergyContainer,
-    "classification": ParticleClassificationContainer,
-    "geometry": ReconstructedGeometryContainer,
+    ReconstructionProperty.ENERGY: ReconstructedEnergyContainer,
+    ReconstructionProperty.PARTICLE_TYPE: ParticleClassificationContainer,
+    ReconstructionProperty.GEOMETRY: ReconstructedGeometryContainer,
 }
 
 __all__ = [
@@ -107,12 +107,12 @@ class StereoMeanCombiner(StereoCombiner):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        supported = {
+        self.supported = {
             ReconstructionProperty.ENERGY,
             ReconstructionProperty.GEOMETRY,
             ReconstructionProperty.PARTICLE_TYPE,
         }
-        if self.property not in supported:
+        if self.property not in self.supported:
             raise NotImplementedError(
                 f"Combination of {self.property} not implemented in {self.__class__.__name__}"
             )
@@ -267,14 +267,21 @@ class StereoMeanCombiner(StereoCombiner):
         """
         Calculate the mean prediction for a single array event.
         """
-        if self.property is ReconstructionProperty.ENERGY:
-            self._combine_energy(event)
 
-        elif self.property is ReconstructionProperty.PARTICLE_TYPE:
-            self._combine_classification(event)
+        properties = [
+            self.property & itm
+            for itm in self.supported
+            if self.property & itm in ReconstructionProperty
+        ]
+        for propert in properties:
+            if property is ReconstructionProperty.ENERGY:
+                self._combine_energy(event)
 
-        elif self.property is ReconstructionProperty.GEOMETRY:
-            self._combine_altaz(event)
+            elif property is ReconstructionProperty.PARTICLE_TYPE:
+                self._combine_classification(event)
+
+            elif property is ReconstructionProperty.GEOMETRY:
+                self._combine_altaz(event)
 
     def predict_table(self, mono_predictions: Table) -> Table:
         """

--- a/ctapipe/reco/stereo_combination.py
+++ b/ctapipe/reco/stereo_combination.py
@@ -273,14 +273,14 @@ class StereoMeanCombiner(StereoCombiner):
             for itm in self.supported
             if self.property & itm in ReconstructionProperty
         ]
-        for propert in properties:
-            if property is ReconstructionProperty.ENERGY:
+        for prop in properties:
+            if prop is ReconstructionProperty.ENERGY:
                 self._combine_energy(event)
 
-            elif property is ReconstructionProperty.PARTICLE_TYPE:
+            elif prop is ReconstructionProperty.PARTICLE_TYPE:
                 self._combine_classification(event)
 
-            elif property is ReconstructionProperty.GEOMETRY:
+            elif prop is ReconstructionProperty.GEOMETRY:
                 self._combine_altaz(event)
 
     def predict_table(self, mono_predictions: Table) -> Table:

--- a/ctapipe/reco/tests/test_sklearn.py
+++ b/ctapipe/reco/tests/test_sklearn.py
@@ -129,7 +129,7 @@ def test_regressor(model_cls, example_table, log_target, example_subarray):
     assert np.isfinite(reco_energy[valid]).all()
     assert np.isnan(reco_energy[~valid]).all()
 
-    assert regressor.stereo_combiner.property == "energy"
+    assert regressor.stereo_combiner.property == ReconstructionProperty.ENERGY
     assert regressor.stereo_combiner.prefix == model_cls
 
 

--- a/ctapipe/tools/tests/test_apply_models.py
+++ b/ctapipe/tools/tests/test_apply_models.py
@@ -35,7 +35,7 @@ def test_apply_energy_regressor(
         raises=True,
     )
     assert ret == 0
-
+    print(output_path)
     prefix = "ExtraTreesRegressor"
     table = read_table(output_path, f"/dl2/event/subarray/energy/{prefix}")
     for col in "obs_id", "event_id":
@@ -107,7 +107,7 @@ def test_apply_all(
     prefix_en = "ExtraTreesRegressor"
     prefix_disp = "disp"
 
-    table = read_table(output_path, f"/dl2/event/subarray/classification/{prefix_clf}")
+    table = read_table(output_path, f"/dl2/event/subarray/particle_type/{prefix_clf}")
     for col in "obs_id", "event_id":
         # test file is produced using 0.17, the descriptions don't match
         # assert table[col].description == EventIndexContainer.fields[col].description
@@ -134,7 +134,7 @@ def test_apply_all(
     trigger = read_table(output_path, "/dl1/event/subarray/trigger")
 
     subarray_tables = (
-        f"/dl2/event/subarray/classification/{prefix_clf}",
+        f"/dl2/event/subarray/particle_type/{prefix_clf}",
         f"/dl2/event/subarray/geometry/{prefix_disp}",
         f"/dl2/event/subarray/energy/{prefix_en}",
     )
@@ -146,7 +146,7 @@ def test_apply_all(
     tel_trigger = read_table(output_path, "/dl1/event/telescope/trigger")
     for tel_id in subarray.tel:
         tel_keys = (
-            f"/dl2/event/telescope/classification/{prefix_clf}/tel_{tel_id:03d}",
+            f"/dl2/event/telescope/particle_type/{prefix_clf}/tel_{tel_id:03d}",
             f"/dl2/event/telescope/geometry/{prefix_disp}/tel_{tel_id:03d}",
             f"/dl2/event/telescope/energy/{prefix_en}/tel_{tel_id:03d}",
         )


### PR DESCRIPTION
A first start at addressing the need in #2291 of a reconstructor indicating it reconstructs many properties. 

I changed  `ReconstructionProperties` into a enum of `Flag` type, meaning a reconstructor can say it provides both geometry and particle type by setting
`self.property = ReconstructionProperty.ENERGY | ReconstructionProperty.PARTICLE_TYPE`

It is also possible to pick out a list of properties a reconstructor supports given a flag combination in `self.property` using this (slightly unreadable) list comprehension
```
        properties = [
            self.property & itm
            for itm in self.supported
            if self.property & itm in ReconstructionProperty
        ]
``` 