### PR TITLE
Add missing cache=True to numba compilation

### DIFF
--- a/ctapipe/image/extractor.py
+++ b/ctapipe/image/extractor.py
@@ -139,6 +139,7 @@ def extract_around_peak(
     ],
     "(s),(),()->(),()",
     nopython=True,
+    cache=True,
 )
 def extract_sliding_window(waveforms, width, sampling_rate_ghz, sum_, peak_time):
     """

--- a/ctapipe/image/muon/intensity_fitter.py
+++ b/ctapipe/image/muon/intensity_fitter.py
@@ -35,7 +35,7 @@ CIRCLE_SQUARE_AREA_RATIO = np.pi / 4
 SQRT2 = np.sqrt(2)
 
 
-@vectorize([double(double, double, double)])
+@vectorize([double(double, double, double)], cache=True)
 def chord_length(radius, rho, phi):
     """
     Function for integrating the length of a chord across a circle
@@ -202,7 +202,7 @@ def image_prediction(
     )
 
 
-@vectorize([double(double, double, double)])
+@vectorize([double(double, double, double)], cache=True)
 def gaussian_cdf(x, mu, sig):
     """
     Function to compute values of a given gaussians

--- a/docs/changes/2477.optimization.rst
+++ b/docs/changes/2477.optimization.rst
@@ -1,0 +1,1 @@
+Add ``cache=True`` to some numba-compiled functions which were missing it.


### PR DESCRIPTION
This shaved of a third of the import time (of course only of the second import) of `ctapipe.io` as reported by @GernotMaier here: #2476 