### PR TITLE
Do not use events outside fov bins for cut optimization

### DIFF
--- a/docs/changes/3013.bugfix.rst
+++ b/docs/changes/3013.bugfix.rst
@@ -1,4 +1,3 @@
-Since we do not use fov bins in the cut optimization yet, events outside the fov bins used for the irfs
-were used in the cut optimization, which results in cuts which do not actually maximize the sensitivity
-for the relevant fov.
-This fixes that issue until we implement fov bins for the cut optimization.
+Fix a bug in the event weighting that resulted in events outside of the selected FoV range for the sensitivity
+computation being used in the cut optimization leading to results where the selected cuts did not necessarily provide
+the best sensitivity in the selected FoV range.

--- a/docs/changes/3013.bugfix.rst
+++ b/docs/changes/3013.bugfix.rst
@@ -1,0 +1,4 @@
+Since we do not use fov bins in the cut optimization yet, events outside the fov bins used for the irfs
+were used in the cut optimization, which results in cuts which do not actually maximize the sensitivity
+for the relevant fov.
+This fixes that issue until we implement fov bins for the cut optimization.

--- a/src/ctapipe/io/dl2_tables_preprocessing.py
+++ b/src/ctapipe/io/dl2_tables_preprocessing.py
@@ -469,6 +469,11 @@ class DL2EventLoader(Component):
         ValueError
             If ``fov_offset_bins`` is required but not provided.
         """
+        # Re-initialize weights = 0 to exclude events outside fov bins
+        # in the cut optimization.
+        # This will become unnecessary once fov bins are used during cut optimization.
+        events["weight"] = 0.0
+
         if (
             kind == "gammas"
             and self.target_spectrum.normalization.unit.is_equivalent(


### PR DESCRIPTION
Since we do not use fov bins in the cut optimization yet, events outside the fov bins used for the irfs
were used in the cut optimization, which results in cuts which do not actually maximize the sensitivity
for the relevant fov.
This fixes that issue until we implement fov bins for the cut optimization.

This was found in #2789 