### PR TITLE
Ignore `tables.NaturalNameWarning` in `write_table`s meta

### DIFF
--- a/src/ctapipe/io/astropy_helpers.py
+++ b/src/ctapipe/io/astropy_helpers.py
@@ -2,7 +2,9 @@
 """
 Functions to help adapt internal ctapipe data to astropy formats and conventions
 """
+
 import os
+import warnings
 from contextlib import ExitStack
 from uuid import uuid4
 
@@ -210,8 +212,10 @@ def write_table(
             h5_table = h5file.get_node(path)
             h5_table.append(table.as_array())
 
-        for key, val in table.meta.items():
-            h5_table.attrs[key] = val
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", tables.NaturalNameWarning)
+            for key, val in table.meta.items():
+                h5_table.attrs[key] = val
 
         for key, val in attrs.items():
             h5_table.attrs[key] = val


### PR DESCRIPTION
Get a lot of 
```
NaturalNameWarning: object name is not a valid Python identifier: 'OBSGEO-X'; it does not match the pattern ``^[a-zA-Z_][a-zA-Z0-9_]*$``; you will not be able to use natural naming to access this object; using ``getattr()`` will still work, though
  check_attribute_name(name)
```
Warnings flushing my logs from [astropy_helpers.write_table](https://github.com/cta-observatory/ctapipe/blob/e5999e2667ddc7253dd86703a46b497fc3ae7ae0/src/ctapipe/io/astropy_helpers.py#L116) while executing `ctapipe-apply-models`