### PR TITLE
Add env variable to disable numba cache

### DIFF
--- a/docs/api-reference/core/index.rst
+++ b/docs/api-reference/core/index.rst
@@ -35,25 +35,29 @@ Serialization and Deserialization are simply specialized Components that perform
 
 
 .. toctree::
-  :maxdepth: 1
+   :maxdepth: 1
 
-  traits
+   traits
 
 
 Reference/API
 =============
 
 .. automodapi:: ctapipe.core
-    :no-inheritance-diagram:
+   :no-inheritance-diagram:
+
+.. automodapi:: ctapipe.core.env
+   :no-inheritance-diagram:
+   :include-all-objects:
 
 .. automodapi:: ctapipe.core.component
-    :no-inheritance-diagram:
+   :no-inheritance-diagram:
 
 .. automodapi:: ctapipe.core.telescope_component
-    :no-inheritance-diagram:
+   :no-inheritance-diagram:
 
 .. automodapi:: ctapipe.core.tool
-    :no-inheritance-diagram:
+   :no-inheritance-diagram:
 
 .. automodapi:: ctapipe.core.container
-    :no-inheritance-diagram:
+   :no-inheritance-diagram:

--- a/docs/changes/2836.feature.rst
+++ b/docs/changes/2836.feature.rst
@@ -1,0 +1,2 @@
+Add support for disabling numba caching via ``CTAPIPE_DISABLE_NUMBA_CACHE=1`` environment variable.
+See https://github.com/numba/numba/issues/10128 for why this might be needed.

--- a/src/ctapipe/calib/camera/calibrator.py
+++ b/src/ctapipe/calib/camera/calibrator.py
@@ -11,6 +11,7 @@ from numba import float32, float64, guvectorize, int64
 
 from ctapipe.containers import DL0CameraContainer, DL1CameraContainer, PixelStatus
 from ctapipe.core import TelescopeComponent
+from ctapipe.core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 from ctapipe.core.traits import (
     BoolTelescopeParameter,
     ComponentName,
@@ -372,7 +373,7 @@ def shift_waveforms(waveforms, time_shift_samples):
     [(float64[:], int64, float64[:]), (float32[:], int64, float32[:])],
     "(s),()->(s)",
     nopython=True,
-    cache=True,
+    cache=not CTAPIPE_DISABLE_NUMBA_CACHE,
 )
 def _shift_waveforms_by_integer(waveforms, integer_shift, shifted_waveforms):
     n_samples = waveforms.size

--- a/src/ctapipe/core/env.py
+++ b/src/ctapipe/core/env.py
@@ -1,0 +1,27 @@
+"""
+Environment variables to configure ctapipe.
+"""
+import os
+
+__all__ = [
+    "CTAPIPE_DISABLE_NUMBA_CACHE",
+]
+
+
+def env_bool(key, default=False):
+    """
+    Parse a boolean environment variable.
+
+    ``"1"``, ``"true"`` and ``"on"`` are treated as truthy, case-insensitive.
+
+    If the variable is not set, ``default`` is returned.
+    """
+    val = os.getenv(key)
+    if val is None:
+        return default
+
+    return val.lower() in {"1", "true", "on"}
+
+
+#: Boolean flag. Set this variable to a truthy value disable numba caching.
+CTAPIPE_DISABLE_NUMBA_CACHE = env_bool("CTAPIPE_DISABLE_NUMBA_CACHE")

--- a/src/ctapipe/fitting.py
+++ b/src/ctapipe/fitting.py
@@ -1,11 +1,13 @@
 import numpy as np
 from numba import njit
 
+from .core.env import CTAPIPE_DISABLE_NUMBA_CACHE
+
 EPS = 2 * np.finfo(np.float64).eps
 FIT_RNG = np.random.default_rng(0)
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def design_matrix(x):
     """
     Build the design matrix for linear regression for
@@ -21,7 +23,7 @@ def design_matrix(x):
     return X
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def linear_regression(X, y):
     """
     Analytical linear regression
@@ -40,7 +42,7 @@ def linear_regression(X, y):
     return np.linalg.inv(mat) @ X.T @ y
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def residual_sum_of_squares(X, y, beta):
     """Calculate the residual sum of squares
 
@@ -56,7 +58,7 @@ def residual_sum_of_squares(X, y, beta):
     return np.sum(residuals(X, y, beta) ** 2)
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def residuals(X, y, beta):
     """Calculate the residuals of a linear regression
 
@@ -72,7 +74,7 @@ def residuals(X, y, beta):
     return y - (X[:, 0] * beta[0] + beta[1])
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def choose_two_without_replacement(rng, n):
     values = np.empty(2, dtype=np.int64)
 
@@ -88,7 +90,7 @@ def choose_two_without_replacement(rng, n):
     return values
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def _lts_single_sample(X, y, sample_size, max_iterations, rng, eps=1e-12):
     # randomly draw 2 points for the initial fit
     sample = choose_two_without_replacement(rng, len(y))
@@ -178,7 +180,7 @@ def lts_linear_regression(
     )
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def _lts_linear_regression(
     x,
     y,

--- a/src/ctapipe/image/extractor.py
+++ b/src/ctapipe/image/extractor.py
@@ -47,6 +47,7 @@ from ctapipe.core.traits import (
 )
 from ctapipe.instrument import CameraDescription
 
+from ..core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 from .cleaning import tailcuts_clean
 from .hillas import camera_to_shower_coordinates, hillas_parameters
 from .invalid_pixels import InvalidPixelHandler
@@ -62,7 +63,7 @@ from .timing import timing_parameters
     ],
     "(s),(),(),(),()->(),()",
     nopython=True,
