### PR TITLE
Make provenance information in log optional

### DIFF
--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -173,6 +173,13 @@ class Tool(Application):
         help="Logging Level for File Logging",
     ).tag(config=True)
 
+    log_include_provenance = Bool(
+        default_value=False,
+        help="Control if provenance information"
+        "is printed in log in addition to the"
+        "provenance file."
+    ).tag(config=True)
+
     quiet = Bool(default_value=False).tag(config=True)
     overwrite = Bool(default_value=False).tag(config=True)
 
@@ -456,7 +463,8 @@ class Tool(Application):
             output_str = " ".join([x["url"] for x in activity.output])
             self.log.info("Output: %s", output_str)
 
-        self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
+        if self.log_include_provenance:
+            self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
         self.provenance_log.parent.mkdir(parents=True, exist_ok=True)
         with open(self.provenance_log, mode="a+") as provlog:
             provlog.write(Provenance().as_json(indent=3))

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -177,7 +177,7 @@ class Tool(Application):
         default_value=False,
         help="Control if provenance information"
         "is printed in log in addition to the"
-        "provenance file."
+        "provenance file.",
     ).tag(config=True)
 
     quiet = Bool(default_value=False).tag(config=True)

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -173,13 +173,6 @@ class Tool(Application):
         help="Logging Level for File Logging",
     ).tag(config=True)
 
-    log_include_provenance = Bool(
-        default_value=False,
-        help="Control if provenance information"
-        "is printed in log in addition to the"
-        "provenance file.",
-    ).tag(config=True)
-
     quiet = Bool(default_value=False).tag(config=True)
     overwrite = Bool(default_value=False).tag(config=True)
 
@@ -463,8 +456,7 @@ class Tool(Application):
             output_str = " ".join([x["url"] for x in activity.output])
             self.log.info("Output: %s", output_str)
 
-        if self.log_include_provenance:
-            self.log.debug("PROVENANCE: '%s'", Provenance().as_json(indent=3))
+        self.log.debug("PROVENANCE: 'Details about provenance is found in %s'",self.provenance_log)
         self.provenance_log.parent.mkdir(parents=True, exist_ok=True)
         with open(self.provenance_log, mode="a+") as provlog:
             provlog.write(Provenance().as_json(indent=3))

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -456,7 +456,9 @@ class Tool(Application):
             output_str = " ".join([x["url"] for x in activity.output])
             self.log.info("Output: %s", output_str)
 
-        self.log.debug("PROVENANCE: 'Details about provenance is found in %s'",self.provenance_log)
+        self.log.debug(
+            "PROVENANCE: 'Details about provenance is found in %s'", self.provenance_log
+        )
         self.provenance_log.parent.mkdir(parents=True, exist_ok=True)
         with open(self.provenance_log, mode="a+") as provlog:
             provlog.write(Provenance().as_json(indent=3))

--- a/docs/changes/2328.feature.rst
+++ b/docs/changes/2328.feature.rst
@@ -1,1 +1,1 @@
-Make provenance information in log optional by adding new configruation option `log_include_provenance` which defaults to off.
+Make provenance information in log optional by adding new configruation option "log_include_provenance" which defaults to off.

--- a/docs/changes/2328.feature.rst
+++ b/docs/changes/2328.feature.rst
@@ -1,1 +1,1 @@
-Make provenance information in log optional by adding new configruation option "log_include_provenance" which defaults to off.
+Remove writing the full provenance information to the log  and instead simply refer the reader to the actual provenance file.

--- a/docs/changes/2328.feature.rst
+++ b/docs/changes/2328.feature.rst
@@ -1,0 +1,1 @@
+Make provenance information in log optional by adding new configruation option `log_include_provenance` which defaults to off.


### PR DESCRIPTION
The inclusion of all the packages in the environment into the provenance information makes it so long it usually completely dominates the line count of any logfile. This change adds a option that defaults to not including provenance in the log (in addition to it being written to a file).