### PR TITLE
Add functionality for array-event-wise aggregation of dl1 image parameters

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -410,13 +410,16 @@ class MorphologyContainer(Container):
     n_large_islands = Field(-1, "Number of > 50 pixel islands")
 
 
-class StatisticsContainer(Container):
+class BaseStatisticsContainer(Container):
     """Store descriptive statistics"""
 
     max = Field(np.float32(nan), "value of pixel with maximum intensity")
     min = Field(np.float32(nan), "value of pixel with minimum intensity")
     mean = Field(np.float32(nan), "mean intensity")
     std = Field(np.float32(nan), "standard deviation of intensity")
+
+
+class StatisticsContainer(BaseStatisticsContainer):
     skewness = Field(nan, "skewness of intensity")
     kurtosis = Field(nan, "kurtosis of intensity")
 
@@ -521,6 +524,10 @@ class DL1Container(Container):
     tel = Field(
         default_factory=partial(Map, DL1CameraContainer),
         description="map of tel_id to DL1CameraContainer",
+    )
+    aggregate = Field(
+        default_factory=partial(Map, BaseStatisticsContainer),
+        description="map of image parameter to aggregation statistics",
     )
 
 

--- a/ctapipe/image/__init__.py
+++ b/ctapipe/image/__init__.py
@@ -60,7 +60,7 @@ from .pixel_likelihood import (
     neg_log_likelihood_numeric,
 )
 from .reducer import DataVolumeReducer, NullDataVolumeReducer, TailCutsDataVolumeReducer
