### PR TITLE
Interpolator

### DIFF
--- a/src/ctapipe/io/hdf5eventsource.py
+++ b/src/ctapipe/io/hdf5eventsource.py
@@ -52,7 +52,7 @@ from .astropy_helpers import read_table
 from .datalevels import DataLevel
 from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader
-from .pointing import PointingInterpolator
+from .interpolating import Interpolator
 from .tableloader import DL2_SUBARRAY_GROUP, DL2_TELESCOPE_GROUP, POINTING_GROUP
 
 __all__ = ["HDF5EventSource"]
@@ -585,7 +585,7 @@ class HDF5EventSource(EventSource):
 
         pointing_interpolator = None
         if POINTING_GROUP in self.file_.root:
-            pointing_interpolator = PointingInterpolator(
+            pointing_interpolator = Interpolator(
                 h5file=self.file_,
                 parent=self,
             )

--- a/src/ctapipe/io/interpolating.py
+++ b/src/ctapipe/io/interpolating.py
@@ -117,10 +117,12 @@ class Interpolator(Component):
         ----------
         tel_id : int
             Telescope id
-        pointing_table : astropy.table.Table
+        input_table : astropy.table.Table
             Table of pointing values, expected columns
             are ``time`` as ``Time`` column, ``azimuth`` and ``altitude``
-            as quantity columns.
+            as quantity columns for pointing and pointing correction data.
+            For pedestal data the quantity column is expected as
+            ``pedestal`` and for gain data as ``gain``.
         """
 
         if "gain" in set(input_table.colnames):
@@ -188,8 +190,8 @@ class Interpolator(Component):
                 time, gain, **self.interp_options
             )
 
-    def _read_parameter_table(self, tel_id, table_location=None):
-        if table_location is None:
+    def _read_parameter_table(self, tel_id, table_location="pointing"):
+        if table_location == "pointing":
             table_location = f"/dl0/monitoring/telescope/pointing/tel_{tel_id:03d}"
 
         input_table = read_table(

--- a/src/ctapipe/io/interpolating.py
+++ b/src/ctapipe/io/interpolating.py
@@ -1,0 +1,247 @@
+from typing import Any
+
+import astropy.units as u
+import numpy as np
+import tables
+from astropy.time import Time
+from scipy.interpolate import interp1d
+
+from ctapipe.core import Component, traits
+
+from .astropy_helpers import read_table
+
+
+class StepInterpolator:
+
+    """
+    Step function Interpolator for the gain and pedestals
+
+    Parameters
+    ----------
+    values : None | np.array
+        Numpy array of the data that is to be interpolated.
+        The first dimension needs to be an index over time
+    times : None | np.array
+        Time values over which data are to be interpolated
+        need to be sorted and have same length as first dimension of values
+    """
+
+    def __init__(
+        self,
+        times,
+        values,
+        bounds_error=True,
+        fill_value="extrapolate",
+        assume_sorted=True,
+        copy=False,
+    ):
+        self.values = values
+        self.times = times
+        self.bounds_error = bounds_error
+        self.fill_value = fill_value
+
+    def __call__(self, point):
+        if point < self.times[0]:
+            if self.bounds_error:
+                raise ValueError("below the interpolation range")
+
+            if self.fill_value == "extrapolate":
+                return self.values[0]
+
+            else:
+                a = np.empty(self.values[0].shape)
+                a[:] = np.nan
+                return a
+
+        else:
+            i = np.searchsorted(self.times, point, side="left")
+            return self.values[i - 1]
+
+
+class Interpolator(Component):
+    """
+    Interpolate pointing and calibration parameters from a monitoring table to a given timestamp.
+
+    Parameters
+    ----------
+    h5file : None | tables.File
+        A open hdf5 file with read access.
+    table_location: | str
+        location where the monitoring data is expected to be stored in that file
+    interpolation_method: | str
+        method of interpolation to be used
+    """
+
+    bounds_error = traits.Bool(
+        default_value=True,
+        help="If true, raises an exception when trying to extrapolate out of the given table",
+    ).tag(config=True)
+
+    extrapolate = traits.Bool(
+        help="If bounds_error is False, this flag will specify whether values outside"
+        "the available values are filled with nan (False) or extrapolated (True).",
+        default_value=False,
+    ).tag(config=True)
+
+    def __init__(
+        self, h5file=None, table_location=None, interpolation_method=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if h5file is not None and not isinstance(h5file, tables.File):
+            raise TypeError("h5file must be a tables.File")
+        self.h5file = h5file
+
+        if table_location is not None and not isinstance(table_location, str):
+            raise TypeError("table_location must be a string")
+        self.table_location = table_location
+
+        self.interp_options: dict[str, Any] = dict(assume_sorted=True, copy=False)
+        if self.bounds_error:
+            self.interp_options["bounds_error"] = True
+        elif self.extrapolate:
+            self.interp_options["bounds_error"] = False
+            self.interp_options["fill_value"] = "extrapolate"
+        else:
+            self.interp_options["bounds_error"] = False
+            self.interp_options["fill_value"] = np.nan
+
+        self._alt_interpolators = {}
+        self._az_interpolators = {}
+        self._ped_interpolators = {}
+        self._gain_interpolators = {}
+
+    def add_table(self, tel_id, input_table):
+        """
+        Add a table to this interpolator
+
+        Parameters
+        ----------
+        tel_id : int
+            Telescope id
+        pointing_table : astropy.table.Table
+            Table of pointing values, expected columns
+            are ``time`` as ``Time`` column, ``azimuth`` and ``altitude``
+            as quantity columns.
+        """
+
+        if "gain" in set(input_table.colnames):
+            self.parameter_type = "gain"
+            # here i want to detect if the table contains pointing, gain or pedestal information
+            # can this be a loop? Should this be a function?
+            missing = {"time", "gain"} - set(input_table.colnames)
+            if len(missing) > 0:
+                raise ValueError(f"Table is missing required column(s): {missing}")
+
+        elif "pedestal" in set(input_table.colnames):
+            self.parameter_type = "pedestal"
+            missing = {"time", "pedestal"} - set(input_table.colnames)
+            if len(missing) > 0:
+                raise ValueError(f"Table is missing required column(s): {missing}")
+
+        elif "azimuth" in set(input_table.colnames):
+            self.parameter_type = "pointing"
+            missing = {"time", "azimuth", "altitude"} - set(input_table.colnames)
+            if len(missing) > 0:
+                raise ValueError(f"Table is missing required column(s): {missing}")
+
+            for col in ("azimuth", "altitude"):
+                unit = input_table[col].unit
+                if unit is None or not u.rad.is_equivalent(unit):
+                    raise ValueError(f"{col} must have units compatible with 'rad'")
+
+            if not isinstance(input_table["time"], Time):
+                raise TypeError(
+                    "'time' column of pointing table must be astropy.time.Time"
+                )
+        # sort first, so it's not done twice for each interpolator
+        input_table.sort("time")
+        if self.parameter_type == "pointing":
+            az = input_table["azimuth"].quantity.to_value(u.rad)
+            # prepare azimuth for interpolation by "unwrapping": i.e. turning
+            # [359, 1] into [359, 361]. This assumes that if we get values like
+            # [359, 1] the telescope moved 2 degrees through 0, not 358 degrees
+            # the other way around. This should be true for all telescopes given
+            # the sampling speed of pointing values and their maximum movement speed.
+            # No telescope can turn more than 180° in 2 seconds.
+            az = np.unwrap(az)
+            alt = input_table["altitude"].quantity.to_value(u.rad)
+            mjd = input_table["time"].tai.mjd
+            self._az_interpolators[tel_id] = interp1d(mjd, az, **self.interp_options)
+            self._alt_interpolators[tel_id] = interp1d(mjd, alt, **self.interp_options)
+
+        elif self.parameter_type == "pedestal":
+            time = input_table["time"]
+
+            ped = input_table["pedestal"]
+
+            self._ped_interpolators[tel_id] = StepInterpolator(
+                time, ped, **self.interp_options
+            )
+
+        elif self.parameter_type == "gain":
+            time = input_table["time"]
+
+            gain = input_table["gain"]
+
+            self._gain_interpolators[tel_id] = StepInterpolator(
+                time, gain, **self.interp_options
+            )
+
+    def _read_parameter_table(self, tel_id, table_location=None):
+        if table_location is None:
+            table_location = f"/dl0/monitoring/telescope/pointing/tel_{tel_id:03d}"
+
+        pointing_table = read_table(
+            self.h5file,
+            table_location,
+        )
+        self.add_table(tel_id, pointing_table)
+
+    def __call__(self, tel_id, time):
+        """
+        Interpolate alt/az for given time and tel_id.
+
+        Parameters
+        ----------
+        tel_id : int
+            telescope id
+        time : astropy.time.Time
+            time for which to interpolate the pointing
+
+        Returns
+        -------
+        altitude : astropy.units.Quantity[deg]
+            interpolated altitude angle
+        azimuth : astropy.units.Quantity[deg]
+            interpolated azimuth angle
+        """
+
+        if not any(
+            [
+                tel_id in x
+                for x in (
+                    self._az_interpolators,
+                    self._ped_interpolators,
+                    self._gain_interpolators,
+                )
+            ]
+        ):
+            if self.h5file is not None:
+                self._read_parameter_table(tel_id)
+            else:
+                raise KeyError(f"No table available for tel_id {tel_id}")
+
+        if self.parameter_type == "pointing":
+            mjd = time.tai.mjd
+            az = u.Quantity(self._az_interpolators[tel_id](mjd), u.rad, copy=False)
+            alt = u.Quantity(self._alt_interpolators[tel_id](mjd), u.rad, copy=False)
+            return alt, az
+
+        elif self.parameter_type == "pedestal":
+            ped = self._ped_interpolators[tel_id](time)
+            return ped
+
+        elif self.parameter_type == "gain":
+            gain = self._gain_interpolators[tel_id](time)
+            return gain

--- a/src/ctapipe/io/tableloader.py
+++ b/src/ctapipe/io/tableloader.py
@@ -14,7 +14,7 @@ from astropy.utils.decorators import lazyproperty
 from ..core import Component, Provenance, traits
 from ..instrument import FocalLengthKind, SubarrayDescription
 from .astropy_helpers import join_allow_empty, read_table
-from .pointing import PointingInterpolator
+from .interpolating import Interpolator
 
 __all__ = ["TableLoader"]
 
@@ -248,7 +248,7 @@ class TableLoader(Component):
 
         Provenance().add_input_file(self.input_url, role="Event data")
 
-        self._pointing_interpolator = PointingInterpolator(
+        self._pointing_interpolator = Interpolator(
             h5file=self.h5file,
             parent=self,
         )

--- a/src/ctapipe/io/tests/test_interpolator.py
+++ b/src/ctapipe/io/tests/test_interpolator.py
@@ -1,0 +1,214 @@
+import astropy.units as u
+import numpy as np
+import pytest
+import tables
+from astropy.table import Table
+from astropy.time import Time
+
+
+def test_simple():
+    """Test interpolator"""
+    from ctapipe.io.interpolating import Interpolator
+
+    t0 = Time("2022-01-01T00:00:00")
+
+    table = Table(
+        {
+            "time": t0 + np.arange(0.0, 10.1, 2.0) * u.s,
+            "azimuth": np.linspace(0.0, 10.0, 6) * u.deg,
+            "altitude": np.linspace(70.0, 60.0, 6) * u.deg,
+        },
+    )
+
+    table_pedestal = Table(
+        {
+            "time": np.arange(0.0, 10.1, 2.0),
+            "pedestal": np.reshape(np.random.normal(4.0, 1.0, 1850 * 6), (6, 1850)),
+        },
+    )
+
+    table_gain = Table(
+        {
+            "time": np.arange(0.0, 10.1, 2.0),
+            "gain": np.reshape(np.random.normal(1.0, 0.2, 1850 * 6), (6, 1850)),
+        },
+    )
+
+    interpolator = Interpolator()
+    interpolator_pedestal = Interpolator()
+    interpolator_gain = Interpolator()
+    interpolator.add_table(1, table)
+    interpolator_pedestal.add_table(1, table_pedestal)
+    interpolator_gain.add_table(1, table_gain)
+
+    alt, az = interpolator(tel_id=1, time=t0 + 1 * u.s)
+    assert u.isclose(alt, 69 * u.deg)
+    assert u.isclose(az, 1 * u.deg)
+
+    pedestal = interpolator_pedestal(tel_id=1, time=1.0)
+    assert all(pedestal == table_pedestal["pedestal"][0])
+
+    gain = interpolator_gain(tel_id=1, time=1.0)
+    assert all(gain == table_gain["gain"][0])
+
+    with pytest.raises(KeyError):
+        interpolator(tel_id=2, time=t0 + 1 * u.s)
+    with pytest.raises(KeyError):
+        interpolator_pedestal(tel_id=2, time=1.0)
+    with pytest.raises(KeyError):
+        interpolator_gain(tel_id=2, time=1.0)
+
+
+def test_azimuth_switchover():
+    """Test pointing interpolation"""
+    from ctapipe.io.interpolating import Interpolator
+
+    t0 = Time("2022-01-01T00:00:00")
+
+    table = Table(
+        {
+            "time": t0 + [0, 1, 2] * u.s,
+            "azimuth": [359, 1, 3] * u.deg,
+            "altitude": [60, 61, 62] * u.deg,
+        },
+    )
+
+    interpolator = Interpolator()
+    interpolator.add_table(1, table)
+
+    alt, az = interpolator(tel_id=1, time=t0 + 0.5 * u.s)
+    assert u.isclose(az, 360 * u.deg)
+    assert u.isclose(alt, 60.5 * u.deg)
+
+
+def test_invalid_input():
+    """Test invalid pointing tables raise nice errors"""
+    from ctapipe.io.interpolating import Interpolator
+
+    wrong_time = Table(
+        {
+            "time": [1, 2, 3] * u.s,
+            "azimuth": [1, 2, 3] * u.deg,
+            "altitude": [1, 2, 3] * u.deg,
+        }
+    )
+
+    interpolator = Interpolator()
+    with pytest.raises(TypeError, match="astropy.time.Time"):
+        interpolator.add_table(1, wrong_time)
+
+    wrong_unit = Table(
+        {
+            "time": Time(1.7e9 + np.arange(3), format="unix"),
+            "azimuth": [1, 2, 3] * u.m,
+            "altitude": [1, 2, 3] * u.deg,
+        }
+    )
+    with pytest.raises(ValueError, match="compatible with 'rad'"):
+        interpolator.add_table(1, wrong_unit)
+
+    wrong_unit = Table(
+        {
+            "time": Time(1.7e9 + np.arange(3), format="unix"),
+            "azimuth": [1, 2, 3] * u.deg,
+            "altitude": [1, 2, 3],
+        }
+    )
+    with pytest.raises(ValueError, match="compatible with 'rad'"):
+        interpolator.add_table(1, wrong_unit)
+
+
+def test_hdf5(tmp_path):
+    from ctapipe.io import write_table
+    from ctapipe.io.interpolating import Interpolator
+
+    t0 = Time("2022-01-01T00:00:00")
+
+    table = Table(
+        {
+            "time": t0 + np.arange(0.0, 10.1, 2.0) * u.s,
+            "azimuth": np.linspace(0.0, 10.0, 6) * u.deg,
+            "altitude": np.linspace(70.0, 60.0, 6) * u.deg,
+        },
+    )
+
+    path = tmp_path / "pointing.h5"
+    write_table(table, path, "/dl0/monitoring/telescope/pointing/tel_001")
+    with tables.open_file(path) as h5file:
+        interpolator = Interpolator(h5file)
+        alt, az = interpolator(tel_id=1, time=t0 + 1 * u.s)
+        assert u.isclose(alt, 69 * u.deg)
+        assert u.isclose(az, 1 * u.deg)
+
+
+def test_bounds():
+    """Test invalid pointing tables raise nice errors"""
+    from ctapipe.io.interpolating import Interpolator
+
+    t0 = Time("2022-01-01T00:00:00")
+
+    table_pointing = Table(
+        {
+            "time": t0 + np.arange(0.0, 10.1, 2.0) * u.s,
+            "azimuth": np.linspace(0.0, 10.0, 6) * u.deg,
+            "altitude": np.linspace(70.0, 60.0, 6) * u.deg,
+        },
+    )
+
+    table_pedestal = Table(
+        {
+            "time": np.arange(0.0, 10.1, 2.0),
+            "pedestal": np.reshape(np.random.normal(4.0, 1.0, 1850 * 6), (6, 1850)),
+        },
+    )
+
+    table_gain = Table(
+        {
+            "time": np.arange(0.0, 10.1, 2.0),
+            "gain": np.reshape(np.random.normal(1.0, 0.2, 1850 * 6), (6, 1850)),
+        },
+    )
+
+    interpolator_pointing = Interpolator()
+    interpolator_pedestal = Interpolator()
+    interpolator_gain = Interpolator()
+    interpolator_pointing.add_table(1, table_pointing)
+    interpolator_pedestal.add_table(1, table_pedestal)
+    interpolator_gain.add_table(1, table_gain)
+
+    with pytest.raises(ValueError, match="below the interpolation range"):
+        interpolator_pointing(tel_id=1, time=t0 - 0.1 * u.s)
+
+    with pytest.raises(ValueError, match="below the interpolation range"):
+        interpolator_pedestal(tel_id=1, time=-0.1)
+
+    with pytest.raises(ValueError, match="below the interpolation range"):
+        interpolator_gain(tel_id=1, time=-0.1)
+
+    with pytest.raises(ValueError, match="above the interpolation range"):
+        interpolator_pointing(tel_id=1, time=t0 + 10.2 * u.s)
+
+    interpolator_pointing = Interpolator(bounds_error=False)
+    interpolator_pedestal = Interpolator(bounds_error=False)
+    interpolator_gain = Interpolator(bounds_error=False)
+    interpolator_pointing.add_table(1, table_pointing)
+    interpolator_pedestal.add_table(1, table_pedestal)
+    interpolator_gain.add_table(1, table_gain)
+
+    for dt in (-0.1, 10.1) * u.s:
+        alt, az = interpolator_pointing(tel_id=1, time=t0 + dt)
+        assert np.isnan(alt.value)
+        assert np.isnan(az.value)
+
+    assert all(np.isnan(interpolator_pedestal(tel_id=1, time=-0.1)))
+    assert all(np.isnan(interpolator_gain(tel_id=1, time=-0.1)))
+
+    interpolator = Interpolator(bounds_error=False, extrapolate=True)
+    interpolator.add_table(1, table_pointing)
+    alt, az = interpolator(tel_id=1, time=t0 - 1 * u.s)
+    assert u.isclose(alt, 71 * u.deg)
+    assert u.isclose(az, -1 * u.deg)
+
+    alt, az = interpolator(tel_id=1, time=t0 + 11 * u.s)
+    assert u.isclose(alt, 59 * u.deg)
+    assert u.isclose(az, 11 * u.deg)


### PR DESCRIPTION
This PR is for extending the pointing interpolator to also handle pedestal and gain. This request is related to issue [#2565](https://github.com/cta-observatory/ctapipe/issues/2565). 

A new interpolator is added based on the searchsorted function in numpy and set up to accept the same options as interp1d class from numpy that is already in use for the pointing interpolation. This interpolator is creating a step function that applies a pedestal or gain calibration after a corresponding timestamp until the next pedestal or gain value is available. 

The new interpolator is able to interpolate array-like objects to handle 

It is currently set up to automatically recognise what data is interpolated and picks an appropriate interpolator based on that determination. This can be changed to require a choice when the data that is to be interpolated is added.

The pointing interpolator has a location for the pointing data hardcoded into it that is used by default for now to avoid having to change code elsewhere. This scheme can be extended to have the place of pointing corrections, pedestals or gain at hand as well.

Tests have been included that check that the step interpolation works as expected. 