### PR TITLE
Fix broken urls in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,11 +71,11 @@ or via::
 
   pip install ctapipe
 
-**Note**: to install a specific version of ctapipe take look at the documentation `here <https://ctapipe.readthedocs.org/en/latest/getting_started_users/>`__.
+**Note**: to install a specific version of ctapipe take look at the documentation `here <https://ctapipe.readthedocs.io/en/latest/user-guide/index.html>`__.
 
 **Note**: ``mamba`` is a C++ reimplementation of conda and can be found `here <https://github.com/mamba-org/mamba>`__.
 
 Note this is *pre-alpha* software and is not yet stable enough for end-users (expect large API changes until the first stable 1.0 release).
 
 Developers should follow the development install instructions found in the
-`documentation <https://ctapipe.readthedocs.org/en/latest/getting_started/>`__.
+`documentation <https://ctapipe.readthedocs.io/en/latest/developer-guide/getting-started.html>`__.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,6 +290,7 @@ html_theme_options = {
         "version_match": version_match,
         "json_url": json_url,
     },
+    "navigation_with_keys": False,
     "use_edit_page_button": True,
     "icon_links_label": "Quick Links",
     "icon_links": [


### PR DESCRIPTION
This fixes broken urls in the README after the restructuring of the docs.