### PR TITLE
Use signal_fraction for training particle classifier 

### DIFF
--- a/docs/changes/2465.api.rst
+++ b/docs/changes/2465.api.rst
@@ -1,0 +1,2 @@
+Replace ``n_signal`` and ``n_background`` options in ``ctapipe-train-particle-classifier``
+with ``n_events`` and ``signal_fraction``, where ``signal_fraction`` = n_signal / (n_signal + n_background).

--- a/src/ctapipe/resources/train_particle_classifier.yaml
+++ b/src/ctapipe/resources/train_particle_classifier.yaml
@@ -6,13 +6,11 @@
 # ======================================================================
 
 TrainParticleClassifier:
-  random_seed: 0              # Seed used for sampling n_* events for training.
-  n_signal:                   # The number of signal events used for training that can be provided
+  random_seed: 0              # Seed used for sampling n_events for training.
+  n_events:                   # The number of events used for training that can be provided
     # - [type, "LST*", 1000]  # independently for each telescope type (e.g. "LST_LST_LSTCam").
-    # - [type, "MST*", 1000]  # If not specified, all events in the file are used.
-  n_background:               # Same as above, but for background events.
-    # - [type, "LST*", 1000]
-    # - [type, "MST*", 1000]
+    # - [type, "MST*", 1000]  # If not specified, as many events as possible are used.
+  signal_fraction: 0.5        # signal_fraction = n_signal / n_events
 
   CrossValidator:
     n_cross_validations: 5

--- a/src/ctapipe/tools/tests/test_train.py
+++ b/src/ctapipe/tools/tests/test_train.py
@@ -64,7 +64,7 @@ def test_sampling(tmp_path, dl2_shower_geometry_file):
     )
 
 
-def test_signal_ratio(tmp_path, gamma_train_clf, proton_train_clf):
+def test_signal_fraction(tmp_path, gamma_train_clf, proton_train_clf):
     from ctapipe.tools.train_particle_classifier import TrainParticleClassifier
 
     tool = TrainParticleClassifier()
@@ -74,7 +74,7 @@ def test_signal_ratio(tmp_path, gamma_train_clf, proton_train_clf):
 
     with pytest.raises(
         ToolConfigurationError,
-        match="The signal_ratio has to be between 0 and 1",
+        match="The signal_fraction has to be between 0 and 1",
     ):
         run_tool(
             tool,
@@ -83,7 +83,7 @@ def test_signal_ratio(tmp_path, gamma_train_clf, proton_train_clf):
                 f"--background={proton_train_clf}",
                 f"--output={out_file}",
                 f"--config={config}",
-                "--signal-ratio=1.1",
+                "--signal-fraction=1.1",
                 "--log-level=INFO",
             ],
             raises=True,
@@ -97,7 +97,7 @@ def test_signal_ratio(tmp_path, gamma_train_clf, proton_train_clf):
             f"--output={out_file}",
             f"--config={config}",
             f"--log-file={log_file}",
-            "--signal-ratio=0.7",
+            "--signal-fraction=0.7",
             "--log-level=INFO",
         ],
     )
@@ -110,7 +110,7 @@ def test_signal_ratio(tmp_path, gamma_train_clf, proton_train_clf):
             n_signal, n_background = [int(line.split(" ")[i]) for i in (7, 10)]
             break
 
-    assert np.allclose(n_signal / (n_signal + n_background), 0.7, atol=1e-5)
+    assert np.allclose(n_signal / (n_signal + n_background), 0.7, atol=1e-4)
 
 
 def test_cross_validation_results(tmp_path, gamma_train_clf, proton_train_clf):

--- a/src/ctapipe/tools/tests/test_train.py
+++ b/src/ctapipe/tools/tests/test_train.py
@@ -89,28 +89,30 @@ def test_signal_fraction(tmp_path, gamma_train_clf, proton_train_clf):
             raises=True,
         )
 
-    run_tool(
-        tool,
-        argv=[
-            f"--signal={gamma_train_clf}",
-            f"--background={proton_train_clf}",
-            f"--output={out_file}",
-            f"--config={config}",
-            f"--log-file={log_file}",
-            "--signal-fraction=0.7",
-            "--log-level=INFO",
-        ],
-    )
+    for frac in [0.7, 0.1]:
+        run_tool(
+            tool,
+            argv=[
+                f"--signal={gamma_train_clf}",
+                f"--background={proton_train_clf}",
+                f"--output={out_file}",
+                f"--config={config}",
+                f"--log-file={log_file}",
+                f"--signal-fraction={frac}",
+                "--log-level=INFO",
+                "--overwrite",
+            ],
+        )
 
-    with open(log_file, "r") as f:
-        log = f.readlines()
+        with open(log_file, "r") as f:
+            log = f.readlines()
 
