### PR TITLE
Store original simtel event in ArrayEventContainer

### DIFF
--- a/docs/changes/2976.feature.rst
+++ b/docs/changes/2976.feature.rst
@@ -1,0 +1,1 @@
+Underlying simtel event can now be accessed at event.meta["simtel_event"] when reading a SimTelEventSource

--- a/src/ctapipe/io/simteleventsource.py
+++ b/src/ctapipe/io/simteleventsource.py
@@ -986,6 +986,7 @@ class SimTelEventSource(EventSource):
             data.meta["origin"] = "hessio"
             data.meta["input_url"] = self.input_url
             data.meta["max_events"] = self.max_events
+            data.meta["simtel_event"] = array_event
 
             telescope_events = array_event["telescope_events"]
             tracking_positions = array_event["tracking_positions"]


### PR DESCRIPTION
Closes #2698. Note that the telescope numbering scheme inside the simtel event is different to the final ArrayEvent.