### PR TITLE
Add wrappper to reconstruct Hist object from table row

### DIFF
--- a/examples/tutorials/histogram_aggregation.py
+++ b/examples/tutorials/histogram_aggregation.py
@@ -231,7 +231,8 @@ chunk_histograms_container = ChunkHistogramContainer(
 chunk_histograms_container.meta = result.meta
 
 # Plot three nearby pixels using Hist's built-in plotting functionality.
-# Requires 'hist[plot]' to be installed in the environment.
+# Requires 'hist[plot]' to be installed in the environment. Reconstruct
+# the full histogram as a Hist object for the chunk using hist_from_container method.
 full_hist = HistogramAggregator.hist_from_container(
     chunk_histograms_container, axis_names=["value", "channel", "pixel"]
 )
@@ -332,20 +333,16 @@ for label, flow_options in FLOW_CONFIGS.items():
         col_name="image",
         masked_elements_of_sample=masked_elements_of_sample,
     )
-    # Create a ChunkHistogramContainer from the aggregated histogram and
-    # metadata for the selected chunk.
-    chunk_histograms_container = ChunkHistogramContainer(
-        **dict(zip(result[chunk_index].colnames, result[chunk_index]))
-    )
-    chunk_histograms_container.meta = result.meta
-    histogram_cont = HistogramAggregator.hist_from_container(
-        chunk_histograms_container,
+    # Create a Hist object from the aggregated histogram and
+    # metadata for the selected chunk using the hist_from_tablerow method.
+    histogram_cont = HistogramAggregator.hist_from_tablerow(
+        result[chunk_index],
         axis_names=["value", "channel", "pixel"],
     )
     histogram = histogram_cont[{"channel": 0, "pixel": pixel_index}]
 
     flow_view = histogram.view(flow=True)
-    axis_kwargs = chunk_histograms_container.meta["axis_kwargs"]
+    axis_kwargs = result.meta["axis_kwargs"]
 
     results[label] = result
     histograms[label] = histogram

--- a/src/ctapipe/monitoring/aggregator.py
+++ b/src/ctapipe/monitoring/aggregator.py
@@ -31,7 +31,7 @@ import astropy.units as u
 import hist
 import numpy as np
 from astropy.stats import sigma_clip
-from astropy.table import Table
+from astropy.table import Row, Table
 from hist import Hist
 from traitlets import TraitError
 
@@ -522,11 +522,56 @@ class HistogramAggregator(BaseAggregator):
         )
 
     @staticmethod
+    def hist_from_tablerow(
+        row: Row,
+        axis_names: list[str] | None = None,
+    ):
+        """Build a ``hist.Hist`` from an Astropy table row produced by the
+        ``HistogramAggregator``.
+
+        This is a thin wrapper that constructs a ``ChunkHistogramContainer``
+        from the provided ``row`` (reading ``n_events``, ``histogram`` and
+        ``row.meta``) and delegates the actual reconstruction to
+        :meth:`hist_from_container`.
+
+        Note
+        ----
+        ``HistogramAggregator.__call__`` produces an ``astropy.table.Table``
+        with one row per chunk. To rebuild the histogram for chunk ``i`` you
+        can do::
+
+            result_table = aggregator(event_table)
+            hist = HistogramAggregator.hist_from_tablerow(result_table[i])
+
+        This helper handles extracting the stored ndarray and metadata from
+        the row and returns a complete ``hist.Hist`` object.
+
+        Parameters
+        ----------
+        row : astropy.table.Row
+            Table row created by ``HistogramAggregator.__call__``. Expected to
+            contain a ``histogram`` ndarray with shape ``(n_bins, *data_dims)``,
+            number of valid events in ``n_events``, and  metadata in ``row.meta``
+            describing the original axis.
+        axis_names : list[str] | None
+            Optional axis names for non-value axes in the rebuilt ``Hist``.
+
+        Returns
+        -------
+        hist.Hist
+            Reconstructed histogram object with axes and counts populated.
+        """
+
+        cont = ChunkHistogramContainer(**dict(zip(row.colnames, row)))
+        cont.meta = row.meta
+        return HistogramAggregator.hist_from_container(cont, axis_names)
+
+    @staticmethod
     def hist_from_container(
         cont: ChunkHistogramContainer,
         axis_names: list[str] | None = None,
     ):
-        """Construct a Hist object from a ChunkHistogramContainer.
+        """Construct a ``hist.Hist`` from a ``ChunkHistogramContainer``.
 
         Parameters
         ----------

--- a/src/ctapipe/monitoring/tests/test_aggregator.py
+++ b/src/ctapipe/monitoring/tests/test_aggregator.py
@@ -137,36 +137,31 @@ def test_histograms_aggregator():
         }
     )
     aggregator = HistogramAggregator(config=config)
