### PR TITLE
Add mamba build for python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,15 @@ jobs:
             python-version: "3.10"
             install-method: mamba
             extra-args: ["codecov"]
+            
+          - os: ubuntu-latest
+            python-version: "3.11"
+            install-method: mamba         
 
           - os: ubuntu-latest
             python-version: "3.11"
             install-method: pip
-
+            
           - os: ubuntu-latest
             python-version: "3.10"
             install-method: pip

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - joblib
   - jupyter
   - matplotlib
-  - numba=0.56
+  - numba>=0.56
   - numpy>=1.17
   - numpydoc
   - pandas


### PR DESCRIPTION
I've been using python 3.11 with mamba for a month or so now, so it should be stable enough to test with (currently we only test 3.11 with pip)