### PR TITLE
Use telescope frame for muon test instead of manual transform

### DIFF
--- a/src/ctapipe/image/muon/tests/test_ring_fitter.py
+++ b/src/ctapipe/image/muon/tests/test_ring_fitter.py
@@ -193,7 +193,6 @@ def test_muon_ring_fitter(
     boundary_thresh,
 ):
     """test MuonRingFitter"""
-
     pytest.importorskip("iminuit")
 
     # Dynamically retrieve the fixture for the specified camera
@@ -288,6 +287,7 @@ def test_muon_ring_fitter_error_calculator(
     width,
 ):
     """test MuonRingFitter error_calculator"""
+    pytest.importorskip("iminuit")
 
     # Dynamically retrieve the fixture for the specified camera
     tel = request.getfixturevalue(tel_fixture_name)


### PR DESCRIPTION
@burmist-git Another PR targeting yours to use the TelescopeFrame instead of the manual transformation you added.