### PR TITLE
Fix pytest deprecation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,12 @@ nitpick_ignore = add_reference_type(
         "ctapipe.core.container.T1",
         "ctapipe.core.container.T2",
         "DTypeLike",
+        # astropy, new errors in 8.0, see https://github.com/astropy/astropy/issues/19933
+        "Attribute",
+        "r.BaseDifferential",
+        "r.BaseRepresentation",
+        "r.BaseRepresentationOrDifferential",
+        "RepresentationMapping",
     ],
 )
 nitpick_ignore += add_reference_type(

--- a/src/ctapipe/coordinates/tests/test_ground_frame.py
+++ b/src/ctapipe/coordinates/tests/test_ground_frame.py
@@ -32,7 +32,7 @@ mc_positions = [
 ] * u.m
 
 
-@pytest.mark.parametrize("location,expected", zip(locations, mc_positions))
+@pytest.mark.parametrize(("location", "expected"), list(zip(locations, mc_positions)))
 def test_ground_frame_to_earth_location(location, expected):
     from ctapipe.coordinates import GroundFrame
 

--- a/src/ctapipe/image/tests/test_leakage.py
+++ b/src/ctapipe/image/tests/test_leakage.py
@@ -79,7 +79,7 @@ containers = (
 )
 
 
-@pytest.mark.parametrize("image,expected", zip(images, containers))
+@pytest.mark.parametrize(("image", "expected"), list(zip(images, containers)))
 def test_leakage_toy(image, expected):
     from ctapipe.image.leakage import leakage_parameters
 

--- a/src/ctapipe/instrument/tests/test_optics.py
+++ b/src/ctapipe/instrument/tests/test_optics.py
@@ -46,8 +46,12 @@ def test_construct_optics():
 
 
 @pytest.mark.parametrize(
-    "optics_name,focal_length",
-    zip(["LST", "MST", "ASTRI"], [28, 16, 2.15] * u.m),
+    ("optics_name", "focal_length"),
+    [
+        ("LST", 28 * u.m),
+        ("MST", 16 * u.m),
+        ("ASTRI", 2.15 * u.m),
+    ],
 )
 def test_optics_from_name(optics_name, focal_length, svc_path):
     # test with file written by dump-instrument


### PR DESCRIPTION
Fixes the current CI failures after the pytest 9.1 release.