-
-    histo_chunk = aggregator(hist_table, masked_elements_of_sample=None)
-    histo_cont = ChunkHistogramContainer(
-        **dict(zip(histo_chunk[0].colnames, histo_chunk[0]))
-    )
-    histo_cont.meta = histo_chunk[0].meta
-
-    # , meta=histo_chunk.meta
-    histo = HistogramAggregator.hist_from_container(
-        histo_cont, axis_names=["value", "channel", "pixel"]
+    chunks = aggregator(hist_table, masked_elements_of_sample=None)
+    hist_object = HistogramAggregator.hist_from_tablerow(
+        chunks[0], axis_names=["value", "channel", "pixel"]
     )
 
-    assert histo_cont.histogram.shape == (40, 2, 8)
-    assert histo_cont.meta["bin_edges"].shape == (41,)
-    assert histo_cont.n_events.shape == (2, 8)
-    np.testing.assert_array_equal(histo_cont.n_events, np.full((2, 8), 200))
-    assert histo.values().shape == (40, 2, 8)
+    assert chunks[0]["histogram"].shape == (40, 2, 8)
+    assert chunks[0].meta["bin_edges"].shape == (41,)
+    assert chunks[0]["n_events"].shape == (2, 8)
+    np.testing.assert_array_equal(chunks[0]["n_events"], np.full((2, 8), 200))
+    assert hist_object.values().shape == (40, 2, 8)
 
     # Configured Regular axis is [0, 200] with 40 bins.
-    np.testing.assert_allclose(histo_chunk.meta["bin_edges"], np.linspace(0, 200, 41))
+    np.testing.assert_allclose(chunks[0].meta["bin_edges"], np.linspace(0, 200, 41))
 
     # With a wide range all events should be counted for each pixel.
-    np.testing.assert_array_equal(histo.values().sum(axis=0), np.full((2, 8), 200))
+    np.testing.assert_array_equal(
+        hist_object.values().sum(axis=0), np.full((2, 8), 200)
+    )
 
     # Recover channel means from the histogram and check the introduced low-gain shift.
-    bin_centers = histo_chunk.meta["bin_centers"]
+    bin_centers = chunks[0].meta["bin_centers"]
     weighted_sum = np.sum(
-        histo.values() * bin_centers[:, np.newaxis, np.newaxis], axis=0
+        hist_object.values() * bin_centers[:, np.newaxis, np.newaxis], axis=0
     )
-    counts = np.sum(histo.values(), axis=0)
+    counts = np.sum(hist_object.values(), axis=0)
     weighted_mean = weighted_sum / counts
     channel_mean = weighted_mean.mean(axis=1)
     np.testing.assert_allclose(
@@ -207,13 +202,12 @@ def test_histograms_aggregator_masks_and_nan_handling():
             }
         }
     )
+    # Aggregate the histogram with the mask and NaN in the data
     aggregator = HistogramAggregator(config=config)
     chunks = aggregator(hist_table, masked_elements_of_sample=mask)
-    cont = ChunkHistogramContainer(**dict(zip(chunks[0].colnames, chunks[0])))
-    cont.meta = chunks.meta
-
-    hist_object = HistogramAggregator.hist_from_container(
-        cont, axis_names=["value", "channel", "pixel"]
+    # Reconstruct a Hist object from the first chunk using hist_from_tablerow()
+    hist_object = HistogramAggregator.hist_from_tablerow(
+        chunks[0], axis_names=["value", "channel", "pixel"]
     )
 
     # Fully masked pixel should receive no entries.
@@ -276,7 +270,7 @@ def test_histograms_aggregator_underflow_overflow(underflow, overflow):
     assert axis_kwargs["overflow"] is overflow
     assert axis_kwargs["name"] == "value"
 
-    # Reconstruct a Hist from the container and verify the stored counts.
+    # Reconstruct a Hist from the container using hist_from_container()
     cont = ChunkHistogramContainer(**dict(zip(chunks[0].colnames, chunks[0])))
     cont.meta = chunks.meta
     hist_object = HistogramAggregator.hist_from_container(
@@ -417,10 +411,8 @@ def test_histograms_aggregator_axis_classes(
     config = Config({"HistogramAggregator": {"axis_definition": axis_definition}})
     aggregator = HistogramAggregator(config=config)
     chunks = aggregator(hist_table, masked_elements_of_sample=None)
-    cont = ChunkHistogramContainer(**dict(zip(chunks[0].colnames, chunks[0])))
-    cont.meta = chunks.meta
-    hist_object = HistogramAggregator.hist_from_container(
-        cont, axis_names=["value", "channel", "pixel"]
+    hist_object = HistogramAggregator.hist_from_tablerow(
+        chunks[0], axis_names=["value", "channel", "pixel"]
     )
 
     assert chunks[0]["histogram"].shape == expected_counts.shape


### PR DESCRIPTION
Added thin wrapper for reconstruct Hist object from table rows produced by the `HistogramAggregator`. I found it super convenient to have such a wrapper. In case you disagree, please close the PR. Otherwise, please review and merge into `histo_agg` branch. Thanks in advance!