### PR TITLE
Make StereoCombiner configurable in ApplyModels

### DIFF
--- a/src/ctapipe/tools/apply_models.py
+++ b/src/ctapipe/tools/apply_models.py
@@ -149,7 +149,20 @@ class ApplyModels(Tool):
 
         self._reconstructors = []
         for path in self.reconstructor_paths:
-            r = Reconstructor.read(path, parent=self, subarray=self.loader.subarray)
+            r = Reconstructor.read(
+                path,
+                parent=self,
+                subarray=self.loader.subarray,
+            )
+            # DispReconstructor hat norm_cls und sign_cls - keine model_cls
+            r.stereo_combiner = Reconstructor.from_name(
+                r.__class__.__name__,
+                subarray=self.loader.subarray,
+                parent=self,
+                prefix=r.prefix,
+                model_cls=r.model_cls,
+            ).stereo_combiner
+
             if self.n_jobs:
                 r.n_jobs = self.n_jobs
             self._reconstructors.append(r)

--- a/src/ctapipe/tools/apply_models.py
+++ b/src/ctapipe/tools/apply_models.py
@@ -154,13 +154,18 @@ class ApplyModels(Tool):
                 parent=self,
                 subarray=self.loader.subarray,
             )
-            # DispReconstructor hat norm_cls und sign_cls - keine model_cls
+
+            # Init new Reconstructor with config parameters and overwrite the StereoCombiner
+            model_keys = ["model_cls", "norm_cls", "sign_cls"]
+            model_kwargs = {
+                key: getattr(r, key) for key in model_keys if hasattr(r, key)
+            }
             r.stereo_combiner = Reconstructor.from_name(
                 r.__class__.__name__,
                 subarray=self.loader.subarray,
                 parent=self,
                 prefix=r.prefix,
-                model_cls=r.model_cls,
+                **model_kwargs,
             ).stereo_combiner
 
             if self.n_jobs:


### PR DESCRIPTION
Since the loaded joblib-pickled ``Reconstructor``s in ``ApplyModels`` https://github.com/cta-observatory/ctapipe/blob/e5999e2667ddc7253dd86703a46b497fc3ae7ae0/src/ctapipe/tools/apply_models.py#L152 are already instantiated, one cannot change their traits via the config system, which leads to a not configurable ``StereoCombiner``.

Instantiating a new ``Reconstructor.from_name(parent=self)`` and handing over its ``StereoCombiner`` would solve this Problem.

Fixes #2720 
