### PR TITLE
Feature: EventWeighter

### DIFF
--- a/docs/api-reference/irf/event_weighter.rst
+++ b/docs/api-reference/irf/event_weighter.rst
@@ -1,0 +1,12 @@
+.. _event_weighter:
+
+***************
+Event Weighting
+***************
+
+
+Reference/ API
+==============
+
+.. automodapi:: ctapipe.irf.event_weighter
+    :no-inheritance-diagram:

--- a/docs/api-reference/irf/index.rst
+++ b/docs/api-reference/irf/index.rst
@@ -34,6 +34,7 @@ Submodules
     benchmarks
     binning
     spectra
+    event_weighter
 
 
 Reference/API

--- a/docs/api-reference/irf/irfs.rst
+++ b/docs/api-reference/irf/irfs.rst
@@ -1,7 +1,7 @@
 .. _irfs:
 
 **************
-IRF components
+IRF generation
 **************
 
 

--- a/docs/changes/2927.feature.rst
+++ b/docs/changes/2927.feature.rst
@@ -1,8 +1,8 @@
 Introduces a new Component `~ctapipe.irf.EventWeighter` that has different
 implementations of spectral event weighting:
 
-* `SimpleEventWeigher`: spectral weighting for the full FOV
-* `RadialEventWeighter`: spectral weighing in radial bins in the  FOV
+* `~ctapipe.irf.SimpleEventWeighter`: spectral weighting for the full FOV
+* `~ctapipe.irf.RadialEventWeighter`: spectral weighing in radial bins in the  FOV
 
 They operate on a pre-processed table of DL2 information, where you specify the
 energy and FOV coordinate columns to use. The interface is as follows:

--- a/docs/changes/2927.feature.rst
+++ b/docs/changes/2927.feature.rst
@@ -1,0 +1,40 @@
+Introduces a new Component `~ctapipe.irf.EventWeighter` that has different implementations of spectral event weighting:
+
+* `SimpleEventWeigher`: spectral weighting for the full FOV
+* `RadialEventWeighter`: spectral weighing in radial bins in the  FOV
+* `PolarEventWeighter`: spectral weighting in radial+azimuthal (r,phi) bins in the FOV
+
+They operate on a pre-processed table of DL2 information, where you specify the energy and FOV coordinate columns to use.  The interface is as follows:
+
+.. code-block:: python
+
+  from astropy.table import QTable
+
+  from ctapipe.irf import RadialEventWeighter  spectrum_from_name
+
+  table = QTable(
+      dict(
+          true_energy=[1.0, 2.0, 0.5, 0.2] * u.TeV,
+          true_fov_offset=[0.1, 1.2, 2.2, 3.2] * u.deg,
+      )
+  )
+  weighter = RadialEventWeighter(
+      source_spectrum=spectrum_from_name("IRFDOC_ELECTRON_SPECTRUM"),
+      target_spectrum_name="CRAB_HEGRA",
+      fov_offset_max=5.0*u.deg,
+      fov_offset_n_bins=5,
+  )
+
+  table_with_weights = weighter(table)
+  print(table_with_weights)
+
+
+::
+
+  true_energy true_fov_offset       weight       fov_offset_bin
+      TeV           deg
+  ----------- --------------- ------------------ --------------
+          1.0             0.1 12.399508446433442              1
+          2.0             1.2  7.247055871572714              2
+          0.5             2.2 1.4149219056909543              3
+          0.2             3.2 0.4812883464910382              4

--- a/docs/changes/2927.feature.rst
+++ b/docs/changes/2927.feature.rst
@@ -1,10 +1,11 @@
-Introduces a new Component `~ctapipe.irf.EventWeighter` that has different implementations of spectral event weighting:
+Introduces a new Component `~ctapipe.irf.EventWeighter` that has different
+implementations of spectral event weighting:
 
 * `SimpleEventWeigher`: spectral weighting for the full FOV
 * `RadialEventWeighter`: spectral weighing in radial bins in the  FOV
-* `PolarEventWeighter`: spectral weighting in radial+azimuthal (r,phi) bins in the FOV
 
-They operate on a pre-processed table of DL2 information, where you specify the energy and FOV coordinate columns to use.  The interface is as follows:
+They operate on a pre-processed table of DL2 information, where you specify the
+energy and FOV coordinate columns to use. The interface is as follows:
 
 .. code-block:: python
 

--- a/src/ctapipe/irf/__init__.py
+++ b/src/ctapipe/irf/__init__.py
@@ -38,7 +38,13 @@ from .optimize import (
     PointSourceSensitivityOptimizer,
     ThetaPercentileCutCalculator,
 )
