### PR TITLE
Bugfix: don't intercept normal SystemExit(0) in Tool

### DIFF
--- a/docs/changes/2575.bugfix.rst
+++ b/docs/changes/2575.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a redundant error message in ``Tool`` caused by normal ``SystemExit(0)``

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -453,9 +453,8 @@ class Tool(Application):
                     raise
             except SystemExit as err:
                 exit_status = err.code
-                if (
-                    exit_status != 0
-                ):  # Do nothing if SystemExit was called with the exit code 0 (e.g. with -h option)
+                # Do nothing if SystemExit was called with the exit code 0 (e.g. with -h option)
+                if exit_status != 0:
                     if raises:
                         raise  # do not re-intercept in tests
                     else:

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -452,18 +452,21 @@ class Tool(Application):
                 if raises:
                     raise
             except SystemExit as err:
-                if raises:
-                    raise  # do not re-intercept in tests
-                else:
-                    exit_status = err.code
-                    self.log.exception(
-                        "Caught SystemExit with exit code %s", exit_status
-                    )
-                    Provenance().finish_activity(
-                        activity_name=self.name,
-                        status="error",
-                        exit_code=exit_status,
-                    )
+                exit_status = err.code
+                if (
+                    exit_status != 0
+                ):  # Do nothing if SystemExit was called with the exit code 0 (e.g. with -h option)
+                    if raises:
+                        raise  # do not re-intercept in tests
+                    else:
+                        self.log.exception(
+                            "Caught SystemExit with exit code %s", exit_status
+                        )
+                        Provenance().finish_activity(
+                            activity_name=self.name,
+                            status="error",
+                            exit_code=exit_status,
+                        )
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                     self.write_provenance()


### PR DESCRIPTION
The interception of `SystemExit` introduced harmless, but annoying bug: the error message was printed while calling any tool with `help` option, i.e.:
```shell
2024-07-08 11:21:59,498 ERROR [ctapipe.ctapipe-quickstart] (tool.run): Caught SystemExit with exit code 0
Traceback (most recent call last):
  File "/Users/mdalchen/work/dpps/code/ctapipe/src/ctapipe/core/tool.py", line 412, in run
    self.initialize(argv)
  File "/Users/mdalchen/work/dpps/code/ctapipe/src/ctapipe/core/tool.py", line 242, in initialize
    self.parse_command_line(argv)
  File "/Users/mdalchen/miniforge3/envs/cta-dev/lib/python3.11/site-packages/traitlets/config/application.py", line 118, in inner
    return method(app, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdalchen/miniforge3/envs/cta-dev/lib/python3.11/site-packages/traitlets/config/application.py", line 870, in parse_command_line
    self.exit(0)
  File "/Users/mdalchen/miniforge3/envs/cta-dev/lib/python3.11/site-packages/traitlets/config/application.py", line 1062, in exit
```

<details>
<summary>Full log</summary>

