### PR TITLE
Fix StereoTrigger non-deterministically discarding LST-1 in prod6 files

### DIFF
--- a/docs/changes/2552.bugfix.rst
+++ b/docs/changes/2552.bugfix.rst
@@ -1,0 +1,6 @@
+Fix ``SoftwareTrigger`` not correctly handling different telescope
+types that have the same string representation, e.g. the four LSTs
+in prod6 files.
+
+Telescopes that have the same string representation now always are treated
+as one group in ``SoftwareTrigger``.

--- a/src/ctapipe/tools/process.py
+++ b/src/ctapipe/tools/process.py
@@ -301,7 +301,6 @@ class ProcessorTool(Tool):
             disable=not self.progress_bar,
         ):
             self.log.debug("Processing event_id=%s", event.index.event_id)
-
             if not self.event_type_filter(event):
                 continue
 


### PR DESCRIPTION
This was one of the weirder bugs I have ever tracked down. The symptom was that in consecutive runs of `ctapipe-process` on the same input file, sometimes LST-1 was missing from the output completely.

Tracking it down to the SoftwareTrigger class, which used a mixture of using ``TelescopeDescription`` and its string representation for storing and looking up things.

The dict `_ids_by_type` was the culprit, its content depended on the hash of str(TelescopeDescription), which was random, since hash of strings are random for security reasons in python.