### PR TITLE
Use local dummy server to test behavior of nonexistent file

### DIFF
--- a/src/ctapipe/utils/tests/conftest.py
+++ b/src/ctapipe/utils/tests/conftest.py
@@ -1,0 +1,37 @@
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from threading import Event, Thread
+
+import pytest
+
+
+class Server(Thread):
+    def __init__(self, directory):
+        super().__init__()
+        self.event = Event()
+        handler = partial(SimpleHTTPRequestHandler, directory=directory)
+        self.httpd = HTTPServer(("", 0), handler)
+        self.url = f"http://localhost:{self.httpd.server_port}"
+        self.httpd.timeout = 0.1
+        self.httpd.handle_timeout = lambda: None
+
+    def run(self):
+        with self.httpd:
+            while not self.event.is_set():
+                self.httpd.handle_request()
+
+
+@pytest.fixture(scope="module")
+def server_tmp_path(tmp_path_factory):
+    return tmp_path_factory.mktemp("server")
+
+
+@pytest.fixture(scope="module")
+def server(server_tmp_path):
+    s = Server(server_tmp_path)
+    s.start()
+    try:
+        yield s
+    finally:
+        s.event.set()
+        s.join()

--- a/src/ctapipe/utils/tests/test_datasets.py
+++ b/src/ctapipe/utils/tests/test_datasets.py
@@ -21,7 +21,7 @@ def test_find_datasets():
     assert not str(r[0]).endswith("gz")
 
 
-def test_datasets_in_custom_path(tmpdir_factory, monkeypatch):
+def test_datasets_in_custom_path(tmpdir_factory, monkeypatch, server):
     """
     check that a dataset in a user-defined CTAPIPE_SVC_PATH is located
     """
@@ -43,7 +43,7 @@ def test_datasets_in_custom_path(tmpdir_factory, monkeypatch):
     assert path == Path(dataset_path)
 
     with pytest.raises(FileNotFoundError):
-        datasets.get_dataset_path("does_not_exist")
+        datasets.get_dataset_path("does_not_exist", url=server.url)
 
     # try using find_all_matching_datasets:
 

--- a/src/ctapipe/utils/tests/test_download.py
+++ b/src/ctapipe/utils/tests/test_download.py
@@ -1,30 +1,6 @@
 import os
-from functools import partial
-from http.server import HTTPServer, SimpleHTTPRequestHandler
-from threading import Event, Thread
 
 import pytest
-
-
-class Server(Thread):
-    def __init__(self, directory):
-        super().__init__()
-        self.event = Event()
-        handler = partial(SimpleHTTPRequestHandler, directory=directory)
-        self.httpd = HTTPServer(("", 0), handler)
-        self.url = f"http://localhost:{self.httpd.server_port}"
-        self.httpd.timeout = 0.1
-        self.httpd.handle_timeout = lambda: None
-
-    def run(self):
-        with self.httpd:
-            while not self.event.is_set():
-                self.httpd.handle_request()
-
-
-@pytest.fixture(scope="module")
-def server_tmp_path(tmp_path_factory):
-    return tmp_path_factory.mktemp("server")
 
 
 @pytest.fixture(scope="module")
@@ -33,17 +9,6 @@ def test_file(server_tmp_path):
     with path.open("w") as f:
         f.write("foo,bar\n1,2\n3,4")
     return path
-
-
-@pytest.fixture(scope="module")
-def server(server_tmp_path):
-    s = Server(server_tmp_path)
-    s.start()
-    try:
-        yield s
-    finally:
-        s.event.set()
-        s.join()
 
 
 def test_download_file(server, test_file, tmp_path):


### PR DESCRIPTION
Further mitigation of the issues we have with the minio server at DESY.

This avoids requesting a non-existent file by making the test with the local dummy server we already user for other tests, not the real test data server.