### PR TITLE
Allow filtering by telescope event type in software trigger

### DIFF
--- a/docs/changes/2941.feature.rst
+++ b/docs/changes/2941.feature.rst
@@ -1,0 +1,5 @@
+Add option to filter out telescope events using their trigger ``EventType``
+in ``SoftwareTrigger``.
+This is can be used e.g. to study mono telescope performance from Prod6
+simulations by analyzing only telescope events with ``RANDOM_MONO`` event type
+or muon tagging by only analyzing ``MUON`` events.


### PR DESCRIPTION
From a discussion with @mdpunch (cc @mdebony), the nectar cam people would like to analyze the mono performance of nectarcam from the Prod6 simulations by only looking at the `RANDOM_MONO` events.

To make this straight forward with normal ctapipe tools, we need an option to filter out telescope events by telescope event type.

This fits well with the `SoftwareTrigger`, so I added an option there.

```
ctapipe-process -i ../data/gamma_20deg_180deg_run000001___cta-prod6-2156m-LaPalma-dark+magic_cone10.simtel.zst -c nectarcams_prod6_north.yaml -c random_mono.yaml -o random_mono.dl1.h5 --progress --overwrite
```

Result:
[random_mono.dl1.h5.zip](https://github.com/user-attachments/files/25123441/random_mono.dl1.h5.zip)



Config used:

```
### This is NEW
SoftwareTrigger:
  allowed_telescope_event_types:
    - RANDOM_MONO
###

# rest is standard DL0 to DL1 config
DataWriter:
  write_dl1_images: true
  write_dl1_parameters: true

  # save some disk space with a fixed-point transformation
  transform_image: true
  transform_peak_time: true

CameraCalibrator:
  image_extractor_type:
    - ['type', '*', 'NeighborPeakWindowSum']

ImageProcessor:
  image_cleaner_type: TailcutsImageCleaner

  TailcutsImageCleaner:
    picture_threshold_pe:
      - [type, "MST*NectarCam", 9.0]
    boundary_threshold_pe:
      - [type, "MST*NectarCam", 4.5]
    keep_isolated_pixels: False
    min_picture_neighbors: 2

  ImageQualityQuery:
    quality_criteria:
      - ["enough_pixels", "np.count_nonzero(image) > 2"]
      - ["enough_charge", "image.sum() > 50"]
```

with a second config file for all nectarcams in prod6 north:

```
EventSource:
  # MST NectarCams in prod6 north
  allowed_tels: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]


DataWriter:
  Instrument:
    site: CTAO-North
    class_: Subarray
    id_: alpha
    version: Prod6 NectarCam Random Mono
```