### PR TITLE
Fix h_max definition

### DIFF
--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -79,11 +79,11 @@ def subarray_prod3_paranal():
 
 
 @pytest.fixture(scope="session")
-def example_subarray(subarray_prod5_paranal):
+def example_subarray(subarray_prod3_paranal):
     """
     Subarray corresponding to the example event
     """
-    return subarray_prod5_paranal
+    return subarray_prod3_paranal
 
 
 @pytest.fixture(scope="function")

--- a/ctapipe/conftest.py
+++ b/ctapipe/conftest.py
@@ -79,11 +79,11 @@ def subarray_prod3_paranal():
 
 
 @pytest.fixture(scope="session")
-def example_subarray(subarray_prod3_paranal):
+def example_subarray(subarray_prod5_paranal):
     """
     Subarray corresponding to the example event
     """
-    return subarray_prod3_paranal
+    return subarray_prod5_paranal
 
 
 @pytest.fixture(scope="function")

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -922,7 +922,7 @@ class ReconstructedGeometryContainer(Container):
     )
     h_max = Field(
         nan * u.m,
-        "reconstructed vertical height (above sea level) of the shower maximum",
+        "reconstructed vertical height above sea level of the shower maximum",
         unit=u.m,
     )
     h_max_uncert = Field(nan * u.m, "uncertainty of h_max", unit=u.m)
@@ -930,7 +930,7 @@ class ReconstructedGeometryContainer(Container):
     is_valid = Field(
         False,
         (
-            "direction validity flag. True if the shower direction"
+            "Geometry validity flag. True if the shower geometry"
             "was properly reconstructed by the algorithm"
         ),
     )

--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -920,8 +920,13 @@ class ReconstructedGeometryContainer(Container):
         "reconstructed core position uncertainty along tilted frame Y axis",
         unit=u.m,
     )
-    h_max = Field(nan * u.m, "reconstructed height of the shower maximum", unit=u.m)
+    h_max = Field(
+        nan * u.m,
+        "reconstructed vertical height (above sea level) of the shower maximum",
+        unit=u.m,
+    )
     h_max_uncert = Field(nan * u.m, "uncertainty of h_max", unit=u.m)
