### PR TITLE
AstroQuantity.physical_type from default_value

### DIFF
--- a/docs/changes/3012.feature.rst
+++ b/docs/changes/3012.feature.rst
@@ -1,0 +1,2 @@
+If an ``AstroQuantity`` is defined without a ``physical_type`` but including the ``default_value``,
+the ``physical_type`` is extracted from the ``default_value``.

--- a/src/ctapipe/core/tests/test_traits.py
+++ b/src/ctapipe/core/tests/test_traits.py
@@ -332,6 +332,17 @@ def test_quantity():
     ):
         c.energy = 5 * u.m
 
+    class SomeComponentWithEnergyDefaultValueAndNonePhysicalType(Component):
+        energy = AstroQuantity(default_value=5 * u.TeV, physical_type=None)
+
+    c = SomeComponentWithEnergyDefaultValueAndNonePhysicalType()
+    with pytest.raises(
+        TraitError,
+        match=f"Given quantity is of physical type {u.get_physical_type(5 * u.m)}."
+        + f" Expected {u.physical.energy}.",
+    ):
+        c.energy = 5 * u.m
+
     # Give a u.quantity as physical type
     with pytest.raises(
         TraitError,

--- a/src/ctapipe/core/tests/test_traits.py
+++ b/src/ctapipe/core/tests/test_traits.py
@@ -320,6 +320,19 @@ def test_quantity():
 
     c = AnotherComponentWithEnergyTrait()
 
+    # Definition of physical type via default value
+    class SomeComponentWithEnergyDefaultValue(Component):
+        energy = AstroQuantity(default_value=5 * u.TeV)
+
+    c = SomeComponentWithEnergyDefaultValue()
+    with pytest.raises(
+        TraitError,
+        match=f"Given quantity is of physical type {u.get_physical_type(5 * u.m)}."
+        + f" Expected {u.physical.energy}.",
+    ):
+        c.energy = 5 * u.m
+
+    # Give a u.quantity as physical type
     with pytest.raises(
         TraitError,
         match="Given physical type must be either of type"
@@ -330,10 +343,11 @@ def test_quantity():
         class SomeBadComponentWithEnergyTrait(Component):
             energy = AstroQuantity(physical_type=5 * u.TeV)
 
+    # Default value and physical type do not match
     with pytest.raises(
         TraitError,
         match=f"Given physical type {u.physical.energy} does not match"
-        + f" physical type of the default value, {u.get_physical_type(5 * u.m)}.",
+        + f" the default value's physical type {u.get_physical_type(5 * u.m)}.",
     ):
 
         class AnotherBadComponentWithEnergyTrait(Component):

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -98,26 +98,33 @@ class AstroQuantity(TraitType):
     def __init__(self, physical_type=None, **kwargs):
         super().__init__(**kwargs)
         if physical_type is not None:
-            if isinstance(physical_type, u.PhysicalType):
-                self.physical_type = physical_type
-            elif isinstance(physical_type, u.UnitBase):
-                self.physical_type = u.get_physical_type(physical_type)
-            else:
-                raise TraitError(
-                    "Given physical type must be either of type"
-                    " astropy.units.PhysicalType or a subclass of"
-                    f" astropy.units.UnitBase, was {type(physical_type)}."
-                )
-        else:
+            self.physical_type = None
+        elif isinstance(physical_type, u.PhysicalType):
             self.physical_type = physical_type
+        elif isinstance(physical_type, u.UnitBase):
+            self.physical_type = u.get_physical_type(physical_type)
+        else:
+            raise TraitError(
+                "Given physical type must be either of type"
+                " astropy.units.PhysicalType or a subclass of"
+                f" astropy.units.UnitBase, was {type(physical_type)}."
+            )
 
-        if self.default_value is not Undefined and self.physical_type is not None:
+        if self.default_value is not Undefined and self.default_value is not None:
+            self._validate_default_value()
+
+    def _validate_default_value(self):
+        if self.physical_type is not None:
             default_type = u.get_physical_type(self.default_value)
             if default_type != self.physical_type:
                 raise TraitError(
                     f"Given physical type {self.physical_type} does not match"
-                    f" physical type of the default value, {default_type}."
+                    f" the default value's physical type {default_type}."
                 )
+        else:
+            if not isinstance(self.default_value, u.Quantity):
+                self.default_value = u.Quantity(self.default_value)
+            self.physical_type = u.get_physical_type(self.default_value)
 
     @property
     def info_text(self):

--- a/src/ctapipe/core/traits.py
+++ b/src/ctapipe/core/traits.py
@@ -97,7 +97,7 @@ class AstroQuantity(TraitType):
 
     def __init__(self, physical_type=None, **kwargs):
         super().__init__(**kwargs)
-        if physical_type is not None:
+        if physical_type is None:
             self.physical_type = None
         elif isinstance(physical_type, u.PhysicalType):
             self.physical_type = physical_type


### PR DESCRIPTION
If an ``AstroQuantity`` is defined without a ``physical_type`` but including the ``default_value``, the ``physical_type`` is now extracted from the ``default_value``.

Also the code complexity of ``__init__`` is reduced.