### PR TITLE
Fix service data file structure and symlinks

### DIFF
--- a/src/ctapipe/instrument/conftest.py
+++ b/src/ctapipe/instrument/conftest.py
@@ -157,8 +157,8 @@ def svc_path(tmp_path, instrument_dir, monkeypatch):
     - array-element-ids.json: telescope ID to name mapping (fixed schema)
     - subarray-ids.json: subarray definitions
     - positions/: ECSV files with telescope positions for each site
-    - array-elements/{ae_id:03d}/: symlinks to telescope-type directories
-    - array-elements/{type}/: telescope type directories with optics, camera geometry, and readout files
+    - array-elements/{type}/: shared telescope-type directories with optics, camera geometry, and readout files
+    - array-elements/{ae_id:03d}/: real directories, each containing per-file symlinks to the shared type files
 
     The schemas follow:
     https://gitlab.cta-observatory.org/cta-computing/common/identifiers
@@ -273,26 +273,26 @@ def svc_path(tmp_path, instrument_dir, monkeypatch):
         overwrite=True,
     )
 
-    # Create symlinks from ae_id to telescope type directories
-    # LSTN-01, 02, 03, 04 -> LSTN
+    # Create real ae_id directories with per-file symlinks to shared type files
     for ae_id in [1, 2, 3, 4]:
-        symlink_path = array_elements_dir / f"{ae_id:03d}"
-        symlink_path.symlink_to("LSTN")
+        ae_id_str = f"{ae_id:03d}"
+        ae_dir = array_elements_dir / ae_id_str
+        ae_dir.mkdir()
+        for suffix in ["optics.ecsv", "camgeom.fits.gz", "camreadout.fits.gz"]:
+            (ae_dir / f"{ae_id_str}.{suffix}").symlink_to(f"../LSTN/LSTN.{suffix}")
 
-    # MSTN-01, 02 -> MSTN
     for ae_id in [5, 6]:
-        symlink_path = array_elements_dir / f"{ae_id:03d}"
-        symlink_path.symlink_to("MSTN")
+        ae_id_str = f"{ae_id:03d}"
+        ae_dir = array_elements_dir / ae_id_str
+        ae_dir.mkdir()
+        for suffix in ["optics.ecsv", "camgeom.fits.gz", "camreadout.fits.gz"]:
+            (ae_dir / f"{ae_id_str}.{suffix}").symlink_to(f"../MSTN/MSTN.{suffix}")
 
-    # Set CTAPIPE_SVC_PATH to include tmp_path, positions directory,
-    # telescope type directories, and instrument_dir (for legacy from_name methods)
-    # This allows get_table_dataset to find files named LSTN.optics.ecsv, etc.
-    # and also the legacy optics.fits.gz and camera files
+    # CTAPIPE_SVC_PATH: include each ae_id directory so {ae_id}.* files are found
     search_paths = [
         str(tmp_path),
         str(positions_dir),
-        str(lst_dir),
-        str(mst_nectarcam_dir),
+        *[str(array_elements_dir / f"{ae_id:03d}") for ae_id in range(1, 7)],
         str(instrument_dir),
     ]
     monkeypatch.setenv("CTAPIPE_SVC_PATH", os.pathsep.join(search_paths))
@@ -356,41 +356,13 @@ def svc_path_aeid_specific(tmp_path, instrument_dir, monkeypatch):
     array_elements_dir = tmp_path / "instrument" / "array-elements"
     array_elements_dir.mkdir(parents=True)
 
-    # Create LSTN telescope type directory (for symlink resolution)
+    lst_geom_path = get_dataset_path("LSTcam.camgeom.fits.gz")
+    lst_readout_path = get_dataset_path("LSTcam.camreadout.fits.gz")
+
+    # Create shared LSTN telescope type directory with shared files
     lst_dir = array_elements_dir / "LSTN"
     lst_dir.mkdir()
 
