### PR TITLE
Remove python warnings

### DIFF
--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -3,8 +3,6 @@ Definition of the `CameraCalibrator` class, providing all steps needed to apply
 calibration and image extraction, as well as supporting algorithms.
 """
 
-import warnings
-
 import astropy.units as u
 import numpy as np
 from numba import float32, float64, guvectorize, int64

--- a/ctapipe/calib/camera/calibrator.py
+++ b/ctapipe/calib/camera/calibrator.py
@@ -129,7 +129,7 @@ class CameraCalibrator(TelescopeComponent):
         self.image_extractors = {}
 
         if image_extractor is None:
-            for (_, _, name) in self.image_extractor_type:
+            for _, _, name in self.image_extractor_type:
                 self.image_extractors[name] = ImageExtractor.from_name(
                     name, subarray=self.subarray, parent=self
                 )
@@ -156,7 +156,7 @@ class CameraCalibrator(TelescopeComponent):
     def _check_r1_empty(self, waveforms):
         if waveforms is None:
             if not self._r1_empty_warn:
-                warnings.warn(
+                self.log.debug(
                     "Encountered an event with no R1 data. "
                     "DL0 is unchanged in this circumstance."
                 )
@@ -168,7 +168,7 @@ class CameraCalibrator(TelescopeComponent):
     def _check_dl0_empty(self, waveforms):
         if waveforms is None:
             if not self._dl0_empty_warn:
-                warnings.warn(
+                self.log.warning(
                     "Encountered an event with no DL0 data. "
                     "DL1 is unchanged in this circumstance."
                 )
@@ -245,7 +245,6 @@ class CameraCalibrator(TelescopeComponent):
                 is_valid=True,
             )
         else:
-
             # shift waveforms if time_shift calibration is available
             if time_shift is not None:
                 if self.apply_waveform_time_shift.tel[tel_id]:

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -101,11 +101,6 @@ def test_check_r1_empty(example_event, example_subarray):
     calibrator = CameraCalibrator(subarray=example_subarray)
     tel_id = list(example_event.r0.tel)[0]
     waveform = example_event.r1.tel[tel_id].waveform.copy()
-    with pytest.warns(UserWarning):
-        example_event.r1.tel[tel_id].waveform = None
-        calibrator._calibrate_dl0(example_event, tel_id)
-        assert example_event.dl0.tel[tel_id].waveform is None
-
     assert calibrator._check_r1_empty(None) is True
     assert calibrator._check_r1_empty(waveform) is False
 
@@ -115,8 +110,7 @@ def test_check_r1_empty(example_event, example_subarray):
     )
     event = ArrayEventContainer()
     event.dl0.tel[tel_id].waveform = np.full((2048, 128), 2)
-    with pytest.warns(UserWarning):
-        calibrator(event)
+    calibrator(event)
     assert (event.dl0.tel[tel_id].waveform == 2).all()
     assert (event.dl1.tel[tel_id].image == 2 * 128).all()
 
@@ -126,19 +120,13 @@ def test_check_dl0_empty(example_event, example_subarray):
     tel_id = list(example_event.r0.tel)[0]
     calibrator._calibrate_dl0(example_event, tel_id)
     waveform = example_event.dl0.tel[tel_id].waveform.copy()
-    with pytest.warns(UserWarning):
-        example_event.dl0.tel[tel_id].waveform = None
-        calibrator._calibrate_dl1(example_event, tel_id)
-        assert example_event.dl1.tel[tel_id].image is None
-
     assert calibrator._check_dl0_empty(None) is True
     assert calibrator._check_dl0_empty(waveform) is False
 
     calibrator = CameraCalibrator(subarray=example_subarray)
     event = ArrayEventContainer()
     event.dl1.tel[tel_id].image = np.full(2048, 2)
-    with pytest.warns(UserWarning):
-        calibrator(event)
+    calibrator(event)
     assert (event.dl1.tel[tel_id].image == 2).all()
 
 
@@ -267,7 +255,6 @@ def test_shift_waveforms():
 
 
 def test_invalid_pixels(example_event, example_subarray):
-
     # switching off the corrections makes it easier to test for
     # the exact value of 1.0
     config = Config(

--- a/ctapipe/calib/camera/tests/test_calibrator.py
+++ b/ctapipe/calib/camera/tests/test_calibrator.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 
 import astropy.units as u
 import numpy as np
-import pytest
 from scipy.stats import norm
 from traitlets.config import Config
 

--- a/docs/changes/2421.bugfix.rst
+++ b/docs/changes/2421.bugfix.rst
@@ -1,5 +1,5 @@
 Remove warnings about missing R1 or DL0 data when using the CameraCalibrator.
-These were previously emitted directly as pytho warnings and did not use the 
+These were previously emitted directly as python warnings and did not use the 
 component logging system, which they now do.
 As we do not actually expect R1 to be present it was also moved down to
 debug level.

--- a/docs/changes/2421.bugfix.rst
+++ b/docs/changes/2421.bugfix.rst
@@ -1,0 +1,5 @@
+Remove warnings about missing R1 or DL0 data when using the CameraCalibrator.
+These were previously emitted directly as pytho warnings and did not use the 
+component logging system, which they now do.
+As we do not actually expect R1 to be present it was also moved down to
+debug level.


### PR DESCRIPTION
- Use logging of the component
- No R1 is expected, so its just debug level
- No DL0 is not expected, so keep it as warning
- Fixes #2407 