### PR TITLE
Set disable=None by default in ctapipe tools

### DIFF
--- a/ctapipe/tools/merge.py
+++ b/ctapipe/tools/merge.py
@@ -28,11 +28,11 @@ class MergeTool(Tool):
     examples = """
     To merge several files in the current directory:
 
-    > ctapipe-merge file1.h5 file2.h5 file3.h5 --output=/path/output_file.h5 --progress
+    > ctapipe-merge file1.h5 file2.h5 file3.h5 --output=/path/output_file.h5
 
     For merging files from a specific directory with a specific pattern, use:
 
-    > ctapipe-merge --input-dir=/input/dir/ --output=/path/output_file.h5 --progress
+    > ctapipe-merge --input-dir=/input/dir/ --output=/path/output_file.h5
     --pattern='*.dl1.h5'
 
     If no pattern is given, all .h5 files in the given directory will be taken as input.
@@ -52,9 +52,10 @@ class MergeTool(Tool):
         help="Input CTA HDF5 files",
     ).tag(config=True)
 
-    progress_bar = Bool(
-        False,
-        help="Show progress bar during processing",
+    disable_progress_bar = Bool(
+        default_value=None,
+        allow_none=True,
+        help="Disable the progress bar during processing",
     ).tag(config=True)
 
     file_pattern = Unicode(
@@ -77,9 +78,9 @@ class MergeTool(Tool):
     }
 
     flags = {
-        "progress": (
-            {"MergeTool": {"progress_bar": True}},
-            "Show a progress bar for all given input files",
+        "disable-progress": (
+            {"MergeTool": {"disable_progress_bar": True}},
+            "Disable the progress bar",
         ),
         "overwrite": (
             {"HDF5Merger": {"overwrite": True}},
@@ -174,7 +175,7 @@ class MergeTool(Tool):
             self.input_files,
             desc="Merging",
             unit="Files",
-            disable=not self.progress_bar,
+            disable=self.disable_progress_bar,
         ):
             try:
                 self.merger(input_path)

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -53,17 +53,19 @@ class ProcessorTool(Tool):
     )
     examples = """
     To process data with all default values:
-    > ctapipe-process --input events.simtel.gz --output events.dl1.h5 --progress
+    > ctapipe-process --input events.simtel.gz --output events.dl1.h5
 
     Or use an external configuration file, where you can specify all options:
-    > ctapipe-process --config stage1_config.json --progress
+    > ctapipe-process --config stage1_config.json
 
     The config file should be in JSON or python format (see traitlets docs). For an
     example, see ctapipe/examples/stage1_config.json in the main code repo.
     """
 
-    progress_bar = Bool(
-        help="show progress bar during processing", default_value=False
+    disable_progress_bar = Bool(
+        help="Disable the progress bar during processing",
+        default_value=None,
+        allow_none=True,
     ).tag(config=True)
 
     force_recompute_dl1 = Bool(
@@ -90,11 +92,9 @@ class ProcessorTool(Tool):
             {"DataWriter": {"overwrite": True}},
             "Overwrite output file if it exists",
         ),
-        **flag(
-            "progress",
-            "ProcessorTool.progress_bar",
-            "show a progress bar during event processing",
-            "don't show a progress bar during event processing",
+        "disable-progress": (
+            {"DataWriter": {"disable_progress_bar": True}},
+            "Disable the progress bar during event processing",
         ),
         **flag(
             "recompute-dl1",
@@ -295,7 +295,7 @@ class ProcessorTool(Tool):
             desc=self.event_source.__class__.__name__,
             total=self.event_source.max_events,
             unit="ev",
-            disable=not self.progress_bar,
+            disable=self.disable_progress_bar,
         ):
 
             self.log.debug("Processessing event_id=%s", event.index.event_id)

--- a/ctapipe/tools/tests/test_process.py
+++ b/ctapipe/tools/tests/test_process.py
@@ -500,3 +500,38 @@ def test_only_trigger_and_simulation(tmp_path):
         assert len(events) == 7
         assert "tels_with_trigger" in events.colnames
         assert "true_energy" in events.colnames
+
+
+@pytest.mark.parametrize("is_tty", [True, False])
+def test_progress_bar(
+    tmp_path,
+    monkeypatch,
+    is_tty,
+    dl1_parameters_file,
+):
+    import sys
+    from io import StringIO
+
+    config = resource_file("stage2_config.json")
+
+    # Simulate tty or non-tty environment
+    monkeypatch.setattr(sys, "stdout", StringIO() if is_tty else sys.stdout)
+
+    captured = run_tool(
+        ProcessorTool(),
+        argv=[
+            f"--config={config}",
+            f"--input={dl1_parameters_file}",
+            f"--output={tmp_path}/dl1b_from_dl1b.dl1.h5",
+            "--write-parameters",
+            "--overwrite",
+        ],
+        cwd=tmp_path,
+        raises=False,
+    )
+
+    # Check if the progress bar was not displayed in non-tty mode
+    if is_tty:
+        assert "ev/s" in captured.out
+    else:
+        assert "ev/s" not in captured.out


### PR DESCRIPTION
Sets `tqdm(..., disable=None)` in process and merge ctapipe tools.

By default the progress bar is displayed when running the tools in interactive mode. If they are executed in non-tty mode the progress bar is disabled. There is also a command line option `--disable-progress` to disable it.

I added some tests to check the expected behavior in both tty and non-tty modes.

Solves #2366