### PR TITLE
Add one more type annotation to Field overloads

### DIFF
--- a/src/ctapipe/core/container.py
+++ b/src/ctapipe/core/container.py
@@ -170,7 +170,7 @@ class Field[T]:
         if default_factory is not None and default is not None:
             raise ValueError("Must only provide one of default or default_factory")
 
-    # we only specify the Descriptor protocol __get__ here has it helps type checkers
+    # we only specify the Descriptor protocol __get__ & __set__ here has it helps type checkers
     # and IDEs to provide insights on types of container fields. It is not actually used at runtime
     # since the ContainerMeta turns Fields into __slots__ based access to member variables.
     # 1. When accessed via the class (e.g., MyContainer.foo), only owner present
@@ -184,7 +184,14 @@ class Field[T]:
     def __get__(
         self, instance: "Container | None", owner: "Type[Container]"
     ) -> T | Self:
-        raise NotImplementedError("Fields should only be used with Containers")
+        raise NotImplementedError(
+            f"Fields should only be used with Containers ({instance, owner})"
+        )
+
+    def __set__(self, instance: "Container | None", value: T) -> None:
+        raise NotImplementedError(
+            f"Fields should only be used with Containers ({instance, value})"
+        )
 
     def __repr__(self):
         if self.default_factory is not None:

--- a/src/ctapipe/core/container.py
+++ b/src/ctapipe/core/container.py
@@ -85,7 +85,7 @@ class Field[T]:
         unit: None = None,
         ucd: Any = None,
         dtype: None = None,
-        type: None = None,
+        type: Type[T] | None = None,
         ndim: None = None,
         allow_none: bool = False,
         max_length: None = None,


### PR DESCRIPTION
While going over the container definitions in #2204, I noticed one missing case where my IDE was complaining about invalid args:

<img width="1283" height="230" alt="Screenshot_20260417_165408" src="https://github.com/user-attachments/assets/71692749-3e05-488a-a178-dc743617186a" />


Now:

<img width="536" height="182" alt="Screenshot_20260417_165313" src="https://github.com/user-attachments/assets/affa224d-f73d-41bd-b443-8a161500350a" />
