### PR TITLE
Use sysmon coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ env:
   MPLBACKEND: Agg
   PYTEST_ADDOPTS: --color=yes
   GITHUB_PR_NUMBER: ${{ github.event.number }}
-
+  COVERAGE_CORE: sysmon
+  
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   PYTEST_ADDOPTS: --color=yes
   GITHUB_PR_NUMBER: ${{ github.event.number }}
   COVERAGE_CORE: sysmon
-  
+
 jobs:
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Triggered by a discussion with ACADA people that they observe very bad performance under 3.12 and coverage testing, I found the option to use an "experimental" (what ever that actually means) new way of tracing coverage information available under 3.12 and above.

The differences seem to be quite stark:

| Version | Pipeline Before | Pipeline Now | Tests Before | Tests Now |
| :-: | :-: | :-: | :-: | :-: | 
| 3.10 | 13:55 | 13:10 | 11:49 | 11:32 |
| 3.12 | 14:23 | 09:23| 12:41 | 07:33 |
| 3.13 | 15:25| 09:39 | 14:12 | 08:08 |
 