### PR TITLE
Fix indentation in docs resulting in wrong rendering

### DIFF
--- a/ctapipe/image/pixel_likelihood.py
+++ b/ctapipe/image/pixel_likelihood.py
@@ -72,8 +72,8 @@ def neg_log_likelihood_approx(image, prediction, spe_width, pedestal):
 
         - \\ln{P} = \\frac{\\ln{2 π} + \\ln{θ}}{2} + \\frac{(s - μ)^2}{2 θ}
 
-        We keep the constants in this because the actual value of the likelihood
-        can be used to calculate a goodness-of-fit value
+    We keep the constants in this because the actual value of the likelihood
+    can be used to calculate a goodness-of-fit value
 
 
     Parameters


### PR DESCRIPTION
Fixes the text being rendered as math here:

https://ctapipe.readthedocs.io/en/latest/api/ctapipe.image.pixel_likelihood.neg_log_likelihood_approx.html