### PR TITLE
Fix periodicity behavior of chord_length

### DIFF
--- a/docs/changes/2873.bugfix.rst
+++ b/docs/changes/2873.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug in the ``chord_length`` function used by the  ``MuonIntensityFitter`` likelihood function
+that resulted in incorrect periodicity. The function returned 0 outside of the domain phi [-π, π].

--- a/src/ctapipe/image/muon/intensity_fitter.py
+++ b/src/ctapipe/image/muon/intensity_fitter.py
@@ -68,7 +68,10 @@ def chord_length(radius, rho, phi):
 
 
     """
-    discriminant_norm = 1 - (rho**2 * np.sin(phi) ** 2)
+    sin_phi = np.sin(phi)
+    cos_phi = np.cos(phi)
+
+    discriminant_norm = 1 - (rho**2 * sin_phi**2)
     valid = discriminant_norm >= 0
 
     if not valid:
@@ -76,13 +79,12 @@ def chord_length(radius, rho, phi):
 
     if rho <= 1.0:
         # muon has hit the mirror
-        effective_chord_length = radius * (
-            np.sqrt(discriminant_norm) + rho * np.cos(phi)
-        )
+        effective_chord_length = radius * (np.sqrt(discriminant_norm) + rho * cos_phi)
     else:
         # muon did not hit the mirror
+
         # Filtering out non-physical solutions for phi
-        if np.abs(phi) < np.arcsin(1.0 / rho):
+        if (np.abs(sin_phi) < (1.0 / rho)) & (cos_phi > 0):
             effective_chord_length = 2 * radius * np.sqrt(discriminant_norm)
         else:
             return 0

--- a/src/ctapipe/image/muon/tests/test_intensity_fit.py
+++ b/src/ctapipe/image/muon/tests/test_intensity_fit.py
@@ -55,6 +55,22 @@ def test_chord_length(
     assert np.isclose(length, expected_length, atol=1e-15)
 
 
+@pytest.mark.parametrize("rho", [0.5, 1.2])
+def test_chord_length_periodicity(rho):
+    from ctapipe.image.muon.intensity_fitter import chord_length
+
+    radius = 10.0
+
+    phi1 = np.linspace(0, 2 * np.pi, 1000)
+    reference_length = chord_length(radius, rho, phi1)
+
+    for offset in (-2 * np.pi, 2 * np.pi):
+        phi2 = phi1 + offset
+        offset_length = chord_length(radius, rho, phi2)
+
+        np.testing.assert_array_almost_equal(reference_length, offset_length)
+
+
 def test_muon_efficiency_fit(prod5_lst, reference_location):
     from ctapipe.coordinates import TelescopeFrame
     from ctapipe.image.muon.intensity_fitter import (


### PR DESCRIPTION
```
In [1]: from ctapipe.image.muon.intensity_fitter import chord_length
In [2]: import numpy as np
In [3]: phi = np.linspace(0, 2 * np.pi, 500)
In [4]: %timeit chord_length(10.0, 1.2, phi)
```

This branch:
```
5.6 μs ± 12.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

On branch of #2872:
```
7.6 μs ± 28.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

```python
from ctapipe.image.muon.intensity_fitter import chord_length
import numpy as np
import matplotlib.pyplot as plt


phi = np.linspace(-4 * np.pi, 4 * np.pi, 1000)

fig, ax = plt.subplots(1, 1, layout="constrained", sharex=True)

for rho in (0.5, 1.2):
    ax.plot(phi, chord_length(10, rho, phi), label=f"{rho = }")

ax.legend()
fig.savefig("chord_length.png")
plt.show()
```

Before:
<img width="640" height="480" alt="chord_length" src="https://github.com/user-attachments/assets/a7969594-8380-4637-b316-685047f6981f" />



Now:
<img width="640" height="480" alt="chord_length" src="https://github.com/user-attachments/assets/c35a4f1b-a3ec-4a50-986f-c9fbbc4bb2ed" />