-from .statistics import descriptive_statistics
+from .statistics import FeatureAggregator, descriptive_statistics
 from .timing import timing_parameters
 
 __all__ = [
@@ -119,4 +119,5 @@ __all__ = [
     "TailCutsDataVolumeReducer",
     "InvalidPixelHandler",
     "NeighborAverage",
+    "FeatureAggregator",
 ]

--- a/ctapipe/image/statistics.py
+++ b/ctapipe/image/statistics.py
@@ -1,10 +1,19 @@
+import astropy.units as u
 import numpy as np
+from astropy.stats import circmean, circstd
+from astropy.table import Table
 from numba import njit
 
-from ..containers import StatisticsContainer
+from ..containers import (
+    ArrayEventContainer,
+    BaseStatisticsContainer,
+    StatisticsContainer,
+)
+from ..core import Component
+from ..core.traits import List, Tuple, Unicode
+from ..vectorization import max_ufunc, min_ufunc, weighted_mean_ufunc
 
-
-__all__ = ["descriptive_statistics", "skewness", "kurtosis"]
+__all__ = ["descriptive_statistics", "skewness", "kurtosis", "FeatureAggregator"]
 
 
 @njit(cache=True)
@@ -82,7 +91,7 @@ def kurtosis(data, mean=None, std=None, fisher=True):
 def descriptive_statistics(
     values, container_class=StatisticsContainer
 ) -> StatisticsContainer:
-    """ compute intensity statistics of an image  """
+    """compute intensity statistics of an image"""
     mean = values.mean()
     std = values.std()
     return container_class(
@@ -93,3 +102,134 @@ def descriptive_statistics(
         skewness=skewness(values, mean=mean, std=std),
         kurtosis=kurtosis(values, mean=mean, std=std),
     )
+
+
+class FeatureAggregator(Component):
+    """Array-event-wise aggregation of image parameters."""
+
+    image_parameters = List(
+        Tuple(Unicode(), Unicode()),
+        default_value=[],
+        help=(
+            "List of 2-Tuples of Strings: ('prefix', 'feature'). "
+            "The image parameter to be aggregated is 'prefix_feature'."
+        ),
+    ).tag(config=True)
+
+    def __call__(self, event: ArrayEventContainer) -> None:
+        """Fill event container with aggregated image parameters."""
+        for prefix, feature in self.image_parameters:
+            values = []
+            unit = None
+            for tel_id in event.dl1.tel.keys():
+                value = event.dl1.tel[tel_id].parameters[prefix][feature]
+                if isinstance(value, u.Quantity):
+                    if not unit:
+                        unit = value.unit
+                    value = value.to_value(unit)
+
+                valid = value >= 0 if prefix == "morphology" else ~np.isnan(value)
+                if valid:
+                    values.append(value)
+
+            if len(values) > 0:
+                if feature.endswith(("psi", "phi")):
+                    mean = circmean(
+                        u.Quantity(values, unit, copy=False).to_value(u.rad)
+                    )
+                    std = circstd(u.Quantity(values, unit, copy=False).to_value(u.rad))
+                else:
+                    mean = np.mean(values)
+                    std = np.std(values)
+
+                # Use the same dtype for all columns, independent of the dtype
+                # of the aggregated image parameter, since `_mean` and `_std`
+                # requiere floats anyway.
+                max = np.float64(np.max(values))
+                min = np.float64(np.min(values))
+            else:
+                max = np.nan
+                min = np.nan
+                mean = np.nan
+                std = np.nan
+
+            if unit:
+                max = u.Quantity(max, unit, copy=False)
+                min = u.Quantity(min, unit, copy=False)
+                if feature.endswith(("psi", "phi")):
+                    mean = u.Quantity(mean, u.rad, copy=False).to(unit)
+                    std = u.Quantity(std, u.rad, copy=False).to(unit)
+                else:
+                    mean = u.Quantity(mean, unit, copy=False)
+                    std = u.Quantity(std, unit, copy=False)
+
+            event.dl1.aggregate[prefix + "_" + feature] = BaseStatisticsContainer(
+                max=max, min=min, mean=mean, std=std, prefix=prefix + "_" + feature
+            )
+
+    def aggregate_table(self, mono_parameters: Table) -> dict[str, Table]:
+        """
+        Construct table containing aggregated image parameters
+        from table of telescope events.
+        """
+        agg_tables = {}
+        for prefix, feature in self.image_parameters:
+            col = prefix + "_" + feature
+            unit = mono_parameters[col].quantity.unit
+            if prefix == "morphology":
+                valid = mono_parameters[col] >= 0
+            else:
+                valid = ~np.isnan(mono_parameters[col])
+
+            valid_parameters = mono_parameters[valid]
+            array_events, indices, multiplicity = np.unique(
+                mono_parameters["obs_id", "event_id"],
+                return_inverse=True,
+                return_counts=True,
+            )
+            agg_table = Table(array_events)
+            for colname in ("obs_id", "event_id"):
+                agg_table[colname].description = mono_parameters[colname].description
+
+            n_array_events = len(array_events)
+            if len(valid_parameters) > 0:
+                mono_column = valid_parameters[col]
+                means = weighted_mean_ufunc(
+                    mono_column,
+                    np.array([1]),
+                    n_array_events,
+                    indices[valid],
+                )
+                # FIXME: This has the same problem of strange NaNs as
+                # e.g. "energy_uncert" generated by the StereoMeanCombiner!
+                # Output is also incorrect, but I don't understand why...
+                vars = weighted_mean_ufunc(
+                    (mono_column - np.repeat(means, multiplicity)[valid]) ** 2,
+                    np.array([1]),
+                    n_array_events,
+                    indices[valid],
+                )
+                max = max_ufunc(
+                    mono_column,
+                    n_array_events,
+                    indices[valid],
+                )
+                min = min_ufunc(
+                    mono_column,
+                    n_array_events,
+                    indices[valid],
+                )
+            else:
+                means = np.full(n_array_events, np.nan)
+                vars = np.full(n_array_events, np.nan)
+                max = np.full(n_array_events, np.nan)
+                min = np.full(n_array_events, np.nan)
+
+            agg_table[col + "_max"] = u.Quantity(max, unit, copy=False)
+            agg_table[col + "_min"] = u.Quantity(min, unit, copy=False)
+            agg_table[col + "_mean"] = u.Quantity(means, unit, copy=False)
+            agg_table[col + "_std"] = u.Quantity(np.sqrt(vars), unit, copy=False)
+
+            agg_tables[col] = agg_table
+
+        return agg_tables

--- a/ctapipe/io/datawriter.py
+++ b/ctapipe/io/datawriter.py
@@ -207,6 +207,11 @@ class DataWriter(Component):
         help="Store muon parameters if available", default_value=False
     ).tag(config=True)
 
+    write_dl1_aggregates = Bool(
+        help="Store array-event-wise aggregated DL1 image parameters if available",
+        default_value=False,
+    ).tag(config=True)
+
     compression_level = Int(
         help="compression level, 0=None, 9=maximum", default_value=5, min=0, max=9
     ).tag(config=True)
@@ -338,6 +343,9 @@ class DataWriter(Component):
 
         if self.write_muon_parameters:
             self._write_muon_telescope_events(event)
+
+        if self.write_dl1_aggregates:
+            self._write_dl1_aggregates(event)
 
     def _write_constant_pointing(self, event):
         """
@@ -725,6 +733,16 @@ class DataWriter(Component):
             self._writer.write(
                 f"dl1/event/telescope/muon/{table_name}",
                 [tel_index, muon.ring, muon.parameters, muon.efficiency],
+            )
+
+    def _write_dl1_aggregates(self, event: ArrayEventContainer):
+        """
+        Write array-event-wise aggregated DL1 image parameters.
+        """
+        for feature_name, container in event.dl1.aggregate.items():
+            self._writer.write(
+                table_name=f"dl1/event/aggregate/{feature_name}",
+                containers=[event.index, container],
             )
 
     def _write_dl2_telescope_events(self, event: ArrayEventContainer):

--- a/ctapipe/io/tableloader.py
+++ b/ctapipe/io/tableloader.py
@@ -24,6 +24,7 @@ PARAMETERS_GROUP = "/dl1/event/telescope/parameters"
 IMAGES_GROUP = "/dl1/event/telescope/images"
 MUON_GROUP = "/dl1/event/telescope/muon"
 TRIGGER_TABLE = "/dl1/event/subarray/trigger"
+PARAMETER_AGGS_GROUP = "/dl1/event/aggregate"
 SHOWER_TABLE = "/simulation/event/subarray/shower"
 TRUE_IMAGES_GROUP = "/simulation/event/telescope/images"
 TRUE_PARAMETERS_GROUP = "/simulation/event/telescope/parameters"
@@ -180,6 +181,9 @@ class TableLoader(Component):
         config=True
     )
     dl1_muons = traits.Bool(False, help="load muon ring parameters").tag(config=True)
+    dl1_aggregates = traits.Bool(
+        False, help="load array-event-wise aggregated image parameters"
+    ).tag(config=True)
 
     dl2 = traits.Bool(True, help="load available dl2 stereo parameters").tag(
         config=True
@@ -276,6 +280,7 @@ class TableLoader(Component):
             "dl1_parameters": PARAMETERS_GROUP,
             "dl1_images": IMAGES_GROUP,
             "dl1_muons": MUON_GROUP,
+            "dl1_aggregates": PARAMETER_AGGS_GROUP,
             "true_parameters": TRUE_PARAMETERS_GROUP,
             "true_images": TRUE_IMAGES_GROUP,
             "observation_info": OBSERVATION_TABLE,
@@ -376,6 +381,7 @@ class TableLoader(Component):
         self,
         start=None,
         stop=None,
+        dl1_aggregates=None,
         dl2=None,
         simulated=None,
         observation_info=None,
@@ -386,6 +392,8 @@ class TableLoader(Component):
         Parameters
         ----------
 
+        dl1_aggregates: bool
+            load available aggregated dl1 image parameters
         dl2: bool
             load available dl2 stereo parameters
         simulated: bool
@@ -403,10 +411,12 @@ class TableLoader(Component):
             Table with primary index columns "obs_id" and "event_id".
         """
         updated_args = self._check_args(
+            dl1_aggregates=dl1_aggregates,
             dl2=dl2,
             simulated=simulated,
             observation_info=observation_info,
         )
+        dl1_aggregates = updated_args["dl1_aggregates"]
         dl2 = updated_args["dl2"]
         simulated = updated_args["simulated"]
         observation_info = updated_args["observation_info"]
@@ -419,20 +429,29 @@ class TableLoader(Component):
             showers = read_table(self.h5file, SHOWER_TABLE, start=start, stop=stop)
             table = _merge_subarray_tables(table, showers)
 
-        if dl2:
-            if DL2_SUBARRAY_GROUP in self.h5file:
-                for group_name in self.h5file.root[DL2_SUBARRAY_GROUP]._v_children:
-                    group_path = f"{DL2_SUBARRAY_GROUP}/{group_name}"
-                    group = self.h5file.root[group_path]
+        if dl2 and DL2_SUBARRAY_GROUP in self.h5file:
+            for group_name in self.h5file.root[DL2_SUBARRAY_GROUP]._v_children:
+                group_path = f"{DL2_SUBARRAY_GROUP}/{group_name}"
+                group = self.h5file.root[group_path]
 
-                    for algorithm in group._v_children:
-                        dl2 = read_table(
-                            self.h5file,
-                            f"{group_path}/{algorithm}",
-                            start=start,
-                            stop=stop,
-                        )
-                        table = _merge_subarray_tables(table, dl2)
+                for algorithm in group._v_children:
+                    dl2 = read_table(
+                        self.h5file,
+                        f"{group_path}/{algorithm}",
+                        start=start,
+                        stop=stop,
+                    )
+                    table = _merge_subarray_tables(table, dl2)
+
+        if dl1_aggregates and PARAMETER_AGGS_GROUP in self.h5file:
+            for group_name in self.h5file.root[PARAMETER_AGGS_GROUP]._v_children:
+                aggs = read_table(
+                    self.h5file,
+                    f"{PARAMETER_AGGS_GROUP}/{group_name}",
+                    start=start,
+                    stop=stop,
+                )
+                table = _merge_subarray_tables(table, aggs)
 
         if observation_info:
             table = self._join_observation_info(table)

--- a/ctapipe/tools/aggregate_features.py
+++ b/ctapipe/tools/aggregate_features.py
@@ -1,0 +1,175 @@
+"""
+Tool to aggregate DL1 image parameters array-event-wise.
+"""
+import numpy as np
+import tables
+from tqdm.auto import tqdm
+
+from ..core import Tool, ToolConfigurationError
+from ..core.traits import Bool, Integer, Path, flag
+from ..image import FeatureAggregator
+from ..io import HDF5Merger, TableLoader, read_table, write_table
+from ..io.tableloader import _join_subarray_events
+
+__all__ = ["AggregateFeatures"]
+
+
+class AggregateFeatures(Tool):
+    """
+    Aggregate DL1 image parameters array-event-wise.
+
+    This tool calculates the maximal, minimal, and mean value,
+    as well as the standart deviation for any given DL1 image parameter
+    for all array events given as input.
+    """
+
+    name = "ctapipe-aggregate-image-parameters"
+    description = __doc__
+    examples = """
+    ctapipe-aggregate-image-parameters \\
+        --input gamma.dl1.h5 \\
+        --output gamma_incl_agg.dl1.h5
+    """
+
+    input_path = Path(
+        default_value=None,
+        allow_none=False,
+        directory_ok=False,
+        exists=True,
+        help="Input file containing DL1 image parameters",
+    ).tag(config=True)
+
+    output_path = Path(
+        default_value=None,
+        allow_none=False,
+        directory_ok=False,
+        help="Output file",
+    ).tag(config=True)
+
+    chunk_size = Integer(
+        default_value=100000,
+        allow_none=True,
+        help="How many array events to load at once for making predictions",
+    ).tag(config=True)
+
+    progress_bar = Bool(
+        help="Show progress bar during processing",
+        default_value=True,
+    ).tag(config=True)
+
+    aliases = {
+        ("i", "input"): "AggregateFeatures.input_path",
+        ("o", "output"): "AggregateFeatures.output_path",
+        "chunk-size": "AggregateFeatures.chunk_size",
+    }
+
+    flags = {
+        **flag(
+            "progress",
+            "AggregateFeatures.progress_bar",
+            "show a progress bar during event processing",
+            "don't show a progress bar during event processing",
+        ),
+        **flag(
+            "dl1-parameters",
+            "HDF5Merger.dl1_parameters",
+            "Include dl1 parameters in output",
+            "Exclude dl1 parameters in output",
+        ),
+        **flag(
+            "dl1-images",
+            "HDF5Merger.dl1_images",
+            "Include dl1 images in output",
+            "Exclude dl1 images in output",
+        ),
+        **flag(
+            "true-parameters",
+            "HDF5Merger.true_parameters",
+            "Include true parameters in output",
+            "Exclude true parameters in output",
+        ),
+        **flag(
+            "true-images",
+            "HDF5Merger.true_images",
+            "Include true images in output",
+            "Exclude true images in output",
+        ),
+        "overwrite": (
+            {
+                "HDF5Merger": {"overwrite": True},
+                "AggregateFeatures": {"overwrite": True},
+            },
+            "Overwrite output file if it exists",
+        ),
+    }
+
+    classes = [TableLoader, FeatureAggregator]
+
+    def setup(self):
+        """Initilize components form config."""
+        self.check_output(self.output_path)
+        self.log.info("Copying to output destination.")
+        with HDF5Merger(self.output_path, parent=self) as merger:
+            merger(self.input_path)
+
+        self.h5file = self.enter_context(tables.open_file(self.output_path, mode="r+"))
+        self.loader = self.enter_context(
+            TableLoader(
+                self.input_path,
+                parent=self,
+            )
+        )
+        self.aggregator = FeatureAggregator(parent=self)
+        if len(self.aggregator.image_parameters) == 0:
+            raise ToolConfigurationError(
+                "No image parameters to aggregate are specified."
+            )
+
+    def start(self):
+        """Aggregate DL1 image parameters for input tables."""
+        chunk_iterator = self.loader.read_telescope_events_chunked(
+            self.chunk_size,
+            dl2=False,
+            simulated=False,
+            true_parameters=False,
+        )
+        bar = tqdm(
+            chunk_iterator,
+            desc="Aggregating parameters",
+            unit=" Array Events",
+            total=chunk_iterator.n_total,
+            disable=not self.progress_bar,
+        )
+        with bar:
+            for chunk, (start, stop, table) in enumerate(chunk_iterator):
+                self.log.debug("Aggregating for chunk %d", chunk)
+                agg_tables = self.aggregator.aggregate_table(table)
+
+                # to ensure events are stored in the correct order,
+                # we resort to trigger table order
+                trigger = read_table(
+                    self.h5file, "/dl1/event/subarray/trigger", start=start, stop=stop
+                )[["obs_id", "event_id"]]
+                trigger["__sort_index__"] = np.arange(len(trigger))
+
+                for colname, agg_table in agg_tables.items():
+                    agg_table = _join_subarray_events(trigger, agg_table)
+                    agg_table.sort("__sort_index__")
+                    del agg_table["__sort_index__"]
+
+                    write_table(
+                        agg_table,
+                        self.output_path,
+                        f"/dl1/event/aggregate/{colname}",
+                        append=True,
+                    )
+
+                bar.update(stop - start)
+
+
+def main():
+    AggregateFeatures().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/ctapipe/tools/process.py
+++ b/ctapipe/tools/process.py
@@ -7,9 +7,9 @@ import sys
 from tqdm.auto import tqdm
 
 from ..calib import CameraCalibrator, GainSelector
-from ..core import QualityQuery, Tool
+from ..core import QualityQuery, Tool, ToolConfigurationError
 from ..core.traits import Bool, classes_with_traits, flag
-from ..image import ImageCleaner, ImageModifier, ImageProcessor
+from ..image import FeatureAggregator, ImageCleaner, ImageModifier, ImageProcessor
 from ..image.extractor import ImageExtractor
 from ..image.muon import MuonProcessor
 from ..instrument import SoftwareTrigger
@@ -137,6 +137,12 @@ class ProcessorTool(Tool):
             "store DL1/Event/Telescope muon parameters in output",
             "don't store DL1/Event/Telescope muon parameters in output",
         ),
