### PR TITLE
Use debug logging for plugin loading details

### DIFF
--- a/src/ctapipe/core/plugins.py
+++ b/src/ctapipe/core/plugins.py
@@ -10,12 +10,12 @@ def detect_and_import_plugins(group):
     """detect and import plugins with given prefix,"""
     modules = set()
     for entry_point in installed_entry_points.select(group=group):
-        log.info("Loading %s plugin: %s", group, entry_point.value)
+        log.debug("Loading %s plugin: %s", group, entry_point.value)
         try:
             plugin = entry_point.load()
             if plugin.__module__.split(".")[0] != "ctapipe":
                 modules.add(plugin.__module__)
-            log.info("Entrypoint provides: %s", plugin)
+            log.debug("Entrypoint provides: %s", plugin)
         except Exception:
             log.exception("Error loading %s plugin: '%s'", group, entry_point.value)
 


### PR DESCRIPTION
When running with log-level _INFO_, ctapipe now has some very verbose messages about plugins that are too much information for that log level. I think this should be debug only, as the user generally doesn't care.  If a list of plugins is needed, `ctapipe-info` should be used, or we should write them to the provenance system perhaps.

This PR just turns the following to DEBUG level:

```
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe_test_plugin:PluginReconstructor
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe_test_plugin.PluginReconstructor'>
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:DispReconstructor
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.DispReconstructor'>
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:EnergyRegressor
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.EnergyRegressor'>
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.hillas_intersection:HillasIntersection
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.hillas_intersection.HillasIntersection'>
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.hillas_reconstructor:HillasReconstructor
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.hillas_reconstructor.HillasReconstructor'>
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:ParticleClassifier
2024-05-28 17:12:09,821 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.ParticleClassifier'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe_test_plugin:PluginReconstructor
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe_test_plugin.PluginReconstructor'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:DispReconstructor
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.DispReconstructor'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:EnergyRegressor
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.EnergyRegressor'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.hillas_intersection:HillasIntersection
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.hillas_intersection.HillasIntersection'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.hillas_reconstructor:HillasReconstructor
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.hillas_reconstructor.HillasReconstructor'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:ParticleClassifier
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.ParticleClassifier'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe_test_plugin:PluginReconstructor
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe_test_plugin.PluginReconstructor'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:DispReconstructor
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.DispReconstructor'>
2024-05-28 17:12:09,822 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:EnergyRegressor
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.EnergyRegressor'>
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.hillas_intersection:HillasIntersection
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.hillas_intersection.HillasIntersection'>
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.hillas_reconstructor:HillasReconstructor
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.hillas_reconstructor.HillasReconstructor'>
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Loading ctapipe_reco plugin: ctapipe.reco.sklearn:ParticleClassifier
2024-05-28 17:12:09,823 INFO [ctapipe.core.plugins] (plugins.detect_and_import_plugins): Entrypoint provides: <class 'ctapipe.reco.sklearn.ParticleClassifier'>
```