### PR TITLE
Unpin python 3.13 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
           - name: Linux (3.13, pip)
             os: ubuntu-24.04
-            python-version: "3.13.3"
+            python-version: "3.13"
             install-method: pip
             extras: tests,all
 


### PR DESCRIPTION
python 3.13.5 was released fixing the regression that caused numba compilation failures in 3.13.4