### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ import os
 import sys
 from pathlib import Path
 
-from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
+from sphinx_gallery.sorting import ExplicitOrder
 
 import ctapipe
 
@@ -177,7 +177,7 @@ sphinx_gallery_conf = {
             "../examples/visualization",
         ]
     ),
-    "within_subsection_order": FileNameSortKey,
+    "within_subsection_order": "FileNameSortKey",
     "nested_sections": False,
     "filename_pattern": r".*\.py",
     "copyfile_regex": r".*\.png",
@@ -205,7 +205,6 @@ master_doc = "index"
 # have all links automatically associated with the right domain.
 default_role = "py:obj"
 
-suppress_warnings = ["ref.citation"]  # ignore citation not referenced warnings
 
 # General information about the project.
 
@@ -414,8 +413,10 @@ intersphinx_mapping = {
 }
 
 
-# workaround for sphinx-gallery-conf not being cacheable and warning resulting in docs failure
-suppress_warnings = ["config.cache"]
+# workaround for ipywidgets and sklearn having duplicate definitions in intersphinx
+suppress_warnings = [
+    "intersphinx.external",
+]
 
 bibtex_bibfiles = ["references.bib"]
 bibtex_encoding = "utf8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
     "nbsphinx",
     "numpydoc",
     "sphinx-design",
-    "sphinx-gallery",
+    "sphinx-gallery >= 0.16.0",
     "sphinxcontrib-bibtex",
     "jupyter",
     "notebook",


### PR DESCRIPTION
Was failing with warnings about duplicate object definitions in intersphinx, I opened issues with the upstream projects.

I also updated the sphinx-gallery config for the new version fixing the caching issue discussed here #2536