### PR TITLE
Improve info tool dependencies option

### DIFF
--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -53,7 +53,7 @@ def get_module_version(name):
     try:
         module = import_module(name)
         return module.__version__
-    except AttributeError:
+    except (AttributeError, ModuleNotFoundError):
         try:
             return version(name)
         except Exception:

--- a/ctapipe/tools/tests/test_info.py
+++ b/ctapipe/tools/tests/test_info.py
@@ -1,0 +1,78 @@
+"""Test ctapipe-info functionality."""
+
+
+def test_info_version(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--version",
+    )
+
+    assert result.success
+    assert result.stderr == ""
+
+
+def test_info_tools(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--tools",
+    )
+
+    assert result.success
+    assert result.stderr == ""
+
+
+def test_info_dependencies(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--dependencies",
+    )
+
+    assert result.success
+    assert result.stderr == ""
+
+
+def test_info_system(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--system",
+    )
+
+    assert result.success
+    assert result.stderr == ""
+
+
+def test_info_plugins(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--plugins",
+    )
+
+    assert result.success
+    assert result.stderr == ""
+
+
+def test_info_eventsources(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--event-sources",
+    )
+
+    assert result.success
+    assert result.stderr == ""
+
+
+def test_info_all(script_runner):
+
+    result = script_runner.run(
+        "ctapipe-info",
+        "--all",
+    )
+
+    assert result.success
+    assert result.stderr == ""

--- a/ctapipe/tools/tests/test_tools.py
+++ b/ctapipe/tools/tests/test_tools.py
@@ -53,12 +53,6 @@ def test_display_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
     run_tool(DisplayDL1Calib(), ["--help-all"], raises=True)
 
 
-def test_info():
-    from ctapipe.tools.info import info
-
-    info(show_all=True)
-
-
 def test_fileinfo(tmp_path, dl1_image_file):
     """check we can run ctapipe-fileinfo and get results"""
     import yaml

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - psutil
   - pytables
   - pytest
+  - pytest-console-scripts
   - pytest-cov
   - pytest-runner
   - pytest-astropy-header

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ tests =
     tomli
     pytest_astropy_header
     h5py
-
+    pytest-console-scripts
 
 docs =
     sphinx ~=3.5


### PR DESCRIPTION
While porting this for SWGO software I modified the code to read the dependencies at runtime from `setup.cfg` (like we do already for the Sphinx documentation configuration).

While doing this I noticed that the code using `importlib.import_module` sometimes gives rise to a `ModuleNotFoundError`exception, so I added it to the first `try/except` block to fallback to `importlib.metadata.version` and only if that also fails we give up.

I also used [pytest-console-scripts](https://github.com/kvas-it/pytest-console-scripts) to create 1 test for each flag (but see [this issue](https://github.com/kvas-it/pytest-console-scripts/issues/57) I opened there, even though I tested each of them separately).