### PR TITLE
Update exception handling in tools

### DIFF
--- a/docs/changes/2594.optimization.rst
+++ b/docs/changes/2594.optimization.rst
@@ -1,0 +1,5 @@
+Update exception handling in tools
+
+- Remove ``SystemExit`` handling in ``Tool.run()``
+- Add a possibility to register custom exceptions and handle them in ``Tool.run()``
+  with the preservation of the exit code.

--- a/docs/changes/2594.optimization.rst
+++ b/docs/changes/2594.optimization.rst
@@ -1,5 +1,4 @@
 Update exception handling in tools
 
-- Remove ``SystemExit`` handling in ``Tool.run()``
 - Add a possibility to register custom exceptions and handle them in ``Tool.run()``
   with the preservation of the exit code.

--- a/docs/changes/2594.optimization.rst
+++ b/docs/changes/2594.optimization.rst
@@ -1,4 +1,4 @@
 Update exception handling in tools
 
-- Add a possibility to register custom exceptions and handle them in ``Tool.run()``
+- Add a possibility to handle custom exception in ``Tool.run()``
   with the preservation of the exit code.

--- a/src/ctapipe/core/tests/test_run_tool.py
+++ b/src/ctapipe/core/tests/test_run_tool.py
@@ -1,4 +1,3 @@
-import sys
 from subprocess import CalledProcessError
 
 import pytest
@@ -16,16 +15,6 @@ def test_run_tool_raises_exit_code():
 
     ret = run_tool(ErrorTool(), ["--non-existing-alias"], raises=False)
     assert ret == 2
-
-    class SysExitTool(Tool):
-        def setup(self):
-            pass
-
-        def start(self):
-            sys.exit(4)
-
-    ret = run_tool(SysExitTool(), raises=False)
-    assert ret == 4
 
     with pytest.raises(CalledProcessError):
         run_tool(ErrorTool(), ["--non-existing-alias"], raises=True)

--- a/src/ctapipe/core/tests/test_run_tool.py
+++ b/src/ctapipe/core/tests/test_run_tool.py
@@ -1,3 +1,4 @@
+import sys
 from subprocess import CalledProcessError
 
 import pytest
@@ -15,6 +16,16 @@ def test_run_tool_raises_exit_code():
 
     ret = run_tool(ErrorTool(), ["--non-existing-alias"], raises=False)
     assert ret == 2
+
+    class SysExitTool(Tool):
+        def setup(self):
+            pass
+
+        def start(self):
+            sys.exit(4)
+
+    ret = run_tool(SysExitTool(), raises=False)
+    assert ret == 4
 
     with pytest.raises(CalledProcessError):
         run_tool(ErrorTool(), ["--non-existing-alias"], raises=True)

--- a/src/ctapipe/core/tests/test_tool.py
+++ b/src/ctapipe/core/tests/test_tool.py
@@ -381,12 +381,41 @@ def test_tool_raises():
         def start(self):
             raise ValueError("1 does not equal 0.")
 
+    class CustomErrorNoExitCode(Exception):
+        pass
+
+    class CustomErrorWithExitCode(Exception):
+        exit_code = 42
+
+    class ToolCustomExceptionNoExitCode(Tool):
+        name = "CustomException"
+        description = "This tool raises a custom exception without an exit code."
+        custom_exceptions = (CustomErrorNoExitCode,)
+
+        def start(self):
+            raise CustomErrorNoExitCode("This is a custom exception.")
+
+    class ToolCustomExceptionWithExitCode(Tool):
+        name = "CustomException"
+        description = "This tool raises a custom exception with a custom exit code."
+        custom_exceptions = (CustomErrorWithExitCode,)
+
+        def start(self):
+            raise CustomErrorWithExitCode("This is a custom exception.")
+
     assert run_tool(ToolGood(), raises=True) == 0
 
     assert run_tool(ToolBad(), raises=False) == 1
 
+    assert run_tool(ToolCustomExceptionNoExitCode(), raises=False) == 1
+
+    assert run_tool(ToolCustomExceptionWithExitCode(), raises=False) == 42
+
     with pytest.raises(ValueError):
         run_tool(ToolBad(), raises=True)
