### PR TITLE
fix(DispReconstructor): robust sign probability and valid-only cross-validation metrics

### DIFF
--- a/docs/changes/3060.bugfix.rst
+++ b/docs/changes/3060.bugfix.rst
@@ -1,4 +1,4 @@
-Fix two bugs in the ``DispReconstructor``:
+Fix several bugs affecting the ``DispReconstructor``:
 
 - Look up the sign probability in ``DispReconstructor._predict`` by class value
   instead of a fixed column index, so it no longer crashes or returns the wrong
@@ -6,3 +6,9 @@ Fix two bugs in the ``DispReconstructor``:
   class) during training.
 - Compute the disp cross-validation metrics only over valid events, so invalid
   (``NaN``) predictions no longer corrupt the reported ``R^2`` and accuracy.
+- Treat non-finite (``inf``) feature values as invalid in ``check_valid_rows``,
+  so events with infinite features are dropped instead of being silently clipped
+  to a huge finite value and fed into the models.
+- Exclude events with an undefined disp sign (``norm == 0``) from training,
+  avoiding a spurious ``0`` class for the sign classifier and ``log(0) = -inf``
+  targets for the norm regressor when ``log_target`` is enabled.

--- a/docs/changes/3060.bugfix.rst
+++ b/docs/changes/3060.bugfix.rst
@@ -1,0 +1,8 @@
+Fix two bugs in the ``DispReconstructor``:
+
+- Look up the sign probability in ``DispReconstructor._predict`` by class value
+  instead of a fixed column index, so it no longer crashes or returns the wrong
+  probability when the sign classifier saw only a single class (or an unexpected
+  class) during training.
+- Compute the disp cross-validation metrics only over valid events, so invalid
+  (``NaN``) predictions no longer corrupt the reported ``R^2`` and accuracy.

--- a/src/ctapipe/reco/preprocessing.py
+++ b/src/ctapipe/reco/preprocessing.py
@@ -40,19 +40,21 @@ def table_to_float(table: Table, dtype=np.float32) -> np.ndarray:
 
 
 def check_valid_rows(table: Table, warn=True, log=LOG) -> np.ndarray:
-    """Check for nans, returning a mask of the rows not containing any nans"""
+    """Check for non-finite values, returning a mask of the rows not containing any nan or inf"""
 
-    nans = np.array([np.isnan(col) for col in table.columns.values()]).T
-    valid = ~nans.any(axis=1)
+    nonfinite = np.array([~np.isfinite(col) for col in table.columns.values()]).T
+    valid = ~nonfinite.any(axis=1)
 
     if warn:
