### PR TITLE
Processing gain-selected dl1 data with the pixel stats tool

### DIFF
--- a/docs/changes/2715.bugfix.rst
+++ b/docs/changes/2715.bugfix.rst
@@ -1,0 +1,1 @@
+Fix processing gain-selected dl1 data with the ``PixelStatisticsCalculatorTool``.

--- a/src/ctapipe/monitoring/outlier.py
+++ b/src/ctapipe/monitoring/outlier.py
@@ -66,7 +66,7 @@ class RangeOutlierDetector(OutlierDetector):
 
     def __call__(self, column):
         # Validate that the shape of the statistic values has three dimensions
-        if len(column.shape) != 3:
+        if column.ndim != 3:
             raise ValueError(
                 f"Invalid shape of the column '{column.name}': '{column.shape}'. "
                 "Expected the statistic values of shape (n_entries, n_channels, n_pixels)."
@@ -100,7 +100,7 @@ class MedianOutlierDetector(OutlierDetector):
 
     def __call__(self, column):
         # Validate that the shape of the statistic values has three dimensions
-        if len(column.shape) != 3:
+        if column.ndim != 3:
             raise ValueError(
                 f"Invalid shape of the column '{column.name}': '{column.shape}'. "
                 "Expected the statistic values of shape (n_entries, n_channels, n_pixels)."
@@ -137,7 +137,7 @@ class StdOutlierDetector(OutlierDetector):
 
     def __call__(self, column):
         # Validate that the shape of the statistic values has three dimensions
-        if len(column.shape) != 3:
+        if column.ndim != 3:
             raise ValueError(
                 f"Invalid shape of the column '{column.name}': '{column.shape}'. "
                 "Expected the statistic values of shape (n_entries, n_channels, n_pixels)."

--- a/src/ctapipe/monitoring/outlier.py
+++ b/src/ctapipe/monitoring/outlier.py
@@ -65,6 +65,12 @@ class RangeOutlierDetector(OutlierDetector):
     ).tag(config=True)
 
     def __call__(self, column):
+        # Validate that the shape of the statistic values has three dimensions
+        if len(column.shape) != 3:
+            raise ValueError(
+                f"Invalid shape of the column '{column.name}': '{column.shape}'. "
+                "Expected the statistic values of shape (n_entries, n_channels, n_pixels)."
+            )
         # Remove outliers is statistical values out a given range
         outliers = np.logical_or(
             column < self.validity_range[0],
@@ -93,6 +99,12 @@ class MedianOutlierDetector(OutlierDetector):
     ).tag(config=True)
 
     def __call__(self, column):
+        # Validate that the shape of the statistic values has three dimensions
+        if len(column.shape) != 3:
+            raise ValueError(
+                f"Invalid shape of the column '{column.name}': '{column.shape}'. "
+                "Expected the statistic values of shape (n_entries, n_channels, n_pixels)."
+            )
         # Camera median
         camera_median = np.ma.median(column, axis=2)
         # Detect outliers based on the deviation of the median distribution
@@ -124,6 +136,12 @@ class StdOutlierDetector(OutlierDetector):
     ).tag(config=True)
 
     def __call__(self, column):
+        # Validate that the shape of the statistic values has three dimensions
+        if len(column.shape) != 3:
+            raise ValueError(
+                f"Invalid shape of the column '{column.name}': '{column.shape}'. "
+                "Expected the statistic values of shape (n_entries, n_channels, n_pixels)."
+            )
         # Camera median
         camera_median = np.ma.median(column, axis=2)
         # Camera std

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -82,6 +82,8 @@ class PixelStatisticsCalculatorTool(Tool):
         TableLoader,
     ] + classes_with_traits(PixelStatisticsCalculator)
 
+    DL1_COLUMN_NAMES = ["image", "peak_time"]
+
     def setup(self):
         # Read the input data with the 'TableLoader'
         self.input_data = self.enter_context(
@@ -137,6 +139,13 @@ class PixelStatisticsCalculatorTool(Tool):
                     f"Column '{self.input_column_name}' not found "
                     f"in the input data for telescope 'tel_id={tel_id}'."
                 )
+            # Check if the dl1 data is gain selected and add an extra dimension for n_channels
+            for col_name in self.DL1_COLUMN_NAMES:
+                if (
+                    col_name in dl1_table.colnames
+                    and len(dl1_table[col_name].shape) == 2
+                ):
+                    dl1_table[col_name] = dl1_table[col_name][:, np.newaxis]
             # Perform the first pass of the statistics calculation
             aggregated_stats = self.stats_calculator.first_pass(
                 table=dl1_table,

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -141,10 +141,7 @@ class PixelStatisticsCalculatorTool(Tool):
                 )
             # Check if the dl1 data is gain selected and add an extra dimension for n_channels
             for col_name in self.DL1_COLUMN_NAMES:
-                if (
-                    col_name in dl1_table.colnames
-                    and len(dl1_table[col_name].shape) == 2
-                ):
+                if col_name in dl1_table.colnames and dl1_table[col_name].ndim == 2:
                     dl1_table[col_name] = dl1_table[col_name][:, np.newaxis]
             # Perform the first pass of the statistics calculation
             aggregated_stats = self.stats_calculator.first_pass(

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -57,14 +57,14 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
     )
     # Check that the output file has been created
     assert monitoring_file.exists()
-    # Check that the output file is not empty
-    mean_column = read_table(
-        monitoring_file,
-        path=f"/dl1/monitoring/telescope/statistics/tel_{tel_id:03d}",
-    )["mean"]
-    assert mean_column is not None
     # Check if the shape of the aggregated statistic values has three dimension
-    assert len(mean_column.shape) == 3
+    assert (
+        read_table(
+            monitoring_file,
+            path=f"/dl1/monitoring/telescope/statistics/tel_{tel_id:03d}",
+        )["mean"].ndim
+        == 3
+    )
     # Read subarray description from the created monitoring file
     subarray = SubarrayDescription.from_hdf(monitoring_file)
     # Check for the selected telescope

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -29,6 +29,13 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
                 "stats_aggregator_type": [
                     ("id", tel_id, "PlainAggregator"),
                 ],
+                "outlier_detector_list": [
+                    {
+                        "apply_to": "mean",
+                        "name": "MedianOutlierDetector",
+                        "config": {"median_range_factors": [-2.0, 2.0]},
+                    }
+                ],
             },
             "PlainAggregator": {
                 "chunk_size": 1,
@@ -51,13 +58,13 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
     # Check that the output file has been created
     assert monitoring_file.exists()
     # Check that the output file is not empty
-    assert (
-        read_table(
-            monitoring_file,
-            path=f"/dl1/monitoring/telescope/statistics/tel_{tel_id:03d}",
-        )["mean"]
-        is not None
-    )
+    mean_column = read_table(
+        monitoring_file,
+        path=f"/dl1/monitoring/telescope/statistics/tel_{tel_id:03d}",
+    )["mean"]
+    assert mean_column is not None
+    # Check if the shape of the aggregated statistic values has three dimension
+    assert len(mean_column.shape) == 3
     # Read subarray description from the created monitoring file
     subarray = SubarrayDescription.from_hdf(monitoring_file)
     # Check for the selected telescope


### PR DESCRIPTION
We noticed that we can not process gain-selected data. This PR is a bug fix for processing gain-selected dl1 data with the pixel stats tool and its components. I extended the unit tests accordingly. Before the unit tests were passing since we did not include the detection of outliers in the pixel tool testing.