-from .spectra import ENERGY_FLUX_UNIT, FLUX_UNIT, SPECTRA, Spectra
+from .spectra import (
+    ENERGY_FLUX_UNIT,
+    FLUX_UNIT,
+    SPECTRA,
+    Spectra,
+    spectrum_from_simulation_config,
+)
 
 __all__ = [
     "AngularResolution2dMaker",
@@ -65,4 +71,5 @@ __all__ = [
     "PolarEventWeighter",
     "RadialEventWeighter",
     "SimpleEventWeighter",
+    "spectrum_from_simulation_config",
 ]

--- a/src/ctapipe/irf/__init__.py
+++ b/src/ctapipe/irf/__init__.py
@@ -43,6 +43,7 @@ from .spectra import (
     FLUX_UNIT,
     SPECTRA,
     Spectra,
+    spectrum_from_name,
     spectrum_from_simulation_config,
 )
 
@@ -72,4 +73,5 @@ __all__ = [
     "RadialEventWeighter",
     "SimpleEventWeighter",
     "spectrum_from_simulation_config",
+    "spectrum_from_name",
 ]

--- a/src/ctapipe/irf/__init__.py
+++ b/src/ctapipe/irf/__init__.py
@@ -20,7 +20,6 @@ from .binning import (
 )
 from .event_weighter import (
     EventWeighter,
-    PolarEventWeighter,
     RadialEventWeighter,
     SimpleEventWeighter,
 )
@@ -69,7 +68,6 @@ __all__ = [
     "check_bins_in_range",
     "make_bins_per_decade",
     "EventWeighter",
-    "PolarEventWeighter",
     "RadialEventWeighter",
     "SimpleEventWeighter",
     "spectrum_from_simulation_config",

--- a/src/ctapipe/irf/__init__.py
+++ b/src/ctapipe/irf/__init__.py
@@ -18,6 +18,12 @@ from .binning import (
     check_bins_in_range,
     make_bins_per_decade,
 )
+from .event_weighter import (
+    EventWeighter,
+    PolarEventWeighter,
+    RadialEventWeighter,
+    SimpleEventWeighter,
+)
 from .irfs import (
     BackgroundRate2dMaker,
     EffectiveArea2dMaker,
@@ -55,4 +61,8 @@ __all__ = [
     "FLUX_UNIT",
     "check_bins_in_range",
     "make_bins_per_decade",
+    "EventWeighter",
+    "PolarEventWeighter",
+    "RadialEventWeighter",
+    "SimpleEventWeighter",
 ]

--- a/src/ctapipe/irf/binning.py
+++ b/src/ctapipe/irf/binning.py
@@ -17,6 +17,7 @@ __all__ = [
     "DefaultTrueEnergyBins",
     "DefaultRecoEnergyBins",
     "DefaultFoVOffsetBins",
+    "DefaultFoVPhiBins",
 ]
 
 logger = logging.getLogger(__name__)
@@ -179,13 +180,37 @@ class DefaultFoVOffsetBins(Component):
         default_value=1,
     ).tag(config=True)
 
-    def __init__(self, config=None, parent=None, **kwargs):
-        super().__init__(config=config, parent=parent, **kwargs)
-        self.fov_offset_bins = u.Quantity(
+    @property
+    def fov_offset_bins(self):
+        return u.Quantity(
             np.linspace(
                 self.fov_offset_min.to_value(u.deg),
                 self.fov_offset_max.to_value(u.deg),
                 self.fov_offset_n_bins + 1,
+            ),
+            u.deg,
+        )
+
+
+class DefaultFoVPhiBins(Component):
+    """
+    Base class for creating IRFs with phi dependence.
+
+    The range is always assumed to be (0, 360) deg.
+    """
+
+    fov_phi_n_bins = Integer(
+        help="Number of FoV offset bins",
+        default_value=4,
+    ).tag(config=True)
+
+    @property
+    def fov_phi_bins(self):
+        return u.Quantity(
+            np.linspace(
+                0.0 * u.deg,
+                360.0 * u.deg,
+                self.fov_phi_n_bins + 1,
             ),
             u.deg,
         )

--- a/src/ctapipe/irf/binning.py
+++ b/src/ctapipe/irf/binning.py
@@ -199,7 +199,7 @@ class DefaultFoVPhiBins(Component):
     The range is always assumed to be (0, 360) deg.
     """
 
-    fov_phi_n_bins = Integer(
+    fov_phi_n_bins = Int(
         help="Number of FoV offset bins",
         default_value=4,
     ).tag(config=True)

--- a/src/ctapipe/irf/event_weighter.py
+++ b/src/ctapipe/irf/event_weighter.py
@@ -132,6 +132,9 @@ class EventWeighter(Component):
 class SimpleEventWeighter(EventWeighter):
     """Weights all events spectrally with no spatial binning.
 
+    This should be used for point-like signal gammas and diffuse background
+    events (protons, electrons).
+
     Calling this class adds a column to the output table with the event-wise
     spectral weights, with column name ``weight_column``.
     """
@@ -161,6 +164,9 @@ class SimpleEventWeighter(EventWeighter):
 class RadialEventWeighter(EventWeighter, DefaultFoVOffsetBins):
     """
     Weights in radial (FOV) offset bins in the `~ctapipe.coordinates.NominalFrame`.
+
+    This should only be used for diffuse signal (gamma) events where you want to
+    weight them to a point-source spectrum in radial offset bins.
 
     Calling this class adds a column to the output table with the event-wise
     spectral-spatial weights, with column name ``weight_column``. This

--- a/src/ctapipe/irf/event_weighter.py
+++ b/src/ctapipe/irf/event_weighter.py
@@ -9,7 +9,7 @@ from typing import override
 import numpy as np
 from astropy import units as u
 from astropy.table import QTable
-from pyirf.binning import calculate_bin_indices
+from pyirf.binning import OVERFLOW_INDEX, UNDERFLOW_INDEX, calculate_bin_indices
 from pyirf.spectral import (
     calculate_event_weights,
 )
@@ -161,3 +161,5 @@ class RadialEventWeighter(EventWeighter, DefaultFoVOffsetBins):
         ].description = "True if event's offset was inside the binning range."
 
         events_table.meta["OFFSBINS"] = list(offset_bins.to_value("deg"))
+        events_table.meta["BINOVER"] = OVERFLOW_INDEX
+        events_table.meta["BINUNDR"] = UNDERFLOW_INDEX

--- a/src/ctapipe/irf/event_weighter.py
+++ b/src/ctapipe/irf/event_weighter.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+"""Components for computing event weights."""
+
+from abc import abstractmethod
+from collections.abc import Callable
+from typing import override
+
+import numpy as np
+from astropy import units as u
+from astropy.table import QTable
+from pyirf.spectral import (
+    calculate_event_weights,
+)
+
+from ..core import Component, traits
+from ..core.feature_generator import _shallow_copy_table
+from .binning import DefaultFoVOffsetBins, DefaultFoVPhiBins
+from .spectra import SPECTRA, Spectra
+
+__all__ = [
+    "EventWeighter",
+    "SimpleEventWeighter",
+    "RadialEventWeighter",
+    "PolarEventWeighter",
+]
+
+
+class EventWeighter(Component):
+    """Compute weights to go from source to target spectra."""
+
+    target_spectrum_name = traits.UseEnum(
+        Spectra,
+        default_value=Spectra.CRAB_HEGRA,
+        help="Pre-defined source spectrum to reweight to.",
+    ).tag(config=True)
+
+    is_diffuse = traits.Bool(
+        default_value=True, help="If True, assume the source is diffuse."
+    ).tag(config=True)
+
+    energy_column = traits.Unicode(
+        help="name of energy column", default_value="true_energy"
+    ).tag(config=True)
+    weight_column = traits.Unicode(
+        help="name of output weight column", default_value="weight"
+    ).tag(config=True)
+
+    def __init__(
+        self,
+        source_spectrum: Callable[[u.Quantity], u.Quantity],
+        config=None,
+        parent=None,
+        **kwargs,
+    ):
+        """
+        Parameters
+        ----------
+        source_spectrum: Callable
+            initial spectrum of the events to be processed.
+        target_spectrum: Callable | None
+            target spectrum to weight to. If None, a pre-defined spectrum
+            function from the `target_spectrum_name` attribute will be used`
+        """
+        super().__init__(config=config, parent=parent, **kwargs)
+        self.source_spectrum = source_spectrum
+        self.target_spectrum = SPECTRA[self.target_spectrum_name]
+
+    @abstractmethod
+    def _compute_weights(self, events_table: QTable):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} weighting is not implemented"
+        )
+
+    def __call__(self, events_table: QTable) -> QTable:
+        """Returns shallow copy of input table with a `weight` column added"""
+
+        table = _shallow_copy_table(events_table)
+        self._compute_weights(table)
+        return table
+
+
+class SimpleEventWeighter(EventWeighter):
+    """Weights all events spectrally with no spatial binning.
+
+    Calling this class adds a column to the output table with the event-wise
+    spectral weights, with column name ``weight_column``.
+    """
+
+    fov_offset_max = traits.AstroQuantity(
+        help="upper bound of spatial integral applied to source function",
+        default_value=u.Quantity(10, u.deg),
+        physical_type=u.physical.angle,
+    ).tag(config=True)
+
+    @override
+    def _compute_weights(self, events_table: QTable):
+        energy = events_table[self.energy_column]
+        source_spectrum = self.source_spectrum
+        if self.is_diffuse:
+            source_spectrum = source_spectrum.integrate_cone(
+                0 * u.deg, self.fov_offset_max
+            )
+        weights = calculate_event_weights(
+            energy,
+            target_spectrum=self.target_spectrum,
+            simulated_spectrum=source_spectrum,
+        )
+        events_table[self.weight_column] = weights
+
+
+class RadialEventWeighter(EventWeighter, DefaultFoVOffsetBins):
+    """
+    Weights in radial (FOV) offset bins in the `~ctapipe.coordinates.NominalFrame`.
+
+    Calling this class adds a column to the output table with the event-wise
+    spectral-spatial weights, with column name `weight_column``. This implementation
+    additionally adds the column ``output_table["fov_offset_bin"]``, and the
+    list of offset bin edges in ``output_table.meta["OFFSBINS"]``
+    """
+
+    fov_offset_column = traits.Unicode(
+        help="name of FOV radial offset column", default_value="true_fov_offset"
+    ).tag(config=True)
+
+    @override
+    def _compute_weights(self, events_table: QTable):
+        offset_bins = self.fov_offset_bins
+        offset = events_table[self.fov_offset_column].to_value(offset_bins.unit)
+        energy = events_table[self.energy_column]
+        weights = np.zeros_like(energy.value)
+
+        # note that the bin i from digitize starts at 1 and means:
+        #    offset_bins[i-1] <= offset < offset_bins[ii])
+        r_bin = np.digitize(offset, offset_bins.value)
+
+        for ii in range(0, len(offset_bins)):
+            self.log.debug(
+                f"bin {ii} offset=[{offset_bins[ii - 1]}, {offset_bins[ii]})"
+            )
+            mask = r_bin == ii
+            weights[mask] = calculate_event_weights(
+                true_energy=energy[mask],
+                target_spectrum=self.target_spectrum,
+                simulated_spectrum=self.source_spectrum.integrate_cone(
+                    offset_bins[ii - 1], offset_bins[ii]
+                ),
+            )
+
+        events_table[self.weight_column] = weights
+        events_table["fov_offset_bin"] = r_bin
+
+        events_table.columns["fov_offset_bin"].description = (
+            "Bin i defined as offset[i-1] <= fov_offset < offset[i]. "
+            "Where offset is `OFFSBINS` array found this table's metadata."
+        )
+
+        events_table.meta["OFFSBINS"] = list(offset_bins.to_value("deg"))
+
+
+class PolarEventWeighter(EventWeighter, DefaultFoVOffsetBins, DefaultFoVPhiBins):
+    """
+    Weights in field-of-view polar $(r, \\phi)$ bins in the `~ctapipe.coordinates.NominalFrame`.
+
+    Calling this class adds a column to the output table with the event-wise
+    spectral-spatial weights, with column name ``weight_column``. This
+    implementation additionally adds the columns
+    ``output_table["fov_offset_bin"]``, ``output_table["fov_phi_bin"]``, and the
+    list of offset and phi bin edges in ``output_table.meta["OFFSBINS"]`` and
+    ``output_table.meta["PHIBINS"]`` respectively.
+    """
+
+    fov_offset_column = traits.Unicode(
+        help="name of FOV radial offset column", default_value="true_fov_offset"
+    ).tag(config=True)
+
+    fov_phi_column = traits.Unicode(
+        help="name of the FOV azimuthal coordinate", default_value="true_fov_phi"
+    ).tag(config=True)
+
+    @override
+    def _compute_weights(self, events_table: QTable):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} weighting is not implemented"
+        )

