### PR TITLE
Make HTML reprs for Components recursive

### DIFF
--- a/docs/changes/2926.feature.rst
+++ b/docs/changes/2926.feature.rst
@@ -1,0 +1,1 @@
+the Jupyter notebook HTML representation of `~ctapipe.core.Container` instances now recursively shows the config of sub-components used in the component instance.  This makes it easier to see the full configuration in a user-friendly way.

--- a/src/ctapipe/core/component.py
+++ b/src/ctapipe/core/component.py
@@ -260,7 +260,7 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
             docstring = publish_parts(clean_doc, writer=writer)["html_body"]
         lines = [
             '<div style="border:1px solid black; max-width: 700px; padding:2em; word-wrap:break-word;">',
-            f"<b>{name}</b>",
+            f"<h3>{name}</h3>",
             docstring,
             "<table>",
             "    <colgroup>",
@@ -293,8 +293,9 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
         lines.append("    </tbody>")
         lines.append("</table>")
 
-        for val in self.__dict__.values():
+        for name, val in self.__dict__.items():
             if isinstance(val, Component):
+                lines.append(f"<h4>{name}:</h4>")
                 lines.append(val._repr_html_())
 
         lines.append("</div>")

--- a/src/ctapipe/core/component.py
+++ b/src/ctapipe/core/component.py
@@ -292,6 +292,11 @@ class Component(Configurable, metaclass=AbstractConfigurableMeta):
                 )
         lines.append("    </tbody>")
         lines.append("</table>")
+
+        for val in self.__dict__.values():
+            if isinstance(val, Component):
+                lines.append(val._repr_html_())
+
         lines.append("</div>")
         return "\n".join(lines)
 

--- a/src/ctapipe/core/qualityquery.py
+++ b/src/ctapipe/core/qualityquery.py
@@ -85,9 +85,9 @@ class QualityQuery(Component):
             cols["func"] = ["True"] + self.expressions
         return Table(cols)
 
-    def _repr_html_(self):
-        """display nicely in Jupyter notebooks"""
-        return self.to_table()._repr_html_()
+    # def _repr_html_(self):
+    #    """display nicely in Jupyter notebooks"""
+    #    return self.to_table()._repr_html_()
 
     def __str__(self):
         """Print a formatted string representation of the entire table."""

--- a/src/ctapipe/core/qualityquery.py
+++ b/src/ctapipe/core/qualityquery.py
@@ -85,10 +85,6 @@ class QualityQuery(Component):
             cols["func"] = ["True"] + self.expressions
         return Table(cols)
 
-    # def _repr_html_(self):
-    #    """display nicely in Jupyter notebooks"""
-    #    return self.to_table()._repr_html_()
-
     def __str__(self):
         """Print a formatted string representation of the entire table."""
         return str(self.to_table())


### PR DESCRIPTION
Minor cosmetic change that I found useful when debugging complex Components that contain other components: recurse into any sub-components in the repr. That makes it very clear what other sub-configurations are used, without having to look at `component.get_current_config()` 

Also removed the custom repr for `QualityQuery`, which made is hard to see it's parameters.  To get the same effect, one can still do ` query.to_table()` in a notebook.

## Before:
<img width="781" height="309" alt="image" src="https://github.com/user-attachments/assets/a3dedd4b-9dd4-49cd-b04d-42ff6506c04d" />


## After:
<img width="774" height="528" alt="image" src="https://github.com/user-attachments/assets/d80061e0-c09c-4ed6-88d8-d8c8529f0968" />
