### PR TITLE
Fix Map() repr to be more sane

### DIFF
--- a/docs/changes/2997.bugfix.rst
+++ b/docs/changes/2997.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed confusing ``__repr__`` for `ctapipe.core.Map`. Now it only prints the type
+and values in the map, rather than the full repr of all members. This has no
+effect on any code, just a quality of life improvement for users that look at
+container structures interactively in a notebook or REPL.

--- a/src/ctapipe/core/container.py
+++ b/src/ctapipe/core/container.py
@@ -603,4 +603,4 @@ class Map[K, V](defaultdict[K, V]):
             default = _fqdn(self.default_factory)
         else:
             default = repr(self.default_factory)
-        return f"{self.__class__.__name__}({default}, {dict.__repr__(self)!s})"
+        return f"{self.__class__.__name__}({default}: {list(self.keys())})"

--- a/src/ctapipe/core/container.py
+++ b/src/ctapipe/core/container.py
@@ -603,4 +603,10 @@ class Map[K, V](defaultdict[K, V]):
             default = _fqdn(self.default_factory)
         else:
             default = repr(self.default_factory)
-        return f"{self.__class__.__name__}({default}: {list(self.keys())})"
+
+        key_type = "Any"
+        if self.keys():
+            key_type = type(next(iter(self.keys())))
+            key_type = key_type.__name__ if isclass(key_type) else repr(key_type)
+
+        return f"{self.__class__.__name__}[{key_type}, {default}](keys={list(self.keys())})"


### PR DESCRIPTION
The old repr was basically unreadable, as it printed the reprs of all sub-containers.  This just changes the repr to be actually useful:

```python
event.dl1.tel
```

**After this change:**
```
Map[int, ctapipe.containers.ArrayEventContainer](keys=[13, 6])
```

**Before:** Too much information was given.  The Container _reprs_ are only useful when dealing with a single one, not a list. What the user wants when looking at a Map is just the list of what is inside it.


```
Map(ctapipe.containers.DL1CameraContainer, {np.int16(5): ctapipe.containers.DL1CameraContainer:
                         image: Numpy array of camera image, after waveform
                                extraction.Shape: (n_pixel) if n_channels is 1
                                or data is gain selectedelse: (n_channels,
                                n_pixel) with default None
                     peak_time: Numpy array containing position of the peak of
                                the pulse as determined by the extractor.Shape:
                                (n_pixel) if n_channels is 1 or data is gain
                                selectedelse: (n_channels, n_pixel) with default
                                None
                    image_mask: Boolean numpy array where True means the pixel
                                has passed cleaning. Shape: (n_pixel, ) with
                                default None as a 1-D array with dtype bool
                      is_valid: True if image extraction succeeded, False if
                                failed or in the case of TwoPass methods, that
                                the first pass only was returned. with default
                                False
                  parameters.*: Image parameters with default None with type
                                <class
                                'ctapipe.containers.ImageParametersContainer'>, np.int16(11): ctapipe.containers.DL1CameraContainer:
                         image: Numpy array of camera image, after waveform
                                extraction.Shape: (n_pixel) if n_channels is 1
                                or data is gain selectedelse: (n_channels,
                                n_pixel) with default None
                     peak_time: Numpy array containing position of the peak of
                                the pulse as determined by the extractor.Shape:
                                (n_pixel) if n_channels is 1 or data is gain
                                selectedelse: (n_channels, n_pixel) with default
                                None
                    image_mask: Boolean numpy array where True means the pixel
                                has passed cleaning. Shape: (n_pixel, ) with
                                default None as a 1-D array with dtype bool
                      is_valid: True if image extraction succeeded, False if
                                failed or in the case of TwoPass methods, that
                                the first pass only was returned. with default
                                False
                  parameters.*: Image parameters with default None with type
                                <class
                                'ctapipe.containers.ImageParametersContainer'>})
```
