### PR TITLE
Allow training without cross validation

### DIFF
--- a/ctapipe/reco/sklearn.py
+++ b/ctapipe/reco/sklearn.py
@@ -848,6 +848,9 @@ class CrossValidator(Component):
             )
 
     def __call__(self, telescope_type, table):
+        if self.n_cross_validations == 0:
+            return
+
         if len(table) <= self.n_cross_validations:
             raise TooFewEvents(f"Too few events for {telescope_type}.")
 
@@ -941,6 +944,9 @@ class CrossValidator(Component):
         return prediction, truth, {"R^2": r2, "accuracy": accuracy}
 
     def write(self, overwrite=False):
+        if self.n_cross_validations == 0:
+            return 0
+
         if self.output_path.exists() and not overwrite:
             raise IOError(f"Path {self.output_path} exists and overwrite=False")
 

--- a/ctapipe/tools/tests/test_train.py
+++ b/ctapipe/tools/tests/test_train.py
@@ -122,3 +122,25 @@ def test_cross_validation_results(tmp_path, gamma_train_clf, proton_train_clf):
     )
     assert ret == 0
     assert disp_cv_out_file.exists()
+
+
+def test_no_cross_validation(tmp_path):
+    from ctapipe.tools.train_energy_regressor import TrainEnergyRegressor
+
+    out_file = tmp_path / "energy.pkl"
+
+    tool = TrainEnergyRegressor()
+    config = resource_file("train_energy_regressor.yaml")
+    ret = run_tool(
+        tool,
+        argv=[
+            "--input=dataset://gamma_diffuse_dl2_train_small.dl2.h5",
+            f"--output={out_file}",
+            f"--config={config}",
+            "--CrossValidator.n_cross_validations=0",
+            "--log-level=INFO",
+            "--overwrite",
+        ],
+    )
+    assert ret == 0
+    return out_file

--- a/docs/changes/2310.feature.rst
+++ b/docs/changes/2310.feature.rst
@@ -1,0 +1,2 @@
+Allow disabling the cross validation (by setting ``CrossValidator.n_cross_validations = 0``)
+for the train tools.


### PR DESCRIPTION
Cross validation is handy for hyper parameter optimization locally, but for large GRID processings, we determine performance on the independent test data set, so we are just wasting CPU by doing an n-fold cross validation no-one looks at.

Setting `n_cross_validations = 0` raised an error, so here I make sure that works.