-    cache=True,
+    cache=not CTAPIPE_DISABLE_NUMBA_CACHE,
 )
 def extract_around_peak(
     waveforms, peak_index, width, shift, sampling_rate_ghz, sum_, peak_time
@@ -147,7 +148,7 @@ def extract_around_peak(
     ],
     "(s),(),()->(),()",
     nopython=True,
-    cache=True,
+    cache=not CTAPIPE_DISABLE_NUMBA_CACHE,
 )
 def extract_sliding_window(waveforms, width, sampling_rate_ghz, sum_, peak_time):
     """
@@ -215,7 +216,7 @@ def extract_sliding_window(waveforms, width, sampling_rate_ghz, sum_, peak_time)
     peak_time[0] /= sampling_rate_ghz
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def neighbor_average_maximum(
     waveforms, neighbors_indices, neighbors_indptr, local_weight, broken_pixels
 ):
@@ -1500,7 +1501,7 @@ def deconvolve(
     ],
     "(s),(),()->()",
     nopython=True,
-    cache=True,
+    cache=not CTAPIPE_DISABLE_NUMBA_CACHE,
 )
 def adaptive_centroid(waveforms, peak_index, rel_descend_limit, centroids):
     """

--- a/src/ctapipe/image/modifications.py
+++ b/src/ctapipe/image/modifications.py
@@ -2,6 +2,7 @@ import numpy as np
 from numba import njit
 
 from ..core import TelescopeComponent
+from ..core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 from ..core.traits import BoolTelescopeParameter, FloatTelescopeParameter, Int
 from ..instrument import SubarrayDescription
 
@@ -27,7 +28,7 @@ def _add_noise(image, noise_level, rng=None, correct_bias=True):
     return noisy_image
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def _smear_psf_randomly(
     image, fraction, indices, indptr, smear_probabilities, seed=None
 ):

--- a/src/ctapipe/image/morphology.py
+++ b/src/ctapipe/image/morphology.py
@@ -2,9 +2,10 @@ import numpy as np
 from numba import njit
 
 from ..containers import MorphologyContainer
+from ..core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def _n_islands_sparse_indices(indices, indptr, mask):
     # non-signal pixel get label == 0, we marke the cleaning
     # pixels with -1, so we only have to check labels and not labels and mask

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -14,6 +14,7 @@ from scipy.ndimage import correlate1d
 from ...containers import MuonEfficiencyContainer
 from ...coordinates import TelescopeFrame
 from ...core import TelescopeComponent
+from ...core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 from ...core.traits import FloatTelescopeParameter, IntTelescopeParameter
 from ...exceptions import OptionalDependencyMissing
 from ..pixel_likelihood import neg_log_likelihood_approx
@@ -34,7 +35,7 @@ CIRCLE_SQUARE_AREA_RATIO = np.pi / 4
 SQRT2 = np.sqrt(2)
 
 
-@vectorize([double(double, double, double)], cache=True)
+@vectorize([double(double, double, double)], cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def chord_length(radius, rho, phi):
     """
     Function for integrating the length of a chord across a circle (effective chord length).
@@ -219,7 +220,7 @@ def image_prediction(
     )
 
 
-@vectorize([double(double, double, double)], cache=True)
+@vectorize([double(double, double, double)], cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def gaussian_cdf(x, mu, sig):
     """
     Function to compute values of a given gaussians

--- a/src/ctapipe/image/statistics.py
+++ b/src/ctapipe/image/statistics.py
@@ -4,6 +4,7 @@ import numpy as np
 from numba import float32, float64, guvectorize, int64, njit
 
 from ..containers import ImageStatisticsContainer
+from ..core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 
 __all__ = [
     "arg_n_largest",
@@ -15,7 +16,7 @@ __all__ = [
 ]
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def skewness(data, mean=None, std=None):
     """Calculate skewnewss (normalized third central moment)
     with allowing precomputed mean and std.
@@ -48,7 +49,7 @@ def skewness(data, mean=None, std=None):
     return np.mean(((data - mean) / std) ** 3)
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def kurtosis(data, mean=None, std=None, fisher=True):
     """Calculate kurtosis (normalized fourth central moment)
     with allowing precomputed mean and std.
@@ -116,7 +117,7 @@ def n_largest(n, array):
     ],
     "(n),(p)->(n)",
     nopython=True,
-    cache=True,
+    cache=not CTAPIPE_DISABLE_NUMBA_CACHE,
 )
 def arg_n_largest_gu(dummy, array, idx):
     """

--- a/src/ctapipe/image/timing.py
+++ b/src/ctapipe/image/timing.py
@@ -12,6 +12,7 @@ from ..containers import (
     HillasParametersContainer,
     TimingParametersContainer,
 )
+from ..core.env import CTAPIPE_DISABLE_NUMBA_CACHE
 from ..fitting import lts_linear_regression
 from ..utils.quantities import all_to_value
 from .hillas import camera_to_shower_coordinates
@@ -19,7 +20,7 @@ from .hillas import camera_to_shower_coordinates
 __all__ = ["timing_parameters"]
 
 
-@njit(cache=True)
+@njit(cache=not CTAPIPE_DISABLE_NUMBA_CACHE)
 def rmse(truth, prediction):
     """Root mean squared error"""
     return np.sqrt(np.mean((truth - prediction) ** 2))


### PR DESCRIPTION
```
❯ time python -c 'import ctapipe.image.extractor'
python -c 'import ctapipe.image.extractor'  2.14s user 0.16s system 222% cpu 1.030 total
❯ time CTAPIPE_DISABLE_NUMBA_CACHE=1 NUMBA_DEBUG_CACHE=1 python -c 'import ctapipe.image.extractor'
CTAPIPE_DISABLE_NUMBA_CACHE=1 NUMBA_DEBUG_CACHE=1 python -c   10.67s user 0.46s system 112% cpu 9.901 total
```