### PR TITLE
Allow overriding obs_id by adding offset to run_number in SimTelEventSource

### DIFF
--- a/docs/changes/3008.feature.rst
+++ b/docs/changes/3008.feature.rst
@@ -1,0 +1,4 @@
+Allow overriding the obs_id in SimTelEventSource by adding an offset to the run_number.
+This simplifies processing a large number of runs, where groups of runs have overlapping
+run numbers. Instead of providing individual ``override_obs_id`` per run,
+now an offset can be assigned to each group.

--- a/src/ctapipe/io/simteleventsource.py
+++ b/src/ctapipe/io/simteleventsource.py
@@ -632,7 +632,21 @@ class SimTelEventSource(EventSource):
     override_obs_id = Integer(
         default_value=None,
         allow_none=True,
-        help="Use the given obs_id instead of the run number from sim_telarray",
+        help=(
+            "Use the given obs_id instead of the run number from sim_telarray."
+            " The original run number will be stored in the simulation configuration."
+        ),
+    ).tag(config=True)
+
+    obs_id_offset = Integer(
+        default_value=None,
+        allow_none=True,
+        help=(
+            "Override the obs_id by adding an offset to the run number."
+            " This option is useful if a larger number of runs have overlapping run numbers."
+            " The original run number will be stored in the simulation configuration."
+            " override_obs_id will take precedence if both options are provided."
+        ),
     ).tag(config=True)
 
     def __init__(self, input_url=Undefined, config=None, parent=None, **kwargs):
@@ -1324,14 +1338,20 @@ class SimTelEventSource(EventSource):
         simulation config is filled
         """
 
-        az, alt = self.file_.header["direction"]
+        header = self.file_.header
+        az, alt = header["direction"]
 
         # this event source always contains only a single OB, so we can
         # also assign a single obs_id
         if self.override_obs_id is not None:
             self.obs_id = self.override_obs_id
+        elif self.obs_id_offset is not None:
+            self.obs_id = self.obs_id_offset + header["run"]
         else:
-            self.obs_id = self.file_.header["run"]
+            self.obs_id = header["run"]
+
+        if self.obs_id != header["run"]:
+            self.log.info("Setting obs_id=%d for run=%d", self.obs_id, header["run"])
 
         # simulations at the moment do not have SBs, use OB id
         self.sb_id = self.obs_id
@@ -1355,8 +1375,8 @@ class SimTelEventSource(EventSource):
                 subarray_pointing_lat=alt * u.rad,
                 subarray_pointing_lon=az * u.rad,
                 subarray_pointing_frame=CoordinateFrameType.ALTAZ,
-                actual_start_time=Time(self.file_.header["time"], format="unix"),
-                scheduled_start_time=Time(self.file_.header["time"], format="unix"),
+                actual_start_time=Time(header["time"], format="unix"),
+                scheduled_start_time=Time(header["time"], format="unix"),
             )
         }
 

--- a/src/ctapipe/io/tests/test_simteleventsource.py
+++ b/src/ctapipe/io/tests/test_simteleventsource.py
@@ -701,6 +701,35 @@ def test_override_obs_id(override_obs_id, expected_obs_id, prod5_gamma_simtel_pa
         assert s.obs_ids == [expected_obs_id]
 
         assert s.simulation_config.keys() == {expected_obs_id}
+        assert s.simulation_config[expected_obs_id].run_number == original_run_number
+
+        assert s.observation_blocks.keys() == {expected_obs_id}
+        assert s.scheduling_blocks.keys() == {expected_obs_id}
+
+        # this should always be the original run number
+        assert s.simulation_config[s.obs_id].run_number == original_run_number
+
+        for e in s:
+            assert e.index.obs_id == expected_obs_id
+
+
+@pytest.mark.parametrize(
+    "obs_id_offset,expected_obs_id", [(None, 1), (100, 101), (200, 201)]
+)
+def test_obs_id_offset(obs_id_offset, expected_obs_id, prod5_gamma_simtel_path):
+    """Test for the override_obs_id option"""
+    original_run_number = 1
+
+    with SimTelEventSource(
+        prod5_gamma_simtel_path,
+        obs_id_offset=obs_id_offset,
+    ) as s:
+        assert s.obs_id == expected_obs_id
+        assert s.obs_ids == [expected_obs_id]
+
+        assert s.simulation_config.keys() == {expected_obs_id}
+        assert s.simulation_config[expected_obs_id].run_number == original_run_number
+
         assert s.observation_blocks.keys() == {expected_obs_id}
         assert s.scheduling_blocks.keys() == {expected_obs_id}
 


### PR DESCRIPTION
This should make it easier to process the LSTProd2 simulations, where run numbers are only unique within a node.

This makes it possible to chose one offset per node instead of having to define individual obs ids per run.