+        **flag(
+            "aggregate-dl1-image-parameters",
+            "DataWriter.write_dl1_aggregates",
+            "store array-event-wise aggregated DL1 image parameters in output",
+            "don't store array-event-wise aggregated DL1 image parameters in output",
+        ),
         "camera-frame": (
             {"ImageProcessor": {"use_telescope_frame": False}},
             "Use camera frame for image parameters instead of telescope frame",
@@ -153,6 +159,7 @@ class ProcessorTool(Tool):
             metadata.Instrument,
             metadata.Contact,
             SoftwareTrigger,
+            FeatureAggregator,
         ]
         + classes_with_traits(EventSource)
         + classes_with_traits(ImageCleaner)
@@ -185,6 +192,7 @@ class ProcessorTool(Tool):
         self.calibrate = CameraCalibrator(parent=self, subarray=subarray)
         self.process_images = ImageProcessor(subarray=subarray, parent=self)
         self.process_shower = ShowerProcessor(subarray=subarray, parent=self)
+        self.aggregate = FeatureAggregator(parent=self)
         self.write = self.enter_context(
             DataWriter(event_source=self.event_source, parent=self)
         )
@@ -320,6 +328,13 @@ class ProcessorTool(Tool):
 
             if self.should_compute_dl2:
                 self.process_shower(event)
