### PR TITLE
Add proper typing support for Container fields

### DIFF
--- a/docs/changes/2994.feature.rst
+++ b/docs/changes/2994.feature.rst
@@ -1,0 +1,3 @@
+Improve type hints for ``Container`` and ``Field``, IDEs and LSPs should
+now better detect the correct types of container fields in code and no longer
+complain about things like "Variable of type Field has not attribute length".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,12 @@ nitpick_ignore = add_reference_type(
         "astropy.coordinates.baseframe.BaseCoordinateFrame",
         "astropy.table.table.Table",
         "eventio.simtel.simtelfile.SimTelFile",
+        "ctapipe.core.container.T",
+        "ctapipe.core.container.T1",
+        "ctapipe.core.container.T2",
+        "ctapipe.core.container.K",
+        "ctapipe.core.container.V",
+        "DTypeLike",
     ],
 )
 nitpick_ignore += add_reference_type(
@@ -161,6 +167,11 @@ nitpick_ignore += add_reference_type(
         "-v",  # fix for wrong syntax in a traitlets docstring
         "cls",
         "name",
+        "ctapipe.core.container.T",
+        "ctapipe.core.container.T1",
+        "ctapipe.core.container.T2",
+        "ctapipe.core.container.K",
+        "ctapipe.core.container.V",
     ],
 )
 nitpick_ignore += add_reference_type(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,6 +134,9 @@ nitpick_ignore = add_reference_type(
         "Sentinel",
         "ObserveHandler",
         "dict[K, V]",
+        "T",
+        "T1",
+        "T2",
         "G",
         "K",
         "V",
@@ -144,11 +147,8 @@ nitpick_ignore = add_reference_type(
         "astropy.coordinates.baseframe.BaseCoordinateFrame",
         "astropy.table.table.Table",
         "eventio.simtel.simtelfile.SimTelFile",
-        "ctapipe.core.container.T",
         "ctapipe.core.container.T1",
         "ctapipe.core.container.T2",
-        "ctapipe.core.container.K",
-        "ctapipe.core.container.V",
         "DTypeLike",
     ],
 )
@@ -167,11 +167,11 @@ nitpick_ignore += add_reference_type(
         "-v",  # fix for wrong syntax in a traitlets docstring
         "cls",
         "name",
-        "ctapipe.core.container.T",
-        "ctapipe.core.container.T1",
-        "ctapipe.core.container.T2",
-        "ctapipe.core.container.K",
-        "ctapipe.core.container.V",
+        "T",
+        "T1",
+        "T2",
+        "K",
+        "V",
     ],
 )
 nitpick_ignore += add_reference_type(

--- a/src/ctapipe/core/container.py
+++ b/src/ctapipe/core/container.py
@@ -5,9 +5,11 @@ from functools import partial
 from inspect import isclass
 from pprint import pformat
 from textwrap import dedent, wrap
+from typing import Any, Callable, Generic, Self, Type, TypeVar, overload
 
 import numpy as np
-from astropy.units import Quantity, Unit, UnitConversionError
+from astropy.units import Quantity, Unit, UnitBase, UnitConversionError
+from numpy.typing import DTypeLike, NDArray
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +24,12 @@ class FieldValidationError(ValueError):
     pass
 
 
-class Field:
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+
+
+class Field(Generic[T]):
     """
     Class for storing data in a `Container`.
 
@@ -55,18 +62,104 @@ class Field:
         A callable providing a fresh instance as default value.
     """
 
+    # only default provided
+    @overload
+    def __init__(
+        self,
+        default: T,
+        description: str = "",
+        *,
+        unit: None = None,
+        ucd: Any = None,
+        dtype: None = None,
+        type: None = None,
+        ndim: None = None,
+        allow_none: bool = False,
+        max_length: None = None,
+        default_factory: None = None,
+    ): ...
+
+    # only default_factory provided
+    @overload
+    def __init__(
+        self,
+        default: None = None,
+        description: str = "",
+        *,
+        default_factory: Type[T] | Callable[[], T],
+        unit: None = None,
+        ucd: Any = None,
+        dtype: None = None,
+        type: None = None,
+        ndim: None = None,
+        allow_none: bool = False,
+        max_length: None = None,
+    ): ...
+
+    # default and type given
+    @overload
+    def __init__(
+        self: "Field[T1 | T2]",
+        default: T1,
+        description: str = "",
+        *,
+        type: Type[T2],
+        unit: None = None,
+        ucd: Any = None,
+        dtype: None = None,
+        ndim: None = None,
+        allow_none: bool = False,
+        max_length: None = None,
+        default_factory: None = None,
+    ): ...
+
+    # None default but unit provided -> Quantity | None
+    @overload
+    def __init__(
+        self: "Field[Quantity | None]",
+        default: None,
+        description: str = "",
+        *,
+        unit: UnitBase,
+        type: None = None,
+        ucd: Any = None,
+        dtype: None = None,
+        ndim: None = None,
+        allow_none: bool = False,
+        max_length: None = None,
+        default_factory: None = None,
+    ): ...
+
+    # array case
+    @overload
+    def __init__(
+        self: "Field[NDArray | None]",
+        default: None,
+        description: str = "",
+        *,
+        unit: None = None,
+        type: None = None,
+        ucd: Any = None,
+        dtype: None | DTypeLike = None,
+        ndim: None | int = None,
+        allow_none: bool = False,
+        max_length: None = None,
+        default_factory: None = None,
+    ): ...
+
     def __init__(
         self,
         default=None,
         description="",
+        *,
+        default_factory: Type[T] | Callable[[], T] | None = None,
         unit=None,
         ucd=None,
         dtype=None,
         type=None,
         ndim=None,
-        allow_none=True,
-        max_length=None,
-        default_factory=None,
+        allow_none: bool = True,
+        max_length: int | None = None,
     ):
         self.default = default
         self.default_factory = default_factory
@@ -81,6 +174,22 @@ class Field:
 
         if default_factory is not None and default is not None:
             raise ValueError("Must only provide one of default or default_factory")
+
+    # we only specify the Descriptor protocol __get__ here has it helps type checkers
+    # and IDEs to provide insights on types of container fields. It is not actually used at runtime
+    # since the ContainerMeta turns Fields into __slots__ based access to member variables.
+    # 2. When accessed via the class (e.g., MyContainer.foo), only owner present
+    @overload
+    def __get__(self, instance: None, owner: Any) -> Self: ...
+
+    # 1. access via instance, both arguments present
+    @overload
+    def __get__(self, instance: "Container", owner: "Type[Container]") -> T: ...
+
+    def __get__(
+        self, instance: "Container | None", owner: "Type[Container]"
+    ) -> T | Self:
+        raise NotImplementedError("Fields should only be used with Containers")
 
     def __repr__(self):
         if self.default_factory is not None:
@@ -458,7 +567,11 @@ class Container(metaclass=ContainerMeta):
                 )
 
 