+
+    with pytest.raises(CustomErrorNoExitCode):
+        run_tool(ToolCustomExceptionNoExitCode(), raises=True)
 
 
 def test_exit_stack():

--- a/src/ctapipe/core/tests/test_tool.py
+++ b/src/ctapipe/core/tests/test_tool.py
@@ -390,7 +390,6 @@ def test_tool_raises():
     class ToolCustomExceptionNoExitCode(Tool):
         name = "CustomException"
         description = "This tool raises a custom exception without an exit code."
-        custom_exceptions = (CustomErrorNoExitCode,)
 
         def start(self):
             raise CustomErrorNoExitCode("This is a custom exception.")
@@ -398,7 +397,6 @@ def test_tool_raises():
     class ToolCustomExceptionWithExitCode(Tool):
         name = "CustomException"
         description = "This tool raises a custom exception with a custom exit code."
-        custom_exceptions = (CustomErrorWithExitCode,)
 
         def start(self):
             raise CustomErrorWithExitCode("This is a custom exception.")

--- a/src/ctapipe/core/tests/test_traits.py
+++ b/src/ctapipe/core/tests/test_traits.py
@@ -351,11 +351,11 @@ def test_quantity_tool(capsys):
         run_tool(tool, ["--MyTool.energy=5 m"], raises=True)
 
     captured = capsys.readouterr()
-    assert (
-        captured.err.split(":")[-1]
-        == f" Given quantity is of physical type {u.get_physical_type(5 * u.m)}."
-        + f" Expected {u.physical.energy}.\n"
+    expected = (
+        f" Given quantity is of physical type {u.get_physical_type(5 * u.m)}."
+        f" Expected {u.physical.energy}.\n"
     )
+    assert expected in captured.err
 
 
 def test_quantity_none():

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -87,6 +87,9 @@ class Tool(Application):
     executing. This happens after the ``finish`` method has run or
     in case of exceptions.
 
+    User-defined code can raise custom exceptions both in the components
+    or in the tool methods. If these custom exceptions have an `exit_code` attribute,
+    it will be propagated to the final exit code of the tool.
 
     .. code:: python
 

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -446,10 +446,7 @@ class Tool(Application):
             except Exception as err:
                 current_exception = err
                 exit_status = getattr(err, "exit_code", 1)
-                if exit_status == 1:
-                    self.log.exception("Caught unexpected exception: %s", err)
-                else:
-                    self.log.error("Caught exception: %s", err)
+                self.log.exception("Caught unexpected exception: %s", err)
                 Provenance().finish_activity(
                     activity_name=self.name, status="error", exit_code=exit_status
                 )

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -460,6 +460,8 @@ class Tool(Application):
                     # Finish normally
                     Provenance().finish_activity(activity_name=self.name)
                 else:
+                    if raises:
+                        raise
                     # Finish with error
                     self.log.critical(
                         "Caught SystemExit with exit code %s", exit_status

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -102,6 +102,10 @@ class Tool(Application):
             # Which classes are registered for configuration
             classes = [MyComponent, AdvancedComponent, SecondaryMyComponent]
 
+            # Tuple with the custom exceptions the tool can raise (optional)
+            # If the exception has an exit_code attribute, it will be used
+            custom_exceptions = (MyCustomError, MyOtherError)
+
             # local configuration parameters
             iterations = Integer(5,help="Number of times to run",
                                  allow_none=False).tag(config=True)
@@ -180,6 +184,8 @@ class Tool(Application):
     _log_formatter_cls = ColoredFormatter
 
     provenance_log = Path(directory_ok=False).tag(config=True)
+
+    custom_exceptions = ()
 
     @default("provenance_log")
     def _default_provenance_log(self):
@@ -443,6 +449,19 @@ class Tool(Application):
                 Provenance().finish_activity(
                     activity_name=self.name, status="interrupted", exit_code=exit_status
                 )
+            except self.custom_exceptions as err:
+                self.log.exception("Caught custom exception: %s", err)
+                if hasattr(err, "exit_code"):
+                    exit_status = err.exit_code
+                else:
+                    exit_status = 1
+                Provenance().finish_activity(
+                    activity_name=self.name,
+                    status="error",
+                    exit_code=exit_status,
+                )
+                if raises:
+                    raise
             except Exception as err:
                 self.log.exception("Caught unexpected exception: %s", err)
                 exit_status = 1  # any other error
@@ -451,21 +470,6 @@ class Tool(Application):
                 )
                 if raises:
                     raise
-            except SystemExit as err:
-                exit_status = err.code
-                # Do nothing if SystemExit was called with the exit code 0 (e.g. with -h option)
-                if exit_status != 0:
-                    if raises:
-                        raise  # do not re-intercept in tests
-                    else:
-                        self.log.exception(
-                            "Caught SystemExit with exit code %s", exit_status
-                        )
-                        Provenance().finish_activity(
-                            activity_name=self.name,
-                            status="error",
-                            exit_code=exit_status,
-                        )
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                     self.write_provenance()

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -403,6 +403,7 @@ class Tool(Application):
         #  https://tldp.org/LDP/abs/html/exitcodes.html
 
         exit_status = 0
+        current_exception = None
 
         with self._exit_stack:
             try:
@@ -429,14 +430,13 @@ class Tool(Application):
                 self.log.info("Finished: %s", self.name)
                 Provenance().finish_activity(activity_name=self.name)
             except (ToolConfigurationError, TraitError) as err:
+                current_exception = err
                 self.log.error("%s", err)
                 self.log.error("Use --help for more info")
                 exit_status = 2  # wrong cmd line parameter
                 Provenance().finish_activity(
                     activity_name=self.name, status="error", exit_code=exit_status
                 )
-                if raises:
-                    raise
             except KeyboardInterrupt:
                 self.log.warning("WAS INTERRUPTED BY CTRL-C")
                 exit_status = 130  # Script terminated by Control-C
@@ -444,6 +444,7 @@ class Tool(Application):
                     activity_name=self.name, status="interrupted", exit_code=exit_status
                 )
             except Exception as err:
