### PR TITLE
Add a trait for astropy quantities

### DIFF
--- a/docs/changes/2524.feature.rst
+++ b/docs/changes/2524.feature.rst
@@ -1,0 +1,1 @@
+Add an ``AstroQuantity`` trait which can hold any ``astropy.units.Quantity``.

--- a/src/ctapipe/core/tests/test_traits.py
+++ b/src/ctapipe/core/tests/test_traits.py
@@ -304,6 +304,17 @@ def test_quantity():
     with pytest.raises(TraitError):
         c.quantity = "5 meters"
 
+    with pytest.raises(
+        TraitError,
+        match=f"Given physical type {u.physical.energy} does not match"
+        + " physical type of the default value length.",
+    ):
+
+        class SomeComponentWithEnergyTrait(Component):
+            energy = AstroQuantity(
+                default_value=5 * u.m, physical_type=u.physical.energy
+            )
+
 
 def test_quantity_tool(capsys):
     import astropy.units as u

--- a/src/ctapipe/core/tests/test_traits.py
+++ b/src/ctapipe/core/tests/test_traits.py
@@ -304,13 +304,34 @@ def test_quantity():
     with pytest.raises(TraitError):
         c.quantity = "5 meters"
 
+    # Test definition of physical type
+    class SomeComponentWithEnergyTrait(Component):
+        energy = AstroQuantity(physical_type=u.physical.energy)
+
+    c = SomeComponentWithEnergyTrait()
+
+    class AnotherComponentWithEnergyTrait(Component):
+        energy = AstroQuantity(physical_type=u.TeV)
+
+    c = AnotherComponentWithEnergyTrait()
+
+    with pytest.raises(
+        TraitError,
+        match="Given physical type must be either of type"
+        + " astropy.units.PhysicalType or a subclass of"
+        + f" astropy.units.UnitBase, was {type(5 * u.TeV)}.",
+    ):
+
+        class SomeBadComponentWithEnergyTrait(Component):
+            energy = AstroQuantity(physical_type=5 * u.TeV)
+
     with pytest.raises(
         TraitError,
         match=f"Given physical type {u.physical.energy} does not match"
-        + " physical type of the default value length.",
+        + f" physical type of the default value, {u.get_physical_type(5 * u.m)}.",
     ):
 
-        class SomeComponentWithEnergyTrait(Component):
+        class AnotherBadComponentWithEnergyTrait(Component):
             energy = AstroQuantity(
                 default_value=5 * u.m, physical_type=u.physical.energy
             )
@@ -332,7 +353,8 @@ def test_quantity_tool(capsys):
     captured = capsys.readouterr()
     assert (
         captured.err.split(":")[-1]
-        == f" Given quantity is of physical type length. Expected {u.physical.energy}.\n"
+        == f" Given quantity is of physical type {u.get_physical_type(5 * u.m)}."
+        + f" Expected {u.physical.energy}.\n"
     )
 
 

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -79,14 +79,26 @@ class AstroQuantity(TraitType):
 
     def __init__(self, physical_type=None, **kwargs):
         super().__init__(**kwargs)
-        self.physical_type = physical_type
+        if physical_type is not None:
+            if isinstance(physical_type, u.PhysicalType):
+                self.physical_type = physical_type
+            elif isinstance(physical_type, u.UnitBase):
+                self.physical_type = u.get_physical_type(physical_type)
+            else:
+                raise TraitError(
+                    "Given physical type must be either of type"
+                    " astropy.units.PhysicalType or a subclass of"
+                    f" astropy.units.UnitBase, was {type(physical_type)}."
+                )
+        else:
+            self.physical_type = physical_type
 
         if self.default_value is not Undefined and self.physical_type is not None:
             default_type = u.get_physical_type(self.default_value)
             if default_type != self.physical_type:
                 raise TraitError(
                     f"Given physical type {self.physical_type} does not match"
-                    f" physical type of the default value {default_type}."
+                    f" physical type of the default value, {default_type}."
                 )
 
     def info(self):

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 from urllib.parse import urlparse
 
