### PR TITLE
Prepare changelog for 0.21.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,34 @@
+ctapipe v0.21.2 (2024-06-26)
+============================
+
+A small bugfix release to add support for scipy 1.14.
+
+Also contains a small new feature regarding exit code handling in ``Tool``.
+
+Bug Fixes
+---------
+
+- Replace deprecated usage of scipy sparse matrices, adds support for scipy 1.14. [`#2569 <https://github.com/cta-observatory/ctapipe/pull/2569>`__]
+
+
+New Features
+------------
+
+- Add ``SystemExit`` handling at the ``ctapipe.core.Tool`` level
+
+  If a ``SystemExit`` with a custom error code is generated during the tool execution,
+  the tool will be terminated gracefully and the error code will be preserved and propagated.
+
+  The ``Activity`` statuses have been updated to ``["running", "success", "interrupted", "error"]``.
+  The ``"running"`` status is assigned at init. [`#2566 <https://github.com/cta-observatory/ctapipe/pull/2566>`__]
+
+
+Maintenance
+-----------
+
+- made plugin detection less verbose in logs: DEBUG level used instead of INFO [`#2560 <https://github.com/cta-observatory/ctapipe/pull/2560>`__]
+
+
 ctapipe v0.21.1 (2024-05-15)
 ============================
 

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -10,14 +10,9 @@
     "url": "https://ctapipe.readthedocs.io/en/stable/"
   },
   {
-    "name": "v0.21.1",
-    "version": "v0.21.1",
-    "url": "https://ctapipe.readthedocs.io/en/v0.21.1/"
-  },
-  {
-    "name": "v0.21.0",
-    "version": "v0.21.0",
-    "url": "https://ctapipe.readthedocs.io/en/v0.21.0/"
+    "name": "v0.21.2",
+    "version": "v0.21.2",
+    "url": "https://ctapipe.readthedocs.io/en/v0.21.2/"
   },
   {
     "name": "v0.20.0",

--- a/docs/changes/2560.maintenance.rst
+++ b/docs/changes/2560.maintenance.rst
@@ -1,1 +1,0 @@
-made plugin detection less verbose in logs: DEBUG level used instead of INFO

--- a/docs/changes/2566.feature.rst
+++ b/docs/changes/2566.feature.rst
@@ -1,7 +1,0 @@
-Add ``SystemExit`` handling at the ``ctapipe.core.Tool`` level
-
-If a ``SystemExit`` with a custom error code is generated during the tool execution,
-the tool will be terminated gracefully and the error code will be preserved and propagated.
-
-The ``Activity`` statuses have been updated to ``["running", "success", "interrupted", "error"]``.
-The ``"running"`` status is assigned at init.

--- a/docs/changes/2569.bugfix.rst
+++ b/docs/changes/2569.bugfix.rst
@@ -1,1 +1,0 @@
-Replace deprecated usage of scipy sparse matrices, adds support for scipy 1.14.


### PR DESCRIPTION
Let's make a quick point release so that we support scipy 1.14 with the latest release.