### PR TITLE
Use macos 14 (apple arm) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,11 @@ jobs:
             python-version: "3.12"
             install-method: pip
 
-          - os: macos-latest
+          - os: macos-14
             python-version: "3.10"
             install-method: pip
 
-          - os: macos-latest
+          - os: macos-14
             python-version: "3.12"
             install-method: mamba
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,12 @@ jobs:
             python-version: "3.12"
             install-method: pip
 
-          - os: macos-14
+          # macos 13 image is x86-based
+          - os: macos-13
             python-version: "3.10"
             install-method: pip
 
+          # macos 14 image is arm64 based
           - os: macos-14
             python-version: "3.12"
             install-method: mamba


### PR DESCRIPTION
The macos-latest (currently macos 12 on x86_64 for us, but being transitioned to macos 14) is giving transient failures relatively often that seem unrelated to anything we do here.

Trying to switch to the macos 14 image that's using apple arm.

See: https://github.com/actions/runner-images?tab=readme-ov-file#available-images