### PR TITLE
Load constant pointing in TableLoader

### DIFF
--- a/ctapipe/io/astropy_helpers.py
+++ b/ctapipe/io/astropy_helpers.py
@@ -24,7 +24,7 @@ from .tableio import (
     TimeColumnTransform,
 )
 
-__all__ = ["read_table", "join_allow_empty"]
+__all__ = ["read_table", "write_table", "join_allow_empty"]
 
 
 def read_table(

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -596,11 +596,7 @@ class TableLoader(Component):
             )
             table = _join_telescope_events(table, impacts)
 
-        if (
-            len(table) > 0
-            and pointing
-            and FIXED_POINTING_GROUP in self.h5file.root
-        ):
+        if len(table) > 0 and pointing and FIXED_POINTING_GROUP in self.h5file.root:
             pointing = read_table(
                 self.h5file, f"{FIXED_POINTING_GROUP}/tel_{tel_id:03d}"
             )

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -272,21 +272,10 @@ def test_chunked(dl2_shower_geometry_file):
     stop = chunk_size
 
     with TableLoader(dl2_shower_geometry_file) as table_loader:
-        tel_event_it = table_loader.read_telescope_events_chunked(
-            chunk_size,
-            true_parameters=False,
-        )
-        event_it = table_loader.read_subarray_events_chunked(
-            chunk_size,
-        )
-        by_type_it = table_loader.read_telescope_events_by_type_chunked(
-            chunk_size,
-            true_parameters=False,
-        )
-        by_id_it = table_loader.read_telescope_events_by_id_chunked(
-            chunk_size,
-            true_parameters=False,
-        )
+        tel_event_it = table_loader.read_telescope_events_chunked(chunk_size=chunk_size, true_parameters=False)
+        event_it = table_loader.read_subarray_events_chunked(chunk_size=chunk_size)
+        by_type_it = table_loader.read_telescope_events_by_type_chunked(chunk_size=chunk_size, true_parameters=False)
+        by_id_it = table_loader.read_telescope_events_by_id_chunked(chunk_size=chunk_size, true_parameters=False)
 
         iters = (event_it, tel_event_it, by_type_it, by_id_it)
 
@@ -312,6 +301,12 @@ def test_chunked(dl2_shower_geometry_file):
             # check events are in compatible order
             check_equal_array_event_order(events, tel_events)
             check_equal_array_event_order(trigger[start:stop], events)
+            np.testing.assert_allclose(
+                tel_events["telescope_pointing_altitude"].quantity.to_value(u.deg), 70
+            )
+            np.testing.assert_allclose(
+                tel_events["telescope_pointing_azimuth"].quantity.to_value(u.deg), 0
+            )
 
             # check number of telescope events is correct
             assert len(tel_events) == np.count_nonzero(events["tels_with_trigger"])

--- a/ctapipe/io/tests/test_table_loader.py
+++ b/ctapipe/io/tests/test_table_loader.py
@@ -272,10 +272,16 @@ def test_chunked(dl2_shower_geometry_file):
     stop = chunk_size
 
     with TableLoader(dl2_shower_geometry_file) as table_loader:
-        tel_event_it = table_loader.read_telescope_events_chunked(chunk_size=chunk_size, true_parameters=False)
+        tel_event_it = table_loader.read_telescope_events_chunked(
+            chunk_size=chunk_size, true_parameters=False
+        )
         event_it = table_loader.read_subarray_events_chunked(chunk_size=chunk_size)
-        by_type_it = table_loader.read_telescope_events_by_type_chunked(chunk_size=chunk_size, true_parameters=False)
-        by_id_it = table_loader.read_telescope_events_by_id_chunked(chunk_size=chunk_size, true_parameters=False)
+        by_type_it = table_loader.read_telescope_events_by_type_chunked(
+            chunk_size=chunk_size, true_parameters=False
+        )
+        by_id_it = table_loader.read_telescope_events_by_id_chunked(
+            chunk_size=chunk_size, true_parameters=False
+        )
 
         iters = (event_it, tel_event_it, by_type_it, by_id_it)
 

--- a/docs/changes/2481.feature.rst
+++ b/docs/changes/2481.feature.rst
@@ -1,0 +1,4 @@
+Also load the new fixed pointing information in ``TableLoader``.
+
+Add option ``keep_order`` to ``ctapipe.io.astropy_helpers.join_allow_empty``
+that will keep the original order of rows when performing left or right joins.


### PR DESCRIPTION
This adds the possibility to read the constant pointing stored per observation block introduced in #2438 in the `TableLoader`.