### PR TITLE
Unpin 3.13 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
           - name: Linux (3.13, pip)
             os: ubuntu-24.04
-            python-version: "3.13.3"
+            python-version: "3.13"
             install-method: pip
             extras: tests,all
 


### PR DESCRIPTION
Github runner images now have 3.13.7, no need to pin anymore due to the numba breakage in 3.13.4.

See #2767 