### PR TITLE
Fix sonar complaining about statements in notebooks

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,7 @@ sonar.qualitygate.wait=true
 sonar.language=python
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.9
+
+# ignore "statement has no effect" in the sphinx-gallery examples
+sonar.issue.ignore.multicriteria.r1.ruleKey=python:S905
+sonar.issue.ignore.multicriteria.r1.resourceKey=examples/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,6 @@ sonar.language=python
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.9
 
-# ignore "statement has no effect" in the sphinx-gallery examples
-sonar.issue.ignore.multicriteria.r1.ruleKey=python:S905
-sonar.issue.ignore.multicriteria.r1.resourceKey=examples/**
+# ignore examples for coverage and issues, these are sphinx-gallery notebook scripts
+# which aren't really supported by sonarqube and lead to a lot of false positives
+sonar.exclusions=examples/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,4 @@
 sonar.projectKey=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs
-sonar.qualitygate.wait=true
 sonar.language=python
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.9


### PR DESCRIPTION
Sonarqube complained about statements that "have no effect" in the examples, but these are the output cell values for sphinx-gallery, so not actually a bug