### PR TITLE
Convert metadata Instrument.site to free string instead of enum

### DIFF
--- a/src/ctapipe/io/metadata.py
+++ b/src/ctapipe/io/metadata.py
@@ -176,23 +176,14 @@ class Activity(HasTraits):
 class Instrument(Configurable):
     """Instrumental Context"""
 
-    site = Enum(
-        [
-            "CTA-North",
-            "CTA-South",
-            "SDMC",
-            "HQ",
-            "MAGIC",
-            "HESS",
-            "VERITAS",
-            "FACT",
-            "Whipple",
-            "Other",
-        ],
-        "Other",
-        help="Which site of CTA (or external telescope) "
-        "this instrument is associated with",
+    site = Unicode(
+        default_value="Other",
+        help=(
+            "Which site of CTAO (or external telescope)"
+            " this instrument is associated with"
+        ),
     ).tag(config=True)
+
     class_ = Enum(
         [
             "Array",


### PR DESCRIPTION
I was creating the configuration for prod6 and changed the site name from `CTA-North` to `CTAO-North` and it resulted in an error.

I think having a fixed list of sites here is too restrictive and just using a free string is fine.