--- a/src/ctapipe/irf/event_weighter.py
+++ b/src/ctapipe/irf/event_weighter.py
@@ -16,7 +16,7 @@ from pyirf.spectral import (
 from ..core import Component, traits
 from ..core.feature_generator import _shallow_copy_table
 from .binning import DefaultFoVOffsetBins, DefaultFoVPhiBins
-from .spectra import SPECTRA, Spectra
+from .spectra import Spectra, spectrum_from_name
 
 __all__ = [
     "EventWeighter",
@@ -64,7 +64,7 @@ class EventWeighter(Component):
         """
         super().__init__(config=config, parent=parent, **kwargs)
         self.source_spectrum = source_spectrum
-        self.target_spectrum = SPECTRA[self.target_spectrum_name]
+        self.target_spectrum = spectrum_from_name(self.target_spectrum_name)
 
     @abstractmethod
     def _compute_weights(self, events_table: QTable):

--- a/src/ctapipe/irf/event_weighter.py
+++ b/src/ctapipe/irf/event_weighter.py
@@ -8,14 +8,14 @@ from typing import override
 
 import numpy as np
 from astropy import units as u
-from astropy.table import QTable
+from astropy.table import QTable, Table
 from pyirf.binning import OVERFLOW_INDEX, UNDERFLOW_INDEX, calculate_bin_indices
 from pyirf.spectral import (
     calculate_event_weights,
 )
 
 from ..core import Component, traits
-from ..core.feature_generator import _shallow_copy_table
+from ..core.feature_generator import shallow_copy_table
 from .binning import DefaultFoVOffsetBins
 from .spectra import Spectra, spectrum_from_name
 
@@ -69,10 +69,10 @@ class EventWeighter(Component):
             f"{self.__class__.__name__} weighting is not implemented"
         )
 
-    def __call__(self, events_table: QTable) -> QTable:
+    def __call__(self, events_table: Table | QTable) -> QTable:
         """Returns shallow copy of input table with a ``weight`` column added"""
 
-        table = _shallow_copy_table(events_table)
+        table = shallow_copy_table(events_table, output_cls=QTable)
         self._compute_weights(table)
         return table
 

--- a/src/ctapipe/irf/event_weighter.py
+++ b/src/ctapipe/irf/event_weighter.py
@@ -58,9 +58,6 @@ class EventWeighter(Component):
         ----------
         source_spectrum: Callable
             initial spectrum of the events to be processed.
-        target_spectrum: Callable | None
-            target spectrum to weight to. If None, a pre-defined spectrum
-            function from the `target_spectrum_name` attribute will be used`
         """
         super().__init__(config=config, parent=parent, **kwargs)
         self.source_spectrum = source_spectrum
@@ -73,7 +70,7 @@ class EventWeighter(Component):
         )
 
     def __call__(self, events_table: QTable) -> QTable:
-        """Returns shallow copy of input table with a `weight` column added"""
+        """Returns shallow copy of input table with a ``weight`` column added"""
 
         table = _shallow_copy_table(events_table)
         self._compute_weights(table)

--- a/src/ctapipe/irf/spectra.py
+++ b/src/ctapipe/irf/spectra.py
@@ -21,6 +21,7 @@ __all__ = [
     "SPECTRA",
     "Spectra",
     "spectrum_from_simulation_config",
+    "spectrum_from_name",
 ]
 
 ENERGY_FLUX_UNIT = (1 * u.erg / u.s / u.cm**2).unit
@@ -40,6 +41,14 @@ SPECTRA = {
     Spectra.IRFDOC_ELECTRON_SPECTRUM: IRFDOC_ELECTRON_SPECTRUM,
     Spectra.IRFDOC_PROTON_SPECTRUM: IRFDOC_PROTON_SPECTRUM,
 }
+
+
+def spectrum_from_name(name: str | Spectra) -> Callable:
+    """
+    Return spectrum function given a name or Spectra enum value.
+    """
+    spectrum_value = Spectra(name)
+    return SPECTRA[spectrum_value]
 
 
 logger = logging.getLogger(__name__)

--- a/src/ctapipe/irf/spectra.py
+++ b/src/ctapipe/irf/spectra.py
@@ -101,18 +101,19 @@ def spectrum_from_simulation_config(
     # Currently we do not support those, so we raise exceptions here to
     # avoid that we incorrectly compute the effective area, which would have
     # a high scientific impact.
-    for itm in [
+    cols = [
         "spectral_index",
         "energy_range_min",
         "energy_range_max",
         "max_scatter_range",
         "max_viewcone_radius",
         "min_viewcone_radius",
-    ]:
-        if len(np.unique(simulation_configuration_table[itm])) > 1:
-            raise NotImplementedError(
-                f"Unsupported: '{itm}' differs across simulation runs"
-            )
+    ]
+
+    if len(np.unique(simulation_configuration_table[cols], axis=0)) > 1:
+        raise NotImplementedError(
+            f"Unsupported: {', '.join(cols)} must not differ across simulation runs"
+        )
 
     n_showers_config = (
         simulation_configuration_table["n_showers"]

--- a/src/ctapipe/irf/spectra.py
+++ b/src/ctapipe/irf/spectra.py
@@ -1,22 +1,38 @@
 """Definition of spectra to be used to calculate event weights for irf computation"""
 
-from enum import Enum
+import logging
+from collections.abc import Callable
+from enum import StrEnum
 
 import astropy.units as u
-from pyirf.spectral import CRAB_HEGRA, IRFDOC_ELECTRON_SPECTRUM, IRFDOC_PROTON_SPECTRUM
+import numpy as np
+from astropy.table import Table
+from pyirf.simulations import SimulatedEventsInfo
+from pyirf.spectral import (
+    CRAB_HEGRA,
+    IRFDOC_ELECTRON_SPECTRUM,
+    IRFDOC_PROTON_SPECTRUM,
+    PowerLaw,
+)
 
-__all__ = ["ENERGY_FLUX_UNIT", "FLUX_UNIT", "SPECTRA", "Spectra"]
+__all__ = [
+    "ENERGY_FLUX_UNIT",
+    "FLUX_UNIT",
+    "SPECTRA",
+    "Spectra",
+    "spectrum_from_simulation_config",
+]
 
 ENERGY_FLUX_UNIT = (1 * u.erg / u.s / u.cm**2).unit
 FLUX_UNIT = (1 / u.erg / u.s / u.cm**2).unit
 
 
-class Spectra(Enum):
+class Spectra(StrEnum):
     """Spectra for calculating event weights"""
 
-    CRAB_HEGRA = 1
-    IRFDOC_ELECTRON_SPECTRUM = 2
-    IRFDOC_PROTON_SPECTRUM = 3
+    CRAB_HEGRA = "CRAB_HEGRA"
+    IRFDOC_ELECTRON_SPECTRUM = "IRFDOC_ELECTRON_SPECTRUM"
+    IRFDOC_PROTON_SPECTRUM = "IRFDOC_PROTON_SPECTRUM"
 
 
 SPECTRA = {
@@ -24,3 +40,87 @@ SPECTRA = {
     Spectra.IRFDOC_ELECTRON_SPECTRUM: IRFDOC_ELECTRON_SPECTRUM,
     Spectra.IRFDOC_PROTON_SPECTRUM: IRFDOC_PROTON_SPECTRUM,
 }
+
+
+logger = logging.getLogger(__name__)
+
+
+def spectrum_from_simulation_config(
+    simulation_configuration_table: Table,
+    shower_distribution_table: Table | None,
+    obs_time: u.Quantity,
+    method: str = "powerlaw",
+) -> Callable[[u.Quantity], u.Quantity]:
+    """
+    Return simulated spectrum function from configuration information..
+
+    Note this currently implements only PowerLaw spectra, but in the future will returnq a
+
+    Parameters
+    ----------
+    simulation_configuration_table: Table
+        table as read by TableLoader.read_simulation_configuration()
+    shower_distribution_table: Table
+        table of simulated shower distribution as read from TableLoader.read_shower_distribution()
+    obs_time: u.Quantity['s']
+        Observation time in a unit convertible to seconds.
+    method: str
+        "powerlaw" (for assuming powerlaw distributions), or "histogram" to return an
+        interpolation function from the underlying distribution histogram.
+
+    Returns
+    -------
+    Callable:
+       simulated spectrum function.
+    """
+
+    if method != "powerlaw":
+        return NotImplementedError(f"Method '{method}' is not implemented")
+
+    n_showers: int = 0
+    if shower_distribution_table:
+        n_showers = shower_distribution_table["n_entries"].sum()
+    else:
+        logger.warning(
+            "Simulation distributions were not found in the input files, "
+            "falling back to estimating the number of showers from the "
+            "simulation configuration."
+        )
+
+    # Some tight consistency checks. Eventually we will support using the
+    # arbitrary shower distribution and non-flat spatial distributions.
+    # Currently we do not support those, so we raise exceptions here to
+    # avoid that we incorrectly compute the effective area, which would have
+    # a high scientific impact.
+    for itm in [
+        "spectral_index",
+        "energy_range_min",
+        "energy_range_max",
+        "max_scatter_range",
+        "max_viewcone_radius",
+        "min_viewcone_radius",
+    ]:
+        if len(np.unique(simulation_configuration_table[itm])) > 1:
+            raise NotImplementedError(
+                f"Unsupported: '{itm}' differs across simulation runs"
+            )
+
+    n_showers_config = (
+        simulation_configuration_table["n_showers"]
+        * simulation_configuration_table["shower_reuse"]
+    ).sum()
+    if n_showers == 0:
+        n_showers = n_showers_config
+
+    assert n_showers_config == n_showers, "Inconsistent number of simulated showers"
+    sim_info = SimulatedEventsInfo(
+        n_showers=n_showers,
+        energy_min=simulation_configuration_table["energy_range_min"].quantity[0],
+        energy_max=simulation_configuration_table["energy_range_max"].quantity[0],
+        max_impact=simulation_configuration_table["max_scatter_range"].quantity[0],
+        spectral_index=simulation_configuration_table["spectral_index"][0],
+        viewcone_max=simulation_configuration_table["max_viewcone_radius"].quantity[0],
+        viewcone_min=simulation_configuration_table["min_viewcone_radius"].quantity[0],
+    )
+
+    return PowerLaw.from_simulation(sim_info, obstime=obs_time)

--- a/src/ctapipe/irf/tests/test_event_weighter.py
+++ b/src/ctapipe/irf/tests/test_event_weighter.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.table import QTable
+
+from ctapipe.irf.event_weighter import RadialEventWeighter, SimpleEventWeighter
+
+
+@pytest.fixture(scope="function")
+def example_weight_table():
+    table = QTable(
+        dict(
+            true_energy=[1.0, 2.0, 0.5, 0.2] * u.TeV,
+            true_fov_offset=[0.1, 1.2, 2.2, 3.2] * u.deg,
+        )
+    )
+    table.meta["VERSION"] = 1.0
+    table.columns["true_energy"].description = "True energy of particle"
+    return table
+
+
+def test_simple_weights(example_weight_table):
+    from ctapipe.irf.spectra import PowerLaw
+
+    table = example_weight_table
+
+    source_spectrum = PowerLaw(
+        normalization=u.Quantity(0.00027, "TeV-1 s-1 sr-1 m-2"),
+        index=-2.0,
+        e_ref=1.0 * u.TeV,
+    )
+
+    weight1 = SimpleEventWeighter(
+        source_spectrum=source_spectrum, target_spectrum_name="CRAB_HEGRA"
+    )
+
+    table_w1 = weight1(table)
+
+    assert np.all(table_w1["weight"] > 0.0)
+    assert np.all(table_w1["weight"] <= 1.0)
+
+
+def test_flat_weighting(example_weight_table):
+    """Check that if source and target spectra are the same,  we get 1.0."""
+    from ctapipe.irf.spectra import SPECTRA, Spectra
+
+    table = example_weight_table
+
+    weight = SimpleEventWeighter(
+        source_spectrum=SPECTRA[Spectra.CRAB_HEGRA],
+        target_spectrum_name=Spectra.CRAB_HEGRA.name,
+        is_diffuse=False,
+    )
+
+    w = weight(table)["weight"]
+
+    assert np.allclose(w, 1.0)
+
+
+def test_radial_weights(example_weight_table):
+    from ctapipe.irf.spectra import PowerLaw
+
+    table = example_weight_table
+
+    source_spectrum = PowerLaw(
+        normalization=u.Quantity(0.00027, "TeV-1 s-1 sr-1 m-2"),
+        index=-2.0,
+        e_ref=1.0 * u.TeV,
+    )
+
+    weight = RadialEventWeighter(
+        source_spectrum=source_spectrum,
+        target_spectrum_name="CRAB_HEGRA",
+        fov_offset_min=0.0 * u.deg,
+        fov_offset_max=5.0 * u.deg,
+        fov_offset_n_bins=5,
+    )
+
+    assert np.allclose(weight.fov_offset_bins, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] * u.deg)
+
+    table_w = weight(table)
+
+    assert "fov_offset_bin" in table_w.colnames
+    assert "OFFSBINS" in table_w.meta
+    assert table_w.meta["OFFSBINS"] == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+
+    for ii in range(0, 7):
+        mask = table_w["fov_offset_bin"] == ii
+
+        if ii == 0:
+            # there should be no 0th bin
+            assert len(table_w[mask]) == 0
+        elif ii == 6:
+            # for outlier bin 6, weights should be all 0
+            assert np.all(table_w["weight"][mask] == 0.0)
+        else:
+            # for bins 1-5,weights  should be positive in this case
+            assert np.all(table_w["weight"][mask] >= 0.0)
+
+
+def test_radial_weights_fits(example_weight_table, tmp_path):
+    """Test round-tripping to FITS"""
+    from astropy.table import Table
+
+    from ctapipe.irf.spectra import PowerLaw
+
+    table = example_weight_table
+
+    source_spectrum = PowerLaw(
+        normalization=u.Quantity(0.00027, "TeV-1 s-1 sr-1 m-2"),
+        index=-2.0,
+        e_ref=1.0 * u.TeV,
+    )
+
+    weight = RadialEventWeighter(
+        source_spectrum=source_spectrum,
+        target_spectrum_name="CRAB_HEGRA",
+        fov_offset_min=0.0 * u.deg,
+        fov_offset_max=5.0 * u.deg,
+        fov_offset_n_bins=5,
+    )
+
+    table_w = weight(table)
+    table_w.write(tmp_path / "test.fits")
+
+    assert Table.read(tmp_path / "test.fits").meta["OFFSBINS"] == [
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        5.0,
+    ]

--- a/src/ctapipe/irf/tests/test_event_weighter.py
+++ b/src/ctapipe/irf/tests/test_event_weighter.py
@@ -44,12 +44,12 @@ def test_simple_weights(example_weight_table):
 
 def test_flat_weighting(example_weight_table):
     """Check that if source and target spectra are the same,  we get 1.0."""
-    from ctapipe.irf.spectra import SPECTRA, Spectra
+    from ctapipe.irf.spectra import Spectra, spectrum_from_name
 
     table = example_weight_table
 
     weight = SimpleEventWeighter(
-        source_spectrum=SPECTRA[Spectra.CRAB_HEGRA],
+        source_spectrum=spectrum_from_name(Spectra.CRAB_HEGRA),
         target_spectrum_name=Spectra.CRAB_HEGRA.name,
         is_diffuse=False,
     )

--- a/src/ctapipe/irf/tests/test_event_weighter.py
+++ b/src/ctapipe/irf/tests/test_event_weighter.py
@@ -5,7 +5,11 @@ import pytest
 from astropy import units as u
 from astropy.table import QTable
 
-from ctapipe.irf.event_weighter import RadialEventWeighter, SimpleEventWeighter
+from ctapipe.irf.event_weighter import (
+    PolarEventWeighter,
+    RadialEventWeighter,
+    SimpleEventWeighter,
+)
 
 
 @pytest.fixture(scope="function")
@@ -14,6 +18,7 @@ def example_weight_table():
         dict(
             true_energy=[1.0, 2.0, 0.5, 0.2] * u.TeV,
             true_fov_offset=[0.1, 1.2, 2.2, 3.2] * u.deg,
+            true_fov_phi=[45.0, 45.0, 268.0, 120.0] * u.deg,
         )
     )
     table.meta["VERSION"] = 1.0
@@ -133,3 +138,50 @@ def test_radial_weights_fits(example_weight_table, tmp_path):
         4.0,
         5.0,
     ]
+
+
+def test_polar_weights(example_weight_table):
+    from ctapipe.irf.spectra import PowerLaw
+
+    table = example_weight_table
+
+    source_spectrum = PowerLaw(
+        normalization=u.Quantity(0.00027, "TeV-1 s-1 sr-1 m-2"),
+        index=-2.0,
+        e_ref=1.0 * u.TeV,
+    )
+
+    weight = PolarEventWeighter(
+        source_spectrum=source_spectrum,
+        target_spectrum_name="CRAB_HEGRA",
+        fov_offset_min=0.0 * u.deg,
+        fov_offset_max=5.0 * u.deg,
+        fov_offset_n_bins=5,
+        fov_phi_n_bins=4,
+    )
+
+    assert np.allclose(weight.fov_offset_bins, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] * u.deg)
+    assert np.allclose(weight.fov_phi_bins, [0.0, 90.0, 180.0, 270.0, 360.0] * u.deg)
+
+    table_w = weight(table)
+
+    assert "fov_offset_bin" in table_w.colnames
+    assert "fov_phi_bin" in table_w.colnames
+    assert "OFFSBINS" in table_w.meta
+    assert "PHIBINS" in table_w.meta
+    assert table_w.meta["OFFSBINS"] == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert table_w.meta["PHIBINS"] == [0.0, 90.0, 180.0, 270.0, 360.0]
+
+    for ii in range(0, 7):
+        for jj in range(0, 4):
+            mask = (table_w["fov_offset_bin"] == ii) & (table_w["fov_phi_bin"] == jj)
+
+            if ii == 0 or jj == 0:
+                # there should be no 0th bin
+                assert len(table_w[mask]) == 0
+            elif ii == 6 or jj == 5:
+                # for outlier bin 6,5, weights should be all 0
+                assert np.all(table_w["weight"][mask] == 0.0)
+            else:
+                # for other bins, should have a weight
+                assert np.all(table_w["weight"][mask] >= 0.0)