+                current_exception = err
                 exit_status = getattr(err, "exit_code", 1)
                 if exit_status == 1:
                     self.log.exception("Caught unexpected exception: %s", err)
@@ -452,17 +453,14 @@ class Tool(Application):
                 Provenance().finish_activity(
                     activity_name=self.name, status="error", exit_code=exit_status
                 )
-                if raises:
-                    raise
             except SystemExit as err:
                 exit_status = err.code
                 if exit_status == 0:
                     # Finish normally
                     Provenance().finish_activity(activity_name=self.name)
                 else:
-                    if raises:
-                        raise
                     # Finish with error
+                    current_exception = err
                     self.log.critical(
                         "Caught SystemExit with exit code %s", exit_status
                     )
@@ -474,6 +472,8 @@ class Tool(Application):
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                     self.write_provenance()
+                if raises and current_exception:
+                    raise current_exception
 
         self.exit(exit_status)
 

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -470,6 +470,22 @@ class Tool(Application):
                 )
                 if raises:
                     raise
+            except SystemExit as err:
+                exit_status = err.code
+                if (
+                    exit_status != 0
+                ):  # Do nothing if SystemExit was called with the exit code 0 (e.g. with -h option)
+                    if raises:
+                        raise  # do not re-intercept in tests
+                    else:
+                        self.log.exception(
+                            "Caught SystemExit with exit code %s", exit_status
+                        )
+                        Provenance().finish_activity(
+                            activity_name=self.name,
+                            status="error",
+                            exit_code=exit_status,
+                        )
             finally:
                 if not {"-h", "--help", "--help-all"}.intersection(self.argv):
                     self.write_provenance()

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -88,7 +88,7 @@ class Tool(Application):
     in case of exceptions.
 
     User-defined code can raise custom exceptions both in the components
-    or in the tool methods. If these custom exceptions have an `exit_code` attribute,
+    or in the tool methods. If these custom exceptions have an ``exit_code`` attribute,
     it will be propagated to the final exit code of the tool.
 
     .. code:: python


### PR DESCRIPTION
Following some real-world experience with my own changes proposed before, I believe this would be a better way to handle custom runtime exceptions with the custom exit codes.
- ~~Remove SystemExit handling in `Tool.run()`~~
  - decided to keep
- Add a possibility to register custom exceptions and handle them in `Tool.run()` with the preservation of the exit code.