### PR TITLE
EventViewer as part of ctapipe-process tool

### DIFF
--- a/src/ctapipe/tools/process.py
+++ b/src/ctapipe/tools/process.py
@@ -31,6 +31,7 @@ from ..io.hdf5dataformat import (
 )
 from ..reco import Reconstructor, ShowerProcessor
 from ..utils import EventTypeFilter
+from ..visualization import EventViewer
 
 COMPATIBLE_DATALEVELS = [
     DataLevel.R1,
@@ -106,6 +107,13 @@ class ProcessorTool(Tool):
         default_value=[],
     ).tag(config=True)
 
+    event_viewer_name = ComponentName(
+        EventViewer,
+        default_value="QTEventViewer",
+    ).tag(config=True)
+
+    open_viewer = Bool(False, help="Open EventViewer").tag(config=True)
+
     aliases = {
         ("i", "input"): "EventSource.input_url",
         ("o", "output"): "DataWriter.output_path",
@@ -163,6 +171,12 @@ class ProcessorTool(Tool):
             "store DL1/Event/Telescope muon parameters in output",
             "don't store DL1/Event/Telescope muon parameters in output",
         ),
+        **flag(
+            "viewer",
+            "ProcessorTool.open_viewer",
+            "Open EventViewer",
+            "Do not open EventViewer",
+        ),
         "camera-frame": (
             {"ImageProcessor": {"use_telescope_frame": False}},
             "Use camera frame for image parameters instead of telescope frame",
@@ -190,6 +204,7 @@ class ProcessorTool(Tool):
         + classes_with_traits(ImageModifier)
         + classes_with_traits(EventTypeFilter)
         + classes_with_traits(Reconstructor)
+        + classes_with_traits(EventViewer)
     )
 
     def setup(self):
@@ -258,6 +273,11 @@ class ProcessorTool(Tool):
             self.process_muons = MuonProcessor(subarray=subarray, parent=self)
 
         self.event_type_filter = EventTypeFilter(parent=self)
+
+        if self.open_viewer:
+            self.event_viewer = EventViewer.from_name(self.event_viewer_name, subarray)
+        else:
+            self.event_viewer = None
 
     @property
     def should_compute_dl2(self):
@@ -379,6 +399,9 @@ class ProcessorTool(Tool):
 
             if self.should_compute_dl2:
                 self.process_shower(event)
+
+            if self.event_viewer is not None:
+                self.event_viewer(event)
 
             self.write(event)
 

--- a/src/ctapipe/tools/process.py
+++ b/src/ctapipe/tools/process.py
@@ -109,7 +109,7 @@ class ProcessorTool(Tool):
 
     event_viewer_name = ComponentName(
         EventViewer,
-        default_value="QTEventViewer",
+        default_value="QtEventViewer",
     ).tag(config=True)
 
     open_viewer = Bool(False, help="Open EventViewer").tag(config=True)

--- a/src/ctapipe/visualization/__init__.py
+++ b/src/ctapipe/visualization/__init__.py
@@ -4,12 +4,12 @@ Visualization: Methods for displaying data
 
 from .mpl_array import ArrayDisplay
 from .mpl_camera import CameraDisplay
-from .qt_eventviewer import QTEventViewer
+from .qt_eventviewer import QtEventViewer
 from .viewer import EventViewer
 
 __all__ = [
     "CameraDisplay",
     "ArrayDisplay",
     "EventViewer",
-    "QTEventViewer",
+    "QtEventViewer",
 ]

