### PR TITLE
Store subarray description in the output file of the stats tool

### DIFF
--- a/docs/changes/2696.feature.rst
+++ b/docs/changes/2696.feature.rst
@@ -1,1 +1,1 @@
-Store also the SubarrayDescription in the camera monitoring data produced by the stats tool 
+Store also the SubarrayDescription in the camera monitoring data produced by the stats tool

--- a/docs/changes/2696.feature.rst
+++ b/docs/changes/2696.feature.rst
@@ -1,0 +1,1 @@
+Store also the SubarrayDescription in the camera monitoring data produced by the stats tool 

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -99,14 +99,14 @@ class PixelStatisticsCalculatorTool(Tool):
                 )
         self.input_data.dl1_images = True
         # Load the subarray description from the input file
-        subarray = SubarrayDescription.from_hdf(self.input_data.input_url)
+        self.subarray = SubarrayDescription.from_hdf(self.input_data.input_url)
         # Get the telescope ids from the input data or use the allowed_tels configuration
         self.tel_ids = (
-            subarray.tel_ids if self.allowed_tels is None else self.allowed_tels
+            self.subarray.tel_ids if self.allowed_tels is None else self.allowed_tels
         )
         # Initialization of the statistics calculator
         self.stats_calculator = PixelStatisticsCalculator(
-            parent=self, subarray=subarray
+            parent=self, subarray=self.subarray
         )
 
     def start(self):
@@ -171,13 +171,21 @@ class PixelStatisticsCalculatorTool(Tool):
                 f"/dl1/monitoring/telescope/{self.output_table_name}/tel_{tel_id:03d}",
                 overwrite=self.overwrite,
             )
-
-    def finish(self):
         self.log.info(
             "DL1 monitoring data was stored in '%s' under '%s'",
             self.output_path,
             f"/dl1/monitoring/telescope/{self.output_table_name}",
         )
+
+    def finish(self):
+        # Store the subarray description in the output file
+        self.subarray.to_hdf(self.output_path, overwrite=self.overwrite)
+        self.log.info(
+            "Subarray description was stored in '%s'",
+            self.output_path,
+        )
+        # Close the file in the TableLoader
+        self.input_data.close()
         self.log.info("Tool is shutting down")
 
 

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -84,8 +84,10 @@ class PixelStatisticsCalculatorTool(Tool):
 
     def setup(self):
         # Read the input data with the 'TableLoader'
-        self.input_data = TableLoader(
-            parent=self,
+        self.input_data = self.enter_context(
+            TableLoader(
+                parent=self,
+            )
         )
         # Check that the input and output files are not the same
         if self.input_data.input_url == self.output_path:
@@ -104,7 +106,7 @@ class PixelStatisticsCalculatorTool(Tool):
         self.subarray = (
             subarray
             if self.allowed_tels is None
-            else subarray.select_subarray(self.allowed_tels, "Subarray")
+            else subarray.select_subarray(self.allowed_tels)
         )
         # Initialization of the statistics calculator
         self.stats_calculator = PixelStatisticsCalculator(
@@ -186,8 +188,6 @@ class PixelStatisticsCalculatorTool(Tool):
             "Subarray description was stored in '%s'",
             self.output_path,
         )
-        # Close the file in the TableLoader
-        self.input_data.close()
         self.log.info("Tool is shutting down")
 
 

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -99,10 +99,12 @@ class PixelStatisticsCalculatorTool(Tool):
                 )
         self.input_data.dl1_images = True
         # Load the subarray description from the input file
-        self.subarray = SubarrayDescription.from_hdf(self.input_data.input_url)
-        # Get the telescope ids from the input data or use the allowed_tels configuration
-        self.tel_ids = (
-            self.subarray.tel_ids if self.allowed_tels is None else self.allowed_tels
+        subarray = SubarrayDescription.from_hdf(self.input_data.input_url)
+        # Select a new subarray if the allowed_tels configuration is used
+        self.subarray = (
+            subarray
+            if self.allowed_tels is None
+            else subarray.select_subarray(self.allowed_tels, "Subarray")
         )
         # Initialization of the statistics calculator
         self.stats_calculator = PixelStatisticsCalculator(
@@ -111,7 +113,7 @@ class PixelStatisticsCalculatorTool(Tool):
 
     def start(self):
         # Iterate over the telescope ids and calculate the statistics
-        for tel_id in self.tel_ids:
+        for tel_id in self.subarray.tel_ids:
             # Read the whole dl1 images for one particular telescope
             dl1_table = self.input_data.read_telescope_events_by_id(
                 telescopes=[

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -8,6 +8,7 @@ from traitlets.config.loader import Config
 
 from ctapipe.core import run_tool
 from ctapipe.core.tool import ToolConfigurationError
+from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import read_table
 from ctapipe.tools.calculate_pixel_stats import PixelStatisticsCalculatorTool
 
@@ -57,6 +58,10 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
         )["mean"]
         is not None
     )
+    # Read subarray description frm the created monitoring file
+    subarray = SubarrayDescription.from_hdf(monitoring_file)
+    # Check for the selected telescope
+    assert subarray.tel_ids[0] == tel_id
 
 
 def test_tool_config_error(tmp_path, dl1_image_file):

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -58,7 +58,7 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
         )["mean"]
         is not None
     )
-    # Read subarray description frm the created monitoring file
+    # Read subarray description from the created monitoring file
     subarray = SubarrayDescription.from_hdf(monitoring_file)
     # Check for the selected telescope
     assert subarray.tel_ids[0] == tel_id


### PR DESCRIPTION
We noticed that we would like to run an additional custom `OutlierDetectors` based on the deviation from the expected standard deviation of the number of photoelectrons in the `calibpipe ffactor tool` (see e.g. [calibpipe-MR](https://gitlab.cta-observatory.org/cta-computing/dpps/calibrationpipeline/calibpipe/-/blob/cb6bebf1f42f4c0253c64e0253ff90bb87a25367/src/calibpipe/tools/ffactor_calibrator.py#L28)). Therefore we need the `SubarrayDescription` in the output file of the `stats tool` since the `OutlierDetectors` are `TelescopeComponents`.