### PR TITLE
Fix activity start order

### DIFF
--- a/ctapipe/core/tests/test_tool.py
+++ b/ctapipe/core/tests/test_tool.py
@@ -432,6 +432,7 @@ def test_activity(tmp_path):
     """check that the config is correctly in the provenance"""
 
     class MyTool(Tool):
+        name = "test_prov_log"
         description = "test"
         userparam = Float(5.0, help="parameter").tag(config=True)
 
@@ -450,8 +451,13 @@ def test_activity(tmp_path):
         ],
     )
 
-    provlog = json.loads(tool.provenance_log.read_text())
-    inputs = provlog[0]["input"]
+    activities = json.loads(tool.provenance_log.read_text())
+    # provlog contains all activities from all tests, last one is the tool we just ran
+    provlog = activities[-1]
+    assert provlog["activity_name"] == MyTool.name
+
+    # test config file is in inputs, regression test for #2313
+    inputs = provlog["input"]
     assert len(inputs) == 1
     assert inputs[0]["role"] == "Tool Configuration"
     assert inputs[0]["url"] == str(config_path)

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -405,11 +405,14 @@ class Tool(Application):
 
         with self._exit_stack:
             try:
-                self.initialize(argv)
                 self.log.info(f"Starting: {self.name}")
                 Provenance().start_activity(self.name)
+
+                self.initialize(argv)
+
                 self.setup()
                 self.is_setup = True
+
                 self.log.debug(f"CONFIG: {self.get_current_config()}")
                 Provenance().add_config(self.get_current_config())
 

--- a/docs/changes/2312.bugfix.rst
+++ b/docs/changes/2312.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for config files not being included as inputs in provenance log.


### PR DESCRIPTION
By not starting the activity before calling initialize,
an extra activity was started only containing the config files
and the config files were not included in the provenance of the actual
tool run.