### PR TITLE
Add property to EventSource for support of CTAO reference metadata

### DIFF
--- a/docs/changes/2644.feature.rst
+++ b/docs/changes/2644.feature.rst
@@ -1,0 +1,6 @@
+Since not all ``EventSource`` plugins support providing the CTAO reference metadata,
+the ``EventSource`` now has a property ``supports_reference_metadata`` which can
+be overridden by subclasses to signal the support for reading reference metadata.
+
+This avoids a warning for not being able to read reference metadata for
+sources that cannot support it (yet), like the ``SimTelEventSource``.

--- a/src/ctapipe/io/eventsource.py
+++ b/src/ctapipe/io/eventsource.py
@@ -165,7 +165,14 @@ class EventSource(Component):
         if self.max_events:
             self.log.info(f"Max events being read = {self.max_events}")
 
-        Provenance().add_input_file(str(self.input_url), role="DL0/Event")
+        add_meta = self.supports_reference_metadata
+        Provenance().add_input_file(
+            str(self.input_url), role="DL0/Event", add_meta=add_meta
+        )
+
+    @property
+    def supports_reference_metadata(self) -> bool:
+        return True
 
     @staticmethod
     @abstractmethod

--- a/src/ctapipe/io/simteleventsource.py
+++ b/src/ctapipe/io/simteleventsource.py
@@ -350,8 +350,6 @@ def read_atmosphere_profile_from_simtel(
 
     if isinstance(simtelfile, str | Path):
         context_manager = SimTelFile(simtelfile)
-        # FIXME: simtel files currently do not have CTAO reference
-        # metadata, should be set to True once we store metadata
         Provenance().add_input_file(
             filename=simtelfile,
             role="ctapipe.atmosphere.AtmosphereDensityProfile",
@@ -567,6 +565,10 @@ class SimTelEventSource(EventSource):
     @property
     def is_simulation(self):
         return True
+
+    @property
+    def supports_reference_metadata(self) -> bool:
+        return False
 
     @property
     def datalevels(self):


### PR DESCRIPTION
* Set to false for SimTelEventSource
* Silences a warning for SimTelEventSource, which at least currently cannot support the reference metadata.