### PR TITLE
Make function to compute true disp public in ctapipe.reco

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     - id: end-of-file-fixer
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     - id: codespell
       additional_dependencies:
@@ -19,7 +19,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.6
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/docs/api-reference/reco/index.rst
+++ b/docs/api-reference/reco/index.rst
@@ -74,3 +74,6 @@ Reference/API
 
 .. automodapi:: ctapipe.reco.impact
     :no-inheritance-diagram:
+
+.. automodapi:: ctapipe.reco.disp
+    :no-inheritance-diagram:

--- a/docs/changes/3014.feature.rst
+++ b/docs/changes/3014.feature.rst
@@ -1,0 +1,2 @@
+Add new function ``ctapipe.reco.disp.compute_true_disp`` to compute
+the true disp parameter from a table of DL1 events.

--- a/docs/changes/3014.feature.rst
+++ b/docs/changes/3014.feature.rst
@@ -1,2 +1,6 @@
 Add new function ``ctapipe.reco.disp.compute_true_disp`` to compute
 the true disp parameter from a table of DL1 events.
+
+As part of this change, the disp training now prefers the newer columns
+for individual telescope pointing instead of using only the subarray
+pointing information.

--- a/src/ctapipe/reco/disp.py
+++ b/src/ctapipe/reco/disp.py
@@ -2,17 +2,40 @@
 Common functions related to the disp reconstruction.
 """
 
+import warnings
 from typing import Annotated
 
 import astropy.units as u
 import numpy as np
 from astropy.table import Table
 
+from ..containers import CoordinateFrameType
 from .preprocessing import horizontal_to_telescope
 
 __all__ = [
     "compute_true_disp",
 ]
+
+
+def _get_tel_pointing(table):
+    prefix = "telescope_pointing_"
+    tel_alt = f"{prefix}_altitude"
+    tel_az = f"{prefix}_azimuth"
+
+    if {tel_alt, tel_az}.issubset(table.colnames):
+        return table[tel_alt].quantity, table[tel_az].quantity
+
+    prefix = "subarray_pointing"
+    if not np.all(table[f"{prefix}_frame"] == CoordinateFrameType.ALTAZ.value):
+        raise ValueError(
+            "Subarray pointing information for disp computation"
+            " has to be provided in horizontal coordinates"
+        )
+
+    warnings.warn(
+        "Input table does not contain telescope pointings, falling back to array pointing"
+    )
+    return table[f"{prefix}_lat"].quantity, table[f"{prefix}_lon"].quantity
 
 
 def compute_true_disp(
@@ -36,11 +59,13 @@ def compute_true_disp(
     disp:
         Disp as a signed quantity
     """
+    pointing_alt, pointing_az = _get_tel_pointing(table)
+
     fov_lon, fov_lat = horizontal_to_telescope(
         alt=table["true_alt"],
         az=table["true_az"],
-        pointing_alt=table["subarray_pointing_lat"],
-        pointing_az=table["subarray_pointing_lon"],
+        pointing_alt=pointing_alt,
+        pointing_az=pointing_az,
     )
 
     # numpy's trigonometric functions need radians

--- a/src/ctapipe/reco/disp.py
+++ b/src/ctapipe/reco/disp.py
@@ -17,7 +17,26 @@ __all__ = [
 ]
 
 
-def _get_tel_pointing(table):
+def get_tel_pointing(table):
+    """
+    Get telescope pointing from telescope events table.
+
+    Prefers columns telescope_pointing_{altitude,azimuth} but will fallback
+    to subarray_pointing_{lat,lon,frame} for backwards compatibility with older
+    datasets.
+
+    Parameters
+    ----------
+    table : Table
+        table of telescope events.
+
+    Returns
+    -------
+    alt : u.Quantity[angle]
+        pointing altitude
+    az : u.Quantity[angle]
+        pointing azimuth
+    """
     prefix = "telescope_pointing"
     tel_alt = f"{prefix}_altitude"
     tel_az = f"{prefix}_azimuth"
