### PR TITLE
Fixed unknown configs being silently ignored

### DIFF
--- a/src/ctapipe/core/tests/test_tool.py
+++ b/src/ctapipe/core/tests/test_tool.py
@@ -569,3 +569,27 @@ def test_exit_status_interrupted(tmp_path, provenance):
     provlog = activities[0]
     assert provlog["activity_name"] == InterruptTestTool.name
     assert provlog["status"] == "interrupted"
+
+
+def test_no_ignore_bad_config_type(tmp_path: Path):
+    """Check that if an unknown type of config file is given, an error is raised
+    instead of silently ignoring the file (which is the default for
+    traitlets.config)
+    """
+
+    class SomeTool(Tool):
+        float_option = Float(1.0, help="An option to change")
+
+    test_config_file = """
+    SomeTool:
+        float_option: 200.0
+    """
+
+    bad_conf_path = tmp_path / "test.conf"  # note named "conf" not yaml.
+    bad_conf_path.write_text(test_config_file)
+
+    tool = SomeTool()
+
+    # here we should receive an error.
+    with pytest.raises(ToolConfigurationError):
+        tool.load_config_file(bad_conf_path)

--- a/src/ctapipe/core/tool.py
+++ b/src/ctapipe/core/tool.py
@@ -282,9 +282,16 @@ class Tool(Application):
             with open(path, "rb") as infile:
                 config = Config(toml.load(infile))
             self.update_config(config)
-        else:
-            # fall back to traitlets.config.Application's implementation
+        elif path.suffix in ["json", "py"]:
+            # fall back to traitlets.config.Application's implementation. Note
+            # that if we don't specify the file suffixes here, traitlets seems
+            # to silently ignore unknown ones.
             super().load_config_file(str(path))
+        else:
+            raise ToolConfigurationError(
+                f"The config file '{path}' is not in a known format. "
+                "The file should end in one: yml, yaml, toml, json, py"
+            )
 
         Provenance().add_input_file(path, role="Tool Configuration", add_meta=False)
 


### PR DESCRIPTION
Fixes bug where if a configuration file with unknown file extension is passed to a tool, e.g. `--config myconf.conf` instead of `--config myconf.yaml`, it was silently ignored.   Config files must now have one of the following extensions to be recognized: yml, yaml, toml, json, py, and if not a `ToolConfigurationError` is raised.