### PR TITLE
Fix --overwrite for ApplyModel tool

### DIFF
--- a/ctapipe/tools/apply_models.py
+++ b/ctapipe/tools/apply_models.py
@@ -113,7 +113,7 @@ class ApplyModels(Tool):
         ),
         "overwrite": (
             {
-                "H5Merger": {"overwrite": True},
+                "HDF5Merger": {"overwrite": True},
                 "ApplyModels": {"overwrite": True},
             },
             "Overwrite output file if it exists",

--- a/docs/changes/2311.bugfix.rst
+++ b/docs/changes/2311.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ApplyModels.overwrite``.


### PR DESCRIPTION
Tests didn't catch it because for the tests, the output file never exists, I now explicitly added another run of the tests for the `--overwrite` flag.