-    for line in log:
-        if "Train on" in line:
-            n_signal, n_background = [int(line.split(" ")[i]) for i in (7, 10)]
-            break
+        for line in log[::-1]:
+            if "Train on" in line:
+                n_signal, n_background = [int(line.split(" ")[i]) for i in (7, 10)]
+                break
 
-    assert np.allclose(n_signal / (n_signal + n_background), 0.7, atol=1e-4)
+        assert np.allclose(n_signal / (n_signal + n_background), frac, atol=1e-4)
 
 
 def test_cross_validation_results(tmp_path, gamma_train_clf, proton_train_clf):

--- a/src/ctapipe/tools/train_particle_classifier.py
+++ b/src/ctapipe/tools/train_particle_classifier.py
@@ -205,40 +205,22 @@ class TrainParticleClassifier(Tool):
             n_events=n_background,
         )
         if n_events is None:  # use as many events as possible (keeping signal_fraction)
-            if len(signal) < len(background):
-                if len(background) < 2 * (1 - self.signal_fraction) * len(signal):
-                    n_background = len(background)
-                    n_signal = int(n_background / (1 / self.signal_fraction - 1))
+            if len(signal) < len(background) / (1 / self.signal_fraction - 1):
+                n_signal = len(signal)
+                n_background = int(n_signal * (1 / self.signal_fraction - 1))
 
-                    self.log.info("Sampling %d signal events", n_signal)
-                    idx = self.rng.choice(len(signal), n_signal, replace=False)
-                    idx.sort()
-                    signal = signal[idx]
-                else:
-                    n_background = int(2 * (1 - self.signal_fraction) * len(signal))
-                    n_signal = len(signal)
-
-                    self.log.info("Sampling %d background events", n_background)
-                    idx = self.rng.choice(len(background), n_background, replace=False)
-                    idx.sort()
-                    background = background[idx]
+                self.log.info("Sampling %d background events", n_background)
+                idx = self.rng.choice(len(background), n_background, replace=False)
+                idx.sort()
+                background = background[idx]
             else:
-                if len(signal) < 2 * self.signal_fraction * len(background):
-                    n_signal = len(signal)
-                    n_background = int(n_signal * (1 / self.signal_fraction - 1))
+                n_background = len(background)
+                n_signal = int(n_background / (1 / self.signal_fraction - 1))
 
-                    self.log.info("Sampling %d background events", n_background)
-                    idx = self.rng.choice(len(background), n_background, replace=False)
-                    idx.sort()
-                    background = background[idx]
-                else:
-                    n_signal = int(2 * self.signal_fraction * len(background))
-                    n_background = len(background)
-
-                    self.log.info("Sampling %d signal events", n_signal)
-                    idx = self.rng.choice(len(signal), n_signal, replace=False)
-                    idx.sort()
-                    signal = signal[idx]
+                self.log.info("Sampling %d signal events", n_signal)
+                idx = self.rng.choice(len(signal), n_signal, replace=False)
+                idx.sort()
+                signal = signal[idx]
 
         table = vstack([signal, background])
         self.log.info(

--- a/src/ctapipe/tools/train_particle_classifier.py
+++ b/src/ctapipe/tools/train_particle_classifier.py
@@ -205,18 +205,17 @@ class TrainParticleClassifier(Tool):
             n_events=n_background,
         )
         if n_events is None:  # use as many events as possible (keeping signal_fraction)
-            if len(signal) < len(background) / (1 / self.signal_fraction - 1):
-                n_signal = len(signal)
-                n_background = int(n_signal * (1 / self.signal_fraction - 1))
+            n_signal = len(signal)
+            n_background = len(background)
 
+            if n_signal < (n_signal + n_background) * self.signal_fraction:
+                n_background = int(n_signal * (1 / self.signal_fraction - 1))
                 self.log.info("Sampling %d background events", n_background)
                 idx = self.rng.choice(len(background), n_background, replace=False)
                 idx.sort()
                 background = background[idx]
             else:
-                n_background = len(background)
                 n_signal = int(n_background / (1 / self.signal_fraction - 1))
-
                 self.log.info("Sampling %d signal events", n_signal)
                 idx = self.rng.choice(len(signal), n_signal, replace=False)
                 idx.sort()


### PR DESCRIPTION
This removes the `n_signal` and `n_background` options of `ctapipe-train-particle-classifier`. Instead the total number of training events `n_events` and the `signal_fraction` can be chosen, where
$$\texttt{signal\\_fraction}= \frac{n_s}{n_s + n_b}.$$
If `n_events` is not specified, as many events as possible will be used considering the given `signal_fraction`.

- [x]  If #2455 is merged before this, I will change the default config file accordingly in this PR.