### PR TITLE
Force absences of units for skewness and excess_kurtosis

### DIFF
--- a/docs/changes/2732.bugfix.rst
+++ b/docs/changes/2732.bugfix.rst
@@ -1,0 +1,1 @@
+Fix units (absence of) for skewness and excess kurtosis in muon analysis

--- a/src/ctapipe/image/muon/features.py
+++ b/src/ctapipe/image/muon/features.py
@@ -334,16 +334,14 @@ def radial_light_distribution(
     delta_r = pixel_r - mean
     radial_std_dev = np.sqrt(np.average(delta_r**2, weights=image))
     skewness = (
-        np.average(delta_r**3, weights=image)
-        / radial_std_dev**3
-        * u.dimensionless_unscaled
-    )
+        np.average(delta_r**3, weights=image) / radial_std_dev**3
+    ) * u.dimensionless_unscaled
     excess_kurtosis = (
         np.average(delta_r**4, weights=image) / radial_std_dev**4 - 3.0
     ) * u.dimensionless_unscaled
 
     return (
         radial_std_dev,
-        skewness,
-        excess_kurtosis,
+        skewness.to_value(),
+        excess_kurtosis.to_value(),
     )

--- a/src/ctapipe/image/muon/features.py
+++ b/src/ctapipe/image/muon/features.py
@@ -324,8 +324,8 @@ def radial_light_distribution(
     if np.sum(image) == 0:
         return (
             np.nan * u.deg,
-            np.nan * u.dimensionless_unscaled,
-            np.nan * u.dimensionless_unscaled,
+            np.nan,
+            np.nan,
         )
 
     pixel_r = np.hypot(pixel_fov_lon - center_fov_lon, pixel_fov_lat - center_fov_lat)
@@ -333,15 +333,13 @@ def radial_light_distribution(
     mean = np.average(pixel_r, weights=image)
     delta_r = pixel_r - mean
     radial_std_dev = np.sqrt(np.average(delta_r**2, weights=image))
-    skewness = (
-        np.average(delta_r**3, weights=image) / radial_std_dev**3
-    ) * u.dimensionless_unscaled
+    skewness = (np.average(delta_r**3, weights=image) / radial_std_dev**3).to_value()
     excess_kurtosis = (
         np.average(delta_r**4, weights=image) / radial_std_dev**4 - 3.0
-    ) * u.dimensionless_unscaled
+    ).to_value()
 
     return (
         radial_std_dev,
-        skewness.to_value(),
-        excess_kurtosis.to_value(),
+        skewness,
+        excess_kurtosis,
     )

--- a/src/ctapipe/image/muon/tests/test_muon_features.py
+++ b/src/ctapipe/image/muon/tests/test_muon_features.py
@@ -142,6 +142,12 @@ def test_radial_light_distribution():
     )
 
     assert radial_std_dev.unit == u.deg
+    assert isinstance(
+        skewness, (float, np.floating)
+    ), f"Unexpected type: {type(skewness)}"
+    assert isinstance(
+        excess_kurtosis, (float, np.floating)
+    ), f"Unexpected type: {type(excess_kurtosis)}"
     assert np.isclose(radial_std_dev, expected_std_dev, atol=1e-2)
     assert np.isclose(skewness, expected_skewness, atol=1e-2)
     assert np.isclose(excess_kurtosis, expected_excess_kurtosis, atol=1e-2)


### PR DESCRIPTION
Explicitly convert (dimensionless) skewness and excess_kurtosis to values

Closes #2730 