### PR TITLE
Fix possible out of bounds error in FlashCamExtractor

### DIFF
--- a/docs/changes/2544.bugfix.rst
+++ b/docs/changes/2544.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a possible out-of-bounds array access in the FlashCamExtractor.

--- a/src/ctapipe/image/extractor.py
+++ b/src/ctapipe/image/extractor.py
@@ -1531,7 +1531,7 @@ def adaptive_centroid(waveforms, peak_index, rel_descend_limit, centroids):
         sum_ += waveforms[j]
         jsum += j * waveforms[j]
         j -= 1
-        if waveforms[j] > peak_amplitude:
+        if j >= 0 and waveforms[j] > peak_amplitude:
             descend_limit = rel_descend_limit * peak_amplitude
 
     j = peak_index + 1
@@ -1539,7 +1539,7 @@ def adaptive_centroid(waveforms, peak_index, rel_descend_limit, centroids):
         sum_ += waveforms[j]
         jsum += j * waveforms[j]
         j += 1
-        if waveforms[j] > peak_amplitude:
+        if j < n_samples and waveforms[j] > peak_amplitude:
             descend_limit = rel_descend_limit * peak_amplitude
 
     if sum_ != 0.0:


### PR DESCRIPTION
The code had a possible out of bounds array access in case of the peak not being fully contained in the waveform.

Should fix a segfault reported by @gschwefer 