### PR TITLE
Add more nitpick ignores to fix docs build after traitlets update

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,8 @@ nitpick_ignore = [
     ("py:class", "traitlets.config.application.Application"),
     ("py:class", "traitlets.utils.sentinel.Sentinel"),
     ("py:class", "traitlets.traitlets.ObserveHandler"),
+    ("py:class", "StrDict"),
+    ("py:class", "ClassesType"),
     ("py:obj", "traitlets.traitlets.G"),
     ("py:obj", "traitlets.traitlets.S"),
     ("py:class", "traitlets.traitlets.T"),


### PR DESCRIPTION
Fixes docs build, see this log for example:

https://github.com/cta-observatory/ctapipe/actions/runs/6575346324/job/17862279793?pr=2411#step:6:173