### PR TITLE
Properly transform between camera and telescope frame in muon fitter

### DIFF
--- a/docs/changes/2464.bugfix.rst
+++ b/docs/changes/2464.bugfix.rst
@@ -1,0 +1,6 @@
+Properly transform pixel coordinates between ``CameraFrame``
+and ``TelescopeFrame`` in ``MuonIntensityFitter`` taking.
+Before, ``MuonIntensityFitter`` always used the equivalent focal
+length for transformations, now it is using the focal length
+attached to the ``CameraGeometry``, thus respecting the
+``focal_length_choice`` options of the event sources.


### PR DESCRIPTION
The muon code did some strange things to transform pixel coordinates from camera to telescope frame, probably from code before camera geometries could be transformed as a whole.

