### PR TITLE
Drop support for python 3.8, update env file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --files $(git diff origin/main --name-only)
@@ -33,10 +33,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            python-version: "3.8"
-            install-method: mamba
-
           - os: ubuntu-latest
             python-version: "3.9"
             install-method: mamba
@@ -48,18 +44,18 @@ jobs:
 
           - os: ubuntu-latest
             python-version: "3.11"
-            install-method: pip
+            install-method: mamba
 
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             install-method: pip
 
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
             install-method: mamba
 
           - os: macos-latest
-            python-version: "3.8"
+            python-version: "3.9"
             install-method: pip
 
     defaults:
@@ -147,7 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install doc dependencies
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - ffmpeg
   tools:
-    python: "3.8"
+    python: "3.9"
 
 python:
   install:

--- a/ctapipe/core/provenance.py
+++ b/ctapipe/core/provenance.py
@@ -4,7 +4,6 @@ Provenance-related functionality
 TODO: have this register whenever ctapipe is loaded
 
 """
-
 import json
 import logging
 import os
@@ -14,20 +13,15 @@ import uuid
 from collections import UserList
 from contextlib import contextmanager
 from importlib import import_module
+from importlib.metadata import distributions, version
 from os.path import abspath
 from pathlib import Path
 
 import psutil
 from astropy.time import Time
 
-import ctapipe
-
+from ..version import __version__
 from .support import Singleton
-
-if sys.version_info < (3, 9):
-    from importlib_metadata import distributions, version
-else:
-    from importlib.metadata import distributions, version
 
 log = logging.getLogger(__name__)
 
@@ -318,7 +312,7 @@ def _get_system_provenance():
     bits, linkage = platform.architecture()
 
     return dict(
-        ctapipe_version=ctapipe.__version__,
+        ctapipe_version=__version__,
         ctapipe_resources_version=get_module_version("ctapipe_resources"),
         eventio_version=get_module_version("eventio"),
         ctapipe_svc_path=os.getenv("CTAPIPE_SVC_PATH"),

--- a/ctapipe/tools/info.py
+++ b/ctapipe/tools/info.py
@@ -3,16 +3,12 @@
 import logging
 import os
 import sys
+from importlib.resources import files
 
 from ..core import Provenance, get_module_version
 from ..core.plugins import detect_and_import_plugins
 from ..utils import datasets
 from .utils import get_parser
-
-if sys.version_info < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
 
 __all__ = ["info"]
 

--- a/docs/changes/2342.maintenance.rst
+++ b/docs/changes/2342.maintenance.rst
@@ -1,0 +1,1 @@
+Drop support for python 3.8 in accordance with the NEP 29 schedule.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,7 +266,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/3.9", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - default
 dependencies:
-  - python=3.9
+  - python=3.11
   - pip
   - astropy=5
   - black
@@ -19,8 +19,8 @@ dependencies:
   - joblib
   - jupyter
   - matplotlib
-  - numba=0.56
-  - numpy>=1.17
+  - numba>=0.56
+  - numpy>=1.22
   - numpydoc
   - pandas
   - pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,9 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Astronomy
     Development Status :: 3 - Alpha
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 zip_safe = False
 install_requires=
     astropy ~=5.0


### PR DESCRIPTION
In accordance with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html):

> On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)

Setting to draft for now, since we might do another 0.19.x