### PR TITLE
Modify camera monitoring data format

### DIFF
--- a/docs/changes/2787.feature.rst
+++ b/docs/changes/2787.feature.rst
@@ -1,1 +1,1 @@
-Enable ``ctapipe-merge``.  to be used on camera calibration data and pixel statistics aggregation.
+Enable ``ctapipe-merge`` to be used on camera calibration data and pixel statistics aggregation.

--- a/docs/changes/2787.feature.rst
+++ b/docs/changes/2787.feature.rst
@@ -1,0 +1,1 @@
+Enable ``ctapipe-merge``.  to be used on camera calibration data and pixel statistics aggregation.

--- a/docs/user-guide/data_format/index.rst
+++ b/docs/user-guide/data_format/index.rst
@@ -24,6 +24,9 @@ To read this data, there are two high-level APIs available:
 DL1 Data Format
 ===============
 
+DL1/Event Data format
+---------------------
+
 This describes data that change per-event.
 The following datasets will be written to the group ``/dl1/event/`` in the  output file:
 
@@ -49,6 +52,38 @@ The following datasets will be written to the group ``/dl1/event/`` in the  outp
       - tables of image parameters (one per telescope)
       - :py:class:`~ctapipe.containers.TelEventIndexContainer`, :py:class:`~ctapipe.containers.ImageParametersContainer`
 
+
+DL1/Monitoring Data Format
+--------------------------
+
+This describes data that change per-telescope, but not per regular physics event.
+This is used to store calibration and monitoring information, such as calibration events pixel statistics,
+pedestal values, and other per-telescope monitoring and calibration information.
+The following datasets will be written to the group ``/dl1/monitoring/`` in the output file:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Group/Dataset
+      - Description
+      - Contents
+    * - ``telescope/``
+      - Per-telescope monitoring information
+      - (group)
+    * - | ``telescope/calibration/camera/``
+        | ``coefficients/tel_{TEL_ID:03d}``
+      - tables of camera calibration coefficients (one per telescope)
+      - (TBU)
+    * - | ``telescope/calibration/camera/``
+        | ``pixel_statistics/{pixel_feature}/``
+        | ``tel_{TEL_ID:03d}``
+      - | feature statistics for each pixel in the camera (one per telescope).
+        | ``{pixel_feature}`` is defined as ``{event_type}_{feature_name}``.
+      - | :py:class:`~ctapipe.containers.EventType`,
+        | :py:class:`~ctapipe.containers.StatisticsContainer`,
+        | :py:class:`~ctapipe.containers.ImageStatisticsContainer`,
+        | :py:class:`~ctapipe.containers.IntensityStatisticsContainer`,
+        | :py:class:`~ctapipe.containers.PeakTimeStatisticsContainer`
 
 DL2 Data Format
 ===============

--- a/src/ctapipe/io/hdf5merger.py
+++ b/src/ctapipe/io/hdf5merger.py
@@ -47,32 +47,18 @@ _NODES_TO_CHECK = {
     "/dl1/event/telescope/muon": NodeType.TEL_GROUP,
     "/dl2/event/telescope": NodeType.ITER_TEL_GROUP,
     "/dl2/event/subarray": NodeType.ITER_GROUP,
+    "/dl1/monitoring/subarray/pointing": NodeType.TABLE,
+    "/dl1/monitoring/telescope/pointing": NodeType.TEL_GROUP,
+    "/dl1/monitoring/telescope/camera/calibration_coefficients/": NodeType.TEL_GROUP,
 }
 
+# Column names used for the DL1A data
 DL1_COLUMN_NAMES = ["image", "peak_time"]
