### PR TITLE
Fix pixel picking for multiple displays in same figure

### DIFF
--- a/ctapipe/visualization/mpl_camera.py
+++ b/ctapipe/visualization/mpl_camera.py
@@ -520,6 +520,11 @@ class CameraDisplay:
 
     def _on_pick(self, event):
         """handler for when a pixel is clicked"""
+        if event.artist is not self.pixels:
+            # do nothing if the event was triggered by something
+            # other than this displays pixels artist
+            return
+
         pix_id = event.ind[-1]
         x = self.geom.pix_x[pix_id].to_value(self.unit)
         y = self.geom.pix_y[pix_id].to_value(self.unit)

--- a/docs/changes/2358.bugfix.rst
+++ b/docs/changes/2358.bugfix.rst
@@ -1,0 +1,2 @@
+Fix that the pixel picker of the matplotlib ``CameraDisplay`` triggers
+also for clicks on other ``CameraDisplay`` instances in the same figure.


### PR DESCRIPTION
Events are raised on the figure, so we need to check if the artist that triggered the event actually belongs to the current camera display.