### PR TITLE
Use modern random interface where possible

### DIFF
--- a/examples/tutorials/ctapipe_overview.py
+++ b/examples/tutorials/ctapipe_overview.py
@@ -520,22 +520,22 @@ geometry = loader.subarray.tel[1].camera.geometry
 # Let’s create a toy images with several islands;
 #
 
-np.random.seed(42)
+rng = np.random.default_rng(42)
 
 image = np.zeros(geometry.n_pixels)
 
 
 for i in range(9):
     model = toymodel.Gaussian(
-        x=np.random.uniform(-0.8, 0.8) * u.m,
-        y=np.random.uniform(-0.8, 0.8) * u.m,
-        width=np.random.uniform(0.05, 0.075) * u.m,
-        length=np.random.uniform(0.1, 0.15) * u.m,
-        psi=np.random.uniform(0, 2 * np.pi) * u.rad,
+        x=rng.uniform(-0.8, 0.8) * u.m,
+        y=rng.uniform(-0.8, 0.8) * u.m,
+        width=rng.uniform(0.05, 0.075) * u.m,
+        length=rng.uniform(0.1, 0.15) * u.m,
+        psi=rng.uniform(0, 2 * np.pi) * u.rad,
     )
 
     new_image, sig, bg = model.generate_image(
-        geometry, intensity=np.random.uniform(1000, 3000), nsb_level_pe=5
+        geometry, intensity=rng.uniform(1000, 3000), nsb_level_pe=5
     )
     image += new_image
 

--- a/examples/visualization/array_display.py
+++ b/examples/visualization/array_display.py
@@ -120,8 +120,8 @@ plt.colorbar(ad.telescopes, label="Distance (m)")
 # set of parameters.
 #
 
-np.random.seed(0)
-phis = np.random.uniform(0, 180.0, size=subarray.n_tels) * u.deg
+rng = np.random.default_rng(0)
+phis = rng.uniform(0, 180.0, size=subarray.n_tels) * u.deg
 rhos = np.ones(subarray.n_tels) * 200 * u.m
 
 

--- a/src/ctapipe/image/tests/test_hillas.py
+++ b/src/ctapipe/image/tests/test_hillas.py
@@ -323,8 +323,6 @@ def test_reconstruction_in_telescope_frame(prod5_lst):
     Compare the reconstruction in the telescope
     and camera frame.
     """
-    np.random.seed(42)
-
     geom = prod5_lst.camera.geometry
     telescope_frame = TelescopeFrame()
     camera_frame = geom.frame


### PR DESCRIPTION
Performance of the lts fit is about the same:

```
❯ git switch main
Switched to branch 'main'
170 μs ± 235 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
❯ git switch numba-rng
Switched to branch 'numba-rng'
❯ ipython time_fit.py
169 μs ± 401 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

This is a partial fix for #2392, the image modification still uses the old interface as there is no support for multinomial yet in numba for `numpy.random.Generator`.