-
-
-def _contruct_mon_nodes():
-    """Construct monitoring nodes for the checking of merge-ability"""
-    # Default monitoring nodes to check for merge-ability
-    _MON_NODES_TO_CHECK = {
-        "/dl1/monitoring/subarray/pointing": NodeType.TABLE,
-        "/dl1/monitoring/telescope/pointing": NodeType.TEL_GROUP,
-        "/dl1/monitoring/telescope/camera/calibration_coefficients/": NodeType.TEL_GROUP,
-    }
-    # Add pixel statistics for each event type and dl1 column
-    for dl1_colname in DL1_COLUMN_NAMES:
-        for event_type in EventType:
-            _MON_NODES_TO_CHECK[
-                f"/dl1/monitoring/telescope/camera/pixel_statistics/{event_type.name}_{dl1_colname}"
-            ] = NodeType.TEL_GROUP
-    return _MON_NODES_TO_CHECK
 
 
 def _get_required_nodes(h5file):
     """Return nodes to be required in a new file for appending to ``h5file``"""
     required_nodes = set()
-    _NODES_TO_CHECK.update(_contruct_mon_nodes())
     for node, node_type in _NODES_TO_CHECK.items():
         if node not in h5file.root:
             continue
@@ -430,6 +416,11 @@ class HDF5Merger(Component):
             self._append_table(other, other.root[key])
 
         key = "/dl1/monitoring/telescope/pointing"
+        if self.monitoring and self.telescope_events and key in other.root:
+            self._append_table_group(other, other.root[key])
+
+        # Calibration coefficients monitoring
+        key = "/dl1/monitoring/telescope/camera/calibration_coefficients/"
         if self.monitoring and self.telescope_events and key in other.root:
             self._append_table_group(other, other.root[key])
 

--- a/src/ctapipe/io/hdf5merger.py
+++ b/src/ctapipe/io/hdf5merger.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import tables
 from astropy.time import Time
 
+from ..containers import EventType
 from ..core import Component, Provenance, traits
 from ..instrument.optics import FocalLengthKind
 from ..instrument.subarray import SubarrayDescription
@@ -20,10 +21,10 @@ class NodeType(enum.Enum):
     TABLE = enum.auto()
     # a group comprising tel_XXX tables
     TEL_GROUP = enum.auto()
-    # a group with children of the form /<property group>/<algorithm table>
-    ALGORITHM_GROUP = enum.auto()
-    # a group with children of the form /<property group>/<algorithm group>/<tel_XXX table>
-    ALGORITHM_TEL_GROUP = enum.auto()
+    # a group with children of the form /<property group>/<iter table>
+    ITER_GROUP = enum.auto()
+    # a group with children of the form /<property group>/<iter group>/<tel_XXX table>
+    ITER_TEL_GROUP = enum.auto()
 
 
 #: nodes to check for merge-ability
@@ -44,16 +45,34 @@ _NODES_TO_CHECK = {
     "/dl1/event/telescope/images": NodeType.TEL_GROUP,
     "/dl1/event/telescope/parameters": NodeType.TEL_GROUP,
     "/dl1/event/telescope/muon": NodeType.TEL_GROUP,
-    "/dl2/event/telescope": NodeType.ALGORITHM_TEL_GROUP,
-    "/dl2/event/subarray": NodeType.ALGORITHM_GROUP,
-    "/dl1/monitoring/subarray/pointing": NodeType.TABLE,
-    "/dl1/monitoring/telescope/pointing": NodeType.TEL_GROUP,
+    "/dl2/event/telescope": NodeType.ITER_TEL_GROUP,
+    "/dl2/event/subarray": NodeType.ITER_GROUP,
 }
+
+DL1_COLUMN_NAMES = ["image", "peak_time"]
+
+
+def _contruct_mon_nodes():
+    """Construct monitoring nodes for the checking of merge-ability"""
+    # Default monitoring nodes to check for merge-ability
+    _MON_NODES_TO_CHECK = {
+        "/dl1/monitoring/subarray/pointing": NodeType.TABLE,
+        "/dl1/monitoring/telescope/pointing": NodeType.TEL_GROUP,
+        "/dl1/monitoring/telescope/camera/calibration_coefficients/": NodeType.TEL_GROUP,
+    }
+    # Add pixel statistics for each event type and dl1 column
+    for dl1_colname in DL1_COLUMN_NAMES:
+        for event_type in EventType:
+            _MON_NODES_TO_CHECK[
+                f"/dl1/monitoring/telescope/camera/pixel_statistics/{event_type.name}_{dl1_colname}"
+            ] = NodeType.TEL_GROUP
+    return _MON_NODES_TO_CHECK
 
 
 def _get_required_nodes(h5file):
     """Return nodes to be required in a new file for appending to ``h5file``"""
     required_nodes = set()
