### PR TITLE
Fix error messages for non-existing path

### DIFF
--- a/docs/changes/2591.bugfix.rst
+++ b/docs/changes/2591.bugfix.rst
@@ -1,0 +1,1 @@
+Fix error message for non-existent config files.

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -150,15 +150,15 @@ class Tool(Application):
         trait=Path(
             exists=True,
             directory_ok=False,
-            help=(
-                "List of configuration files with parameters to load "
-                "in addition to command-line parameters. "
-                "The order listed is the order of precedence (later config parameters "
-                "overwrite earlier ones), however parameters specified on the "
-                "command line always have the highest precedence. "
-                "Config files may be in JSON, YAML, TOML, or Python format"
-            ),
-        )
+        ),
+        help=(
+            "List of configuration files with parameters to load "
+            "in addition to command-line parameters. "
+            "The order listed is the order of precedence (later config parameters "
+            "overwrite earlier ones), however parameters specified on the "
+            "command line always have the highest precedence. "
+            "Config files may be in JSON, YAML, TOML, or Python format"
+        ),
     ).tag(config=True)
 
     log_config = Dict(default_value={}).tag(config=True)


### PR DESCRIPTION
Fixes #1881 

Now:

```
❯ ctapipe-process --config /does/not/exist
2024-07-15 17:27:04,877 CRITICAL [ctapipe.ctapipe-process] (application.inner): Bad config encountered during initialization: The 'config_files' trait of a ProcessorTool instance contains a Path of a List which expected a pathlib.Path or non-empty str for an existing file, not the PathError '/does/not/exist': does not exist.
```