### PR TITLE
Bug fix in full numeric pixel likelihood calculation

### DIFF
--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -96,8 +96,9 @@ def neg_log_likelihood_approx(image, prediction, spe_width, pedestal):
     """
     theta = pedestal**2 + prediction * (1 + spe_width**2)
 
-    # This is really 2 times the full log likelihood
-    neg_log_l = np.log(2 * np.pi * theta + EPSILON) + (image - prediction) ** 2 / theta
+    neg_log_l = 0.5 * (
+        np.log(2 * np.pi * theta + EPSILON) + (image - prediction) ** 2 / theta
+    )
 
     return np.sum(neg_log_l)
 

--- a/ctapipe/image/tests/test_pixel_likelihood.py
+++ b/ctapipe/image/tests/test_pixel_likelihood.py
@@ -2,6 +2,7 @@ import numpy as np
 from ctapipe.image import (
     neg_log_likelihood,
     neg_log_likelihood_approx,
+    neg_log_likelihood_numeric,
     mean_poisson_likelihood_gaussian,
     chi_squared,
     mean_poisson_likelihood_full,
@@ -56,11 +57,11 @@ def test_full_likelihood():
 
     full_like_small = neg_log_likelihood(image_small, expectation_small, spe, pedestal)
     exp_diff = full_like_small - np.sum(
-        np.asarray([2.75630505, 2.62168656, 3.39248449])
+        np.asarray([1.37815294, 1.31084662, 1.69627197])
     )
 
     # Check against known values
-    assert exp_diff / np.sum(full_like_small) < 1e-4
+    assert np.abs(exp_diff / np.sum(full_like_small)) < 1e-4
 
     image_large = np.array([40, 50, 60])
     expectation_large = np.array([50, 50, 50])
@@ -68,15 +69,21 @@ def test_full_likelihood():
     full_like_large = neg_log_likelihood(image_large, expectation_large, spe, pedestal)
     # Check against known values
     exp_diff = full_like_large - np.sum(
-        np.asarray([7.45489137, 5.99305388, 7.66226007])
+        np.asarray([3.72744569, 2.99652694, 3.83113004])
     )
 
-    assert exp_diff / np.sum(full_like_large) < 1e-4
+    assert np.abs(exp_diff / np.sum(full_like_large)) < 3e-4
 
     gaus_like_large = neg_log_likelihood_approx(
         image_large, expectation_large, spe, pedestal
     )
 
+    numeric_like_large = neg_log_likelihood_numeric(
+        image_large, expectation_large, spe, pedestal
+    )
+
     # Check thats in large signal case the full expectation is equal to the
     # gaussian approximation (to 5%)
-    assert np.all(np.abs((full_like_large - gaus_like_large) / full_like_large) < 0.05)
+    assert np.all(
+        np.abs((numeric_like_large - gaus_like_large) / numeric_like_large) < 0.05
+    )


### PR DESCRIPTION
This fixes a bug in the implementation of the full numeric pixel likelihood from [de Naurois 2009 ](https://arxiv.org/pdf/0907.2610.pdf), eq 21, in `neg_log_likelihood_numeric`. The approximate likelihood in `neg_log_likelihood_approx` is adjusted for consistency, which is important given they are combined in the `neg_log_likelihood` function. This was not caught in the tests because these also had a bug, which is now fixed too.

I will also implement the fix in the ImPACT branch where the overall pixel likelihood interface changes.  