### PR TITLE
Add possibility to compute multiplicities using `FeatureGenerator`

### DIFF
--- a/ctapipe/core/feature_generator.py
+++ b/ctapipe/core/feature_generator.py
@@ -1,6 +1,8 @@
 """
 Generate Features.
 """
+from collections import ChainMap
+
 from .component import Component
 from .expression_engine import ExpressionEngine
 from .traits import List, Tuple, Unicode
@@ -51,7 +53,7 @@ class FeatureGenerator(Component):
         self.engine = ExpressionEngine(expressions=self.features)
         self._feature_names = [name for name, _ in self.features]
 
-    def __call__(self, table):
+    def __call__(self, table, **kwargs):
         """
         Apply feature generation to the input table.
 
@@ -60,8 +62,9 @@ class FeatureGenerator(Component):
         however the new columns won't be visible in the input table.
         """
         table = _shallow_copy_table(table)
+        lookup = ChainMap(table, kwargs)
 
-        for result, name in zip(self.engine(table), self._feature_names):
+        for result, name in zip(self.engine(lookup), self._feature_names):
             if name in table.colnames:
                 raise FeatureGeneratorException(f"{name} is already a column of table.")
             try:

--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -427,7 +427,7 @@ class SubarrayDescription:
 
     def get_tel_ids_for_type(self, tel_type) -> Tuple[int]:
         """
-        return list of tel_ids that have the given tel_type
+        return tuple of tel_ids that have the given tel_type
 
         Parameters
         ----------
@@ -447,6 +447,25 @@ class SubarrayDescription:
             return tuple(
                 tel_id for tel_id, descr in self.tels.items() if str(descr) == tel_type
             )
+
+    def get_tel_indices_for_type(self, tel_type):
+        """
+        return tuple of telescope indices that have the given tel_type
+
+        Parameters
+        ----------
+        tel_type: str or TelescopeDescription
+           telescope type string (e.g. 'MST_MST_NectarCam')
+        """
+        return self.tel_ids_to_indices(self.get_tel_ids_for_type(tel_type))
+
+    def multiplicity(self, tel_mask, tel_type=None):
+        if tel_type is None:
+            return np.count_nonzero(tel_mask, axis=-1)
+
+        return np.count_nonzero(
+            tel_mask[..., self.get_tel_indices_for_type(tel_type)], axis=-1
+        )
 
     def get_tel_ids(
         self, telescopes: Iterable[Union[int, str, TelescopeDescription]]

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -246,3 +246,27 @@ def test_unknown_telescopes(example_subarray):
 
     with pytest.raises(UnknownTelescopeID):
         example_subarray.select_subarray([300, 201])
+
+
+def test_multiplicity(subarray_prod5_paranal):
+
+    subarray = subarray_prod5_paranal.select_subarray([1, 2, 20, 21, 80, 81])
+
+    mask = np.array([True, False, True, True, False, False])
+
+    assert subarray.multiplicity(mask) == 3
+    assert subarray.multiplicity(mask, "LST_LST_LSTCam") == 1
+    assert subarray.multiplicity(mask, "MST_MST_FlashCam") == 2
+    assert subarray.multiplicity(mask, "SST_ASTRI_CHEC") == 0
+
+    masks = np.array(
+        [
+            [True, False, True, True, False, False],
+            [True, True, False, True, False, True],
+        ]
+    )
+
+    np.testing.assert_equal(subarray.multiplicity(masks), [3, 4])
+    np.testing.assert_equal(subarray.multiplicity(masks, "LST_LST_LSTCam"), [1, 2])
+    np.testing.assert_equal(subarray.multiplicity(masks, "MST_MST_FlashCam"), [2, 1])
+    np.testing.assert_equal(subarray.multiplicity(masks, "SST_ASTRI_CHEC"), [0, 1])


### PR DESCRIPTION
Add `multiplicity` method to `SubarrayDescription` and use a `ChainMap` to allow additional information to be passed to the `FeatureGenerator` other than the table to allow calling `SubarrayDescription.multiplicity` in `FeatureGenerator`.