### PR TITLE
Fix coverage report not being found by codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         if: contains(matrix.extra-args, 'codecov')
+        with:
+          fail_ci_if_error: true
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
         run: |
           cd $(mktemp -d)
           pytest -n auto --dist loadscope \
-            --cov --cov-report=xml \
+            --cov --cov-report=xml:$GITHUB_WORKSPACE/coverage.xml \
             --doctest-modules --doctest-glob='*.rst' \
-            --ignore=$HOME/work/ctapipe/ctapipe/docs/conf.py \
-            --pyargs ctapipe $HOME/work/ctapipe/ctapipe/docs
+            --ignore=$GITHUB_WORKSPACE/docs/conf.py \
+            --pyargs ctapipe $GITHUB_WORKSPACE/docs
 
           ctapipe-info --version
 


### PR DESCRIPTION
Since we run our tests in a temporary directory, codecov didn't find the `coverage.xml`.

Due to a stupid default of `fail_ci_if_error`, this was silently ignored and the CI was still green. 
We didn't notice the missing codecov reports.

This fixes it by specifying the absolute path for coverage.xml and to make sure this does not happen again, I also set `fail_ci_if_error` to `true`