```shell
> ctapipe-quickstart -h
Generate quick start files and directory structure.

Options
=======
The options below are convenience aliases to configurable class-options,
as listed in the "Equivalent to" description-line of the aliases.
To see all configurable class-options for some <cmd>, use:
    <cmd> --help-all

-q, --quiet
    Disable console logging.
    Equivalent to: [--Tool.quiet=True]
-v, --verbose
    Set log level to DEBUG
    Equivalent to: [--Tool.log_level=DEBUG]
--overwrite
    Overwrite existing output files without asking
    Equivalent to: [--Tool.overwrite=True]
--debug
    Set log-level to debug, for the most verbose logging.
    Equivalent to: [--Application.log_level=10]
--show-config
    Show the application's configuration (human-readable format)
    Equivalent to: [--Application.show_config=True]
--show-config-json
    Show the application's configuration (json format)
    Equivalent to: [--Application.show_config_json=True]
-c, --config=<list-item-1>...
    Default: []
    Equivalent to: [--Tool.config_files]
--log-level=<Enum>
    Set the log level by value or name.
    Choices: any of [0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL']
    Default: 30
    Equivalent to: [--Tool.log_level]
"""Classes to handle configurable command-line user interfaces."""

import html
import logging
import logging.config
import os
import pathlib
import re
import textwrap
from abc import abstractmethod
from contextlib import ExitStack
from inspect import cleandoc
from subprocess import CalledProcessError
from tempfile import mkdtemp

import yaml
from docutils.core import publish_parts
from traitlets import TraitError

try:
    import tomli as toml

    HAS_TOML = True
except ImportError:
    HAS_TOML = False

from traitlets import List, default
from traitlets.config import Application, Config, Configurable

from .. import __version__ as version
from . import Provenance
from .component import Component
from .logging import ColoredFormatter, create_logging_config
from .traits import Bool, Dict, Enum, Path

__all__ = ["Tool", "ToolConfigurationError"]


class CollectTraitWarningsHandler(logging.NullHandler):
    regex = re.compile(".*Config option.*not recognized")

    def __init__(self):
        super().__init__()
        self.errors = []

    def handle(self, record):
        if self.regex.match(record.msg) and record.levelno == logging.WARNING:
            self.errors.append(record.msg)


class ToolConfigurationError(Exception):
    def __init__(self, message):
        # Call the base class constructor with the parameters it needs
        self.message = message


class Tool(Application):
"src/ctapipe/core/tool.py" 669L, 23974B

-l, --log-file=<Path>
    Filename for the log
    Default: None
    Equivalent to: [--Tool.log_file]
--log-file-level=<Enum>
    Logging Level for File Logging
    Choices: any of [0, 10, 20, 30, 40, 50, 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL']
    Default: 'INFO'
    Equivalent to: [--Tool.log_file_level]
--provenance-log=<Path>
    Default: traitlets.Undefined
    Equivalent to: [--Tool.provenance_log]
-d, --workdir=<Path>
    working directory where configuration files should be written
    Default: './Work'
    Equivalent to: [--QuickStartTool.workdir]
-n, --name=<Unicode>
    Contact name
    Default: ''
    Equivalent to: [--QuickStartTool.contact_name]
-e, --email=<Unicode>
    Contact email
    Default: ''
    Equivalent to: [--QuickStartTool.contact_email]
-o, --org=<Unicode>
    Contact organization
    Default: ''
    Equivalent to: [--QuickStartTool.contact_organization]

Examples
--------

    To be prompted for contact info:

            ctapipe-quickstart --workdir MyProduction

        Or specify it all in the command-line:

            ctapipe-quickstart --name "my name" --email "me@thing.com" --org "My Organization" --workdir Work

To see all available configurables, use `--help-all`.

2024-07-08 11:21:59,498 ERROR [ctapipe.ctapipe-quickstart] (tool.run): Caught SystemExit with exit code 0
Traceback (most recent call last):
  File "/Users/mdalchen/work/dpps/code/ctapipe/src/ctapipe/core/tool.py", line 412, in run
    self.initialize(argv)
  File "/Users/mdalchen/work/dpps/code/ctapipe/src/ctapipe/core/tool.py", line 242, in initialize
    self.parse_command_line(argv)
  File "/Users/mdalchen/miniforge3/envs/cta-dev/lib/python3.11/site-packages/traitlets/config/application.py", line 118, in inner
    return method(app, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdalchen/miniforge3/envs/cta-dev/lib/python3.11/site-packages/traitlets/config/application.py", line 870, in parse_command_line
    self.exit(0)
  File "/Users/mdalchen/miniforge3/envs/cta-dev/lib/python3.11/site-packages/traitlets/config/application.py", line 1062, in exit
```
 </details>
 
With this fix in case a `SystemExit` with exit code 0 is intercepted, nothing will be done (`finally` clause is still honored)