### PR TITLE
Improve error messages of expression engine

### DIFF
--- a/ctapipe/core/expression_engine.py
+++ b/ctapipe/core/expression_engine.py
@@ -37,14 +37,16 @@ class ExpressionEngine:
                 ) from err
 
     def __call__(self, locals):
-        for expr in self.compiled:
+        for compiled, expression in zip(self.compiled, self.expressions):
             try:
-                yield eval(expr, ALLOWED_GLOBALS, locals)
+                yield eval(compiled, ALLOWED_GLOBALS, locals)
             except NameError as err:
-                raise ExpressionError(f"Error evaluating expression '{expr}': {err}")
+                raise ExpressionError(
+                    f"Error evaluating expression '{expression}': {err}"
+                ) from None
             except Exception as err:
                 raise ExpressionError(
-                    f"Error evaluating expression '{expr}': {err}"
+                    f"Error evaluating expression '{expression}': {err}"
                 ) from err
 
     def __getstate__(self):


### PR DESCRIPTION
After the change to pre-compiling the expressions in `__init__`, the error messages were very suboptimal:

Before:
```
Error evaluating expression '<code object <module> at 0x7f9a2a2a2660, file "ctapipe.core.expression_engine", line 1>': name 'RandomForestRegresser_is_valid' is not defined
```

After:
```
Error evaluating expression '('ValidEnergy', 'RandomForestRegresser_is_valid')': name 'RandomForestRegresser_is_valid' is not defined
```