### PR TITLE
Rename single changelog file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ Bug Fixes
 - The ```HillasIntersection``` method used to fail when individual events were reconstructed to originate from a FoV offset of more than 90 degrees.
   This is now fixed by returning an INVALID container for a reconstructed offset of larger than 45 degrees. [`#2265 <https://github.com/cta-observatory/ctapipe/pull/2265>`__]
 
+- Fixed a bug in the calculation of the full numeric pixel likelihood and the corresponding tests. [`#2388 <https://github.com/cta-observatory/ctapipe/pull/2388>`__]
+
 
 Maintenance
 -----------

--- a/docs/changes/2388.bug.rst
+++ b/docs/changes/2388.bug.rst
@@ -1,1 +1,0 @@
-Fixed a bug in the calculation of the full numeric pixel likelihood and the corresponding tests.


### PR DESCRIPTION
Changelog file has wrong name. Should be `bugfix.rst` and not `bug.rst` otherwise it won't get rendered by towncrier