### PR TITLE
Fix HDF5EventSource.__len__ if allowed_tels is not None

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -194,7 +194,13 @@ class SubarrayDescription:
         np.array:
             array of corresponding tel indices
         """
-        tel_ids = np.array(tel_ids, dtype=int, copy=False).ravel()
+        if isinstance(tel_ids, (int, np.integer)):
+            pass
+        elif not isinstance(tel_ids, np.ndarray):
+            tel_ids = np.fromiter(tel_ids, dtype=int, count=len(tel_ids))
+        else:
+            tel_ids = np.array(tel_ids, dtype=int, copy=False).ravel()
+
         return self.tel_index_array[tel_ids]
 
     def tel_ids_to_mask(self, tel_ids):

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -91,7 +91,15 @@ def test_tel_indexing(example_subarray):
         assert sub.tel_index_array[tel_id] == sub.tel_indices[tel_id]
 
     assert sub.tel_ids_to_indices(1) == 0
+    assert sub.tel_ids_to_indices(np.uint16(2)) == 1
     assert np.all(sub.tel_ids_to_indices([1, 2, 3]) == np.array([0, 1, 2]))
+
+    # test it also works with sets
+    assert np.all(sub.tel_ids_to_indices({1, 2, 3}) == np.array([0, 1, 2]))
+
+    # and dict-keys
+    tel_data = {1: "foo", 2: "bar", 3: "baz"}
+    assert np.all(sub.tel_ids_to_indices(tel_data.keys()) == np.array([0, 1, 2]))
 
 
 def test_tel_ids_to_mask(prod5_lst):

--- a/ctapipe/io/hdf5eventsource.py
+++ b/ctapipe/io/hdf5eventsource.py
@@ -325,8 +325,19 @@ class HDF5EventSource(EventSource):
         """
         return self._simulation_configs
 
+    @lazyproperty
+    def _n_events_with_allowed_tels(self):
+        if self.allowed_tels is None:
+            return len(self.file_.root.dl1.event.subarray.trigger)
+
+        triggered_tels = self.file_.root.dl1.event.subarray.trigger.col(
+            "tels_with_trigger"
+        )
+        tel_idx = self.subarray.tel_ids_to_indices(self.allowed_tels)
+        return np.count_nonzero(np.any(triggered_tels[:, tel_idx], axis=1))
+
     def __len__(self):
-        n_events = len(self.file_.root.dl1.event.subarray.trigger)
+        n_events = self._n_events_with_allowed_tels
         if self.max_events is not None:
             return min(n_events, self.max_events)
         return n_events


### PR DESCRIPTION
One of the possible solutions for #2324, however, this performs a potentially expensive operation just to get the correct `__len__`, which is currently only used to provide a nice progress bar, so it might be better just to remove `__len__`.