### PR TITLE
Treat deprecation warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ astropy_header = true
 addopts = ["-ra", "--strict-config", "--strict-markers"]
 
 filterwarnings = [
+    "error::DeprecationWarning",
     "error::astropy.utils.exceptions.AstropyDeprecationWarning",
     "error::ctapipe.utils.deprecation.CTAPipeDeprecationWarning",
     "error::ctapipe.instrument.FromNameWarning",

--- a/src/ctapipe/tools/tests/test_tools.py
+++ b/src/ctapipe/tools/tests/test_tools.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 
 # pylint: disable=C0103,C0116,C0415
 import pytest
@@ -22,6 +23,9 @@ PROD5B_PATH = get_dataset_path(
 def test_display_dl1(tmp_path, dl1_image_file, dl1_parameters_file):
     from ctapipe.tools.display_dl1 import DisplayDL1Calib
 
+    # close all figures before switching mpl backends
+    # fixes a deprecation warning / pending error in newer mpl versions
+    plt.close("all")
     mpl.use("Agg")
 
     # test simtel


### PR DESCRIPTION
To prevent issues such as #2568, I switch on the option that deprecation warnings are treated as errors in the CI