### PR TITLE
Install ffmpeg on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,13 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  apt_packages:
+    - ffmpeg
+  tools:
+    python: "3.8"
+
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
This adds the ffmpeg package to the readthedocs config.


I also enabled pull request builds on readthedocs, so we should be notified of issues now in PRs and be able to preview the docs.