@@ -59,7 +78,7 @@ def compute_true_disp(
     disp:
         Disp as a signed quantity
     """
-    pointing_alt, pointing_az = _get_tel_pointing(table)
+    pointing_alt, pointing_az = get_tel_pointing(table)
 
     fov_lon, fov_lat = horizontal_to_telescope(
         alt=table["true_alt"],

--- a/src/ctapipe/reco/disp.py
+++ b/src/ctapipe/reco/disp.py
@@ -1,0 +1,62 @@
+"""
+Common functions related to the disp reconstruction.
+"""
+
+from typing import Annotated
+
+import astropy.units as u
+import numpy as np
+from astropy.table import Table
+
+from .preprocessing import horizontal_to_telescope
+
+__all__ = [
+    "compute_true_disp",
+]
+
+
+def compute_true_disp(
+    table: Table, project_disp: bool = True
+) -> Annotated[u.Quantity, "angle"]:
+    """
+    Compute true disp parameter from a table of DL1 events.
+
+    Parameters
+    ----------
+    table:
+        DL1 telescope events table as created by `ctapipe.io.TableLoader.read_telescope_events`.
+    project_disp:
+        If true, the true source position of the gamma-ray is projected onto the reconstructed
+        shower axis for computing the disp norm.
+        Otherwise, the euclidean distance from the center of gravity to the true source position
+        is used.
+
+    Returns
+    -------
+    disp:
+        Disp as a signed quantity
+    """
+    fov_lon, fov_lat = horizontal_to_telescope(
+        alt=table["true_alt"],
+        az=table["true_az"],
+        pointing_alt=table["subarray_pointing_lat"],
+        pointing_az=table["subarray_pointing_lon"],
+    )
+
+    # numpy's trigonometric functions need radians
+    psi = table["hillas_psi"].quantity.to_value(u.rad)
+    cog_lon = table["hillas_fov_lon"].quantity
+    cog_lat = table["hillas_fov_lat"].quantity
+
+    delta_lon = fov_lon - cog_lon
+    delta_lat = fov_lat - cog_lat
+
+    true_disp = np.cos(psi) * delta_lon + np.sin(psi) * delta_lat
+    true_sign = np.sign(true_disp)
+
+    if project_disp:
+        true_norm = np.abs(true_disp)
+    else:
+        true_norm = np.sqrt((fov_lon - cog_lon) ** 2 + (fov_lat - cog_lat) ** 2)
+
+    return true_norm * true_sign

--- a/src/ctapipe/reco/disp.py
+++ b/src/ctapipe/reco/disp.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def _get_tel_pointing(table):
-    prefix = "telescope_pointing_"
+    prefix = "telescope_pointing"
     tel_alt = f"{prefix}_altitude"
     tel_az = f"{prefix}_azimuth"
 

--- a/src/ctapipe/reco/sklearn.py
+++ b/src/ctapipe/reco/sklearn.py
@@ -20,11 +20,8 @@ from tables import open_file
 from tqdm import tqdm
 from traitlets import TraitError, observe
 
-from ctapipe.exceptions import TooFewEvents
-
 from ..containers import (
     ArrayEventContainer,
-    CoordinateFrameType,
     DispContainer,
     ParticleClassificationContainer,
     ReconstructedEnergyContainer,
@@ -39,7 +36,9 @@ from ..core import (
     ToolConfigurationError,
     traits,
 )
+from ..exceptions import TooFewEvents
 from ..io import write_table
+from .disp import get_tel_pointing
 from .preprocessing import collect_features, table_to_X, telescope_to_horizontal
 from .reconstructor import ReconstructionProperty, Reconstructor
 from .stereo_combination import StereoCombiner
@@ -834,7 +833,7 @@ class DispReconstructor(Reconstructor):
         fov_lon = table["hillas_fov_lon"].quantity + disp * np.cos(psi)
         fov_lat = table["hillas_fov_lat"].quantity + disp * np.sin(psi)
 
-        pointing_alt, pointing_az = self._get_pointing(table)
+        pointing_alt, pointing_az = get_tel_pointing(table)
         alt, az = telescope_to_horizontal(
             lon=fov_lon,
             lat=fov_lat,
@@ -870,31 +869,6 @@ class DispReconstructor(Reconstructor):
             for disp, sign in self._models.values():
                 disp.n_jobs = n_jobs.new
                 sign.n_jobs = n_jobs.new
-
-    def _get_pointing(self, table):
-        # prefer to use pointing interpolated to event
-        if "telescope_pointing_altitude" in table.colnames:
-            return (
-                table["telescope_pointing_altitude"].quantity,
-                table["telescope_pointing_azimuth"].quantity,
-            )
-
-        # fallback to fixed pointing of ob
-        if len(np.unique(table["subarray_pointing_frame"])) > 1:
-            msg = "Subarray pointing frame must be the same for all events"
-            raise NotImplementedError(msg)
-
-        # for now only allow fixed altaz, real data should have telescope monitoring
-        # pointing and simulations have fixed pointing in alt az
-        frame_type = CoordinateFrameType(table["subarray_pointing_frame"][0])
-        if frame_type is CoordinateFrameType.ALTAZ:
-            return (
-                table["subarray_pointing_lat"].quantity,
-                table["subarray_pointing_lon"].quantity,
-            )
-
-        msg = f"Only AltAz frame supported for fixed subarray pointing, got {frame_type.name}"
-        raise NotImplementedError(msg)
 
 
 class CrossValidator(Component):

--- a/src/ctapipe/reco/tests/test_disp.py
+++ b/src/ctapipe/reco/tests/test_disp.py
@@ -1,0 +1,61 @@
+from contextlib import ExitStack
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from ctapipe.containers import CoordinateFrameType
+from ctapipe.reco.disp import compute_true_disp
+from ctapipe.reco.preprocessing import telescope_to_horizontal
+
+
+def make_disp_table(subarray_pointing):
+    pointing_alt = np.full(3, 70) * u.deg
+    pointing_az = np.full(3, 20) * u.deg
+    fov_lon = np.array([1, 0, -1]) * u.deg
+    fov_lat = np.array([0, 2, 0]) * u.deg
+    true_alt, true_az = telescope_to_horizontal(
+        lon=fov_lon,
+        lat=fov_lat,
+        pointing_alt=pointing_alt,
+        pointing_az=pointing_az,
+    )
+
+    table = Table(
+        {
+            "obs_id": [1, 1, 1],
+            "event_id": [1, 2, 3],
+            "tel_id": [1, 1, 1],
+            "true_alt": true_alt,
+            "true_az": true_az,
+            "hillas_psi": [0, 90, 0] * u.deg,
+            "hillas_fov_lon": [0.25, -1.0, 0.5] * u.deg,
+            "hillas_fov_lat": [-0.5, 0.5, 1.0] * u.deg,
+        }
+    )
+
+    if subarray_pointing:
+        table["subarray_pointing_frame"] = np.int8(CoordinateFrameType.ALTAZ.value)
+        table["subarray_pointing_lat"] = pointing_alt
+        table["subarray_pointing_lon"] = pointing_az
+    else:
+        table["telescope_pointing_altitude"] = pointing_alt
+        table["telescope_pointing_azimuth"] = pointing_az
+
+    return table
+
+
+@pytest.mark.parametrize("subarray_pointing", [False, True])
+def test_compute_true_disp(subarray_pointing):
+    table = make_disp_table(subarray_pointing=subarray_pointing)
+
+    with ExitStack() as stack:
+        # we expect a warning, but only in the subarray_pointing case
+        if subarray_pointing:
+            msg = "falling back to array pointing"
+            stack.enter_context(pytest.warns(UserWarning, match=msg))
+
+        disp = compute_true_disp(table)
+
+    np.testing.assert_allclose(disp.to_value(u.deg), [0.75, 1.5, -1.5])

--- a/src/ctapipe/reco/tests/test_sklearn.py
+++ b/src/ctapipe/reco/tests/test_sklearn.py
@@ -310,5 +310,5 @@ def test_disp_fixed_icrs_pointing(disp_reconstructor_path):
     disp_reconstructor_path, _ = disp_reconstructor_path
     disp_model = DispReconstructor.read(disp_reconstructor_path)
 
-    with pytest.raises(NotImplementedError, match="Only AltAz frame supported"):
+    with pytest.raises(ValueError, match="horizontal coordinates"):
         disp_model.predict_table(disp_model.subarray.tel[1], events)

--- a/src/ctapipe/tools/train_disp_reconstructor.py
+++ b/src/ctapipe/tools/train_disp_reconstructor.py
@@ -2,7 +2,6 @@
 Tool for training the DispReconstructor
 """
 
-import astropy.units as u
 import numpy as np
 
 from ctapipe.core import Tool
@@ -10,7 +9,7 @@ from ctapipe.core.traits import Bool, Int, IntTelescopeParameter, Path
 from ctapipe.exceptions import InputMissing
 from ctapipe.io import TableLoader
 from ctapipe.reco import CrossValidator, DispReconstructor
-from ctapipe.reco.preprocessing import horizontal_to_telescope
+from ctapipe.reco.disp import compute_true_disp
 
 from .utils import read_training_events
 
@@ -150,7 +149,7 @@ class TrainDispReconstructor(Tool):
                 log=self.log,
                 n_events=self.n_events.tel[tel_type],
             )
