### PR TITLE
Fix docstring of EventSource

### DIFF
--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -201,8 +201,16 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
     @classmethod
     def non_abstract_subclasses(cls):
         """
-        get dict{name: cls} of non abstract subclasses,
-        subclasses can possibly be defined in plugins
+        Get a dict of all non-abstract subclasses of this class.
+
+        This method is using the entry-point plugin system
+        to also check for registered plugin implementations.
+
+        Returns
+        -------
+        subclasses : dict[str, type]
+            A dict mapping the name to the class of all found,
+            non-abstract  subclasses of this class.
         """
         if hasattr(cls, "plugin_entry_point"):
             detect_and_import_plugins(cls.plugin_entry_point)

--- a/ctapipe/core/component.py
+++ b/ctapipe/core/component.py
@@ -202,7 +202,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
     def non_abstract_subclasses(cls):
         """
         get dict{name: cls} of non abstract subclasses,
-        subclasses can possibly be definded in plugins
+        subclasses can possibly be defined in plugins
         """
         if hasattr(cls, "plugin_entry_point"):
             detect_and_import_plugins(cls.plugin_entry_point)

--- a/ctapipe/io/eventsource.py
+++ b/ctapipe/io/eventsource.py
@@ -50,9 +50,11 @@ class EventSource(Component):
     An ``EventSource`` can also be created through the configuration system,
     by passing ``config`` or ``parent`` as appropriate.
     E.g. if using ``EventSource`` inside of a ``Tool``, you would do:
+
     >>> self.source = EventSource(parent=self) # doctest: +SKIP
 
     To loop through the events in a file:
+
     >>> source = EventSource(input_url="dataset://gamma_prod5.simtel.zst", max_events=2)
     >>> for event in source:
     ...     print(event.count)


### PR DESCRIPTION
The example code was not properly rendered due to a missing blank line before.