### PR TITLE
Accept CEP 002

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .pytest_cache
 *.log
+docs/sg_execution_times.rst
 
 # Compiled files
 *.py[co]

--- a/docs/developer-guide/ceps/accepted/cep-002.rst
+++ b/docs/developer-guide/ceps/accepted/cep-002.rst
@@ -4,10 +4,10 @@
 CEP 2 - Event Structure
 ***********************
 
-* Status: draft
-* Discussion: NA
-* Date accepted: NA
-* Last revised: 2023-04-04
+* Status: accepted
+* Discussion: [`#2304 <https://github.com/cta-observatory/ctapipe/pull/2304>`__]
+* Date accepted: 2023-10-26
+* Last revised: 2023-09-08
 * Author: Maximilian Linhoff
 * Created: 2023-04-04
 

--- a/docs/developer-guide/ceps/index.rst
+++ b/docs/developer-guide/ceps/index.rst
@@ -34,6 +34,8 @@ Proposed CEPs
 Rejected CEPs
 =============
 
+There are no rejected CEPs currently.
+
 .. .. toctree::
 ..    :maxdepth: 1
 ..    :glob:

--- a/docs/developer-guide/ceps/proposed/cep-003-remove-image-parameters-in-camera-frame.rst
+++ b/docs/developer-guide/ceps/proposed/cep-003-remove-image-parameters-in-camera-frame.rst
@@ -4,9 +4,9 @@
 CEP 3 - Dropping Support for Image Parameters in CameraFrame
 ************************************************************
 
-* Status: draft
-* Discussion: NA
-* Date accepted: NA
+* Status: proposed
+* Discussion: DataPipe F2F Meeting and [`#2405 <https://github.com/cta-observatory/ctapipe/pull/2405>`__], ctapipe developer meeting 2023-11-24
+* Date accepted: 
 * Last revised: 2023-09-22
 * Author: Maximilian Linhoff
 * Created: 2023-09-22


### PR DESCRIPTION
Please use this PR to comment on a  proposed *ctapipe enhancement proposal*  (CEP):  **[CEP-002: change the internal event structure](https://ctapipe.readthedocs.io/en/latest/developer-guide/ceps/proposed/cep-002.html)**.  

Recall that ctapipe releases before 1.0.0 are subject to small and large changes in the API, and this is one such large change that has been discussed for several years now.  Note that this affects any code that uses ctapipe, and therefore adopting it will require some changes to local code and scripts.  This CEP has already been internally discussed in #2304, and is now open for public comment.

Please **read the proposal** for [CEP-002 in the ctapipe docs](https://ctapipe.readthedocs.io/en/latest/developer-guide/ceps/proposed/cep-002.html) and give constructive comments here if anything is ambiguous or missing.  

Details about what is a CEP and how we incorporate them can be found in the documentation as [CEP-001](https://ctapipe.readthedocs.io/en/latest/developer-guide/ceps/accepted/cep-001.html)