-    # For telescope 001: create ae_id-specific files with custom optics
-    ae_001_dir = array_elements_dir / "001"
-    ae_001_dir.symlink_to("LSTN")
-
-    # Create 001.optics with slightly different parameters (empty table with metadata)
-    optics_001 = QTable()
-    optics_001.meta["TAB_VER"] = "4.0"
-    optics_001.meta["optics_name"] = "LSTN-01-Custom"
-    optics_001.meta["size_type"] = SizeType.LST.value
-    optics_001.meta["reflector_shape"] = ReflectorShape.PARABOLIC.value
-    optics_001.meta["n_mirrors"] = 1
-    optics_001.meta["equivalent_focal_length"] = str(28.0 * u.m)
-    optics_001.meta["effective_focal_length"] = str(
-        28.5 * u.m
-    )  # Different from default
-    optics_001.meta["mirror_area"] = str(390.0 * u.m**2)  # Different from default
-    optics_001.meta["n_mirror_tiles"] = 198
-    ascii.write(optics_001, lst_dir / "001.optics.ecsv", format="ecsv", overwrite=True)
-
-    # Copy camera files with 001 prefix
-    lst_geom_path = get_dataset_path("LSTcam.camgeom.fits.gz")
-    shutil.copy(lst_geom_path, lst_dir / "001.camgeom.fits.gz")
-
-    lst_readout_path = get_dataset_path("LSTcam.camreadout.fits.gz")
-    shutil.copy(lst_readout_path, lst_dir / "001.camreadout.fits.gz")
-
-    # For telescope 002: create symlink but use shared telescope-type files as fallback
-    ae_002_dir = array_elements_dir / "002"
-    ae_002_dir.symlink_to("LSTN")
-
-    # Create shared LSTN files (002 will fall back to these, empty table with metadata)
     lst_optics = QTable()
     lst_optics.meta["TAB_VER"] = "4.0"
     lst_optics.meta["optics_name"] = "LSTN"
@@ -406,11 +378,47 @@ def svc_path_aeid_specific(tmp_path, instrument_dir, monkeypatch):
     shutil.copy(lst_geom_path, lst_dir / "LSTN.camgeom.fits.gz")
     shutil.copy(lst_readout_path, lst_dir / "LSTN.camreadout.fits.gz")
 
-    # Set CTAPIPE_SVC_PATH
+    # Telescope 001: real directory, custom optics file, camera files symlink to LSTN
+    ae_001_dir = array_elements_dir / "001"
+    ae_001_dir.mkdir()
+
+    optics_001 = QTable()
+    optics_001.meta["TAB_VER"] = "4.0"
+    optics_001.meta["optics_name"] = "LSTN-01-Custom"
+    optics_001.meta["size_type"] = SizeType.LST.value
+    optics_001.meta["reflector_shape"] = ReflectorShape.PARABOLIC.value
+    optics_001.meta["n_mirrors"] = 1
+    optics_001.meta["equivalent_focal_length"] = str(28.0 * u.m)
+    optics_001.meta["effective_focal_length"] = str(
+        28.5 * u.m
+    )  # Different from default
+    optics_001.meta["mirror_area"] = str(390.0 * u.m**2)  # Different from default
+    optics_001.meta["n_mirror_tiles"] = 198
+    ascii.write(
+        optics_001, ae_001_dir / "001.optics.ecsv", format="ecsv", overwrite=True
+    )
+
+    (ae_001_dir / "001.camgeom.fits.gz").symlink_to("../LSTN/LSTN.camgeom.fits.gz")
+    (ae_001_dir / "001.camreadout.fits.gz").symlink_to(
+        "../LSTN/LSTN.camreadout.fits.gz"
+    )
+
+    # Telescope 002: real directory, all files are symlinks to shared LSTN files
+    ae_002_dir = array_elements_dir / "002"
+    ae_002_dir.mkdir()
+
+    (ae_002_dir / "002.optics.ecsv").symlink_to("../LSTN/LSTN.optics.ecsv")
+    (ae_002_dir / "002.camgeom.fits.gz").symlink_to("../LSTN/LSTN.camgeom.fits.gz")
+    (ae_002_dir / "002.camreadout.fits.gz").symlink_to(
+        "../LSTN/LSTN.camreadout.fits.gz"
+    )
+
+    # Set CTAPIPE_SVC_PATH: include each ae_id directory so files are found by flat search
     search_paths = [
         str(tmp_path),
         str(positions_dir),
-        str(lst_dir),
+        str(ae_001_dir),
+        str(ae_002_dir),
         str(instrument_dir),
     ]
     monkeypatch.setenv("CTAPIPE_SVC_PATH", os.pathsep.join(search_paths))

