### PR TITLE
Lazy import resolution for CTAO-specific monitoring containers

### DIFF
--- a/docs/changes/3059.feature.rst
+++ b/docs/changes/3059.feature.rst
@@ -1,0 +1,1 @@
+Implement lazy loading of optional containers defined in external plugins via entrypoints.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,6 +158,9 @@ nitpick_ignore = add_reference_type(
         "r.BaseRepresentation",
         "r.BaseRepresentationOrDifferential",
         "RepresentationMapping",
+        "BaseDifferential",
+        "BaseRepresentation",
+        "BaseRepresentationOrDifferential",
     ],
 )
 nitpick_ignore += add_reference_type(

--- a/src/ctapipe/containers.py
+++ b/src/ctapipe/containers.py
@@ -12,15 +12,19 @@ from astropy.time import Time
 from numpy import nan
 
 from .core.container import Container, Field, Map, TimeResolution
+from .core.plugins import lazy_entry_point
 
 __all__ = [
     "ArrayEventContainer",
+    "BendingModelContainer",
+    "CDMContainer",
     "ConcentrationContainer",
     "DL0CameraContainer",
     "DL0Container",
     "DL1CameraContainer",
     "DL1Container",
     "DL2Container",
+    "DriveContainer",
     "EventIndexContainer",
     "EventType",
     "HillasParametersContainer",
@@ -54,6 +58,7 @@ __all__ = [
     "SimulatedShowerContainer",
     "SimulatedShowerDistribution",
     "SimulationConfigContainer",
+    "StarGuiderContainer",
     "TelEventIndexContainer",
     "BaseTimingParametersContainer",
     "TimingParametersContainer",
@@ -73,6 +78,29 @@ __all__ = [
     "ObservationBlockState",
 ]
 
+
+_MONITORING_ENTRY_POINT_GROUP = "ctapipe_monitoring_containers"
+
+DriveContainer = lazy_entry_point(
+    _MONITORING_ENTRY_POINT_GROUP,
+    "drive",
+    qualname="ctapipe_mon_acada.fitsdataformat.DriveContainer",
+)
+BendingModelContainer = lazy_entry_point(
+    _MONITORING_ENTRY_POINT_GROUP,
+    "bending_model",
+    qualname="ctapipe_mon_acada.fitsdataformat.BendingModelContainer",
+)
+StarGuiderContainer = lazy_entry_point(
+    _MONITORING_ENTRY_POINT_GROUP,
+    "starguider",
+    qualname="ctapipe_mon_acada.fitsdataformat.StarGuiderContainer",
+)
+CDMContainer = lazy_entry_point(
+    _MONITORING_ENTRY_POINT_GROUP,
+    "cdm",
+    qualname="ctapipe_mon_acada.fitsdataformat.CDMContainer",
+)
 
 # see https://github.com/astropy/astropy/issues/6509
 NAN_TIME = Time(0, format="mjd", scale="tai")
@@ -1350,6 +1378,26 @@ class TelescopeMonitoringContainer(Container):
     pointing = Field(
         default_factory=TelescopePointingContainer,
         description="Telescope pointing positions",
+    )
+    drive = Field(
+        default_factory=DriveContainer,
+        description="Container for monitoring data for drive",
+        allow_none=True,
+    )
+    bending_model = Field(
+        default_factory=BendingModelContainer,
+        description="Container for monitoring data for bending model",
+        allow_none=True,
+    )
+    starguider = Field(
+        default_factory=StarGuiderContainer,
+        description="Container for StarGuider monitoring data",
+        allow_none=True,
+    )
+    cdm = Field(
+        default_factory=CDMContainer,
+        description="Container for CDM monitoring data",
+        allow_none=True,
     )
 
 

--- a/src/ctapipe/core/plugins.py
+++ b/src/ctapipe/core/plugins.py
@@ -1,6 +1,7 @@
 """ctapipe plugin system"""
 
 import logging
+from functools import lru_cache
 from importlib.metadata import entry_points
 
 log = logging.getLogger(__name__)
@@ -37,3 +38,79 @@ def detect_and_import_reco_plugins():
     These plugins are meant to provide `~ctapipe.reco.Reconstructor` implementations
     """
     return detect_and_import_plugins(group="ctapipe_reco")
+
+
+@lru_cache(maxsize=None)
+def resolve_entry_point(group, name):
+    """Load a single entry point by group and exact name.
+
+    Parameters
+    ----------
+    group : str
+        entry-point group to look up, e.g. "ctapipe_monitoring_containers"
+    name : str
+        entry-point name within `group`, e.g. "drive"
+
+    Returns
+    -------
+    object or None
+        the loaded object, or None if no plugin registers `name` under
+        `group`.
+
+    Raises
+    ------
+    RuntimeError
+        if more than one plugin registers the same name within `group`.
+    """
+    matches = list(installed_entry_points.select(group=group, name=name))
+
+    if not matches:
+        return None
+
+    if len(matches) > 1:
+        candidates = [m.value for m in matches]
+        raise RuntimeError(
+            f"Multiple plugins registered {name!r} under entry-point "
+            f"group {group!r}: {candidates}."
+        )
+
+    entry_point = matches[0]
+    log.debug("Loading %s plugin: %s", group, entry_point.value)
+    return entry_point.load()
+
+
+def lazy_entry_point(group, name, qualname=None):
+    """Build a class usable as a Container Field's `default_factory` that
+    resolves and instantiates a plugin-registered class the first time it
+    is called, rather than when this function is called.
+
+    Resolves to None at call time if no plugin registers `name` under
+    `group`.
+
+    Parameters
+    ----------
+    group : str
+        entry-point group to look up
+    name : str
+        entry-point name within `group`
+    qualname : str, optional
+        name to report in reprs/docs for the returned class; defaults to
+        `name`
+
+    Returns
+    -------
+    type
+        a class whose instantiation resolves and instantiates the
+        plugin-registered class, or returns None if unregistered.
+    """
+
+    class _LazyEntryPointContainer:
+        def __new__(cls):
+            target_cls = resolve_entry_point(group, name)
+            if target_cls is None:
+                return None
+            return target_cls()
+
+    _LazyEntryPointContainer.__name__ = qualname or name
+    _LazyEntryPointContainer.__qualname__ = _LazyEntryPointContainer.__name__
+    return _LazyEntryPointContainer

--- a/src/ctapipe/core/tests/test_plugins.py
+++ b/src/ctapipe/core/tests/test_plugins.py
@@ -1,0 +1,146 @@
+from importlib.metadata import EntryPoint, EntryPoints
+
+import pytest
+
+from ctapipe.core import plugins
+
+
+class _RealTargetContainer:
+    """Module-level so it's a real importable target for EntryPoint.load()."""
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for importlib.metadata.EntryPoint."""
+
+    def __init__(self, name, value, obj, group="some_group"):
+        self.name = name
+        self.value = value
+        self.group = group
+        self._obj = obj
+
+    def load(self):
+        return self._obj
+
+
+class _FakeEntryPoints:
+    """Stand-in for importlib.metadata.EntryPoints backed by an explicit
+    list of fake entry points, filtered the same way .select() would be.
+    """
+
+    def __init__(self, entry_points=()):
+        self._entry_points = list(entry_points)
+
+    def select(self, *, group, name=None):
+        return [
+            ep
+            for ep in self._entry_points
+            if ep.group == group and (name is None or ep.name == name)
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _clear_entry_point_cache():
+    plugins.resolve_entry_point.cache_clear()
+    yield
+    plugins.resolve_entry_point.cache_clear()
+
+
+@pytest.fixture
+def real_drive_entry_point(monkeypatch):
+    """Register a real importlib.metadata.EntryPoint pointing at
+    _RealTargetContainer, under group "some_group" / name "drive"."""
+    ep = EntryPoint(
+        name="drive",
+        value="ctapipe.core.tests.test_plugins:_RealTargetContainer",
+        group="some_group",
+    )
+    monkeypatch.setattr(plugins, "installed_entry_points", EntryPoints([ep]))
+
+
+def test_resolve_entry_point_none_when_unregistered(monkeypatch):
+    monkeypatch.setattr(plugins, "installed_entry_points", _FakeEntryPoints())
+
+    assert plugins.resolve_entry_point("some_group", "some_name") is None
+
+
+def test_resolve_entry_point_returns_loaded_object(monkeypatch):
+    sentinel = object()
+    fake_entry_points = _FakeEntryPoints(
+        [_FakeEntryPoint("drive", "some.module:Drive", sentinel)]
+    )
+    monkeypatch.setattr(plugins, "installed_entry_points", fake_entry_points)
+
+    assert plugins.resolve_entry_point("some_group", "drive") is sentinel
+
+
+def test_resolve_entry_point_raises_on_duplicate_registration(monkeypatch):
+    ep_a = _FakeEntryPoint("drive", "pkg_a:Drive", object())
+    ep_b = _FakeEntryPoint("drive", "pkg_b:Drive", object())
+    monkeypatch.setattr(
+        plugins, "installed_entry_points", _FakeEntryPoints([ep_a, ep_b])
+    )
+
+    with pytest.raises(RuntimeError, match="Multiple plugins registered"):
+        plugins.resolve_entry_point("some_group", "drive")
+
+
+def test_resolve_entry_point_loads_real_entry_point(real_drive_entry_point):
+    resolved = plugins.resolve_entry_point("some_group", "drive")
+
+    assert resolved is _RealTargetContainer
+
+
+def test_lazy_entry_point_returns_none_when_unregistered(monkeypatch):
+    monkeypatch.setattr(plugins, "installed_entry_points", _FakeEntryPoints())
+
+    factory = plugins.lazy_entry_point("some_group", "drive")
+
+    assert factory() is None
+
+
+def test_lazy_entry_point_instantiates_registered_class(monkeypatch):
+    class Target:
+        pass
+
+    ep = _FakeEntryPoint("drive", "some.module:Target", Target)
+    monkeypatch.setattr(plugins, "installed_entry_points", _FakeEntryPoints([ep]))
+
+    factory = plugins.lazy_entry_point("some_group", "drive")
+
+    assert isinstance(factory(), Target)
+
+
+def test_lazy_entry_point_raises_on_duplicate_registration(monkeypatch):
+    ep_a = _FakeEntryPoint("drive", "pkg_a:Drive", object())
+    ep_b = _FakeEntryPoint("drive", "pkg_b:Drive", object())
+    monkeypatch.setattr(
+        plugins, "installed_entry_points", _FakeEntryPoints([ep_a, ep_b])
+    )
+
+    factory = plugins.lazy_entry_point("some_group", "drive")
+
+    with pytest.raises(RuntimeError, match="Multiple plugins registered"):
+        factory()
+
+
+def test_lazy_entry_point_does_not_resolve_until_called(monkeypatch):
+    """Building the factory must not touch installed_entry_points at all --
+    resolution happens on factory(), not on lazy_entry_point()."""
+
+    class _ExplodingEntryPoints:
+        def select(self, **kwargs):
+            raise AssertionError("resolve_entry_point should not run yet")
+
+    monkeypatch.setattr(plugins, "installed_entry_points", _ExplodingEntryPoints())
+
+    factory = plugins.lazy_entry_point("some_group", "drive")  # must not raise
+
+    monkeypatch.setattr(plugins, "installed_entry_points", _FakeEntryPoints())
+    assert factory() is None  # now it's safe to resolve, and finds nothing
+
+
+def test_lazy_entry_point_instantiates_real_entry_point(real_drive_entry_point):
+    factory = plugins.lazy_entry_point("some_group", "drive")
+    instance = factory()
+
+    assert isinstance(instance, _RealTargetContainer)


### PR DESCRIPTION
Some of the monitoring containers are defined outside of `ctapipe` in the respective I/O plugins because they are specific to the particular hardware or DAQ settings. Since the `Container` interface doesn't allow dynamic extension, optional fields (defaulting to None) are added and resolved via entrypoints. 