### PR TITLE
Enable processing of interleaved calibration events via the process tool

### DIFF
--- a/src/ctapipe/calib/camera/calibrator.py
+++ b/src/ctapipe/calib/camera/calibrator.py
@@ -294,15 +294,6 @@ class CameraCalibrator(TelescopeComponent):
         if self._check_r1_empty(waveforms):
             return
 
-        if self.image_extractor_type.tel[tel_id] not in [
-            "LocalPeakWindowSum",
-            "FixedWindowSum",
-        ]:
-            raise ValueError(
-                f"Invalid ImageExtractor '{self.image_extractor_type.tel[tel_id]}'."
-                "Valid options: LocalPeakWindowSum FixedWindowSum."
-            )
-
         n_channels, n_pixels, n_samples = waveforms.shape
 
         broken_pixels = event.mon.tel[tel_id].pixel_status.hardware_failing_pixels

--- a/src/ctapipe/calib/camera/calibrator.py
+++ b/src/ctapipe/calib/camera/calibrator.py
@@ -7,7 +7,13 @@ import astropy.units as u
 import numpy as np
 from numba import float32, float64, guvectorize, int64
 
-from ctapipe.containers import DL0CameraContainer, DL1CameraContainer, PixelStatus
+from ctapipe.containers import (
+    DL0CameraContainer,
+    DL1CameraContainer,
+    PixelStatus,
+    EventType,
+)
+
 from ctapipe.core import TelescopeComponent
 from ctapipe.core.traits import (
     BoolTelescopeParameter,
@@ -346,8 +352,8 @@ class CameraCalibrator(TelescopeComponent):
         tel = event.r1.tel or event.dl0.tel or event.dl1.tel
         for tel_id in tel.keys():
             if (
-                self.process_flatfield_events
-                or self.process_pedestal_events
+                event.trigger.event_type == EventType.SKY_PEDESTAL
+                or event.trigger.event_type == EventType.FLATFIELD
             ):
                 self._process_calib(event, tel_id)
             else:

--- a/src/ctapipe/calib/camera/calibrator.py
+++ b/src/ctapipe/calib/camera/calibrator.py
@@ -11,6 +11,7 @@ from ctapipe.containers import DL0CameraContainer, DL1CameraContainer, PixelStat
 from ctapipe.core import TelescopeComponent
 from ctapipe.core.traits import (
     BoolTelescopeParameter,
+    Bool,
     ComponentName,
     TelescopeParameter,
 )
@@ -87,12 +88,12 @@ class CameraCalibrator(TelescopeComponent):
         ),
     ).tag(config=True)
 
-    process_flatfield_events = BoolTelescopeParameter(
+    process_flatfield_events = Bool(
         default_value=False,
         help="Process flatfield events from a calibration data stream.",
     ).tag(config=True)
 
-    process_pedestal_events = BoolTelescopeParameter(
+    process_pedestal_events = Bool(
         default_value=False,
         help="Process pedestal events from a calibration data stream.",
     ).tag(config=True)
@@ -345,8 +346,8 @@ class CameraCalibrator(TelescopeComponent):
         tel = event.r1.tel or event.dl0.tel or event.dl1.tel
         for tel_id in tel.keys():
             if (
-                self.process_flatfield_events.tel[tel_id]
-                or self.process_pedestal_events.tel[tel_id]
+                self.process_flatfield_events
+                or self.process_pedestal_events
             ):
                 self._process_calib(event, tel_id)
             else:

--- a/src/ctapipe/calib/camera/calibrator.py
+++ b/src/ctapipe/calib/camera/calibrator.py
@@ -94,16 +94,6 @@ class CameraCalibrator(TelescopeComponent):
         ),
     ).tag(config=True)
 
