### PR TITLE
Remove references  to ctapipe_resources and fix wrong log message

### DIFF
--- a/docs/api-reference/instrument/index.rst
+++ b/docs/api-reference/instrument/index.rst
@@ -49,20 +49,6 @@ Hierarchy of InstrumentDescription Classes
   optics
 
 
-Other Instrumental Data
-=======================
-
-
-Atmosphere Profiles
--------------------
-
-With the instrument module you can also load standard atmosphere profiles,
-which are read from tables located in ``ctapipe_resources`` by default
-
-The function `get_atmosphere_profile_functions()` returns two interpolation
-functions that convert between height and atmosphere thickness.
-
-
 Reference/API
 =============
 

--- a/docs/api-reference/utils/index.rst
+++ b/docs/api-reference/utils/index.rst
@@ -35,9 +35,8 @@ directory path to the requested file. It currently works as follows:
 1. it checks all directories in the CTA_SVC_PATH environment variable
    (which should be a colon-separated list of directories, like PATH)
 
-2. if it doesn't find it there, it checks the ctapipe_resources module (which
-   should be installed already in the package ctapipe-extra), which contains
-   defaults.
+2. if it doesn't find it there, it tries to download the file from the test data
+   server.
 
 Tabular data can be accessed automatically using
 :func:`get_table_dataset(basename) <.get_table_dataset>`,

--- a/docs/changes/2782.maintenance.rst
+++ b/docs/changes/2782.maintenance.rst
@@ -1,0 +1,4 @@
+- fixed confusing (and incorrect) debug log message in download.py
+- removed all references to ``ctapipe_resources`` in the code and docs, since
+  that module is no longer supported. Updated documentation to mention the
+  remote test data server when applicable.

--- a/src/ctapipe/instrument/camera/readout.py
+++ b/src/ctapipe/instrument/camera/readout.py
@@ -131,7 +131,7 @@ class CameraReadout:
     def from_name(cls, name="NectarCam", version=None):
         """Construct a CameraReadout using the name of the camera and array.
 
-        This expects that there is a resource accessible ``ctapipe_resources``
+        This expects that there is a resource accessible
         via `~ctapipe.utils.get_table_dataset` called
         ``"[array]-[camera].camreadout.fits.gz"`` or
         ``"[array]-[camera]-[version].camgeom.fits.gz"``.

--- a/src/ctapipe/tools/info.py
+++ b/src/ctapipe/tools/info.py
@@ -5,7 +5,6 @@ import logging
 import os
 import sys
 from importlib.metadata import PackageNotFoundError, requires, version
-from importlib.resources import files
 
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
@@ -180,10 +179,6 @@ def _info_resources():
 
     all_resources = sorted(datasets.find_all_matching_datasets(r"\w.*"))
     home = os.path.expanduser("~")
-    try:
-        resource_dir = files("ctapipe_resources")
-    except ImportError:
-        resource_dir = None
 
     fmt = "{name:<30.30s} : {loc:<30.30s}"
     print(fmt.format(name="RESOURCE NAME", loc="LOCATION"))
@@ -192,8 +187,6 @@ def _info_resources():
         if resource.suffix == ".py" or resource.name.startswith("_"):
             continue
         loc = str(resource)
-        if resource_dir is not None:
-            loc = loc.replace(resource_dir, "[ctapipe_resources]")
         loc = loc.replace(home, "~")
         print(fmt.format(name=resource.name, loc=loc))
 

--- a/src/ctapipe/utils/download.py
+++ b/src/ctapipe/utils/download.py
@@ -145,7 +145,7 @@ def download_file_cached(
     path: pathlib.Path
         the full path to the downloaded data.
     """
-    log.debug(f"Fetching '{name}' from cache or remote server.")
+    log.debug("Fetching '%s' from cache or remote server.", name)
 
     base_url = os.environ.get(env_prefix + "URL", default_url).rstrip("/")
     url = base_url + "/" + str(name).lstrip("/")

--- a/src/ctapipe/utils/download.py
+++ b/src/ctapipe/utils/download.py
@@ -137,13 +137,15 @@ def download_file_cached(
     default_url: str
         The default url from which to download ``name``, can be overridden
         by setting the env variable ``env_prefix + URL``
+    progress: bool
+        Whether or not to show a progress bar for downloads
 
     Returns
     -------
     path: pathlib.Path
         the full path to the downloaded data.
     """
-    log.debug(f"File {name} is not available in cache, downloading.")
+    log.debug(f"Fetching '{name}' from cache or remote server.")
 
     base_url = os.environ.get(env_prefix + "URL", default_url).rstrip("/")
     url = base_url + "/" + str(name).lstrip("/")


### PR DESCRIPTION
- incorrect log message: download_file always logged (as DEBUG) _"File {name} is not available in cache, downloading",_ even if the file was available and not downloaded.
- removed all references to ctapipe_resources in the code and docs, since that module has not been used or maintained in a very long time. 