+import astropy.units as u
 import traitlets
 import traitlets.config
 from astropy.time import Time
@@ -17,6 +18,7 @@ from .telescope_component import TelescopeParameter
 
 __all__ = [
     # Implemented here
+    "AstroQuantity",
     "AstroTime",
     "BoolTelescopeParameter",
     "IntTelescopeParameter",
@@ -72,8 +74,33 @@ observe = traitlets.observe
 flag = traitlets.config.boolean_flag
 
 
+class AstroQuantity(TraitType):
+    """A trait containing an ``astropy.units`` quantity."""
+
+    def info(self):
+        info = "An ``astropy.units.Quantity`` instance"
+        if self.allow_none:
+            info += "or None"
+        return info
+
+    def validate(self, obj, value):
+        try:
+            quantity = u.Quantity(value)
+            return quantity
+        except TypeError:
+            return self.error(obj, value)
+        except ValueError:
+            return self.error(obj, value)
+
+    def from_string(self, s: str):
+        if self.allow_none and s == "None":
+            return None
+
+        return u.Quantity(s)
+
+
 class AstroTime(TraitType):
-    """A trait representing a point in Time, as understood by `astropy.time`"""
+    """A trait representing a point in Time, as understood by ``astropy.time``."""
 
     def validate(self, obj, value):
         """try to parse and return an ISO time string"""

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -77,6 +77,14 @@ flag = traitlets.config.boolean_flag
 class AstroQuantity(TraitType):
     """A trait containing an ``astropy.units`` quantity."""
 
+    def __init__(
+        self,
+        physical_type: u.physical.PhysicalType | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.physical_type = physical_type
+
     def info(self):
         info = "An ``astropy.units.Quantity`` instance"
         if self.allow_none:
@@ -86,11 +94,20 @@ class AstroQuantity(TraitType):
     def validate(self, obj, value):
         try:
             quantity = u.Quantity(value)
-            return quantity
         except TypeError:
             return self.error(obj, value)
         except ValueError:
             return self.error(obj, value)
+
+        if self.physical_type is not None:
+            given_type = u.get_physical_type(quantity)
+            if given_type != self.physical_type:
+                raise TraitError(
+                    f"Given quantity is of physical type {given_type}."
+                    f" Expected {self.physical_type}."
+                )
+
+        return quantity
 
 
 class AstroTime(TraitType):

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -92,12 +92,6 @@ class AstroQuantity(TraitType):
         except ValueError:
             return self.error(obj, value)
 
-    def from_string(self, s: str):
-        if self.allow_none and s == "None":
-            return None
-
-        return u.Quantity(s)
-
 
 class AstroTime(TraitType):
     """A trait representing a point in Time, as understood by ``astropy.time``."""

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -81,6 +81,14 @@ class AstroQuantity(TraitType):
         super().__init__(**kwargs)
         self.physical_type = physical_type
 
+        if self.default_value is not Undefined and self.physical_type is not None:
+            default_type = u.get_physical_type(self.default_value)
+            if default_type != self.physical_type:
+                raise TraitError(
+                    f"Given physical type {self.physical_type} does not match"
+                    f" physical type of the default value {default_type}."
+                )
+
     def info(self):
         info = "An ``astropy.units.Quantity`` instance"
         if self.allow_none:

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -77,11 +77,7 @@ flag = traitlets.config.boolean_flag
 class AstroQuantity(TraitType):
     """A trait containing an ``astropy.units`` quantity."""
 
-    def __init__(
-        self,
-        physical_type: u.physical.PhysicalType | None = None,
-        **kwargs,
-    ):
+    def __init__(self, physical_type=None, **kwargs):
         super().__init__(**kwargs)
         self.physical_type = physical_type
 


### PR DESCRIPTION
Having a configurable trait containing an `astropy.units.Quantity` is useful for the irf tool and will probably be useful for other high-level tools, too. 