+    _NODES_TO_CHECK.update(_contruct_mon_nodes())
     for node, node_type in _NODES_TO_CHECK.items():
         if node not in h5file.root:
             continue
@@ -61,15 +80,15 @@ def _get_required_nodes(h5file):
         if node_type in (NodeType.TABLE, NodeType.TEL_GROUP):
             required_nodes.add(node)
 
-        elif node_type is NodeType.ALGORITHM_GROUP:
+        elif node_type is NodeType.ITER_GROUP:
             for kind_group in h5file.root[node]._f_iter_nodes("Group"):
                 for table in kind_group._f_iter_nodes("Table"):
                     required_nodes.add(table._v_pathname)
 
-        elif node_type is NodeType.ALGORITHM_TEL_GROUP:
+        elif node_type is NodeType.ITER_TEL_GROUP:
             for kind_group in h5file.root[node]._f_iter_nodes("Group"):
-                for algorithm_group in kind_group._f_iter_nodes("Group"):
-                    required_nodes.add(algorithm_group._v_pathname)
+                for iter_group in kind_group._f_iter_nodes("Group"):
+                    required_nodes.add(iter_group._v_pathname)
         else:
             raise ValueError(f"Unhandled node type: {node_type} of {node}")
 
@@ -396,8 +415,8 @@ class HDF5Merger(Component):
         key = "/dl2/event/telescope"
         if self.telescope_events and self.dl2_telescope and key in other.root:
             for kind_group in other.root[key]._f_iter_nodes("Group"):
-                for algorithm_group in kind_group._f_iter_nodes("Group"):
-                    self._append_table_group(other, algorithm_group)
+                for iter_group in kind_group._f_iter_nodes("Group"):
+                    self._append_table_group(other, iter_group)
 
         key = "/dl2/event/subarray"
         if self.dl2_subarray and key in other.root:
@@ -405,7 +424,7 @@ class HDF5Merger(Component):
                 for table in kind_group._f_iter_nodes("Table"):
                     self._append_table(other, table)
 
-        # monitoring
+        # Pointing monitoring
         key = "/dl1/monitoring/subarray/pointing"
         if self.monitoring and key in other.root:
             self._append_table(other, other.root[key])
@@ -413,6 +432,13 @@ class HDF5Merger(Component):
         key = "/dl1/monitoring/telescope/pointing"
         if self.monitoring and self.telescope_events and key in other.root:
             self._append_table_group(other, other.root[key])
+
+        # Pixel statistics monitoring
+        for dl1_colname in DL1_COLUMN_NAMES:
+            for event_type in EventType:
+                key = f"/dl1/monitoring/telescope/camera/pixel_statistics/{event_type.name}_{dl1_colname}"
+                if self.monitoring and self.telescope_events and key in other.root:
+                    self._append_table_group(other, other.root[key])
 
         # quality query statistics
         key = "/dl1/service/image_statistics"