-class Map(defaultdict):
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class Map(defaultdict[K, V]):
     """A dictionary of sub-containers that can be added to a Container. This
     may be used e.g. to store a set of identical sub-Containers (e.g. indexed
     by ``tel_id`` or algorithm name).

--- a/src/ctapipe/core/container.py
+++ b/src/ctapipe/core/container.py
@@ -5,7 +5,7 @@ from functools import partial
 from inspect import isclass
 from pprint import pformat
 from textwrap import dedent, wrap
-from typing import Any, Callable, Generic, Self, Type, TypeVar, overload
+from typing import Any, Callable, Self, Type, overload
 
 import numpy as np
 from astropy.units import Quantity, Unit, UnitBase, UnitConversionError
@@ -24,12 +24,7 @@ class FieldValidationError(ValueError):
     pass
 
 
-T = TypeVar("T")
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
-
-
-class Field(Generic[T]):
+class Field[T]:
     """
     Class for storing data in a `Container`.
 
@@ -98,7 +93,7 @@ class Field(Generic[T]):
 
     # default and type given
     @overload
-    def __init__(
+    def __init__[T1, T2](
         self: "Field[T1 | T2]",
         default: T1,
         description: str = "",
@@ -178,11 +173,11 @@ class Field(Generic[T]):
     # we only specify the Descriptor protocol __get__ here has it helps type checkers
     # and IDEs to provide insights on types of container fields. It is not actually used at runtime
     # since the ContainerMeta turns Fields into __slots__ based access to member variables.
-    # 2. When accessed via the class (e.g., MyContainer.foo), only owner present
+    # 1. When accessed via the class (e.g., MyContainer.foo), only owner present
     @overload
     def __get__(self, instance: None, owner: Any) -> Self: ...
 
-    # 1. access via instance, both arguments present
+    # 2. access via instance, both arguments present
     @overload
     def __get__(self, instance: "Container", owner: "Type[Container]") -> T: ...
 
@@ -567,11 +562,7 @@ class Container(metaclass=ContainerMeta):
                 )
 
 
-K = TypeVar("K")
-V = TypeVar("V")
-
-
-class Map(defaultdict[K, V]):
+class Map[K, V](defaultdict[K, V]):
     """A dictionary of sub-containers that can be added to a Container. This
     may be used e.g. to store a set of identical sub-Containers (e.g. indexed
     by ``tel_id`` or algorithm name).


### PR DESCRIPTION
With e.g. pyright installed in an IDE:

Before:

<img width="1190" height="764" alt="Screenshot_20260415_125405" src="https://github.com/user-attachments/assets/d5f0ab28-6c84-4f3f-b619-0787ea542b70" />

Now:

<img width="1190" height="764" alt="Screenshot_20260415_125335" src="https://github.com/user-attachments/assets/ba562e7e-1d59-4e47-9c5a-e44c134673a2" />


And e.g. in `CameraCalibrator`:

Before:
<img width="1102" height="347" alt="Screenshot_20260415_131022" src="https://github.com/user-attachments/assets/6184e820-94bd-438a-9b5a-22cd00e9f73b" />

Now:

<img width="725" height="347" alt="Screenshot_20260415_131045" src="https://github.com/user-attachments/assets/771d3072-af56-4014-b7be-0ff3c82ab178" />

It cannot deduce the type of the `Map`, but that can be explicitly type hinted as well later.