### PR TITLE
Rename GeometryReco to HillasGeometryReco

### DIFF
--- a/ctapipe/reco/__init__.py
+++ b/ctapipe/reco/__init__.py
@@ -5,7 +5,11 @@
 from .hillas_intersection import HillasIntersection
 from .hillas_reconstructor import HillasReconstructor
 from .impact import ImPACTReconstructor
-from .reconstructor import GeometryReconstructor, ReconstructionProperty, Reconstructor
+from .reconstructor import (
+    HillasGeometryReconstructor,
+    ReconstructionProperty,
+    Reconstructor,
+)
 from .shower_processor import ShowerProcessor
 from .sklearn import (
     CrossValidator,
@@ -17,7 +21,7 @@ from .stereo_combination import StereoCombiner, StereoMeanCombiner
 
 __all__ = [
     "Reconstructor",
-    "GeometryReconstructor",
+    "HillasGeometryReconstructor",
     "ReconstructionProperty",
     "ShowerProcessor",
     "HillasReconstructor",

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -30,7 +30,7 @@ from ..coordinates import (
 )
 from ..core import traits
 from .reconstructor import (
-    GeometryReconstructor,
+    HillasGeometryReconstructor,
     InvalidWidthException,
     TooFewTelescopesException,
 )
@@ -44,7 +44,7 @@ INVALID = ReconstructedGeometryContainer(
 )
 
 
-class HillasIntersection(GeometryReconstructor):
+class HillasIntersection(HillasGeometryReconstructor):
     """
     This class is a simple re-implementation of Hillas parameter based event
     reconstruction. e.g. https://arxiv.org/abs/astro-ph/0607333
@@ -249,8 +249,8 @@ class HillasIntersection(GeometryReconstructor):
             az=sky_pos.altaz.az.to(u.rad),
             core_x=grd.x,
             core_y=grd.y,
-            core_tilted_x=u.Quantity(core_x, u.m),
-            core_tilted_y=u.Quantity(core_y, u.m),
+            core_tilted_x=tilt.x,
+            core_tilted_y=tilt.y,
             core_tilted_uncert_x=u.Quantity(core_err_x, u.m),
             core_tilted_uncert_y=u.Quantity(core_err_y, u.m),
             telescopes=[h for h in hillas_dict_mod.keys()],

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -20,7 +20,7 @@ from ..coordinates import (
     project_to_ground,
 )
 from .reconstructor import (
-    GeometryReconstructor,
+    HillasGeometryReconstructor,
     InvalidWidthException,
     TooFewTelescopesException,
 )
@@ -94,7 +94,7 @@ def line_line_intersection_3d(uvw_vectors, origins):
     return np.linalg.inv(S) @ C
 
 
-class HillasReconstructor(GeometryReconstructor):
+class HillasReconstructor(HillasGeometryReconstructor):
     """
     class that reconstructs the direction of an atmospheric shower
     using a simple hillas parametrisation of the camera images it

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -144,7 +144,7 @@ class Reconstructor(TelescopeComponent):
 
 class HillasGeometryReconstructor(Reconstructor):
     """
-    Base class for algorithms predicting only the shower geometry
+    Base class for algorithms predicting only the shower geometry using Hillas Based methods
     """
 
     def _create_hillas_dict(self, event):

--- a/ctapipe/reco/reconstructor.py
+++ b/ctapipe/reco/reconstructor.py
@@ -15,7 +15,7 @@ from ..coordinates import shower_impact_distance
 
 __all__ = [
     "Reconstructor",
-    "GeometryReconstructor",
+    "HillasGeometryReconstructor",
     "TooFewTelescopesException",
     "InvalidWidthException",
     "ReconstructionProperty",
@@ -142,7 +142,7 @@ class Reconstructor(TelescopeComponent):
         return instance
 
 
-class GeometryReconstructor(Reconstructor):
+class HillasGeometryReconstructor(Reconstructor):
     """
     Base class for algorithms predicting only the shower geometry
     """

--- a/ctapipe/reco/tests/test_shower_processor.py
+++ b/ctapipe/reco/tests/test_shower_processor.py
@@ -9,14 +9,14 @@ from traitlets.config.loader import Config
 
 from ctapipe.calib import CameraCalibrator
 from ctapipe.image import ImageProcessor
-from ctapipe.reco import GeometryReconstructor, ShowerProcessor
+from ctapipe.reco import HillasGeometryReconstructor, ShowerProcessor
 
 
 @pytest.mark.parametrize(
     "reconstructor_types",
     [
         [reco_type]
-        for reco_type in GeometryReconstructor.non_abstract_subclasses().keys()
+        for reco_type in HillasGeometryReconstructor.non_abstract_subclasses().keys()
     ]
     + [["HillasReconstructor", "HillasIntersection"]],
 )

--- a/docs/changes/2293.api.rst
+++ b/docs/changes/2293.api.rst
@@ -1,0 +1,1 @@
+Renames ``GeometryReconstructor`` to ``HillasGeometryReconstructor``


### PR DESCRIPTION
Fixes parts of #2291, specifically

> the GeometryReconstructor base class is poorly named, as it is really specific to Hillas-parameter based methods that would be inappropriate for e.g. a deep-learning or model based geometry reconstruction, and it does not set property=ReconstructionProperty.geometry in any case. HillasGeometryReconstructor would be a be better name