### PR TITLE
Drop macos-intel from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
             extras: tests,all
             pytest-markers: "-m 'not vizier'"
 
-          - name: macos (3.12, x86-64, pip)
-            os: macos-26-intel
+          - name: macos (3.12, arm64, pip)
+            os: macos-26
             python-version: "3.12"
             install-method: pip
             extras: tests,all


### PR DESCRIPTION
This drops the macos-intel config from the CI, mainly because it takes over twice as long as other runs.

Apple is also about to drop support for intel-based macs from macos, so I don't think we need to worry too much about this.

Instead, we test the 3.12 with pip on macos arm.