### PR TITLE
Improve reference metadata handling for EventSource

### DIFF
--- a/docs/changes/2648.api.rst
+++ b/docs/changes/2648.api.rst
@@ -1,0 +1,10 @@
+* Add possibility to directly pass the reference metadata to
+  ``Provenance.add_input_file``.
+* Remove the call to ``Provenace.add_input_file`` from the
+  ``EventSource`` base class.
+* Add the proper calls to ``Provenance.add_input_file`` in
+  ``HDF5EventSource`` (providing the metadata) and
+  ``SimTelEventSource`` (not providing metadata yet, but avoiding a warning)
+* Plugin implementations of ``EventSource`` should make sure they
+  register their input files using ``Provenance.add_input_file``, preferably
+  providing also the reference metadata.

--- a/src/ctapipe/conftest.py
+++ b/src/ctapipe/conftest.py
@@ -692,3 +692,17 @@ def dl1_mon_pointing_file(dl1_file, dl1_tmp_path):
         f.remove_node("/configuration/telescope/pointing", recursive=True)
 
     return path
+
+
+@pytest.fixture
+def provenance(monkeypatch):
+    from ctapipe.core import Provenance
+
+    # the singleton nature of Provenance messes with
+    # the order-independence of the tests asserting
+    # the provenance contains the correct information
+    # so we monkeypatch back to an empty state here
+    prov = Provenance()
+    monkeypatch.setattr(prov, "_activities", [])
+    monkeypatch.setattr(prov, "_finished_activities", [])
+    return prov

--- a/src/ctapipe/core/provenance.py
+++ b/src/ctapipe/core/provenance.py
@@ -62,6 +62,138 @@ class MissingReferenceMetadata(UserWarning):
     """Warning raised if reference metadata could not be read from input file."""
 
 
+class _ActivityProvenance:
+    """
+    Low-level helper class to collect provenance information for a given
+    *activity*.  Users should use `Provenance` as a top-level API,
+    not this class directly.
+    """
+
+    def __init__(self, activity_name=sys.executable):
+        self._prov = {
+            "activity_name": activity_name,
+            "activity_uuid": str(uuid.uuid4()),
+            "status": "running",
+            "start": {},
+            "stop": {},
+            "system": {},
+            "input": [],
+            "output": [],
+            "exit_code": None,
+        }
+        self.name = activity_name
+
+    def start(self):
+        """begin recording provenance for this activity. Set's up the system
+        and startup provenance data. Generally should be called at start of a
+        program."""
+        self._prov["start"].update(_sample_cpu_and_memory())
+        self._prov["system"].update(_get_system_provenance())
+
+    def _register(self, what, url, role, add_meta, reference_meta):
+        if what not in {"input", "output"}:
+            raise ValueError("what must be 'input' or 'output'")
+
+        reference_meta = self._get_reference_meta(
+            url=url, reference_meta=reference_meta, read_meta=add_meta
+        )
+        self._prov[what].append(dict(url=url, role=role, reference_meta=reference_meta))
+
+    def register_input(self, url, role=None, add_meta=True, reference_meta=None):
+        """
+        Add a URL of a file to the list of inputs (can be a filename or full
+        url, if no URL specifier is given, assume 'file://')
+
+        Parameters
+        ----------
+        url: str
+            filename or url of input file
+        role: str
+            role name that this input satisfies
+        add_meta: bool
+            If true, try to load reference metadata from input file
+            and add to provenance.
+        """
+        self._register(
+            "input", url, role=role, add_meta=add_meta, reference_meta=reference_meta
+        )
+
+    def register_output(self, url, role=None, add_meta=True, reference_meta=None):
+        """
+        Add a URL of a file to the list of outputs (can be a filename or full
+        url, if no URL specifier is given, assume 'file://')
+
+        Should only be called once the file is finalized, so that reference metadata
+        can be read.
+
+        Parameters
+        ----------
+        url: str
+            filename or url of output file
+        role: str
+            role name that this output satisfies
+        add_meta: bool
+            If true, try to load reference metadata from input file
+            and add to provenance.
+        """
+        self._register(
+            "output", url, role=role, add_meta=add_meta, reference_meta=reference_meta
+        )
+
+    def register_config(self, config):
+        """add a dictionary of configuration parameters to this activity"""
+        self._prov["config"] = config
+
+    def finish(self, status="success", exit_code=0):
+        """record final provenance information, normally called at shutdown."""
+        self._prov["stop"].update(_sample_cpu_and_memory())
+
+        # record the duration (wall-clock) for this activity
+        t_start = Time(self._prov["start"]["time_utc"], format="isot")
+        t_stop = Time(self._prov["stop"]["time_utc"], format="isot")
+        self._prov["status"] = status
+        self._prov["exit_code"] = exit_code
+        self._prov["duration_min"] = (t_stop - t_start).to("min").value
+
+    @property
+    def output(self):
+        return self._prov.get("output", None)
+
+    @property
+    def input(self):
+        return self._prov.get("input", None)
+
+    def sample_cpu_and_memory(self):
+        """
+        Record a snapshot of current CPU and memory information.
+        """
+        if "samples" not in self._prov:
+            self._prov["samples"] = []
+        self._prov["samples"].append(_sample_cpu_and_memory())
+
+    @property
+    def provenance(self):
+        return self._prov
+
+    def _get_reference_meta(
+        self, url, reference_meta=None, read_meta=True
+    ) -> dict | None:
+        # here to prevent circular imports / top-level cross-dependencies
+        from ..io.metadata import read_reference_metadata
+
+        if reference_meta is not None or read_meta is False:
+            return reference_meta
+
+        try:
+            return read_reference_metadata(url).to_dict()
+        except Exception:
+            warnings.warn(
+                f"Could not read reference metadata for input file: {url}",
+                MissingReferenceMetadata,
+            )
+            return None
+
+
 class Provenance(metaclass=Singleton):
     """
     Manage the provenance info for a stack of *activities*
@@ -85,18 +217,18 @@ class Provenance(metaclass=Singleton):
         activity.start()
         self._activities.append(activity)
         log.debug(f"started activity: {activity_name}")
+        return activity
 
-    def _get_current_or_start_activity(self):
+    def _get_current_or_start_activity(self) -> _ActivityProvenance:
         if self.current_activity is None:
             log.info(
                 "No activity has been explicitly started, starting new default activity."
                 " Consider calling Provenance().start_activity(<name>) explicitly."
             )
-            self.start_activity()
-
+            return self.start_activity()
         return self.current_activity
 
-    def add_input_file(self, filename, role=None, add_meta=True):
+    def add_input_file(self, filename, role=None, add_meta=True, reference_meta=None):
         """register an input to the current activity
 
         Parameters