+
+            if self.write.write_dl1_aggregates:
+                if len(self.aggregate.image_parameters) == 0:
+                    raise ToolConfigurationError(
+                        "No DL1 image parameters to aggregate are specified."
+                    )
+                self.aggregate(event)
 
             self.write(event)
 

--- a/ctapipe/vectorization/__init__.py
+++ b/ctapipe/vectorization/__init__.py
@@ -1,0 +1,3 @@
+from .aggregate import max_ufunc, min_ufunc, weighted_mean_ufunc
+
+__all__ = ["weighted_mean_ufunc", "max_ufunc", "min_ufunc"]

--- a/ctapipe/vectorization/aggregate.py
+++ b/ctapipe/vectorization/aggregate.py
@@ -1,0 +1,128 @@
+import numpy as np
+
+__all__ = ["weighted_mean_ufunc", "max_ufunc", "min_ufunc"]
+
+
+def _grouped_add(tel_data, n_array_events, indices):
+    """
+    Calculate the group-wise sum for each array event over the
+    corresponding telescope events. ``indices`` is an array
+    that gives the index of the subarray event for each telescope event,
+    returned by
+    ``np.unique(tel_events[["obs_id", "event_id"]], return_inverse=True)``
+    """
+    combined_values = np.zeros(n_array_events)
+    np.add.at(combined_values, indices, tel_data)
+    return combined_values
+
+
+def weighted_mean_ufunc(tel_values, weights, n_array_events, indices):
+    """
+    Calculate the weighted mean for each array event over the
+    corresponding telescope events.
+
+    Parameters
+    ----------
+    tel_values: np.ndarray
+        values for each telescope event
+    weights: np.ndarray
+        weights used for averaging
+    n_array_events: int
+        number of array events with corresponding telescope events in ``tel_values``
+    indices: np.ndarray
+        index of the subarray event for each telescope event, returned by
+        ``np.unique(tel_events[["obs_id", "event_id"]], return_inverse=True)``
+
+    Returns
+    -------
+    array: np.ndarray
+        weighted mean for each array event
+    """
+    # avoid numerical problems by very large or small weights
+    weights = weights / weights.max()
+    sum_prediction = _grouped_add(
+        tel_values * weights,
+        n_array_events,
+        indices,
+    )
+    sum_of_weights = _grouped_add(
+        weights,
+        n_array_events,
+        indices,
+    )
+    mean = np.full(n_array_events, np.nan)
+    valid = sum_of_weights > 0
+    mean[valid] = sum_prediction[valid] / sum_of_weights[valid]
+    return mean
+
+
+def max_ufunc(tel_values, n_array_events, indices):
+    """
+    Find the maximum value for each array event from the
+    corresponding telescope events.
+
+    Parameters
+    ----------
+    tel_values: np.ndarray
+        values for each telescope event
+    n_array_events: int
+        number of array events with corresponding telescope events in ``tel_values``
+    indices: np.ndarray
+        index of the subarray event for each telescope event, returned by
+        ``np.unique(tel_events[["obs_id", "event_id"]], return_inverse=True)``
+
+    Returns
+    -------
+    array: np.ndarray
+        maximum value for each array event
+    """
+    if np.issubdtype(tel_values[0], np.integer):
+        fillvalue = np.iinfo(tel_values.dtype).min
+    elif np.issubdtype(tel_values[0], np.floating):
+        fillvalue = np.finfo(tel_values.dtype).min
+    else:
+        raise ValueError("Non-numerical dtypes are not supported")
+
+    max_values = np.full(n_array_events, fillvalue)
+    np.maximum.at(max_values, indices, tel_values)
+
+    result = np.full(n_array_events, np.nan)
+    valid = max_values > fillvalue
+    result[valid] = max_values[valid]
+    return result
+
+
+def min_ufunc(tel_values, n_array_events, indices):
+    """
+    Find the minimum value for each array event from the
+    corresponding telescope events.
+
+    Parameters
+    ----------
+    tel_values: np.ndarray
+        values for each telescope event
+    n_array_events: int
+        number of array events with corresponding telescope events in ``tel_values``
+    indices: np.ndarray
+        index of the subarray event for each telescope event, returned by
+        ``np.unique(tel_events[["obs_id", "event_id"]], return_inverse=True)``
+
+    Returns
+    -------
+    array: np.ndarray
+        minimum value for each array event
+    """
+    if np.issubdtype(tel_values[0], np.integer):
+        fillvalue = np.iinfo(tel_values.dtype).max
+    elif np.issubdtype(tel_values[0], np.floating):
+        fillvalue = np.finfo(tel_values.dtype).max
+    else:
+        raise ValueError("Non-numerical dtypes are not supported")
+
+    min_values = np.full(n_array_events, fillvalue)
+    np.minimum.at(min_values, indices, tel_values)
+
+    result = np.full(n_array_events, np.nan)
+    valid = min_values < fillvalue
+    result[valid] = min_values[valid]
+    return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,6 +99,7 @@ console_scripts =
     ctapipe-train-particle-classifier = ctapipe.tools.train_particle_classifier:main
     ctapipe-train-disp-reconstructor = ctapipe.tools.train_disp_reconstructor:main
     ctapipe-apply-models = ctapipe.tools.apply_models:main
+    ctapipe-aggregate-image-parameters = ctapipe.tools.aggregate_features:main
 
 ctapipe_io =
     HDF5EventSource = ctapipe.io.hdf5eventsource:HDF5EventSource


### PR DESCRIPTION
- This adds a new `Component` and a `Tool` for aggregating the telescope-wise dl1 image parameters for each array event.
- `BaseStatisticsContainer` is introduced which does not contain the higher order moments present in `StatisticsContainer`
- The helper functions for vectorizing numpy calculations in `ctapipe.reco.stereo_combination` are refactored and expanded in a new module called `ctapipe.vectorization`  

TODO:
- [ ] Add/ update unit tests