### PR TITLE
Remove unused codecov (got yanked from pypi)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install dependencies
         run: |
           python --version
-          pip install codecov pytest-cov restructuredtext-lint pytest-xdist 'coverage!=6.3.0'
+          pip install pytest-cov restructuredtext-lint pytest-xdist 'coverage!=6.3.0'
           pip install .[all]
           pip install ./test_plugin
           pip freeze


### PR DESCRIPTION
This tool was deprecated since a long time, we didn't actually use it anymore, but is was still being installed.

Today, the whole project got removed from pypi