### PR TITLE
Changed some numpy calls following the numpy 2.0 migration guide

### DIFF
--- a/ctapipe/instrument/camera/geometry.py
+++ b/ctapipe/instrument/camera/geometry.py
@@ -800,7 +800,7 @@ class CameraGeometry:
         x = self.pix_x.value
         y = self.pix_y.value
 
-        return np.row_stack(
+        return np.vstack(
             [
                 x,
                 y,

--- a/ctapipe/instrument/camera/image_conversion.py
+++ b/ctapipe/instrument/camera/image_conversion.py
@@ -1,5 +1,5 @@
-import numpy as np
 import astropy.units as u
+import numpy as np
 
 
 __all__ = [

--- a/ctapipe/instrument/camera/image_conversion.py
+++ b/ctapipe/instrument/camera/image_conversion.py
@@ -1,7 +1,6 @@
 import astropy.units as u
 import numpy as np
 
-
 __all__ = [
     "unskew_hex_pixel_grid",
     "reskew_hex_pixel_grid",

--- a/ctapipe/instrument/camera/image_conversion.py
+++ b/ctapipe/instrument/camera/image_conversion.py
@@ -294,8 +294,8 @@ def get_orthogonal_grid_edges(pix_x, pix_y, scale_aspect=True):
 
     # with the maximal extension of the axes and the size of the pixels,
     # determine the number of bins in each direction
-    n_bins_x = int(np.round_(np.abs(np.max(pix_x) - np.min(pix_x)) / d_x) + 2)
-    n_bins_y = int(np.round_(np.abs(np.max(pix_y) - np.min(pix_y)) / d_y) + 2)
+    n_bins_x = int(np.round(np.abs(np.max(pix_x) - np.min(pix_x)) / d_x) + 2)
+    n_bins_y = int(np.round(np.abs(np.max(pix_y) - np.min(pix_y)) / d_y) + 2)
     x_edges = np.linspace(pix_x.min(), pix_x.max(), n_bins_x)
     y_edges = np.linspace(pix_y.min(), pix_y.max(), n_bins_y)
 

--- a/docs/changes/2406.maintenance.rst
+++ b/docs/changes/2406.maintenance.rst
@@ -1,0 +1,1 @@
+Updated some numpy calls to not use depreciated functions.


### PR DESCRIPTION
I grepped ctapipe for calls to the functions mentioned in the  the numpy 2.0 [migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html), and changed the few instances I found according to the reccomendations in the guide. This closes #2404.

 For completness, these are the functions listed in the guide:
```
np.in1d
np.row_stack
np.trapz
np.add_docstring
np.add_newdoc
np.add_newdoc_ufunc
np.asfarray
np.byte_bounds
np.cast
np.cfloat
np.clongfloat
np.compat
np.complex_
np.DataSource
np.deprecate
np.deprecate_with_doc
np.disp
np.fastCopyAndTranspose
np.find_common_type
np.get_array_wrap
np.float_
np.geterrobj
np.Inf
np.Infinity
np.infty
np.issctype
np.issubclass_
np.issubsctype
np.mat
np.maximum_sctype
np.NaN
np.nbytes
np.NINF
np.NZERO
np.longcomplex
np.longfloat
np.lookfor
np.obj2sctype
np.PINF
np.PZERO
np.recfromcsv
np.recfromtxt
np.round_
np.safe_eval
np.sctype2char
np.sctypes
np.seterrobj
np.set_numeric_ops
np.set_string_function
np.singlecomplex
np.string_
np.source
np.tracemalloc_domain
np.unicode_
np.who
```