--- a/src/ctapipe/visualization/__init__.py
+++ b/src/ctapipe/visualization/__init__.py
@@ -1,9 +1,15 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Visualization: Methods for displaying data
 """
 
 from .mpl_array import ArrayDisplay
 from .mpl_camera import CameraDisplay
+from .qt_eventviewer import QTEventViewer
+from .viewer import EventViewer
 
-__all__ = ["CameraDisplay", "ArrayDisplay"]
+__all__ = [
+    "CameraDisplay",
+    "ArrayDisplay",
+    "EventViewer",
+    "QTEventViewer",
+]

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -2,6 +2,7 @@ from queue import Empty
 
 import astropy.units as u
 import numpy as np
+from PySide6 import QtGui
 from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtWidgets import (
     QApplication,
@@ -213,6 +214,10 @@ class ViewerMainWindow(QMainWindow):
         self.event_thread.start()
 
         self.new_event_signal.connect(self.update_event)
+
+        # set window size slightly smaller than available desktop space
+        size = QtGui.QGuiApplication.primaryScreen().availableGeometry().size()
+        self.resize(0.9 * size)
 
     def update_event(self, event):
         if event is None:

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -115,8 +115,10 @@ class ViewerMainWindow(QMainWindow):
         tel_id = int(tel_id)
         index = self.widget_index[tel_id]
         widget = self.camera_displays[index]
-        widget.display.image = self.current_event.dl1.tel[tel_id].image
+
         self.camera_display_stack.setCurrentIndex(index)
+        widget.display.image = self.current_event.dl1.tel[tel_id].image
+        widget.display.axes.figure.canvas.draw()
 
     def next(self):
         if self.current_event is not None:

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -44,6 +44,7 @@ class ViewerMainWindow(QMainWindow):
         self.subarray = subarray
         self.queue = queue
         self.current_event = None
+        self.setWindowTitle("ctapipe event display")
 
         layout = QVBoxLayout()
 
@@ -91,7 +92,8 @@ class ViewerMainWindow(QMainWindow):
 
         if event.simulation is not None and event.simulation.shower is not None:
             self.label.setText(
-                f"event_id: {event.index.event_id}"
+                f"obs_id: {event.index.obs_id}"
+                f", event_id: {event.index.event_id}"
                 f", E={event.simulation.shower.energy:.3f}"
             )
         else:

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -52,9 +52,14 @@ class ViewerMainWindow(QMainWindow):
         self.label = QLabel(self)
         top.addWidget(self.label)
 
+        tel_selector_layout = QHBoxLayout()
+        label = QLabel(text="tel_id: ")
+        label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignCenter)
+        tel_selector_layout.addWidget(label)
         self.tel_selector = QComboBox(self)
         self.tel_selector.currentTextChanged.connect(self.update_tel_image)
-        top.addWidget(self.tel_selector)
+        tel_selector_layout.addWidget(self.tel_selector)
+        top.addLayout(tel_selector_layout)
 
         layout.addLayout(top)
 
@@ -90,14 +95,11 @@ class ViewerMainWindow(QMainWindow):
         if event is None:
             return
 
+        label = f"obs_id: {event.index.obs_id}" f", event_id: {event.index.event_id}"
         if event.simulation is not None and event.simulation.shower is not None:
-            self.label.setText(
-                f"obs_id: {event.index.obs_id}"
-                f", event_id: {event.index.event_id}"
-                f", E={event.simulation.shower.energy:.3f}"
-            )
-        else:
-            self.label.setText(f"event_id: {event.index.event_id}")
+            label += f", E={event.simulation.shower.energy:.3f}"
+
+        self.label.setText(label)
 
         if event.dl1 is not None:
             tels_with_image = [

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -147,10 +147,7 @@ class SubarrayDataWidget(QWidget):
 
         if (sim := event.simulation) is not None and (shower := sim.shower) is not None:
             impact = GroundFrame(shower.core_x, shower.core_y, 0 * u.m)
-            impact = impact.transform_to(self.display.frame)
-            x = impact.easting.to_value(u.m)
-            y = impact.northing.to_value(u.m)
-            self.true_impact.set_data(x, y)
+            self._update_impact(self.true_impact, impact)
 
         for key, reco in event.dl2.stereo.geometry.items():
             if key not in self.reco_impacts:
@@ -167,12 +164,15 @@ class SubarrayDataWidget(QWidget):
                 self.ax.legend(handles=self.display.legend_elements)
 
             impact = GroundFrame(reco.core_x, reco.core_y, 0 * u.m)
-            impact = impact.transform_to(self.display.frame)
-            x = impact.easting.to_value(u.m)
-            y = impact.northing.to_value(u.m)
-            self.reco_impacts[key].set_data(x, y)
+            self._update_impact(self.reco_impacts[key], impact)
 
         self.canvas.draw()
+
+    def _update_impact(self, artist, impact):
+        impact = impact.transform_to(self.display.frame)
+        x = np.atleast_1d(impact.easting.to_value(u.m))
+        y = np.atleast_1d(impact.northing.to_value(u.m))
+        artist.set_data(x, y)
 
 
 class ViewerMainWindow(QMainWindow):

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -1,0 +1,142 @@
+from PySide6.QtCore import QThread, Signal
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QStackedLayout,
+    QVBoxLayout,
+    QWidget,
+)
+
+# import matplotlib after qt so it can detect which bindings are in use
+from matplotlib.backends import backend_qtagg  # isort: skip
+from matplotlib.figure import Figure  # isort: skip
+
+from .mpl_camera import CameraDisplay
+
+
+class CameraDisplayWidget(QWidget):
+    def __init__(self, geometry, **kwargs):
+        super().__init__(**kwargs)
+
+        self.geometry = geometry
+
+        self.fig = Figure(layout="constrained")
+        self.canvas = backend_qtagg.FigureCanvasQTAgg(self.fig)
+
+        self.ax = self.fig.add_subplot(1, 1, 1)
+        self.display = CameraDisplay(geometry, ax=self.ax)
+        self.display.add_colorbar()
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.canvas)
+        self.setLayout(layout)
+
+
+class ViewerMainWindow(QMainWindow):
+    new_event_signal = Signal()
+
+    def __init__(self, subarray, queue, **kwargs):
+        super().__init__(**kwargs)
+        self.subarray = subarray
+        self.queue = queue
+        self.current_event = None
+
+        layout = QVBoxLayout()
+
+        top = QHBoxLayout()
+        self.label = QLabel(self)
+        top.addWidget(self.label)
+
+        self.tel_selector = QComboBox(self)
+        self.tel_selector.currentTextChanged.connect(self.update_tel_image)
+        top.addWidget(self.tel_selector)
+
+        layout.addLayout(top)
+
+        self.camera_displays = []
+        self.widget_index = {}
+        self.camera_display_stack = QStackedLayout()
+
+        for i, tel in enumerate(self.subarray.telescope_types):
+            widget = CameraDisplayWidget(tel.camera.geometry)
+            self.camera_displays.append(widget)
+            self.camera_display_stack.addWidget(widget)
+
+            for tel_id in subarray.get_tel_ids_for_type(tel):
+                self.widget_index[tel_id] = i
+
+        layout.addLayout(self.camera_display_stack)
+
+        self.next_button = QPushButton("Next Event", parent=self)
+        self.next_button.pressed.connect(self.next)
+        layout.addWidget(self.next_button)
+
+        widget = QWidget(self)
+        widget.setLayout(layout)
+        self.setCentralWidget(widget)
+
+        self.event_thread = EventLoop(self)
+        self.event_thread.start()
+
+        self.new_event_signal.connect(self.update_event)
+
+    def update_event(self):
+        event = self.current_event
+        if event is None:
+            return
+
+        if event.simulation is not None and event.simulation.shower is not None:
+            self.label.setText(
+                f"event_id: {event.index.event_id}"
+                f", E={event.simulation.shower.energy:.3f}"
+            )
+        else:
+            self.label.setText(f"event_id: {event.index.event_id}")
+
+        if event.dl1 is not None:
+            tels_with_image = [
+                str(tel_id)
+                for tel_id, dl1 in event.dl1.tel.items()
+                if dl1.image is not None
+            ]
+            self.tel_selector.clear()
+            self.tel_selector.addItems(tels_with_image)
+            self.tel_selector.setCurrentIndex(0)
+
+    def update_tel_image(self, tel_id):
+        # tel_selector.clear also calls this, but with an empty tel_id
+        if tel_id == "":
+            return
+
+        tel_id = int(tel_id)
+        index = self.widget_index[tel_id]
+        widget = self.camera_displays[index]
+        widget.display.image = self.current_event.dl1.tel[tel_id].image
+        self.camera_display_stack.setCurrentIndex(index)
+
+    def next(self):
+        if self.current_event is not None:
+            self.queue.task_done()
+
+
+class EventLoop(QThread):
+    def __init__(self, display):
+        super().__init__()
+        self.display = display
+
+    def run(self):
+        while True:
+            event = self.display.queue.get()
+            self.display.current_event = event
+            self.display.new_event_signal.emit()
+
+
+def viewer_main(subarray, queue):
+    app = QApplication()
+    window = ViewerMainWindow(subarray, queue)
+    window.show()
+    app.exec_()

--- a/src/ctapipe/visualization/_qt_viewer_impl.py
+++ b/src/ctapipe/visualization/_qt_viewer_impl.py
@@ -225,7 +225,7 @@ class ViewerMainWindow(QMainWindow):
 
         self.current_event = event
 
-        label = f"obs_id: {event.index.obs_id}" f", event_id: {event.index.event_id}"
+        label = f"obs_id: {event.index.obs_id}, event_id: {event.index.event_id}"
         if event.simulation is not None and event.simulation.shower is not None:
             label += f", E={event.simulation.shower.energy:.3f}"
 

--- a/src/ctapipe/visualization/mpl_array.py
+++ b/src/ctapipe/visualization/mpl_array.py
@@ -90,16 +90,22 @@ class ArrayDisplay:
         if title is None:
             title = subarray.name
 
-        tel_types = list({str(tel) for tel in subarray.telescope_types})
+        sorted_tel_types = sorted(
+            subarray.telescope_types,
+            key=lambda tel: tel.optics.mirror_area,
+            reverse=True,
+        )
+        tel_types = list({str(tel) for tel in sorted_tel_types})
         self.tel_type_idx = np.array(
-            [tel_types.index(str(tel)) for tel in self.subarray.tel.values()]
+            [tel_types.index(str(tel)) for tel in self.subarray.tel.values()],
         )
 
         # get default matplotlib color cycle (depends on the current style)
         color_cycle = cycle(plt.rcParams["axes.prop_cycle"].by_key()["color"])
-        cmap = ListedColormap([next(color_cycle) for _ in tel_types])
-        cmap.set_bad("gray")
-        norm = Normalize(vmin=-0.5, vmax=len(tel_types) - 0.5)
+        self.tel_cmap = ListedColormap([next(color_cycle) for _ in tel_types])
+        self.tel_cmap.set_bad("gray")
+        self.tel_norm = Normalize(vmin=-0.5, vmax=len(tel_types) - 0.5)
+        self.tel_colors = self._tel_type_color(self.tel_type_idx)
 
         patches = []
         for x, y, r in zip(
@@ -111,13 +117,13 @@ class ArrayDisplay:
 
         # build the legend:
         self.legend_elements = []
-        for i, tel_type in enumerate(tel_types):
+        for tel_type_index, tel_type in enumerate(tel_types):
             self.legend_elements.append(
                 Line2D(
                     [0],
                     [0],
                     marker="o",
-                    color=cmap(norm(i)),
+                    color=self._tel_type_color(tel_type_index),
                     label=tel_type,
                     markersize=10,
                     alpha=alpha,
@@ -131,10 +137,10 @@ class ArrayDisplay:
         # create the plot
         self.autoupdate = autoupdate
         self.telescopes = PatchCollection(patches, match_original=True)
-        self.telescopes.set_edgecolor(cmap(norm(self.tel_type_idx)))
+        self.telescopes.set_edgecolor(self.tel_colors)
         self.telescopes.set_linewidth(2.0)
-        self.telescopes.set_cmap(cmap)
-        self.telescopes.set_norm(norm)
+        self.telescopes.set_cmap(self.tel_cmap)
+        self.telescopes.set_norm(self.tel_norm)
         self.telescopes.set_array(self.tel_type_idx)
 
         self.axes.add_collection(self.telescopes)
@@ -331,7 +337,6 @@ class ArrayDisplay:
         # transform to GroundFrame
         positions_in_frame = SkyCoord(self.tel_coords, frame=self.frame)
         coords = positions_in_frame.transform_to(GroundFrame())
-        c = self.tel_colors
 
         r = np.array([-range, range])
 
@@ -339,11 +344,12 @@ class ArrayDisplay:
             idx = self.subarray.tel_indices[tel_id]
             x_0 = coords[idx].x.to_value(u.m)
             y_0 = coords[idx].y.to_value(u.m)
+            color = self._tel_color(idx)
 
             psi = core_dict[tel_id]
 
-            x = x_0 + np.cos(psi).value * r
-            y = y_0 + np.sin(psi).value * r
+            x = x_0 + np.cos(psi).to_value(u.one) * r
+            y = y_0 + np.sin(psi).to_value(u.one) * r
 
             # transform back to desired frame
             line = (
@@ -352,11 +358,11 @@ class ArrayDisplay:
                 .cartesian
             )
 
-            self.axes.plot(line.x, line.y, color=c[idx], **kwargs)
+            self.axes.plot(line.x, line.y, color=color, **kwargs)
             self.axes.scatter(
                 positions_in_frame[idx].cartesian.x.to_value(u.m),
                 positions_in_frame[idx].cartesian.y.to_value(u.m),
-                color=c[idx],
+                color=color,
             )
 
     def add_labels(self):
@@ -405,3 +411,9 @@ class ArrayDisplay:
 
         # use zorder to ensure the contours appear under the telescopes.
         self.axes.contour(x, y, background, zorder=0, **kwargs)
+
+    def _tel_type_color(self, tel_type_index):
+        return self.tel_cmap(self.tel_norm(tel_type_index))
+
+    def _tel_color(self, tel_index):
+        return self._tel_type_color(self.tel_type_idx[tel_index])

--- a/src/ctapipe/visualization/qt_eventviewer.py
+++ b/src/ctapipe/visualization/qt_eventviewer.py
@@ -4,12 +4,29 @@ from ..containers import ArrayEventContainer
 from .viewer import EventViewer
 
 
-class QTEventViewer(EventViewer):
+class QtEventViewer(EventViewer):
+    """
+    EventViewer implementation using QT.
+
+    Requires the ctapipe optional dependency ``pyside6``.
+    On Linux using wayland, make sure to have qt6 with wayland support,
+    e.g. when using conda-forge, also install ``qt6-wayland``.
+
+    Qt requires to have the GUI thread be the main thread, so it is started
+    as a subprocess and communication happens through a ``JoinableQueue``.
+
+    Actual GUI implementation is in ``_qt_viewer_impl`` to make this class
+    available always but make the qt dependency optional and error with a
+    nice message in case the optional dependencies are not installed.
+    """
+
     def __init__(self, subarray, **kwargs):
         try:
             from ._qt_viewer_impl import viewer_main
         except ModuleNotFoundError:
-            raise ModuleNotFoundError("PySide6 is needed for this EventViewer")
+            raise ModuleNotFoundError(
+                "PySide6 is needed for this EventViewer"
+            ) from None
 
         super().__init__(subarray=subarray, **kwargs)
 

--- a/src/ctapipe/visualization/qt_eventviewer.py
+++ b/src/ctapipe/visualization/qt_eventviewer.py
@@ -1,0 +1,34 @@
+from multiprocessing import JoinableQueue, Process
+
+from ..containers import ArrayEventContainer
+from .viewer import EventViewer
+
+
+class QTEventViewer(EventViewer):
+    def __init__(self, subarray, **kwargs):
+        try:
+            from ._qt_viewer_impl import viewer_main
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("PySide6 is needed for this EventViewer")
+
+        super().__init__(subarray=subarray, **kwargs)
+
+        self.queue = JoinableQueue()
+        self.gui_process = Process(
+            target=viewer_main,
+            args=(
+                self.subarray,
+                self.queue,
+            ),
+        )
+        self.gui_process.daemon = True
+        self.gui_process.start()
+
+    def __call__(self, event: ArrayEventContainer):
+        self.queue.join()
+        self.queue.put(event)
+
+    def close(self):
+        self.queue.join()
+        self.queue.close()
+        self.gui_process.terminate()

--- a/src/ctapipe/visualization/viewer.py
+++ b/src/ctapipe/visualization/viewer.py
@@ -1,0 +1,18 @@
+from abc import ABCMeta, abstractmethod
+
+from ..containers import ArrayEventContainer
+from ..core import TelescopeComponent
+
+
+class EventViewer(TelescopeComponent, metaclass=ABCMeta):
+    """
+    A component that can display events in some form, e.g. a GUI or Web UI.
+    """
+
+    @abstractmethod
+    def __call__(self, event: ArrayEventContainer):
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass


### PR DESCRIPTION
This adds a QT based GUI EventViewer that can be started and used to browse through event data using `ctapipe-process -i <file> --viewer`.


Add the moment, I only added rudimentary displays of the subarray and of the dl1 intensity image, mainly to test that the general approach works and to gather some early feedback.

I think it should have:

- [ ] Reconstruction view like @kosack is working on here: #2539
- [ ] Waveform view when clicking on a pixel in the image viewers
- [ ] peak_time image
- [ ] table views for the container data

To launch, on this branch make sure to have `pyside6` installed: `mamba install pyside6` and then run:

```
ctapipe-process --viewer -i dataset://gamma_prod5.simtel.zst
```