### PR TITLE
Move to new sonar server

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -79,8 +79,8 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonar-cta-dpps.zeuthen.desy.de
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_CTAO }}
+          SONAR_HOST_URL: https://sonar-ctao.zeuthen.desy.de
         with:
           args: >
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=cta-observatory_ctapipe_AY52EYhuvuGcMFidNyUs
+sonar.projectKey=cta-observatory_ctapipe_6122e87b-83f3-4db1-8287-457e752adf01
 sonar.language=python
 sonar.python.coverage.reportPaths=coverage/coverage.xml
 sonar.python.version=3.10


### PR DESCRIPTION
These changes will only become effective once they are in main unfortunately...

Here, CI will still use the old sonar server.