-    process_flatfield_events = Bool(
-        default_value=False,
-        help="Process flatfield events from a calibration data stream.",
-    ).tag(config=True)
-
-    process_pedestal_events = Bool(
-        default_value=False,
-        help="Process pedestal events from a calibration data stream.",
-    ).tag(config=True)
-
     def __init__(
         self,
         subarray,

--- a/src/ctapipe/containers.py
+++ b/src/ctapipe/containers.py
@@ -483,16 +483,12 @@ class DL1CameraContainer(Container):
 
     image = Field(
         None,
-        "Numpy array of camera image, after waveform extraction." "Shape: (n_pixel)",
-        dtype=np.float32,
-        ndim=1,
+        "Numpy array of camera image, after waveform extraction." "Shape: (n_channel, n_pixel)",
     )
     peak_time = Field(
         None,
         "Numpy array containing position of the peak of the pulse as determined by "
-        "the extractor. Shape: (n_pixel, )",
-        dtype=np.float32,
-        ndim=1,
+        "the extractor. Shape: (n_channel, n_pixel)",
     )
     image_mask = Field(
         None,

--- a/src/ctapipe/tools/process.py
+++ b/src/ctapipe/tools/process.py
@@ -211,12 +211,6 @@ class ProcessorTool(Tool):
         if self.force_recompute_dl2:
             return True
 
-        if (
-            self.calibrate.process_flatfield_events
-            or self.calibrate.process_pedestal_events
-        ):
-            return False
-
         return self.write.write_dl2
 
     @property

--- a/src/ctapipe/tools/process.py
+++ b/src/ctapipe/tools/process.py
@@ -8,7 +8,6 @@ import sys
 from tqdm.auto import tqdm
 
 from ..calib import CameraCalibrator, GainSelector
-from ..containers import EventType
 from ..core import QualityQuery, Tool
 from ..core.traits import Bool, classes_with_traits, flag
 from ..image import ImageCleaner, ImageModifier, ImageProcessor
@@ -111,18 +110,6 @@ class ProcessorTool(Tool):
             "Only compute DL2 if there is no shower reconstruction in the file",
         ),
         **flag(
-            "process-flatfield",
-            "CameraCalibrator.process_flatfield_events",
-            "process flatfield events from a calibration data stream",
-            "don't process flatfield events from a calibration data stream",
-        ),
-        **flag(
-            "process-pedestal",
-            "CameraCalibrator.process_pedestal_events",
-            "process pedestal events from a calibration data stream",
-            "don't process pedestal events from a calibration data stream",
-        ),
-        **flag(
             "write-images",
             "DataWriter.write_dl1_images",
             "store DL1/Event/Telescope images in output",
@@ -202,18 +189,6 @@ class ProcessorTool(Tool):
             DataWriter(event_source=self.event_source, parent=self)
         )
 
-        if (
-            self.calibrate.process_flatfield_events
-            or self.calibrate.process_pedestal_events
-        ):
-            self.log.warning(
-                "DataWriter flags are set automatically when processing of calibration events"
-            )
-            self.write.write_dl1_images = True
-            self.write.write_dl1_parameters = False
-            self.write.write_dl2 = False
-            self.write.write_muon_parameters = False
-
         self.process_muons = MuonProcessor(subarray=subarray, parent=self)
 
         self.event_type_filter = EventTypeFilter(parent=self)
@@ -253,12 +228,6 @@ class ProcessorTool(Tool):
         if DataLevel.DL1_PARAMETERS in self.event_source.datalevels:
             return False
 
-        if (
-            self.calibrate.process_flatfield_events
-            or self.calibrate.process_pedestal_events
-        ):
-            return False
-
         return (
             self.write.write_dl1_parameters
             or self.should_compute_dl2
@@ -277,12 +246,6 @@ class ProcessorTool(Tool):
         ):
             return True
 
-        if (
-            self.calibrate.process_flatfield_events
-            or self.calibrate.process_pedestal_events
-        ):
-            return True
-
         if self.should_compute_dl1:
             return DataLevel.DL1_IMAGES not in self.event_source.datalevels
 
@@ -294,23 +257,7 @@ class ProcessorTool(Tool):
         if self.write.write_muon_parameters:
             return True
 
-        if (
-            self.calibrate.process_flatfield_events
-            or self.calibrate.process_pedestal_events
-        ):
-            return False
-
         return False
-
-    def should_process(self, event):
-        """returns true if event should be processed"""
-        if self.calibrate.process_flatfield_events:
-            return event.trigger.event_type == EventType.FLATFIELD
-
-        if self.calibrate.process_pedestal_events:
-            return event.trigger.event_type == EventType.SKY_PEDESTAL
-
-        return True
 
     def _write_processing_statistics(self):
         """write out the event selection stats, etc."""
@@ -365,12 +312,6 @@ class ProcessorTool(Tool):
             if not self.software_trigger(event):
                 self.log.debug(
                     "Skipping event %i due to software trigger", event.index.event_id
-                )
-                continue
-
-            if not self.should_process(event):
-                self.log.debug(
-                    "Skipping event %i due to calibration settings", event.index.event_id
                 )
                 continue
 


### PR DESCRIPTION
This commit enables the processing of flatfield and sky pedestal events up to dl1-like using the `ctapipe-process` tool. Code changes are tested with interleaved calibration events from LST-1. I needed to tweak the pointing frame in `hdf5eventsource` in order to make it work with the standard `lstchain` R1 interleaved files (not produced with the latest `ctapipe` version).

Currently only tested with the ImageExtractors (LocalPeakWindowSum and FixedWindowSum), which are the default ones.