### PR TITLE
Fill reference_location into SubarrayDescription.tel_coords

### DIFF
--- a/ctapipe/instrument/subarray.py
+++ b/ctapipe/instrument/subarray.py
@@ -154,7 +154,9 @@ class SubarrayDescription:
         pos_y = [p[1].to_value(u.m) for p in self.positions.values()]
         pos_z = [p[2].to_value(u.m) for p in self.positions.values()]
 
-        return SkyCoord(x=pos_x, y=pos_y, z=pos_z, unit=u.m, frame=GroundFrame())
+        frame = GroundFrame(reference_location=self.reference_location)
+
+        return SkyCoord(x=pos_x, y=pos_y, z=pos_z, unit=u.m, frame=frame)
 
     @lazyproperty
     def tel_ids(self):

--- a/ctapipe/instrument/tests/test_subarray.py
+++ b/ctapipe/instrument/tests/test_subarray.py
@@ -15,6 +15,8 @@ from ctapipe.instrument import (
     TelescopeDescription,
 )
 
+LOCATION = EarthLocation(lon=-17 * u.deg, lat=28 * u.deg, height=2200 * u.m)
+
 
 def create_subarray(tel_type, n_tels=10):
     """generate a simple subarray for testing purposes"""
@@ -31,11 +33,7 @@ def create_subarray(tel_type, n_tels=10):
         "test array",
         tel_positions=pos,
         tel_descriptions=tel,
-        reference_location=EarthLocation(
-            lon=-17 * u.deg,
-            lat=28 * u.deg,
-            height=2200 * u.m,
-        ),
+        reference_location=LOCATION,
     )
 
 
@@ -64,6 +62,8 @@ def test_subarray_description(prod5_mst_nectarcam):
     assert u.isclose(sub.optics_types[0].effective_focal_length, 16.445 * u.m)
     assert isinstance(sub.tel_coords, SkyCoord)
     assert len(sub.tel_coords) == n_tels
+
+    assert sub.tel_coords.reference_location == LOCATION
 
     subsub = sub.select_subarray([2, 3, 4, 6], name="newsub")
     assert subsub.n_tels == 4

--- a/docs/changes/2354.bugfix.rst
+++ b/docs/changes/2354.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly fill ``reference_location`` for ``SubarrayDescription.tel_coords``.


### PR DESCRIPTION
The `GroundFrame` instance of the `SubarrayDescription.tel_coords` instance was missing the `reference_location`, making direct transformation to `EarthLocation` impossible.