### PR TITLE
Fix warning in sonarqube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.python.version=3.10
 
 # ignore examples for coverage and issues, these are sphinx-gallery notebook scripts
 # which aren't really supported by sonarqube and lead to a lot of false positives
-sonar.exclusions=examples/**
+sonar.exclusions=examples/**,coverage/coverage.xml


### PR DESCRIPTION
Sonarqube was analyzing the coverage report using its xml linter and complaining about missing git blame info since the file is not part of the repository.

Ignore file for checks.