### PR DESCRIPTION
This is part of the DL2 code refactoring (see #2919).  It introduces a new Component hierachy `ctapipe.irf.EventWeighter` that has different implementations of spectral event weighting:

* `SimpleEventWeigher`: spectral weigting for the full FOV
* `RadialEventWeighter`: spectral weighing in radial bins in the  FOV

They operate on a pre-processed table of DL2 information, where you specify the energy and FOV coordinate columns to use.  The interface is as follows, :

```python
from astropy.table import QTable

from ctapipe.irf import (
    RadialEventWeighter,
    spectrum_from_name,
    spectrum_from_simulation_config,
)

table = QTable(
    dict(
        true_energy=[1.0, 2.0, 0.5, 0.2] * u.TeV,
        true_fov_offset=[0.1, 1.2, 2.2, 3.2] * u.deg,
    )
)
weighter = RadialEventWeighter(
    source_spectrum=spectrum_from_name("IRFDOC_ELECTRON_SPECTRUM"),
    target_spectrum_name="CRAB_HEGRA",
    fov_offset_max=5.0*u.deg,
    fov_offset_n_bins=5,
  )

print(weighter.fov_offset_bins)
table_with_weights = weighter(table)
```
<img width="483" height="247" alt="image" src="https://github.com/user-attachments/assets/bf928d4a-e166-4637-b84f-3cc4a762795c" />

<img width="781" height="552" alt="image" src="https://github.com/user-attachments/assets/91920ccd-db67-4423-b47e-8460dcd01f2c" />