+
     is_valid = Field(
         False,
         (

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -261,19 +261,16 @@ class HillasIntersection(HillasGeometryReconstructor):
         tilt = SkyCoord(x=core_x * u.m, y=core_y * u.m, z=0 * u.m, frame=tilted_frame)
         grd = project_to_ground(tilt)
 
-        if self.subarray.reference_location is not None:
-            h_max = self.reconstruct_h_max(
-                nom.fov_lon,
-                nom.fov_lat,
-                tilt.x,
-                tilt.y,
-                hillas_dict_mod,
-                tel_x,
-                tel_y,
-                90 * u.deg - array_pointing.alt,
-            )
-        else:
-            h_max = u.Quantity(np.nan, u.m)
+        h_max = self.reconstruct_h_max(
+            nom.fov_lon,
+            nom.fov_lat,
+            tilt.x,
+            tilt.y,
+            hillas_dict_mod,
+            tel_x,
+            tel_y,
+            90 * u.deg - array_pointing.alt,
+        )
 
         src_error = np.sqrt(err_fov_lon**2 + err_fov_lat**2)
 

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -506,15 +506,7 @@ class HillasIntersection(HillasGeometryReconstructor):
         mean_height = mean_distance * np.cos(zen.to_value(u.rad))
 
         # Add on the height of the detector above sea level
-        if self.subarray.reference_location is not None:
-            mean_height += self.subarray.reference_location.geodetic.height.to_value(
-                u.m
-            )
-        else:
-            # FIXME: Can remoev this check once we ensure the reference_location is always loaded
-            warnings.warn(
-                "Computing h_max with no reference location. Height will be wrong."
-            )
+        mean_height += self.subarray.reference_location.geodetic.height.to_value(u.m)
 
         if mean_height > 100000 or np.isnan(mean_height):
             mean_height = np.nan

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -261,7 +261,7 @@ class HillasIntersection(HillasGeometryReconstructor):
         tilt = SkyCoord(x=core_x * u.m, y=core_y * u.m, z=0 * u.m, frame=tilted_frame)
         grd = project_to_ground(tilt)
 
-        if self.subarray.reference_location:
+        if self.subarray.reference_location is not None:
             h_max = self.reconstruct_h_max(
                 nom.fov_lon,
                 nom.fov_lat,
@@ -499,17 +499,25 @@ class HillasIntersection(HillasGeometryReconstructor):
             np.array(ty),
         )
         weight = np.array(amp)
-        mean_height = np.sum(height * weight) / np.sum(weight)
+        mean_distance = np.sum(height * weight) / np.sum(weight)
 
         # This value is height above telescope in the tilted system,
         # we should convert to height above ground
-        mean_height *= np.cos(zen)
+        mean_height = mean_distance * np.cos(zen.to_value(u.rad))
 
         # Add on the height of the detector above sea level
-        mean_height += self.subarray.reference_location.geodetic.height.to_value(u.m)
+        if self.subarray.reference_location is not None:
+            mean_height += self.subarray.reference_location.geodetic.height.to_value(
+                u.m
+            )
+        else:
+            # FIXME: Can remoev this check once we ensure the reference_location is always loaded
+            warnings.warn(
+                "Computing h_max with no reference location. Height will be wrong."
+            )
 
         if mean_height > 100000 or np.isnan(mean_height):
-            mean_height = 100000
+            mean_height = np.nan
 
         return u.Quantity(mean_height, u.m)
 

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -44,6 +44,7 @@ INVALID = ReconstructedGeometryContainer(
 )
 
 FOV_ANGULAR_DISTANCE_LIMIT_RAD = (45 * u.deg).to_value(u.rad)
+H_MAX_UPPER_LIMIT_M = 100_000
 
 
 def _far_outside_fov(fov_lat, fov_lon):
@@ -506,7 +507,7 @@ class HillasIntersection(HillasGeometryReconstructor):
         # Add on the height of the detector above sea level
         mean_height += self.subarray.reference_location.geodetic.height.to_value(u.m)
 
-        if mean_height > 100000 or np.isnan(mean_height):
+        if mean_height > H_MAX_UPPER_LIMIT_M:
             mean_height = np.nan
 
         return u.Quantity(mean_height, u.m)

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -310,7 +310,7 @@ class HillasIntersection(HillasGeometryReconstructor):
 
         """
         if len(hillas_parameters) < 2:
-            return None  # Throw away events with < 2 images
+            return (np.nan, np.nan, np.nan, np.nan)  # Throw away events with < 2 images
 
         # Find all pairs of Hillas parameters
         combos = itertools.combinations(list(hillas_parameters.values()), 2)
@@ -382,7 +382,8 @@ class HillasIntersection(HillasGeometryReconstructor):
             core uncertainty X
         """
         if len(hillas_parameters) < 2:
-            return None  # Throw away events with < 2 images
+            return (np.nan, np.nan, np.nan, np.nan)  # Throw away events with < 2 images
+
         hill_list = list()
         tx = list()
         ty = list()

--- a/ctapipe/reco/hillas_intersection.py
+++ b/ctapipe/reco/hillas_intersection.py
@@ -498,7 +498,7 @@ class HillasIntersection(HillasGeometryReconstructor):
             np.array(ty),
         )
         weight = np.array(amp)
-        mean_distance = np.sum(height * weight) / np.sum(weight)
+        mean_distance = np.average(height, weights=weight)
 
         # This value is height above telescope in the tilted system,
         # we should convert to height above ground

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -423,7 +423,7 @@ class HillasReconstructor(HillasGeometryReconstructor):
 
         Returns
         -------
-        astropy.unit.Quantity
+        astropy.unit.Quantity:
             the estimated height above observatory level (not sea level) of the
             shower-max point
 

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -182,7 +182,7 @@ class HillasReconstructor(HillasGeometryReconstructor):
         _, lat, lon = cartesian_to_spherical(*direction)
 
         # estimate max height of shower
-        if self.subarray.reference_location:
+        if self.subarray.reference_location is not None:
             h_max = (
                 HillasReconstructor.estimate_relative_h_max(
                     cog_cartesian, telescope_positions

--- a/ctapipe/reco/hillas_reconstructor.py
+++ b/ctapipe/reco/hillas_reconstructor.py
@@ -182,15 +182,10 @@ class HillasReconstructor(HillasGeometryReconstructor):
         _, lat, lon = cartesian_to_spherical(*direction)
 
         # estimate max height of shower
-        if self.subarray.reference_location is not None:
-            h_max = (
-                HillasReconstructor.estimate_relative_h_max(
-                    cog_cartesian, telescope_positions
-                )
-                + self.subarray.reference_location.geodetic.height
-            )
-        else:
-            h_max = u.Quantity(np.nan, u.m)
+        h_max = (
+            self.estimate_relative_h_max(cog_cartesian, telescope_positions)
+            + self.subarray.reference_location.geodetic.height
+        )
 
         # az is clockwise, lon counter-clockwise, make sure it stays in [0, 2pi)
         az = Longitude(-lon)
@@ -420,6 +415,7 @@ class HillasReconstructor(HillasGeometryReconstructor):
 
         return core_pos_ground, core_pos_tilted
 
+    @staticmethod
     def estimate_relative_h_max(cog_vectors, positions):
         """Estimate the relative (to the observatory) vertical height of
         shower-max by intersecting the lines of the cog directions of each

--- a/ctapipe/reco/tests/test_HillasReconstructor.py
+++ b/ctapipe/reco/tests/test_HillasReconstructor.py
@@ -44,12 +44,9 @@ def test_h_max_results():
     )
 
     cog_cart = altaz_to_righthanded_cartesian(cog_alt, cog_az)
-
-    # creating the fit class and setting the the great circle member
-
-    # performing the direction fit with the minimisation algorithm
-    # and a seed that is perpendicular to the up direction
-    h_max_reco = HillasReconstructor.estimate_h_max(cog_cart, positions)
+    h_max_reco = HillasReconstructor.estimate_relative_h_max(
+        cog_vectors=cog_cart, positions=positions
+    )
 
     # the results should be close to the direction straight up
     assert u.isclose(h_max_reco, 1 * u.km)
@@ -210,7 +207,6 @@ def test_reconstruction_against_simulation_camera_frame(
     ],
 )
 def test_CameraFrame_against_TelescopeFrame(filename):
-
     input_file = get_dataset_path(filename)
     # "gamma_divergent_LaPalma_baseline_20Zd_180Az_prod3_test.simtel.gz"
     # )
@@ -243,7 +239,6 @@ def test_CameraFrame_against_TelescopeFrame(filename):
     reconstructed_events = 0
 
     for event_telescope_frame in source:
-
         calib(event_telescope_frame)
         # make a copy of the calibrated event for the camera frame case
         # later we clean and paramretrize the 2 events in the same way
@@ -281,7 +276,6 @@ def test_CameraFrame_against_TelescopeFrame(filename):
                 elif isinstance(cam, list):
                     assert cam == tel
                 else:
-
                     if cam == 0 or tel == 0:
                         kwargs["atol"] = 1e-6
                     assert np.isclose(cam, tel, **kwargs)

--- a/ctapipe/reco/tests/test_hillas_intersection.py
+++ b/ctapipe/reco/tests/test_hillas_intersection.py
@@ -83,7 +83,7 @@ def test_intersection_xmax_reco(example_subarray):
         ),
     }
 
-    x_max = hill_inter.reconstruct_xmax(
+    x_max = hill_inter.reconstruct_h_max(
         source_x=nom_pos_reco.fov_lon,
         source_y=nom_pos_reco.fov_lat,
         core_x=0 * u.m,

--- a/ctapipe/reco/tests/test_hillas_intersection.py
+++ b/ctapipe/reco/tests/test_hillas_intersection.py
@@ -30,8 +30,8 @@ def test_intersect():
 
 def test_parallel():
     """
-    Simple test to check the intersection of lines. Try to intersect positions at (0,0) and (0,1)
-    with angles parallel and check the behaviour
+    ?    Simple test to check the intersection of lines. Try to intersect positions at (0,0) and (0,1)
+        with angles parallel and check the behaviour
     """
     x1 = 0
     y1 = 0
@@ -83,7 +83,7 @@ def test_intersection_xmax_reco(example_subarray):
         ),
     }
 
-    x_max = hill_inter.reconstruct_h_max(
+    h_max = hill_inter.reconstruct_h_max(
         source_x=nom_pos_reco.fov_lon,
         source_y=nom_pos_reco.fov_lat,
         core_x=0 * u.m,
@@ -93,7 +93,8 @@ def test_intersection_xmax_reco(example_subarray):
         tel_y={1: (0 * u.m), 2: (150 * u.m)},
         zen=zen_pointing,
     )
-    print(x_max)
+
+    assert h_max > 0 * u.m
 
 
 def test_intersection_reco_impact_point_tilted(example_subarray):

--- a/docs/changes/2403.bugfix.rst
+++ b/docs/changes/2403.bugfix.rst
@@ -1,0 +1,14 @@
+Fixed the definition of ``h_max``, which was both inconsistent between
+`ctapipe.reco.HillasReconstructor` and `ctapipe.reco.HillasIntersection`
+implementations, and was also incorrect since it was measured from the
+observatory elevation rather than from sea level.
+
+The value of ``h_max`` is now defined as the height above sea level of the
+shower-max point (in meters), not the distance to that point. Therefore it is
+not corrected for the zenith angle of the shower. This is consistent with the
+options currently used for *CORSIKA*, where the *SLANT* option is set to false,
+meaning heights are actual heights not distances from the impact point, and
+``x_max`` is a *depth*, not a *slant depth*. Note that this definition may be
+inconsistent with other observatories where slant-depths are used, and also note
+that the slant depth or distance to shower max are the more useful quantities
+for shower physics.

--- a/docs/changes/2403.bugfix.rst
+++ b/docs/changes/2403.bugfix.rst
@@ -1,5 +1,5 @@
 Fixed the definition of ``h_max``, which was both inconsistent between
-`ctapipe.reco.HillasReconstructor` and `ctapipe.reco.HillasIntersection`
+`~ctapipe.reco.HillasReconstructor` and `~ctapipe.reco.HillasIntersection`
 implementations, and was also incorrect since it was measured from the
 observatory elevation rather than from sea level.
 


### PR DESCRIPTION
Fixes #2395 

* In HillasReconstructor, Define h_max as the vertical height *above sea level* (including the observatory height) of the shower-max point, and not the distance from the array which was there before. 
* In HillasIntersection, use the correct observatory height value

When #2402  is merged, I will remove the checks for missing reference_location