### PR TITLE
Add method to write default config to Tool and Component.

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -9,6 +9,7 @@ from docutils.core import publish_parts
 from traitlets import TraitError
 from traitlets.config import Configurable
 
+from . import config_writer
 from .plugins import detect_and_import_plugins
 
 __all__ = ["non_abstract_children", "Component"]
@@ -273,3 +274,29 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         state["_trait_values"]["parent"] = None
         state["_trait_notifiers"] = {}
         return state
+
+    @classmethod
+    def _get_default_config(cls):
+        """
+
+        :return:
+        """
+        conf = {cls.__name__: cls.traits(cls, config=True)}
+
+        return conf
+
+    @classmethod
+    def write_default_config(cls, outname=None):
+        """return the current configuration as a dict (e.g. the values
+        of all traits, even if they were not set during configuration)
+        """
+
+        if outname is None:
+            outname = f"{cls.__name__}.yml"
+
+        conf = cls._get_default_config()
+
+        conf_repr = config_writer.trait_dict_to_yaml(conf)
+
+        with open(outname, "w") as obj:
+            obj.write(conf_repr)

--- a/ctapipe/core/config_writer.py
+++ b/ctapipe/core/config_writer.py
@@ -1,0 +1,62 @@
+import logging
+import textwrap
+
+log = logging.getLogger(__name__)
+
+
+def trait_dict_to_yaml(conf, conf_repr="", indent_level=0):
+    """
+    Using a dictionnary of traits, will write this configuration to file. Each value is either a subsection or a
+    trait object so that we can extract value, default value and help message
+
+    :param conf: Dictionnary of traits. Architecture reflect what is needed in the yaml file.
+    :param str conf_repr: internal variable used for recursivity. You shouldn't use that parameter
+
+    :return: str representation of conf, ready to store in a .yaml file
+    """
+    indent_str = "  "
+
+    for k, v in conf.items():
+        if isinstance(v, dict):
+            conf_repr += f"{indent_str * indent_level}{k}:\n"
+            conf_repr = trait_dict_to_yaml(v, conf_repr, indent_level=indent_level + 1)
+        else:
+            conf_repr += _trait_to_str(v, indent_level=indent_level)
+
+    return conf_repr
+
+
+def _trait_to_str(trait, help=True, indent_level=0):
+    """
+    Represent a trait in a futur yaml file, given prior information on its position.
+
+    :param key:
+    :param trait:
+    :param help:
+    :param indent_level:
+    :return:
+    """
+    indent_str = "  "
+
+    def commented(text, indent_level=indent_level, width=144):
+        """return a commented, wrapped block."""
+        return textwrap.fill(
+            text,
+            width=width,
+            initial_indent=indent_str * indent_level + "# ",
+            subsequent_indent=indent_str * indent_level + "# ",
+        )
+
+    trait_repr = "\n"
+
+    if help:
+        h_msg = trait.help
+
+        if h_msg:
+            trait_repr += f"{commented(h_msg, indent_level=indent_level)}\n"
+
+    trait_repr += (
+        f"{indent_str*indent_level}{trait.name}: {trait.get_default_value()}\n"
+    )
+
+    return trait_repr

--- a/ctapipe/core/tool.py
+++ b/ctapipe/core/tool.py
@@ -27,7 +27,7 @@ from traitlets import List, default
 from traitlets.config import Application, Config, Configurable
 
 from .. import __version__ as version
-from . import Provenance
+from . import Provenance, config_writer
 from .component import Component
 from .logging import ColoredFormatter, create_logging_config
 from .traits import Bool, Dict, Enum, Path
@@ -483,6 +483,36 @@ class Tool(Application):
                 conf[self.__class__.__name__].update(val.get_current_config())
 
         return conf
+
+    @classmethod
+    def _get_default_config(cls):
+        """
+
+        :return:
+        """
+        conf = {cls.__name__: cls.traits(cls, config=True)}
+
+        # Get default configuration for all sub-classes defined
+        for val in cls.classes:
+            conf[cls.__name__].update(val._get_default_config())
+
+        return conf
+
+    @classmethod
+    def write_default_config(cls, outname=None):
+        """return the current configuration as a dict (e.g. the values
+        of all traits, even if they were not set during configuration)
+        """
+
+        if outname is None:
+            outname = f"{cls.__name__}.yml"
+
+        conf = cls._get_default_config()
+
+        conf_repr = config_writer.trait_dict_to_yaml(conf)
+
+        with open(outname, "w") as obj:
+            obj.write(conf_repr)
 
     def _repr_html_(self):
         """nice HTML rep, with blue for non-default values"""

--- a/ctapipe/io/metadata.py
+++ b/ctapipe/io/metadata.py
@@ -93,6 +93,16 @@ class Contact(Configurable):
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.name}, email={self.email}, organization={self.organization})"
 
+    @classmethod
+    def _get_default_config(cls):
+        """
+
+        :return:
+        """
+        conf = {cls.__name__: cls.traits(cls, config=True)}
+
+        return conf
+
 
 class Product(HasTraits):
     """Data product information"""
@@ -217,6 +227,16 @@ class Instrument(Configurable):
             f", subtype={self.subtype}, version={self.version}, id_={self.id_}"
             ")"
         )
+
+    @classmethod
+    def _get_default_config(cls):
+        """
+
+        :return:
+        """
+        conf = {cls.__name__: cls.traits(cls, config=True)}
+
+        return conf
 
 
 def _to_dict(hastraits_instance, prefix=""):


### PR DESCRIPTION
After discussions wit Karl and Tomas, I worked on a way to extract default configuration .yaml file, recursively, directly from the class, without having to instanciate anything. 

This is not yet ready for merging, I create the pull request more for discussing what are your thoughts and requests to make this usefull. 

Current issues are:
* We use the default value of EVERY traits in every class in the hierarchy of a given Tool or Component. 
* When default value is undefined, the default config is then non valid and make it difficult to understand what value we're supposed to use, on top of making the yaml file invalid too, because Undefined can't be a valid input. 

Knowing that:
* Will this functionality ever be useful?
* If so, how do we deal with undefined, does that mean that, apart some key parameters such as input file, we force a valid parameter as default?