### PR TITLE
Fix CI after pytest-xdist update

### DIFF
--- a/ctapipe/core/tests/test_provenance.py
+++ b/ctapipe/core/tests/test_provenance.py
@@ -7,8 +7,15 @@ from ctapipe.core.provenance import _ActivityProvenance
 
 
 @pytest.fixture
-def provenance():
+def provenance(monkeypatch):
+    # the singleton nature of Provenance messes with
+    # the order-independence of the tests asserting
+    # the provenance contains the correct information
+    # so we monkeypatch back to an empty state here
     prov = Provenance()
+    monkeypatch.setattr(prov, "_activities", [])
+    monkeypatch.setattr(prov, "_finished_activities", [])
+
     prov.start_activity("test1")
     prov.add_input_file("input.txt")
     prov.add_output_file("output.txt")


### PR DESCRIPTION
The new version 3.5 of pytest-xdist was released yesterday changing the order in which tests are run:

> now sorts scopes by number of tests to assign largest scopes early – in many cases this should improve overall test session running time, as there is less chance of a large scope being left to be processed near the end of the session, leaving other workers idle.

This lead to the `Provenance` tests failing due to the nature of this singleton (it contained the provenance of all applications run prior to the provenance test) not only the ones being tested for.

Fixed by monkeypatching the provenance back to an empty state for the tests.