### PR TITLE
Two small CameraDisplay fixes: subfigures and optional psi_uncertainty

### DIFF
--- a/docs/changes/2762.bugfix.rst
+++ b/docs/changes/2762.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``CameraDisplay`` throwing an error when used in a matplotlib
+subfigure.

--- a/src/ctapipe/visualization/tests/test_mpl.py
+++ b/src/ctapipe/visualization/tests/test_mpl.py
@@ -388,3 +388,21 @@ def test_array_display_axes(tmp_path, subarray_prod5_paranal, layout):
     subarray_prod5_paranal.peek(ax=ax2)
 
     fig.savefig(tmp_path / "double_peek.png")
+
+
+def test_camera_in_subfigure(tmp_path, prod5_lst_cam):
+    """Test for creating camera displays in subfigures"""
+    from ..mpl_camera import CameraDisplay
+
+    fig = plt.figure(layout="constrained")
+    subfigs = fig.subfigures(1, 2)
+
+    ax1 = subfigs[0].subplots(1, 1)
+    d1 = CameraDisplay(prod5_lst_cam, ax=ax1)
+    d1.add_colorbar()
+
+    ax2 = subfigs[1].subplots(1, 1)
+    d2 = CameraDisplay(prod5_lst_cam, ax=ax2)
+    d2.add_colorbar()
+
+    fig.savefig(tmp_path / "subfigures.png")


### PR DESCRIPTION
- Our `CameraDisplay` didn't work when used in subfigures
- Added an option to disable / tweak the visualization of the hillas psi uncertainty