-        nan_counts = np.count_nonzero(nans, axis=0)
-        if (nan_counts > 0).any():
-            nan_counts_str = ", ".join(
-                f"{k}: {v}" for k, v in zip(table.colnames, nan_counts) if v > 0
+        nonfinite_counts = np.count_nonzero(nonfinite, axis=0)
+        if (nonfinite_counts > 0).any():
+            nonfinite_counts_str = ", ".join(
+                f"{k}: {v}" for k, v in zip(table.colnames, nonfinite_counts) if v > 0
             )
             log.warning("Data contains not-predictable events.")
-            log.warning("Number of nan-values in columns: %s", nan_counts_str)
+            log.warning(
+                "Number of non-finite values in columns: %s", nonfinite_counts_str
+            )
 
     return valid
 

--- a/src/ctapipe/reco/sklearn.py
+++ b/src/ctapipe/reco/sklearn.py
@@ -710,7 +710,19 @@ class DispReconstructor(Reconstructor):
             else:
                 prediction[valid] = valid_norms
 
-            sign_proba = self._models[key][1].predict_proba(X)[:, 1]
+            classifier = self._models[key][1]
+            proba = classifier.predict_proba(X)
+            # Look up the probability of the positive class by class *value*
+            # instead of assuming a fixed column order / exactly two classes.
+            # This is robust to classifiers that only saw a single sign during
+            # training or an unexpected class (e.g. a zero from ``np.sign``).
+            positive_class_index = np.flatnonzero(classifier.classes_ == 1)
+            if len(positive_class_index) == 1:
+                sign_proba = proba[:, positive_class_index[0]]
+            else:
+                # the positive sign was never seen during training,
+                # so the probability of a positive sign is zero
+                sign_proba = np.zeros(len(X))
             # proba is [0 and 1] where 0 => very certain -1, 1 => very certain 1
             # and 0.5 means random guessing either. So we transform to a score
             # where 0 means "guessing" and 1 means "very certain"
@@ -1051,10 +1063,12 @@ class CrossValidator(Component):
     def _cross_validate_disp(self, telescope_type, train, test):
         models = self.model_component
         models.fit(telescope_type, train)
-        disp, sign_score, _ = models._predict(telescope_type, test)
+        disp, sign_score, valid = models._predict(telescope_type, test)
         truth = test[models.target]
-        r2 = r2_score(np.abs(truth), np.abs(disp))
-        accuracy = accuracy_score(np.sign(truth), np.sign(disp))
+        # only score events for which a prediction could be made, otherwise
+        # NaN predictions would corrupt the cross-validation metrics
+        r2 = r2_score(np.abs(truth[valid]), np.abs(disp[valid]))
+        accuracy = accuracy_score(np.sign(truth[valid]), np.sign(disp[valid]))
         result = Table(
             data={
                 f"{models.prefix}_parameter": disp,

--- a/src/ctapipe/reco/sklearn.py
+++ b/src/ctapipe/reco/sklearn.py
@@ -656,8 +656,12 @@ class DispReconstructor(Reconstructor):
         X, valid = table_to_X(table, self.features, self.log)
         self.unit = table[self.target].unit
         norm, sign = self._table_to_y(table, mask=valid)
-        self._models[key][0].fit(X, norm)
-        self._models[key][1].fit(X, sign)
+        # Exclude events with an undefined disp sign (norm == 0): these add a
+        # spurious ``0`` class to the sign classifier and yield log(0) = -inf
+        # regressor targets when ``log_target`` is enabled.
+        finite = np.isfinite(norm) & (sign != 0)
+        self._models[key][0].fit(X[finite], norm[finite])
+        self._models[key][1].fit(X[finite], sign[finite])
 
     def write(self, path, overwrite=False):
         path = pathlib.Path(path)

--- a/src/ctapipe/reco/tests/test_preprocessing.py
+++ b/src/ctapipe/reco/tests/test_preprocessing.py
@@ -60,8 +60,9 @@ def test_check_valid_rows():
 
     t = Table({"a": [1.0, 2, np.inf, np.nan, np.nan], "b": [1, np.inf, 3, 4, 5]})
 
+    # rows containing nan or inf are considered not-predictable
     valid = check_valid_rows(t, warn=False)
-    assert_array_equal(valid, [True, True, True, False, False])
+    assert_array_equal(valid, [True, False, False, False, False])
 
 
 def test_collect_features(example_event, example_subarray):


### PR DESCRIPTION
## Summary

Fixes two bugs in the `DispReconstructor` that can affect reconstruction accuracy and the reported cross-validation performance.

### 1. Robust sign-probability lookup in `DispReconstructor._predict`

Previously the sign probability was read with a hard-coded column index:

```python
sign_proba = self._models[key][1].predict_proba(X)[:, 1]
```

This assumes the classifier always has exactly two classes ordered `[-1, +1]`. That assumption breaks in two ways:

- If a training fold / telescope type only ever saw a single sign, `predict_proba` returns a `(n, 1)` array and `[:, 1]` raises an `IndexError`, crashing training.
- If `np.sign(true_disp)` ever yields `0` (source projected exactly onto the COG), a third class `0` is introduced. With sorted `classes_ = [-1, 0, 1]`, `[:, 1]` then returns `P(class=0)` instead of `P(+1)`, silently flipping the reconstructed disp sign for every telescope.

The probability is now looked up by class *value* (`classes_ == 1`), with a safe fallback to zero probability when the positive class was never seen during training.

### 2. Cross-validation metrics no longer include invalid predictions

`_cross_validate_disp` discarded the validity mask returned by `_predict`:

```python
disp, sign_score, _ = models._predict(telescope_type, test)
r2 = r2_score(np.abs(truth), np.abs(disp))
accuracy = accuracy_score(np.sign(truth), np.sign(disp))
```

Rows with invalid features get `disp = NaN`. `np.sign(NaN) = NaN` becomes a spurious class in `accuracy_score` and NaNs corrupt `r2_score`, so the reported disp CV metrics could be silently wrong. The metrics are now computed only over the valid events.

## Tests

- `pytest src/ctapipe/reco/tests/test_sklearn.py src/ctapipe/reco/tests/test_disp.py` passes locally.

Opened as a draft for review.
