### PR TITLE
More ImPACT code cleanup

### DIFF
--- a/src/ctapipe/reco/impact.py
+++ b/src/ctapipe/reco/impact.py
@@ -77,7 +77,6 @@ BACKUP_PED_TABLE = {
     "SST_SST_SST-Camera": 0.5,
     "SST_SST_CHEC": 0.5,
     "SST_ASTRI_ASTRICam": 0.5,
-    "dummy": 0.01,
     "UNKNOWN-960PX": 1.0,
 }
 
@@ -88,7 +87,6 @@ BACKUP_SPE_TABLE = {
     "SST_SST_SST-Camera": 0.6,
     "SST_SST_CHEC": 0.6,
     "SST_ASTRI_ASTRICam": 0.6,
-    "dummy": 0.6,
     "UNKNOWN-960PX": 0.6,
 }
 
@@ -120,9 +118,6 @@ class ImPACTReconstructor(HillasGeometryReconstructor):
         The telescope subarray to use for reconstruction
     atmosphere_profile : ctapipe.atmosphere.AtmosphereDensityProfile
         Density vs. altitude profile of the local atmosphere
-    dummy_reconstructor : bool, optional
-        Option to use a set of dummy templates. This can be used for testing the algorithm,
-        but for any actual reconstruction should be set to its default False
 
     References
     ----------
@@ -162,9 +157,7 @@ class ImPACTReconstructor(HillasGeometryReconstructor):
 
     property = ReconstructionProperty.ENERGY | ReconstructionProperty.GEOMETRY
 
-    def __init__(
-        self, subarray, atmosphere_profile, dummy_reconstructor=False, **kwargs
-    ):
+    def __init__(self, subarray, atmosphere_profile, **kwargs):
         if Minuit is None:
             raise OptionalDependencyMissing("iminuit") from None
 
@@ -203,8 +196,6 @@ class ImPACTReconstructor(HillasGeometryReconstructor):
 
         self.array_direction = None
         self.nominal_frame = None
-
-        self.dummy_reconstructor = dummy_reconstructor
 
     def __call__(self, event):
         """

--- a/src/ctapipe/reco/impact_utilities.py
+++ b/src/ctapipe/reco/impact_utilities.py
@@ -164,6 +164,7 @@ def generate_fake_template(
 def create_dummy_templates(
     output_file,
     energy,
+    tel_type,
     pe=1000.0,
     energy_range=np.logspace(-1, 1, 7),
     dist_range=np.linspace(0, 200, 5),
@@ -192,5 +193,8 @@ def create_dummy_templates(
 
                 template_dict[key] = template.T * pe
 
+    output_dict = {}
+    output_dict["data"] = template_dict
+    output_dict["tel_type"] = tel_type
     with gzip.open(output_file, "wb") as filehandler:
-        pickle.dump(template_dict, filehandler)
+        pickle.dump(output_dict, filehandler)

--- a/src/ctapipe/utils/template_network_interpolator.py
+++ b/src/ctapipe/utils/template_network_interpolator.py
@@ -269,12 +269,21 @@ class TemplateNetworkInterpolator(BaseTemplate):
 
         super().__init__()
 
+        self.template_file = template_file
+
         input_dict = None
         with gzip.open(template_file, "r") as file_list:
             input_dict = pickle.load(file_list)
 
-        keys = np.array(list(input_dict.keys()))
-        values = np.array(list(input_dict.values()), dtype=np.float32)
+        # The dict has at its highest level two keys: data and tel_type.
+        # The first just contains the template dict, the second a string to validate the tel_type
+        # that the templates are made for.
+
+        data_input_dict = input_dict["data"]
+        self.tel_type_string = input_dict["tel_type"]
+
+        keys = np.array(list(data_input_dict.keys()))
+        values = np.array(list(data_input_dict.values()), dtype=np.float32)
         self.no_zenaz = False
         self.bounds = bounds
 
@@ -324,6 +333,10 @@ class TemplateNetworkInterpolator(BaseTemplate):
 
         return interpolated_value
 
+    # Two interpolators are the same if they are generated from the same file
+    def __eq__(self, other):
+        return self.template_file == other.template_file
+
 
 class TimeGradientInterpolator(BaseTemplate):
     """
@@ -339,11 +352,22 @@ class TimeGradientInterpolator(BaseTemplate):
         """
 
         super().__init__()
-        file_list = gzip.open(template_file)
-        input_dict = pickle.load(file_list)
 
-        keys = np.array(list(input_dict.keys()))
-        values = np.array(list(input_dict.values()), dtype=np.float32)
+        self.template_file = template_file
+
+        input_dict = None
+        with gzip.open(template_file, "r") as file_list:
+            input_dict = pickle.load(file_list)
+
+        # The dict has at its highest level two keys: data and tel_type.
+        # The first just contains the template dict, the second a string to validate the tel_type
+        # that the templates are made for.
+
+        data_input_dict = input_dict["data"]
+        self.tel_type_string = input_dict["tel_type"]
+
+        keys = np.array(list(data_input_dict.keys()))
+        values = np.array(list(data_input_dict.values()), dtype=np.float32)
         self.no_zenaz = False
 
         # First check if we even have a zen and azimuth entry
@@ -384,6 +408,10 @@ class TimeGradientInterpolator(BaseTemplate):
             )
 
         return interpolated_value
+
+    # Two interpolators are the same if they are generated from the same file
+    def __eq__(self, other):
+        return self.template_file == other.template_file
 
 
 class DummyTemplateInterpolator:


### PR DESCRIPTION
Hi everyone,

I finally got around to clean up the ImPACT code a bit more.

This PR has 3 major changes:
 - The paths to the input templates are now TelescopeParameters. I also changed the required structure of the templates, they now need to contain a new key tel_type which contains the telescope description as a string to check if they are valid for the telescope they are being used for. This will require a little fix to all currently existing templates, but it is an easy and quick one.
 - The pedestal and spe width parameters are now also TelescopeParameters. For the pedestal_width, I also included the option to read them from the monitoring. In case no values are specified, they fall back to a hardcoded value in a global dict.
 - Finally, for the tests, I removed the need for the dummy_reconstructor option/variable

I look forward to your comments and to discussion on the implementation of these things.