--- a/src/ctapipe/io/hdf5merger.py
+++ b/src/ctapipe/io/hdf5merger.py
@@ -54,6 +54,7 @@ _NODES_TO_CHECK = {
 
 # Column names used for the DL1A data
 DL1_COLUMN_NAMES = ["image", "peak_time"]
+CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/calibration/camera"
 
 
 def _get_required_nodes(h5file):
@@ -420,14 +421,14 @@ class HDF5Merger(Component):
             self._append_table_group(other, other.root[key])
 
         # Calibration coefficients monitoring
-        key = "/dl1/monitoring/telescope/camera/calibration_coefficients/"
+        key = f"{CAMERA_MONITORING_GROUP}/coefficients/"
         if self.monitoring and self.telescope_events and key in other.root:
             self._append_table_group(other, other.root[key])
 
         # Pixel statistics monitoring
         for dl1_colname in DL1_COLUMN_NAMES:
             for event_type in EventType:
-                key = f"/dl1/monitoring/telescope/camera/pixel_statistics/{event_type.name}_{dl1_colname}"
+                key = f"{CAMERA_MONITORING_GROUP}/pixel_statistics/{event_type.name.lower()}_{dl1_colname}"
                 if self.monitoring and self.telescope_events and key in other.root:
                     self._append_table_group(other, other.root[key])
 

--- a/src/ctapipe/monitoring/__init__.py
+++ b/src/ctapipe/monitoring/__init__.py
@@ -4,11 +4,13 @@ Module for handling monitoring data.
 from .aggregator import PlainAggregator, SigmaClippingAggregator, StatisticsAggregator
 from .interpolation import (
     ChunkInterpolator,
-    FlatFieldInterpolator,
+    FlatfieldImageInterpolator,
+    FlatfieldPeakTimeInterpolator,
     LinearInterpolator,
     MonitoringInterpolator,
-    PedestalInterpolator,
+    PedestalImageInterpolator,
     PointingInterpolator,
+    StatisticsInterpolator,
 )
 from .outlier import (
     MedianOutlierDetector,
@@ -29,6 +31,8 @@ __all__ = [
     "LinearInterpolator",
     "PointingInterpolator",
     "ChunkInterpolator",
-    "FlatFieldInterpolator",
-    "PedestalInterpolator",
+    "StatisticsInterpolator",
+    "FlatfieldPeakTimeInterpolator",
+    "FlatfieldImageInterpolator",
+    "PedestalImageInterpolator",
 ]

--- a/src/ctapipe/monitoring/interpolation.py
+++ b/src/ctapipe/monitoring/interpolation.py
@@ -340,22 +340,18 @@ class StatisticsInterpolator(ChunkInterpolator):
 class PedestalImageInterpolator(StatisticsInterpolator):
     """Interpolator for pedestal image tables."""
 
-    telescope_data_group = (
-        "/dl1/monitoring/telescope/camera/pixel_statistics/SKY_PEDESTAL_image"
-    )
+    telescope_data_group = "/dl1/monitoring/telescope/calibration/camera/pixel_statistics/sky_pedestal_image"
 
 
 class FlatfieldImageInterpolator(StatisticsInterpolator):
     """Interpolator for flatfield image tables."""
 
     telescope_data_group = (
-        "/dl1/monitoring/telescope/camera/pixel_statistics/FLATFIELD_image"
+        "/dl1/monitoring/telescope/calibration/camera/pixel_statistics/flatfield_image"
     )
 
 
 class FlatfieldPeakTimeInterpolator(StatisticsInterpolator):
     """Interpolator for flatfield peak time tables."""
 
-    telescope_data_group = (
-        "/dl1/monitoring/telescope/camera/pixel_statistics/FLATFIELD_peak_time"
-    )
+    telescope_data_group = "/dl1/monitoring/telescope/calibration/camera/pixel_statistics/flatfield_peak_time"

--- a/src/ctapipe/monitoring/interpolation.py
+++ b/src/ctapipe/monitoring/interpolation.py
@@ -340,16 +340,22 @@ class StatisticsInterpolator(ChunkInterpolator):
 class PedestalImageInterpolator(StatisticsInterpolator):
     """Interpolator for pedestal image tables."""
 
-    telescope_data_group = "/dl1/monitoring/telescope/camera/SKY_PEDESTAL_image"
+    telescope_data_group = (
+        "/dl1/monitoring/telescope/camera/pixel_statistics/SKY_PEDESTAL_image"
+    )
 
 
 class FlatfieldImageInterpolator(StatisticsInterpolator):
     """Interpolator for flatfield image tables."""
 
-    telescope_data_group = "/dl1/monitoring/telescope/camera/FLATFIELD_image"
+    telescope_data_group = (
+        "/dl1/monitoring/telescope/camera/pixel_statistics/FLATFIELD_image"
+    )
 
 
 class FlatfieldPeakTimeInterpolator(StatisticsInterpolator):
     """Interpolator for flatfield peak time tables."""
 
-    telescope_data_group = "/dl1/monitoring/telescope/camera/FLATFIELD_peak_time"
+    telescope_data_group = (
+        "/dl1/monitoring/telescope/camera/pixel_statistics/FLATFIELD_peak_time"
+    )

--- a/src/ctapipe/resources/calculate_pixel_stats.yaml
+++ b/src/ctapipe/resources/calculate_pixel_stats.yaml
@@ -1,7 +1,6 @@
 PixelStatisticsCalculatorTool:
   allowed_tels: [1,2,3,4]
   input_column_name: image
-  output_table_name: subarray_image
 
 PixelStatisticsCalculator:
   stats_aggregator_type:

--- a/src/ctapipe/resources/calculate_pixel_stats.yaml
+++ b/src/ctapipe/resources/calculate_pixel_stats.yaml
@@ -1,7 +1,7 @@
 PixelStatisticsCalculatorTool:
   allowed_tels: [1,2,3,4]
   input_column_name: image
-  output_table_name: statistics
+  output_table_name: subarray_image
 
 PixelStatisticsCalculator:
   stats_aggregator_type:

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -184,7 +184,7 @@ class PixelStatisticsCalculatorTool(Tool):
                     )
             # Cnstruct the output table name based on the event type and the selected column name
             output_table_name = (
-                f"{EventType(dl1_table["event_type"][0]).name}_{self.input_column_name}"
+                f"{EventType(dl1_table['event_type'][0]).name}_{self.input_column_name}"
             )
             self.log.info(f"{output_table_name}")
             # Write the aggregated statistics and their outlier mask to the output file

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -7,6 +7,7 @@ import pathlib
 import numpy as np
 from astropy.table import vstack
 
+from ctapipe.containers import EventType
 from ctapipe.core import Tool
 from ctapipe.core.tool import ToolConfigurationError
 from ctapipe.core.traits import (
@@ -54,12 +55,6 @@ class PixelStatisticsCalculatorTool(Tool):
         help="Column name of the pixel-wise image data to calculate statistics",
     ).tag(config=True)
 
-    output_table_name = Unicode(
-        default_value="statistics",
-        allow_none=False,
-        help="Table name of the output statistics",
-    ).tag(config=True)
-
     output_path = Path(
         help="Output filename", default_value=pathlib.Path("monitoring.h5")
     ).tag(config=True)
@@ -85,6 +80,7 @@ class PixelStatisticsCalculatorTool(Tool):
     ] + classes_with_traits(PixelStatisticsCalculator)
 
     DL1_COLUMN_NAMES = ["image", "peak_time"]
