### PR TITLE
Fix pydata sphinx theme is not safe for parallel writing warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test:
 	pytest
 
 doc:
-	cd docs && $(MAKE) html SPHINXOPTS="-W --keep-going -n --color -j auto"
+	cd docs && $(MAKE) html SPHINXOPTS="-W --keep-going -n --color"
 	@echo "------------------------------------------------"
 	@echo "Documentation is in: docs/_build/html/index.html"
 


### PR DESCRIPTION
New version of pydata sphinx theme raises a warning that it is not thread safe so better not use parallel sphinx...