@@ -107,7 +239,12 @@ class Provenance(metaclass=Singleton):
             role this input file satisfies (optional)
         """
         activity = self._get_current_or_start_activity()
-        activity.register_input(abspath(filename), role=role, add_meta=add_meta)
+        activity.register_input(
+            abspath(filename),
+            role=role,
+            add_meta=add_meta,
+            reference_meta=reference_meta,
+        )
         log.debug(
             "added input entity '%s' to activity: '%s'",
             filename,
@@ -214,125 +351,6 @@ class Provenance(metaclass=Singleton):
         """remove all tracked activities"""
         self._activities = []
         self._finished_activities = []
-
-
-class _ActivityProvenance:
-    """
-    Low-level helper class to collect provenance information for a given
-    *activity*.  Users should use `Provenance` as a top-level API,
-    not this class directly.
-    """
-
-    def __init__(self, activity_name=sys.executable):
-        self._prov = {
-            "activity_name": activity_name,
-            "activity_uuid": str(uuid.uuid4()),
-            "status": "running",
-            "start": {},
-            "stop": {},
-            "system": {},
-            "input": [],
-            "output": [],
-            "exit_code": None,
-        }
-        self.name = activity_name
-
-    def start(self):
-        """begin recording provenance for this activity. Set's up the system
-        and startup provenance data. Generally should be called at start of a
-        program."""
-        self._prov["start"].update(_sample_cpu_and_memory())
-        self._prov["system"].update(_get_system_provenance())
-
-    def register_input(self, url, role=None, add_meta=True):
-        """
-        Add a URL of a file to the list of inputs (can be a filename or full
-        url, if no URL specifier is given, assume 'file://')
-
-        Parameters
-        ----------
-        url: str
-            filename or url of input file
-        role: str
-            role name that this input satisfies
-        add_meta: bool
-            If true, try to load reference metadata from input file
-            and add to provenance.
-        """
-        reference_meta = self._get_reference_meta(url=url) if add_meta else None
-        self._prov["input"].append(
-            dict(url=url, role=role, reference_meta=reference_meta)
-        )
-
-    def register_output(self, url, role=None, add_meta=True):
-        """
-        Add a URL of a file to the list of outputs (can be a filename or full
-        url, if no URL specifier is given, assume 'file://')
-
-        Should only be called once the file is finalized, so that reference metadata
-        can be read.
-
-        Parameters
-        ----------
-        url: str
-            filename or url of output file
-        role: str
-            role name that this output satisfies
-        add_meta: bool
-            If true, try to load reference metadata from input file
-            and add to provenance.
-        """
-        reference_meta = self._get_reference_meta(url=url) if add_meta else None
-        self._prov["output"].append(
-            dict(url=url, role=role, reference_meta=reference_meta)
-        )
-
-    def register_config(self, config):
-        """add a dictionary of configuration parameters to this activity"""
-        self._prov["config"] = config
-
-    def finish(self, status="success", exit_code=0):
-        """record final provenance information, normally called at shutdown."""
-        self._prov["stop"].update(_sample_cpu_and_memory())
-
-        # record the duration (wall-clock) for this activity
-        t_start = Time(self._prov["start"]["time_utc"], format="isot")
-        t_stop = Time(self._prov["stop"]["time_utc"], format="isot")
-        self._prov["status"] = status
-        self._prov["exit_code"] = exit_code
-        self._prov["duration_min"] = (t_stop - t_start).to("min").value
-
-    @property
-    def output(self):
-        return self._prov.get("output", None)
-
-    @property
-    def input(self):
-        return self._prov.get("input", None)
-
-    def sample_cpu_and_memory(self):
-        """
-        Record a snapshot of current CPU and memory information.
-        """
-        if "samples" not in self._prov:
-            self._prov["samples"] = []
-        self._prov["samples"].append(_sample_cpu_and_memory())
-
-    @property
-    def provenance(self):
-        return self._prov
-
-    def _get_reference_meta(self, url):
-        # here to prevent circular imports / top-level cross-dependencies
-        from ..io.metadata import read_reference_metadata
-
-        try:
-            return read_reference_metadata(url).to_dict()
-        except Exception:
-            warnings.warn(
-                f"Could not read reference metadata for input file: {url}",
-                MissingReferenceMetadata,
-            )
 
 
 def _get_python_packages():

--- a/src/ctapipe/core/tests/test_provenance.py
+++ b/src/ctapipe/core/tests/test_provenance.py
@@ -1,22 +1,8 @@
 import json
 
-import pytest
-
 from ctapipe.core import Provenance
 from ctapipe.core.provenance import _ActivityProvenance
 from ctapipe.io.metadata import Reference
-
-
-@pytest.fixture
-def provenance(monkeypatch):
-    # the singleton nature of Provenance messes with
-    # the order-independence of the tests asserting
-    # the provenance contains the correct information
-    # so we monkeypatch back to an empty state here
-    prov = Provenance()
-    monkeypatch.setattr(prov, "_activities", [])
-    monkeypatch.setattr(prov, "_finished_activities", [])
-    return prov
 
 
 def test_provenance_activity_names(provenance):

--- a/src/ctapipe/io/eventsource.py
+++ b/src/ctapipe/io/eventsource.py
@@ -16,7 +16,7 @@ from ..containers import (
     SimulatedShowerDistribution,
     SimulationConfigContainer,
 )
-from ..core import Provenance, ToolConfigurationError
+from ..core import ToolConfigurationError
 from ..core.component import Component, find_config_in_hierarchy
 from ..core.traits import CInt, Int, Path, Set, TraitError, Undefined
 from ..instrument import SubarrayDescription
@@ -134,23 +134,6 @@ class EventSource(Component):
         return super().__new__(subcls)
 
     def __init__(self, input_url=None, config=None, parent=None, **kwargs):
-        """
-        Class to handle generic input files. Enables obtaining the "source"
-        generator, regardless of the type of file (either hessio or camera
-        file).
-
-        Parameters
-        ----------
-        config : traitlets.loader.Config
-            Configuration specified by config file or cmdline arguments.
-            Used to set traitlet values.
-            Set to None if no configuration to pass.
-        tool : ctapipe.core.Tool
-            Tool executable that is calling this component.
-            Passes the correct logger to the component.
-            Set to None if no Tool to pass.
-        kwargs
-        """
         # traitlets differentiates between not getting the kwarg
         # and getting the kwarg with a None value.
         # the latter overrides the value in the config with None, the former
@@ -165,8 +148,6 @@ class EventSource(Component):
 
         if self.max_events:
             self.log.info(f"Max events being read = {self.max_events}")
-
-        Provenance().add_input_file(str(self.input_url), role="DL0/Event")
 
     @staticmethod
     @abstractmethod

--- a/src/ctapipe/io/eventsource.py
+++ b/src/ctapipe/io/eventsource.py
@@ -79,9 +79,9 @@ class EventSource(Component):
     as these are mutable and may lead to errors when analyzing multiple events.
 
 
-    Attributes
+    Parameters
     ----------
-    input_url : str
+    input_url : str | Path
         Path to the input event file.
     max_events : int
         Maximum number of events to loop through in generator

--- a/src/ctapipe/io/hdf5eventsource.py
+++ b/src/ctapipe/io/hdf5eventsource.py
@@ -44,7 +44,7 @@ from ..containers import (
     TimingParametersContainer,
     TriggerContainer,
 )
-from ..core import Container, Field
+from ..core import Container, Field, Provenance
 from ..core.traits import UseEnum
 from ..instrument import SubarrayDescription
 from ..instrument.optics import FocalLengthKind
@@ -53,6 +53,7 @@ from .astropy_helpers import read_table
 from .datalevels import DataLevel
 from .eventsource import EventSource
 from .hdf5tableio import HDF5TableReader
+from .metadata import _read_reference_metadata_hdf5
 from .tableloader import DL2_SUBARRAY_GROUP, DL2_TELESCOPE_GROUP, POINTING_GROUP
 
 __all__ = ["HDF5EventSource"]
@@ -203,6 +204,11 @@ class HDF5EventSource(EventSource):
         super().__init__(input_url=input_url, config=config, parent=parent, **kwargs)
 
         self.file_ = tables.open_file(self.input_url)
+        meta = _read_reference_metadata_hdf5(self.file_)
+        Provenance().add_input_file(
+            str(self.input_url), role="Event", reference_meta=meta
+        )
+
         self._full_subarray = SubarrayDescription.from_hdf(
             self.input_url,
             focal_length_choice=self.focal_length_choice,

--- a/src/ctapipe/io/simteleventsource.py
+++ b/src/ctapipe/io/simteleventsource.py
@@ -537,6 +537,12 @@ class SimTelEventSource(EventSource):
             skip_calibration=self.skip_calibration_events,
             zcat=not self.back_seekable,
         )
+        # TODO: read metadata from simtel metaparams once we have files that
+        # actually provide the reference metadata.
+        Provenance().add_input_file(
+            str(self.input_url), role="DL0/Event", add_meta=False
+        )
+
         if self.back_seekable and self.is_stream:
             raise OSError("back seekable was required but not possible for inputfile")
         (

--- a/src/ctapipe/io/tests/test_hdf5eventsource.py
+++ b/src/ctapipe/io/tests/test_hdf5eventsource.py
@@ -270,3 +270,18 @@ def test_simulated_events_distribution(dl1_file):
         dist = source.simulated_shower_distributions[1]
         assert dist["n_entries"] == 1000
         assert dist["histogram"].sum() == 1000.0
+
+
+def test_provenance(dl1_file, provenance):
+    """Make sure that HDF5EventSource reads reference metadata and adds to provenance"""
+    from ctapipe.io.metadata import _read_reference_metadata_hdf5
+
+    provenance.start_activity("test_hdf5eventsource")
+    with HDF5EventSource(input_url=dl1_file):
+        pass
+
+    inputs = provenance.current_activity.input
+    assert len(inputs) == 1
+    assert inputs[0]["url"] == str(dl1_file)
+    meta = _read_reference_metadata_hdf5(dl1_file)
+    assert inputs[0]["reference_meta"].product.id_ == meta.product.id_

--- a/src/ctapipe/io/tests/test_simteleventsource.py
+++ b/src/ctapipe/io/tests/test_simteleventsource.py
@@ -641,3 +641,15 @@ def test_shower_distribution(prod5_gamma_simtel_path):
         assert len(distributions) == 1
         distribution = distributions[source.obs_id]
         assert distribution.n_entries == 1000
+
+
+def test_provenance(provenance, prod5_gamma_simtel_path):
+    provenance.start_activity("test_simteleventsource")
+
+    with SimTelEventSource(prod5_gamma_simtel_path):
+        pass
+
+    inputs = provenance.current_activity.input
+    assert len(inputs) == 1
+    assert inputs[0]["url"] == str(prod5_gamma_simtel_path)
+    assert inputs[0]["reference_meta"] is None


### PR DESCRIPTION
The recent addition of attaching the reference metadata of input files to the provenance information implemented only that the reference metadata is read directly by ctapipe from the input file. This made it necessary to either support all possible input file types
or impossible for plugin event sources to provide this metadata on their own. It also makes the assumption 1 EventSource = 1 input file. This is not true for some event sources.

This issue is solved by:
* Adding the possibility to directly provide the reference metadata to `add_input_file`
* Move the responsibility of calling `add_input_file` from the EventSource baseclass to the implementation


This is an alternative implementation to https://github.com/cta-observatory/ctapipe/pull/2644