### PR TITLE
Prevent import of ctapipe.image at import time of ctapipe.io

### DIFF
--- a/ctapipe/io/toymodel.py
+++ b/ctapipe/io/toymodel.py
@@ -16,7 +16,6 @@ from ..containers import (
     SchedulingBlockContainer,
 )
 from ..core import TelescopeComponent, traits
-from ..image import toymodel
 from .datalevels import DataLevel
 from .eventsource import EventSource
 
@@ -97,6 +96,7 @@ class ToyEventSource(TelescopeComponent, EventSource):
             self.event_id += 1
 
     def generate_event(self):
+        from ..image import toymodel
 
         event = ArrayEventContainer(
             index=EventIndexContainer(obs_id=1, event_id=self.event_id),


### PR DESCRIPTION
Import `ctapipe.image.toymodel` in `ctapipe.io.toymodel` only when used, not directly at import time to improve import time of `ctapipe.io` when not using the `toymodel`.