--- a/src/ctapipe/instrument/conftest.py
+++ b/src/ctapipe/instrument/conftest.py
@@ -214,7 +214,7 @@ def svc_path(tmp_path, instrument_dir, monkeypatch):
     )
 
     # Create array-elements directory with telescope-type subdirectories
-    array_elements_dir = tmp_path / "instrument" / "array-elements"
+    array_elements_dir = tmp_path / "array-elements"
     array_elements_dir.mkdir(parents=True)
 
     # Create LSTN telescope type directory and files
@@ -353,7 +353,7 @@ def svc_path_aeid_specific(tmp_path, instrument_dir, monkeypatch):
     )
 
     # Create array-elements directory
-    array_elements_dir = tmp_path / "instrument" / "array-elements"
+    array_elements_dir = tmp_path / "array-elements"
     array_elements_dir.mkdir(parents=True)
 
     lst_geom_path = get_dataset_path("LSTcam.camgeom.fits.gz")

--- a/src/ctapipe/instrument/subarray.py
+++ b/src/ctapipe/instrument/subarray.py
@@ -846,35 +846,6 @@ class SubarrayDescription:
         )
 
     @staticmethod
-    def _resolve_telescope_type(ae_id):
-        """Resolve telescope type by following symlink from ae_id directory.
-
-        Parameters
-        ----------
-        ae_id : int
-            Array element ID
-
-        Returns
-        -------
-        str
-            Telescope type name (e.g., 'LSTN', 'MSTN')
-        """
-        import os
-        from pathlib import Path
-
-        searchpath = os.getenv("CTAPIPE_SVC_PATH")
-        if not searchpath:
-            raise FileNotFoundError("CTAPIPE_SVC_PATH not set")
-
-        ae_id_str = f"{ae_id:03d}"
-        for search_dir in searchpath.split(os.pathsep):
-            candidate = Path(search_dir) / "instrument/array-elements" / ae_id_str
-            if candidate.exists():
-                return candidate.resolve().name
-
-        raise FileNotFoundError(f"instrument/array-elements/{ae_id_str} not found")
-
-    @staticmethod
     def _load_telescope_description(ae_id, tel_name, tel_type):
         """Load telescope description from service data files.
 
@@ -1093,7 +1064,8 @@ class SubarrayDescription:
         for ae_id in tel_positions.keys():
             tel_name = ae_id_to_name.get(ae_id, f"Unknown-{ae_id}")
             try:
-                tel_type = cls._resolve_telescope_type(ae_id)
+                # Derive telescope type from the array element name, e.g. "LSTN-01" -> "LSTN"
+                tel_type = tel_name.split("-")[0]
                 tel_descriptions[ae_id] = cls._load_telescope_description(
                     ae_id, tel_name, tel_type
                 )

--- a/src/ctapipe/instrument/subarray.py
+++ b/src/ctapipe/instrument/subarray.py
@@ -870,9 +870,13 @@ class SubarrayDescription:
         # Helper function to try ae_id file first, then fall back to tel_type
         def load_with_fallback(file_type, role):
             try:
-                return get_table_dataset(f"{ae_id_str}.{file_type}", role=role)
+                return get_table_dataset(
+                    f"array-elements/{ae_id_str}/{ae_id_str}.{file_type}", role=role
+                )
             except FileNotFoundError:
-                return get_table_dataset(f"{tel_type}.{file_type}", role=role)
+                return get_table_dataset(
+                    f"array-elements/{tel_type}/{tel_type}.{file_type}", role=role
+                )
 
         # Load optics
         optics_table = QTable(load_with_fallback("optics", "dl0.sub.svc.optics"))
@@ -1053,7 +1057,7 @@ class SubarrayDescription:
 
         # Load positions
         site = subarray_info["site"]
-        filename = f"{site}_ArrayElementPositions"
+        filename = f"positions/{site}_ArrayElementPositions"
         positions_table = QTable(
             get_table_dataset(filename, role="dl0.sub.svc.arraylayout")
         )

--- a/src/ctapipe/instrument/subarray.py
+++ b/src/ctapipe/instrument/subarray.py
@@ -975,14 +975,23 @@ class SubarrayDescription:
             ├── instrument.meta.json
             ├── array-element-ids.json
             ├── array-elements/
-            │   ├── 001 -> LSTN
-            │   ├── 002 -> LSTN
-            │   ├── 003 -> LSTN
-            │   ├── 004 -> LSTN
-            │   └── LSTN/
-            │       ├── LSTN.camgeom.fits.gz
-            │       ├── LSTN.camreadout.fits.gz
-            │       └── LSTN.optics.ecsv
+            │   ├── LSTN/
+            │   │   ├── LSTN.camgeom.fits.gz
+            │   │   ├── LSTN.camreadout.fits.gz
+            │   │   └── LSTN.optics.ecsv
+            │   ├── MSTN/
+            │   │   ├── MSTN.camgeom.fits.gz
+            │   │   ├── MSTN.camreadout.fits.gz
+            │   │   └── MSTN.optics.ecsv
+            │   ├── 001/
+            │   │   ├── 001.optics.ecsv -> ../LSTN/LSTN.optics.ecsv
+            │   │   ├── 001.camgeom.fits.gz -> ../LSTN/LSTN.camgeom.fits.gz
+            │   │   └── 001.camreadout.fits.gz -> ../LSTN/LSTN.camreadout.fits.gz
+            │   ├── 002/
+            │   │   ├── 002.optics.ecsv -> ../LSTN/LSTN.optics.ecsv
+            │   │   ├── 002.camgeom.fits.gz -> ../LSTN/LSTN.camgeom.fits.gz
+            │   │   └── 002.camreadout.fits.gz -> ../LSTN/LSTN.camreadout.fits.gz
+            │   └── ...
             ├── positions/
             │   ├── CTAO-North_ArrayElementPositions.ecsv
             │   └── CTAO-South_ArrayElementPositions.ecsv
@@ -994,10 +1003,10 @@ class SubarrayDescription:
         - array-element-ids.json: mapping of telescope IDs to names
         - subarray-ids.json: subarray definitions
         - positions/{site}_ArrayElementPositions.ecsv: ECSV files with telescope positions for each site
-        - array-elements/``{ae_id:03d}``/: Instrument description files for each array element. Symlinks may be used to de-duplicate descriptions.
-          Each directory should contain optics.ecsv, camgeom.fits.gz, and camreadout.fits.gz files.
-          Files can be named either ``{ae_id:03d}.*`` (e.g., 001.optics.ecsv) for telescope-specific configurations
-          or ``{type}.*`` (e.g., LSTN.optics.ecsv) for shared configurations across multiple telescopes
+        - array-elements/{type}/: Shared telescope-type directories (e.g., LSTN, MSTN) containing instrument descriptions.
+          Each directory contains optics.ecsv, camgeom.fits.gz, and camreadout.fits.gz files named with the type prefix.
+        - array-elements/``{ae_id:03d}``/: Real directories for each array element, each containing per-file symlinks
+          to the shared type files. Files are named with the ae_id prefix (e.g., 001.optics.ecsv) but point to the type directory.
 
         Parameters
         ----------

--- a/src/ctapipe/tools/dump_instrument.py
+++ b/src/ctapipe/tools/dump_instrument.py
@@ -333,22 +333,28 @@ class DumpInstrumentTool(Tool):
         positions_table.write(positions_file, format="ascii.ecsv", overwrite=True)
         Provenance().add_output_file(positions_file, "ServiceDataPositions")
 
-        # Write files for each telescope (using ae_id as directory name)
+        # Group telescopes by unique TelescopeDescription.
+        # str(tel_desc) = "{size_type}_{optics_name}_{camera_name}" and is used
+        # as the shared type-directory name.
         array_elements_dir = instrument_dir / "array-elements"
         array_elements_dir.mkdir(exist_ok=True, parents=True)
+
+        type_to_first_desc: dict = {}
+        tel_to_type: dict = {}
         for tel_id, tel_desc in sub.tels.items():
-            ae_id_str = f"{tel_id:03d}"
-            ae_dir = array_elements_dir / ae_id_str
-            ae_dir.mkdir(exist_ok=True, parents=True)
+            type_key = str(tel_desc).replace(" ", "_")
+            if type_key not in type_to_first_desc:
+                type_to_first_desc[type_key] = tel_desc
+            tel_to_type[tel_id] = type_key
 
-            type_name = tel_desc.name
-            self.log.debug(
-                "Writing array element %s (%s) to %s", ae_id_str, type_name, ae_dir
-            )
+        # Write shared files once per unique telescope type
+        for type_key, first_desc in type_to_first_desc.items():
+            type_dir = array_elements_dir / type_key
+            type_dir.mkdir(exist_ok=True, parents=True)
+            self.log.debug("Writing shared type directory %s", type_key)
 
-            # Write optics file
             optics_table = QTable()
-            optics = tel_desc.optics
+            optics = first_desc.optics
             optics_table.meta["TAB_VER"] = optics.CURRENT_TAB_VERSION
             optics_table.meta["SOURCE"] = str(self.infile)
             optics_table.meta["optics_name"] = optics.name
@@ -364,20 +370,32 @@ class DumpInstrumentTool(Tool):
             optics_table.meta["mirror_area"] = str(optics.mirror_area)
             optics_table.meta["n_mirror_tiles"] = optics.n_mirror_tiles
 
-            optics_file = ae_dir / f"{ae_id_str}.optics.ecsv"
+            optics_file = type_dir / f"{type_key}.optics.ecsv"
             optics_table.write(optics_file, format="ascii.ecsv", overwrite=True)
             Provenance().add_output_file(optics_file, "ServiceDataOptics")
 
-            # Write camera geometry and readout files
-            # Temporarily set format to 'fits' for service data
             orig_format = self.format
             self.format = "fits"
             try:
                 self.write_single_camera(
-                    tel_desc.camera, outdir=ae_dir, name_prefix=ae_id_str
+                    first_desc.camera, outdir=type_dir, name_prefix=type_key
                 )
             finally:
                 self.format = orig_format
+
+        # Create a real directory for each array element with per-file symlinks
+        # pointing to the shared type directory (deduplication).
+        for tel_id in sub.tel_ids:
+            ae_id_str = f"{tel_id:03d}"
+            ae_dir = array_elements_dir / ae_id_str
+            ae_dir.mkdir(exist_ok=True, parents=True)
+            type_key = tel_to_type[tel_id]
+            self.log.debug(
+                "Writing array element %s -> %s (symlinks)", ae_id_str, type_key
+            )
+            for suffix in ["optics.ecsv", "camgeom.fits.gz", "camreadout.fits.gz"]:
+                link = ae_dir / f"{ae_id_str}.{suffix}"
+                link.symlink_to(f"../{type_key}/{type_key}.{suffix}")
 
         self.log.info("Service data written successfully to %s", self.outdir)
 

--- a/src/ctapipe/tools/dump_instrument.py
+++ b/src/ctapipe/tools/dump_instrument.py
@@ -339,22 +339,15 @@ class DumpInstrumentTool(Tool):
         array_elements_dir = instrument_dir / "array-elements"
         array_elements_dir.mkdir(exist_ok=True, parents=True)
 
-        type_to_first_desc: dict = {}
-        tel_to_type: dict = {}
-        for tel_id, tel_desc in sub.tels.items():
-            type_key = str(tel_desc).replace(" ", "_")
-            if type_key not in type_to_first_desc:
-                type_to_first_desc[type_key] = tel_desc
-            tel_to_type[tel_id] = type_key
-
         # Write shared files once per unique telescope type
-        for type_key, first_desc in type_to_first_desc.items():
+        for index, tel_desc in enumerate(sub.telescope_types):
+            type_key = f"TEL-TYPE-{index:02d}"
             type_dir = array_elements_dir / type_key
             type_dir.mkdir(exist_ok=True, parents=True)
             self.log.debug("Writing shared type directory %s", type_key)
 
             optics_table = QTable()
-            optics = first_desc.optics
+            optics = tel_desc.optics
             optics_table.meta["TAB_VER"] = optics.CURRENT_TAB_VERSION
             optics_table.meta["SOURCE"] = str(self.infile)
             optics_table.meta["optics_name"] = optics.name
@@ -378,18 +371,19 @@ class DumpInstrumentTool(Tool):
             self.format = "fits"
             try:
                 self.write_single_camera(
-                    first_desc.camera, outdir=type_dir, name_prefix=type_key
+                    tel_desc.camera, outdir=type_dir, name_prefix=type_key
                 )
             finally:
                 self.format = orig_format
 
         # Create a real directory for each array element with per-file symlinks
         # pointing to the shared type directory (deduplication).
-        for tel_id in sub.tel_ids:
+        for tel_id, tel_desc in sub.tel.items():
             ae_id_str = f"{tel_id:03d}"
             ae_dir = array_elements_dir / ae_id_str
             ae_dir.mkdir(exist_ok=True, parents=True)
-            type_key = tel_to_type[tel_id]
+            index = sub.telescope_types.index(tel_desc)
+            type_key = f"TEL-TYPE-{index:02d}"
             self.log.debug(
                 "Writing array element %s -> %s (symlinks)", ae_id_str, type_key
             )

--- a/src/ctapipe/tools/tests/test_tools.py
+++ b/src/ctapipe/tools/tests/test_tools.py
@@ -85,7 +85,7 @@ def test_fileinfo(tmp_path, dl1_image_file):
     assert "CTA ACTIVITY ID" in header[str(dl1_image_file)]
 
 
-def test_dump_instrument(tmp_path):
+def test_dump_instrument(tmp_path, monkeypatch):
     from ctapipe.tools.dump_instrument import DumpInstrumentTool
 
     sys.argv = ["dump_instrument"]
@@ -153,20 +153,13 @@ def test_dump_instrument(tmp_path):
     optics_table = QTable.read(optics_file, format="ascii.ecsv")
     assert optics_table.meta.get("TAB_VER") in OpticsDescription.COMPATIBLE_VERSIONS
 
-    ret = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "from ctapipe.instrument import SubarrayDescription; print(SubarrayDescription.from_service_data(1))",
-        ],
-        env={
-            "CTAPIPE_SVC_PATH": str(tmp_path / "instrument")
-        },  # point to the dumped instrument data
-        capture_output=True,
-        check=True,
-        text=True,
-    )
-    assert "MonteCarloArray" in ret.stdout.strip()
+    with monkeypatch.context() as m:
+        from ctapipe.instrument.subarray import SubarrayDescription
+
+        m.setenv("CTAPIPE_SVC_PATH", str(tmp_path / "instrument"))
+        roundtrip_sub = SubarrayDescription.from_service_data(1)
+
+        assert roundtrip_sub == SubarrayDescription.from_hdf(tmp_path / "subarray.h5")
 
     ret = run_tool(DumpInstrumentTool(), ["--help-all"], cwd=tmp_path, raises=True)
     assert ret == 0

--- a/src/ctapipe/tools/tests/test_tools.py
+++ b/src/ctapipe/tools/tests/test_tools.py
@@ -153,6 +153,21 @@ def test_dump_instrument(tmp_path):
     optics_table = QTable.read(optics_file, format="ascii.ecsv")
     assert optics_table.meta.get("TAB_VER") in OpticsDescription.COMPATIBLE_VERSIONS
 
+    ret = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from ctapipe.instrument import SubarrayDescription; print(SubarrayDescription.from_service_data(1))",
+        ],
+        env={
+            "CTAPIPE_SVC_PATH": str(tmp_path / "instrument")
+        },  # point to the dumped instrument data
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    assert "MonteCarloArray" in ret.stdout.strip()
+
     ret = run_tool(DumpInstrumentTool(), ["--help-all"], cwd=tmp_path, raises=True)
     assert ret == 0
 

--- a/src/ctapipe/utils/tests/conftest.py
+++ b/src/ctapipe/utils/tests/conftest.py
@@ -1,0 +1,37 @@
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from threading import Event, Thread
+
+import pytest
+
+
+class Server(Thread):
+    def __init__(self, directory):
+        super().__init__()
+        self.event = Event()
+        handler = partial(SimpleHTTPRequestHandler, directory=directory)
+        self.httpd = HTTPServer(("", 0), handler)
+        self.url = f"http://localhost:{self.httpd.server_port}"
+        self.httpd.timeout = 0.1
+        self.httpd.handle_timeout = lambda: None
+
+    def run(self):
+        with self.httpd:
+            while not self.event.is_set():
+                self.httpd.handle_request()
+
+
+@pytest.fixture(scope="module")
+def server_tmp_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("server")
+
+
+@pytest.fixture(scope="module")
+def server(server_tmp_path):
+    s = Server(server_tmp_path)
+    s.start()
+    try:
+        yield s
+    finally:
+        s.event.set()
+        s.join()

--- a/src/ctapipe/utils/tests/test_datasets.py
+++ b/src/ctapipe/utils/tests/test_datasets.py
@@ -21,7 +21,7 @@ def test_find_datasets():
     assert not str(r[0]).endswith("gz")
 
 
-def test_datasets_in_custom_path(tmpdir_factory, monkeypatch):
+def test_datasets_in_custom_path(tmpdir_factory, monkeypatch, server):
     """
     check that a dataset in a user-defined CTAPIPE_SVC_PATH is located
     """
@@ -43,7 +43,7 @@ def test_datasets_in_custom_path(tmpdir_factory, monkeypatch):
     assert path == Path(dataset_path)
 
     with pytest.raises(FileNotFoundError):
-        datasets.get_dataset_path("does_not_exist")
+        datasets.get_dataset_path("does_not_exist", url=server.url)
 
     # try using find_all_matching_datasets:
 

--- a/src/ctapipe/utils/tests/test_download.py
+++ b/src/ctapipe/utils/tests/test_download.py
@@ -1,30 +1,6 @@
 import os
-from functools import partial
-from http.server import HTTPServer, SimpleHTTPRequestHandler
-from threading import Event, Thread
 
 import pytest
-
-
-class Server(Thread):
-    def __init__(self, directory):
-        super().__init__()
-        self.event = Event()
-        handler = partial(SimpleHTTPRequestHandler, directory=directory)
-        self.httpd = HTTPServer(("", 0), handler)
-        self.url = f"http://localhost:{self.httpd.server_port}"
-        self.httpd.timeout = 0.1
-        self.httpd.handle_timeout = lambda: None
-
-    def run(self):
-        with self.httpd:
-            while not self.event.is_set():
-                self.httpd.handle_request()
-
-
-@pytest.fixture(scope="module")
-def server_tmp_path(tmp_path_factory):
-    return tmp_path_factory.mktemp("server")
 
 
 @pytest.fixture(scope="module")
@@ -33,17 +9,6 @@ def test_file(server_tmp_path):
     with path.open("w") as f:
         f.write("foo,bar\n1,2\n3,4")
     return path
-
-
-@pytest.fixture(scope="module")
-def server(server_tmp_path):
-    s = Server(server_tmp_path)
-    s.start()
-    try:
-        yield s
-    finally:
-        s.event.set()
-        s.join()
 
 
 def test_download_file(server, test_file, tmp_path):


### PR DESCRIPTION
```
instrument tree
.
├── array-element-ids.json
├── array-elements
│   ├── 001
│   │   ├── 001.camgeom.fits.gz -> ../LST_LST_LSTCam/LST_LST_LSTCam.camgeom.fits.gz
│   │   ├── 001.camreadout.fits.gz -> ../LST_LST_LSTCam/LST_LST_LSTCam.camreadout.fits.gz
│   │   └── 001.optics.ecsv -> ../LST_LST_LSTCam/LST_LST_LSTCam.optics.ecsv
│   ...
│   ├── 005
│   │   ├── 005.camgeom.fits.gz -> ../MST_MST_FlashCam/MST_MST_FlashCam.camgeom.fits.gz
│   │   ├── 005.camreadout.fits.gz -> ../MST_MST_FlashCam/MST_MST_FlashCam.camreadout.fits.gz
│   │   └── 005.optics.ecsv -> ../MST_MST_FlashCam/MST_MST_FlashCam.optics.ecsv
│   ...
│   ├── 128
│   │   ├── 128.camgeom.fits.gz -> ../MST_MST_NectarCam/MST_MST_NectarCam.camgeom.fits.gz
│   │   ├── 128.camreadout.fits.gz -> ../MST_MST_NectarCam/MST_MST_NectarCam.camreadout.fits.gz
│   │   └── 128.optics.ecsv -> ../MST_MST_NectarCam/MST_MST_NectarCam.optics.ecsv
│   ...
│   ├── 131
│   │   ├── 131.camgeom.fits.gz -> ../SST_ASTRI_CHEC/SST_ASTRI_CHEC.camgeom.fits.gz
│   │   ├── 131.camreadout.fits.gz -> ../SST_ASTRI_CHEC/SST_ASTRI_CHEC.camreadout.fits.gz
│   │   └── 131.optics.ecsv -> ../SST_ASTRI_CHEC/SST_ASTRI_CHEC.optics.ecsv
│   ...
│   ├── LST_LST_LSTCam
│   │   ├── LST_LST_LSTCam.camgeom.fits.gz
│   │   ├── LST_LST_LSTCam.camreadout.fits.gz
│   │   └── LST_LST_LSTCam.optics.ecsv
│   ├── MST_MST_FlashCam
│   │   ├── MST_MST_FlashCam.camgeom.fits.gz
│   │   ├── MST_MST_FlashCam.camreadout.fits.gz
│   │   └── MST_MST_FlashCam.optics.ecsv
│   ├── MST_MST_NectarCam
│   │   ├── MST_MST_NectarCam.camgeom.fits.gz
│   │   ├── MST_MST_NectarCam.camreadout.fits.gz
│   │   └── MST_MST_NectarCam.optics.ecsv
│   └── SST_ASTRI_CHEC
│       ├── SST_ASTRI_CHEC.camgeom.fits.gz
│       ├── SST_ASTRI_CHEC.camreadout.fits.gz
│       └── SST_ASTRI_CHEC.optics.ecsv
├── instrument.meta.json
├── positions
│   └── CTAO-South_ArrayElementPositions.ecsv
└── subarray-ids.json
```