### PR TITLE
Muon fit chord length fix hole radius correction m

### DIFF
--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -474,7 +474,10 @@ class MuonIntensityFitter(TelescopeComponent):
     ).tag(config=True)
 
     hole_radius_m = FloatTelescopeParameter(
-        help="The radius of the hole in the center of the primary mirror dish in meters. The hole has hexagonal shape (same as a single mirror facet) and is defined as the flat-to-flat distance (LST: 1.51 m, MST: 1.2 m, SST: 0.78 m). We define the hole radius to correspond to the surface area of the hexagon.",
+        help="The radius of the hole in the center of the primary mirror dish in meters."
+        "The hole has hexagonal shape (same as a single mirror facet)."
+        "It is defined with the flat-to-flat distance (LST: 1.51 m, MST: 1.2 m, SST: 0.78 m)."
+        "We approximate the hexagonal hole with a circle that has the same surface area.",
         default_value=[
             ("type", "LST_*", 0.74),
             ("type", "MST_*", 0.59),

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -481,7 +481,7 @@ class MuonIntensityFitter(TelescopeComponent):
         default_value=[
             ("type", "LST_*", 0.74),
             ("type", "MST_*", 0.59),
-            ("type", "SST_1M_*", 0.38),
+            ("type", "SST_*", 0.38),
         ],
     ).tag(config=True)
 

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -474,11 +474,11 @@ class MuonIntensityFitter(TelescopeComponent):
     ).tag(config=True)
 
     hole_radius_m = FloatTelescopeParameter(
-        help="Hole radius of the reflector in m",
+        help="Hole radius of the reflector in m. The radius of the hole in the center of the primary mirror dish, for three telescope types (LST, MST, and SST), has a hexagonal shape (same as a single mirror facets) and is defined by the flat-to-flat distance (LST: 1.51 m, MST: 1.2 m, SST: 0.78 m). We define the hole radius to correspond to the surface area of the hexagon.",
         default_value=[
-            ("type", "LST_*", 0.308),
-            ("type", "MST_*", 0.244),
-            ("type", "SST_1M_*", 0.130),
+            ("type", "LST_*", 0.74),
+            ("type", "MST_*", 0.59),
+            ("type", "SST_1M_*", 0.38),
         ],
     ).tag(config=True)
 

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -475,7 +475,7 @@ class MuonIntensityFitter(TelescopeComponent):
 
     hole_radius_m = FloatTelescopeParameter(
         help="The radius of the hole in the center of the primary mirror dish in meters."
-        "The hole has hexagonal shape (same as a single mirror facet)."
+        "The hole is not circular in shape; however, it can be well approximated as a circle with the same area."
         "It is defined with the flat-to-flat distance (LST: 1.51 m, MST: 1.2 m, SST: 0.78 m)."
         "We approximate the hexagonal hole with a circle that has the same surface area.",
         default_value=[

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -474,7 +474,7 @@ class MuonIntensityFitter(TelescopeComponent):
     ).tag(config=True)
 
     hole_radius_m = FloatTelescopeParameter(
-        help="Hole radius of the reflector in m. The radius of the hole in the center of the primary mirror dish, for three telescope types (LST, MST, and SST), has a hexagonal shape (same as a single mirror facets) and is defined by the flat-to-flat distance (LST: 1.51 m, MST: 1.2 m, SST: 0.78 m). We define the hole radius to correspond to the surface area of the hexagon.",
+        help="The radius of the hole in the center of the primary mirror dish in meters. The hole has hexagonal shape (same as a single mirror facet) and is defined as the flat-to-flat distance (LST: 1.51 m, MST: 1.2 m, SST: 0.78 m). We define the hole radius to correspond to the surface area of the hexagon.",
         default_value=[
             ("type", "LST_*", 0.74),
             ("type", "MST_*", 0.59),

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -481,7 +481,7 @@ class MuonIntensityFitter(TelescopeComponent):
         default_value=[
             ("type", "LST_*", 0.74),
             ("type", "MST_*", 0.59),
-            ("type", "SST_*", 0.38),
+            ("type", "SST_1M_*", 0.38),
         ],
     ).tag(config=True)
 


### PR DESCRIPTION
Define correct hole radius of the reflector in for LST, MST and SST_1M in intensity_fitter.py
Its issue : https://github.com/cta-observatory/ctapipe/issues/2807