+    CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/camera"
 
     def setup(self):
         # Read the input data with the 'TableLoader'
@@ -186,20 +182,22 @@ class PixelStatisticsCalculatorTool(Tool):
                         "No faulty chunks found for telescope 'tel_id=%d'. Skipping second pass.",
                         tel_id,
                     )
-            # Add metadata to the aggregated statistics
-            aggregated_stats.meta["event_type"] = dl1_table["event_type"][0]
-            aggregated_stats.meta["input_column_name"] = self.input_column_name
+            # Cnstruct the output table name based on the event type and the selected column name
+            output_table_name = (
+                f"{EventType(dl1_table["event_type"][0]).name}_{self.input_column_name}"
+            )
+            self.log.info(f"{output_table_name}")
             # Write the aggregated statistics and their outlier mask to the output file
             write_table(
                 aggregated_stats,
                 self.output_path,
-                f"/dl1/monitoring/telescope/{self.output_table_name}/tel_{tel_id:03d}",
+                f"{self.CAMERA_MONITORING_GROUP}/pixel_statistics/{output_table_name}/tel_{tel_id:03d}",
                 overwrite=self.overwrite,
             )
         self.log.info(
             "DL1 monitoring data was stored in '%s' under '%s'",
             self.output_path,
-            f"/dl1/monitoring/telescope/{self.output_table_name}",
+            f"{self.CAMERA_MONITORING_GROUP}/pixel_statistics/{output_table_name}",
         )
 
     def finish(self):

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -182,7 +182,7 @@ class PixelStatisticsCalculatorTool(Tool):
                         "No faulty chunks found for telescope 'tel_id=%d'. Skipping second pass.",
                         tel_id,
                     )
