### PR TITLE
Feature/custom exit codes in tools

### DIFF
--- a/docs/changes/2566.feature.rst
+++ b/docs/changes/2566.feature.rst
@@ -1,0 +1,7 @@
+Add ``SystemExit`` handling at the ``ctapipe.core.Tool`` level
+
+If a ``SystemExit`` with a custom error code is generated during the tool execution,
+the tool will be terminated gracefully and the error code will be preserved and propagated.
+
+The ``Activity`` statuses have been updated to ``["running", "success", "interrupted", "error"]``.
+The ``"running"`` status is assigned at init.

--- a/src/ctapipe/core/provenance.py
+++ b/src/ctapipe/core/provenance.py
@@ -222,7 +222,7 @@ class _ActivityProvenance:
         self._prov = {
             "activity_name": activity_name,
             "activity_uuid": str(uuid.uuid4()),
-            "status": "partial_success",
+            "status": "running",
             "start": {},
             "stop": {},
             "system": {},

--- a/src/ctapipe/core/tests/test_run_tool.py
+++ b/src/ctapipe/core/tests/test_run_tool.py
@@ -1,5 +1,5 @@
-from subprocess import CalledProcessError
 import sys
+from subprocess import CalledProcessError
 
 import pytest
 

--- a/src/ctapipe/core/tests/test_run_tool.py
+++ b/src/ctapipe/core/tests/test_run_tool.py
@@ -1,4 +1,5 @@
 from subprocess import CalledProcessError
+import sys
 
 import pytest
 
@@ -15,5 +16,16 @@ def test_run_tool_raises_exit_code():
 
     ret = run_tool(ErrorTool(), ["--non-existing-alias"], raises=False)
     assert ret == 2
+
+    class SysExitTool(Tool):
+        def setup(self):
+            pass
+
+        def start(self):
+            sys.exit(4)
+
+    ret = run_tool(SysExitTool(), raises=False)
+    assert ret == 4
+
     with pytest.raises(CalledProcessError):
         run_tool(ErrorTool(), ["--non-existing-alias"], raises=True)

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -461,7 +461,7 @@ class Tool(Application):
                     )
                     Provenance().finish_activity(
                         activity_name=self.name,
-                        status="partial_success",
+                        status="error",
                         exit_code=exit_status,
                     )
             finally:

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -452,13 +452,18 @@ class Tool(Application):
                 if raises:
                     raise
             except SystemExit as err:
-                exit_status = err.code
-                self.log.exception("Caught SystemExit with exit code %s", exit_status)
-                Provenance().finish_activity(
-                    activity_name=self.name,
-                    status="partial_success",
-                    exit_code=exit_status,
-                )
+                if raises:
+                    raise  # do not re-intercept in tests
+                else:
+                    exit_status = err.code
+                    self.log.exception(
+                        "Caught SystemExit with exit code %s", exit_status
+                    )
+                    Provenance().finish_activity(
+                        activity_name=self.name,
+                        status="partial_success",
+                        exit_code=exit_status,
+                    )
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                     self.write_provenance()

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -1,4 +1,5 @@
 """Classes to handle configurable command-line user interfaces."""
+
 import html
 import logging
 import logging.config
@@ -445,6 +446,12 @@ class Tool(Application):
                 exit_status = 1  # any other error
                 if raises:
                     raise
+            except SystemExit as err:
+                exit_status = err.code
+                self.log.exception("Caught SystemExit with exit code %s", exit_status)
+                Provenance().finish_activity(
+                    activity_name=self.name, status="SystemExit"
+                )
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                     self.write_provenance()

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -432,25 +432,32 @@ class Tool(Application):
                 self.log.error("%s", err)
                 self.log.error("Use --help for more info")
                 exit_status = 2  # wrong cmd line parameter
+                Provenance().finish_activity(
+                    activity_name=self.name, status="error", exit_code=exit_status
+                )
                 if raises:
                     raise
             except KeyboardInterrupt:
                 self.log.warning("WAS INTERRUPTED BY CTRL-C")
-                Provenance().finish_activity(
-                    activity_name=self.name, status="interrupted"
-                )
                 exit_status = 130  # Script terminated by Control-C
+                Provenance().finish_activity(
+                    activity_name=self.name, status="interrupted", exit_code=exit_status
+                )
             except Exception as err:
                 self.log.exception("Caught unexpected exception: %s", err)
-                Provenance().finish_activity(activity_name=self.name, status="error")
                 exit_status = 1  # any other error
+                Provenance().finish_activity(
+                    activity_name=self.name, status="error", exit_code=exit_status
+                )
                 if raises:
                     raise
             except SystemExit as err:
                 exit_status = err.code
                 self.log.exception("Caught SystemExit with exit code %s", exit_status)
                 Provenance().finish_activity(
-                    activity_name=self.name, status="SystemExit"
+                    activity_name=self.name,
+                    status="partial_success",
+                    exit_code=exit_status,
                 )
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -256,7 +256,7 @@ class Tool(Application):
         self.update_config(self.cli_config)
         self.update_logging_config()
 
-        self.log.info(f"ctapipe version {self.version_string}")
+        self.log.info("ctapipe version %s", self.version_string)
 
     def load_config_file(self, path: str | pathlib.Path) -> None:
         """
@@ -406,7 +406,7 @@ class Tool(Application):
 
         with self._exit_stack:
             try:
-                self.log.info(f"Starting: {self.name}")
+                self.log.info("Starting: %s", self.name)
                 Provenance().start_activity(self.name)
 
                 self.initialize(argv)
@@ -414,7 +414,7 @@ class Tool(Application):
                 self.setup()
                 self.is_setup = True
 
-                self.log.debug(f"CONFIG: {self.get_current_config()}")
+                self.log.debug("CONFIG: %s", self.get_current_config())
                 Provenance().add_config(self.get_current_config())
 
                 # check for any traitlets warnings using our custom handler
@@ -426,7 +426,7 @@ class Tool(Application):
 
                 self.start()
                 self.finish()
-                self.log.info(f"Finished: {self.name}")
+                self.log.info("Finished: %s", self.name)
                 Provenance().finish_activity(activity_name=self.name)
             except (ToolConfigurationError, TraitError) as err:
                 self.log.error("%s", err)
@@ -441,7 +441,7 @@ class Tool(Application):
                 )
                 exit_status = 130  # Script terminated by Control-C
             except Exception as err:
-                self.log.exception(f"Caught unexpected exception: {err}")
+                self.log.exception("Caught unexpected exception: %s", err)
                 Provenance().finish_activity(activity_name=self.name, status="error")
                 exit_status = 1  # any other error
                 if raises:


### PR DESCRIPTION
Following a need in custom exit codes in `ctapipe.core.Tool`, I've implemented an extra catch of `SystemExit` that can be generated during the tool's execution phase that also performs a clean up in the same fashion as in general Exception  interception and propagates the exit code further down. 