### PR TITLE
Make sonar coverage badge link point to coverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
     :target: https://sonar-cta-dpps.zeuthen.desy.de/dashboard?id=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs
     :alt: sonarqube quality gate
 .. |sonarqube_coverage| image:: https://sonar-cta-dpps.zeuthen.desy.de/api/project_badges/measure?project=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs&metric=coverage&token=sqb_a533204f382b350568e922385cab7c2394587458
-    :target: https://sonar-cta-dpps.zeuthen.desy.de/api/project_badges/measure?project=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs&metric=coverage&token=sqb_a533204f382b350568e922385cab7c2394587458)](https://sonar-cta-dpps.zeuthen.desy.de/dashboard?id=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs
+    :target: https://sonar-cta-dpps.zeuthen.desy.de/component_measures?metric=coverage&selected=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs%3Asrc%2Fctapipe&view=treemap&id=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs
     :alt: sonarqube code coverage
 .. |conda| image:: https://anaconda.org/conda-forge/ctapipe/badges/version.svg
   :target: https://anaconda.org/conda-forge/ctapipe


### PR DESCRIPTION
Clicking on the badge would open the badge itself in a new tab.