-            # Cnstruct the output table name based on the event type and the selected column name
+            # Construct the output table name based on the event type and the selected column name
             output_table_name = f"{EventType(dl1_table['event_type'][0]).name.lower()}_{self.input_column_name}"
             # Write the aggregated statistics and their outlier mask to the output file
             write_table(

--- a/src/ctapipe/tools/calculate_pixel_stats.py
+++ b/src/ctapipe/tools/calculate_pixel_stats.py
@@ -80,7 +80,7 @@ class PixelStatisticsCalculatorTool(Tool):
     ] + classes_with_traits(PixelStatisticsCalculator)
 
     DL1_COLUMN_NAMES = ["image", "peak_time"]
-    CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/camera"
+    CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/calibration/camera"
 
     def setup(self):
         # Read the input data with the 'TableLoader'
@@ -183,10 +183,7 @@ class PixelStatisticsCalculatorTool(Tool):
                         tel_id,
                     )
             # Cnstruct the output table name based on the event type and the selected column name
-            output_table_name = (
-                f"{EventType(dl1_table['event_type'][0]).name}_{self.input_column_name}"
-            )
-            self.log.info(f"{output_table_name}")
+            output_table_name = f"{EventType(dl1_table['event_type'][0]).name.lower()}_{self.input_column_name}"
             # Write the aggregated statistics and their outlier mask to the output file
             write_table(
                 aggregated_stats,

--- a/src/ctapipe/tools/merge.py
+++ b/src/ctapipe/tools/merge.py
@@ -155,6 +155,12 @@ class MergeTool(Tool):
             "Include dl2 subarray-wise data",
             "Exclude dl2 subarray-wise data",
         ),
+        **flag(
+            "monitoring",
+            "HDF5Merger.monitoring",
+            "Include monitoring data",
+            "Exclude monitoring data",
+        ),
     }
 
     classes = [HDF5Merger]

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -11,6 +11,8 @@ from ctapipe.core.tool import ToolConfigurationError
 from ctapipe.io import read_table
 from ctapipe.tools.calculate_pixel_stats import PixelStatisticsCalculatorTool
 
+CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/camera"
+
 
 def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
     """check statistics calculation from pixel-wise image data files"""
