### PR TITLE
use correct sonar action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Check artifact
         run: ls -l coverage
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+      - name: Sonarqube Scan
+        uses: SonarSource/sonarqube-scan-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
I didn't realize there were two actions, one for sonar cloud and one for self-deployed sonarqube