-            table[self.models.target] = self._get_true_disp(table)
+            table[self.models.target] = compute_true_disp(table, self.project_disp)
             table = table[
                 self.models.features
                 + [self.models.target, "true_energy", "true_impact_distance"]
@@ -162,32 +161,6 @@ class TrainDispReconstructor(Tool):
             self.log.info("Performing final fit for %s", tel_type)
             self.models.fit(tel_type, table)
             self.log.info("done")
-
-    def _get_true_disp(self, table):
-        fov_lon, fov_lat = horizontal_to_telescope(
-            alt=table["true_alt"],
-            az=table["true_az"],
-            pointing_alt=table["subarray_pointing_lat"],
-            pointing_az=table["subarray_pointing_lon"],
-        )
-
-        # numpy's trigonometric functions need radians
-        psi = table["hillas_psi"].quantity.to_value(u.rad)
-        cog_lon = table["hillas_fov_lon"].quantity
-        cog_lat = table["hillas_fov_lat"].quantity
-
-        delta_lon = fov_lon - cog_lon
-        delta_lat = fov_lat - cog_lat
-
-        true_disp = np.cos(psi) * delta_lon + np.sin(psi) * delta_lat
-        true_sign = np.sign(true_disp)
-
-        if self.project_disp:
-            true_norm = np.abs(true_disp)
-        else:
-            true_norm = np.sqrt((fov_lon - cog_lon) ** 2 + (fov_lat - cog_lat) ** 2)
-
-        return true_norm * true_sign
 
     def finish(self):
         """

--- a/src/ctapipe/tools/train_disp_reconstructor.py
+++ b/src/ctapipe/tools/train_disp_reconstructor.py
@@ -126,25 +126,32 @@ class TrainDispReconstructor(Tool):
         self.log.info("Inputfile: %s", self.loader.input_url)
 
         self.log.info("Training models for %d types", len(types))
+        feature_names = self.models.features + [
+            "true_energy",
+            "true_impact_distance",
+            "true_alt",
+            "true_az",
+            "hillas_fov_lat",
+            "hillas_fov_lon",
+            "hillas_psi",
+        ]
+        optional_columns = [
+            "telescope_pointing_altitude",
+            "telescope_pointing_azimuth",
+            "subarray_pointing_frame",
+            "subarray_pointing_lat",
+            "subarray_pointing_lon",
+        ]
+
         for tel_type in types:
             self.log.info("Loading events for %s", tel_type)
-            feature_names = self.models.features + [
-                "true_energy",
-                "true_impact_distance",
-                "subarray_pointing_lat",
-                "subarray_pointing_lon",
-                "true_alt",
-                "true_az",
-                "hillas_fov_lat",
-                "hillas_fov_lon",
-                "hillas_psi",
-            ]
             table = read_training_events(
                 loader=self.loader,
                 chunk_size=self.chunk_size,
                 telescope_type=tel_type,
                 reconstructor=self.models,
                 feature_names=feature_names,
+                optional_columns=optional_columns,
                 rng=self.rng,
                 log=self.log,
                 n_events=self.n_events.tel[tel_type],

--- a/src/ctapipe/tools/utils.py
+++ b/src/ctapipe/tools/utils.py
@@ -81,6 +81,12 @@ def get_all_descriptions():
     return descriptions
 
 
+def _add_optional_columns(table, columns, optional_columns):
+    for column in optional_columns:
+        if column in table.colnames and column not in columns:
+            columns.append(column)
+
+
 def read_training_events(
     loader: TableLoader,
     chunk_size: Int,
@@ -112,10 +118,7 @@ def read_training_events(
         n_events_in_file += len(table_chunk)
 
         if len(table) == 0 and optional_columns is not None:
-            # add present optional columns
-            for column in optional_columns:
-                if column in table_chunk.colnames:
-                    columns.append(column)
+            _add_optional_columns(table_chunk, columns, optional_columns)
 
         mask = reconstructor.quality_query.get_table_mask(table_chunk)
         table_chunk = table_chunk[mask]

--- a/src/ctapipe/tools/utils.py
+++ b/src/ctapipe/tools/utils.py
@@ -12,13 +12,12 @@ from pathlib import Path
 import numpy as np
 from astropy.table import vstack
 
-from ..containers import CoordinateFrameType
 from ..core.traits import Int
 from ..exceptions import TooFewEvents
 from ..instrument import TelescopeDescription
 from ..io import TableLoader
 from ..reco.preprocessing import check_valid_rows
-from ..reco.sklearn import DispReconstructor, SKLearnReconstructor
+from ..reco.sklearn import SKLearnReconstructor
 
 LOG = logging.getLogger(__name__)
 
@@ -87,10 +86,11 @@ def read_training_events(
     chunk_size: Int,
     telescope_type: TelescopeDescription,
     reconstructor: type[SKLearnReconstructor],
-    feature_names: list,
+    feature_names: list[str],
     rng: np.random.Generator,
     log=LOG,
     n_events=None,
+    optional_columns: list[str] | None = None,
 ):
     """Chunked loading of events for training ML models"""
     chunk_iterator = loader.read_telescope_events_chunked(
@@ -99,25 +99,23 @@ def read_training_events(
         true_parameters=False,
         instrument=True,
         observation_info=True,
+        pointing=True,
     )
     table = []
     n_events_in_file = 0
     n_valid_events_in_file = 0
     n_non_predictable = 0
+    columns = feature_names.copy()
 
     for chunk, (_, _, table_chunk) in enumerate(chunk_iterator):
         log.debug("Events read from chunk %d: %d", chunk, len(table_chunk))
         n_events_in_file += len(table_chunk)
 
-        if isinstance(reconstructor, DispReconstructor):
-            if not np.all(
-                table_chunk["subarray_pointing_frame"]
-                == CoordinateFrameType.ALTAZ.value
-            ):
-                raise ValueError(
-                    "Pointing information for training data"
-                    " has to be provided in horizontal coordinates"
-                )
+        if len(table) == 0 and optional_columns is not None:
+            # add present optional columns
+            for column in optional_columns:
+                if column in table_chunk.colnames:
+                    columns.append(column)
 
         mask = reconstructor.quality_query.get_table_mask(table_chunk)
         table_chunk = table_chunk[mask]
@@ -131,7 +129,7 @@ def read_training_events(
         table_chunk = reconstructor.feature_generator(
             table_chunk, subarray=loader.subarray
         )
-        table_chunk = table_chunk[feature_names]
+        table_chunk = table_chunk[columns]
 
         valid = check_valid_rows(table_chunk)
         if not np.all(valid):


### PR DESCRIPTION
```python
from ctapipe.io import TableLoader
from ctapipe.reco.disp import compute_true_disp

with TableLoader(path) as loader:
    tel_events = loader.read_telescope_events(telescopes=[1], observation_info=True)

tel_events["true_disp"] = compute_true_disp(tel_events)
```

Some plots:

<img width="1920" height="1440" alt="true_disp_vs_impact" src="https://github.com/user-attachments/assets/d1ff16d4-fae9-479a-9245-8987efe7ee17" />
<img width="1920" height="1440" alt="true_disp_vs_energy" src="https://github.com/user-attachments/assets/e43b40e1-caf6-4c5a-be6d-53ea76421825" />
