### PR TITLE
Add option to override obs_id in SimTelEventSource

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -772,6 +772,7 @@ class SimulationConfigContainer(Container):
     Configuration parameters of the simulation
     """
 
+    run_number = Field(np.int32(-1), description="Original sim_telarray run number")
     corsika_version = Field(nan, description="CORSIKA version * 1000")
     simtel_version = Field(nan, description="sim_telarray version * 1000")
     energy_range_min = Field(

--- a/ctapipe/io/tests/test_simteleventsource.py
+++ b/ctapipe/io/tests/test_simteleventsource.py
@@ -604,3 +604,25 @@ def test_starting_grammage():
     with SimTelEventSource(path, focal_length_choice="EQUIVALENT") as source:
         e = next(iter(source))
         assert e.simulation.shower.starting_grammage == 580 * u.g / u.cm**2
+
+
+@pytest.mark.parametrize("override_obs_id,expected_obs_id", [(None, 1), (5, 5)])
+def test_override_obs_id(override_obs_id, expected_obs_id, prod5_gamma_simtel_path):
+    """Test for the override_obs_id option"""
+    original_run_number = 1
+
+    with SimTelEventSource(
+        prod5_gamma_simtel_path, override_obs_id=override_obs_id
+    ) as s:
+        assert s.obs_id == expected_obs_id
+        assert s.obs_ids == [expected_obs_id]
+
+        assert s.simulation_config.keys() == {expected_obs_id}
+        assert s.observation_blocks.keys() == {expected_obs_id}
+        assert s.scheduling_blocks.keys() == {expected_obs_id}
+
+        # this should alway be the original run number
+        assert s.simulation_config[s.obs_id].run_number == original_run_number
+
+        for e in s:
+            assert e.index.obs_id == expected_obs_id

--- a/docs/changes/2411.features.rst
+++ b/docs/changes/2411.features.rst
@@ -1,0 +1,3 @@
+Add option ``override_obs_id`` to ``SimTelEventSource`` which allows
+assigning new, unique ``obs_ids`` in case productions re-use CORSIKA run
+numbers.


### PR DESCRIPTION
Simulations were performed that re-use the same CORSIKA run numbers, e.g. different pointing positions for the same particles in prod5 and also different particles for the same pointing.

To still enable unique obs_ids in merged files for these productions, an "override_obs_id" option is added to the ``SimTelEventSource`` that can be used to assign new, globally unique ids.

The original run number is added to the ``SimulationConfigContainer``.

We have discussed before to decouple simulation obs_ids from CORSIKA / simtel run numbers.

This is a first step in enabling this. This was triggered also because the LST MC production reuses run numbers in a way that completely prevented merging files for model training.