### PR TITLE
Fix sonar for pull requests

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -19,11 +19,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout branch or tag
+        uses: actions/checkout@v4
+        if: github.event.workflow_run.event != 'pull_request'
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+
+      - name: Checkout Pull Request merge result
+        uses: actions/checkout@v4
+        if: github.event.workflow_run.event == 'pull_request'
+        with:
+          ref: refs/pull/${{ github.event.workflow_run.pull_requests[0].number }}/merge
+          fetch-depth: 0
+
+      - name: Git info
+        run: |
+          git status
+          git log -n 5 --oneline
 
       - name: 'Download code coverage'
         uses: actions/github-script@v7


### PR DESCRIPTION
Note: I put this as documentation only since this workflow is only active once it reaches the main branch, so running the CI for this MR doesn't make sense.

I debugged and verified this in this test project here:  https://github.com/cta-observatory/sonar-test where I could rapidly update the workflow in the main branch and see that it works with the merge request builds.


Fixes #2668 