@@ -22,7 +24,6 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
             "PixelStatisticsCalculatorTool": {
                 "allowed_tels": [3],
                 "input_column_name": "image",
-                "output_table_name": "statistics",
             },
             "PixelStatisticsCalculator": {
                 "stats_aggregator_type": [
@@ -60,7 +61,7 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
     assert (
         read_table(
             monitoring_file,
-            path=f"/dl1/monitoring/telescope/statistics/tel_{tel_id:03d}",
+            path=f"{CAMERA_MONITORING_GROUP}/pixel_statistics/SUBARRAY_image/tel_{tel_id:03d}",
         )["mean"].ndim
         == 3
     )
@@ -74,7 +75,6 @@ def test_tool_config_error(tmp_path, dl1_image_file):
         {
             "PixelStatisticsCalculatorTool": {
                 "input_column_name": "image_charges",
-                "output_table_name": "statistics",
             }
         }
     )

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -12,7 +12,7 @@ from ctapipe.io import read_table
 from ctapipe.tools.calculate_pixel_stats import PixelStatisticsCalculatorTool
 from ctapipe.tools.merge import MergeTool
 
-CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/camera"
+CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/calibration/camera"
 DL1_COLUMN_NAMES = ["image", "peak_time"]
 
 
@@ -49,7 +49,7 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
             PixelStatisticsCalculatorTool(config=config),
             argv=[
                 f"--input_url={dl1_image_file}",
-                f"--output_path={tmp_path}/SUBARRAY_{col_name}_monitoring.dl1.h5",
+                f"--output_path={tmp_path}/subarray_{col_name}_monitoring.dl1.h5",
                 f"--PixelStatisticsCalculatorTool.input_column_name={col_name}",
                 "--overwrite",
             ],
@@ -62,8 +62,8 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
     run_tool(
         MergeTool(),
         argv=[
-            f"{tmp_path}/SUBARRAY_image_monitoring.dl1.h5",
-            f"{tmp_path}/SUBARRAY_peak_time_monitoring.dl1.h5",
+            f"{tmp_path}/subarray_image_monitoring.dl1.h5",
+            f"{tmp_path}/subarray_peak_time_monitoring.dl1.h5",
             f"--output={monitoring_file}",
             "--monitoring",
             "--single-ob",
@@ -79,7 +79,7 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
         assert (
             read_table(
                 monitoring_file,
-                path=f"{CAMERA_MONITORING_GROUP}/pixel_statistics/SUBARRAY_{col_name}/tel_{tel_id:03d}",
+                path=f"{CAMERA_MONITORING_GROUP}/pixel_statistics/subarray_{col_name}/tel_{tel_id:03d}",
             )["mean"].ndim
             == 3
         )

--- a/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
+++ b/src/ctapipe/tools/tests/test_calculate_pixel_stats.py
@@ -10,8 +10,10 @@ from ctapipe.core import run_tool
 from ctapipe.core.tool import ToolConfigurationError
 from ctapipe.io import read_table
 from ctapipe.tools.calculate_pixel_stats import PixelStatisticsCalculatorTool
+from ctapipe.tools.merge import MergeTool
 
 CAMERA_MONITORING_GROUP = "/dl1/monitoring/telescope/camera"
+DL1_COLUMN_NAMES = ["image", "peak_time"]
 
 
 def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
@@ -23,7 +25,6 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
         {
             "PixelStatisticsCalculatorTool": {
                 "allowed_tels": [3],
-                "input_column_name": "image",
             },
             "PixelStatisticsCalculator": {
                 "stats_aggregator_type": [
@@ -42,29 +43,46 @@ def test_calculate_pixel_stats_tool(tmp_path, dl1_image_file):
             },
         }
     )
-    # Set the output file path
+    for col_name in DL1_COLUMN_NAMES:
+        # Run the tool with the configuration and the input file
+        run_tool(
+            PixelStatisticsCalculatorTool(config=config),
+            argv=[
+                f"--input_url={dl1_image_file}",
+                f"--output_path={tmp_path}/SUBARRAY_{col_name}_monitoring.dl1.h5",
+                f"--PixelStatisticsCalculatorTool.input_column_name={col_name}",
+                "--overwrite",
+            ],
+            cwd=tmp_path,
+            raises=True,
+        )
+    # Run the merge tool to combine the statistics
+    # from the two files into a single monitoring file
     monitoring_file = tmp_path / "monitoring.dl1.h5"
-    # Run the tool with the configuration and the input file
     run_tool(
-        PixelStatisticsCalculatorTool(config=config),
+        MergeTool(),
         argv=[
-            f"--input_url={dl1_image_file}",
-            f"--output_path={monitoring_file}",
-            "--overwrite",
+            f"{tmp_path}/SUBARRAY_image_monitoring.dl1.h5",
+            f"{tmp_path}/SUBARRAY_peak_time_monitoring.dl1.h5",
+            f"--output={monitoring_file}",
+            "--monitoring",
+            "--single-ob",
         ],
         cwd=tmp_path,
         raises=True,
     )
     # Check that the output file has been created
     assert monitoring_file.exists()
-    # Check if the shape of the aggregated statistic values has three dimension
-    assert (
-        read_table(
-            monitoring_file,
-            path=f"{CAMERA_MONITORING_GROUP}/pixel_statistics/SUBARRAY_image/tel_{tel_id:03d}",
-        )["mean"].ndim
-        == 3
-    )
+    # Check if the shape of the aggregated statistic values
+    # has three dimension for both merged tables
+    for col_name in DL1_COLUMN_NAMES:
+        assert (
+            read_table(
+                monitoring_file,
+                path=f"{CAMERA_MONITORING_GROUP}/pixel_statistics/SUBARRAY_{col_name}/tel_{tel_id:03d}",
+            )["mean"].ndim
+            == 3
+        )
 
 
 def test_tool_config_error(tmp_path, dl1_image_file):


### PR DESCRIPTION
This PR implements the camera monitoring data format, which we will be proposing next week at the DPPS workshop. HDF5merger is updated accordingly, so that we can use the `ctapipe-merge` for our camcalib data files.