### PR TITLE
Add containment-weighted-intensity stereo weighting

### DIFF
--- a/docs/changes/3062.feature.rst
+++ b/docs/changes/3062.feature.rst
@@ -1,0 +1,5 @@
+Add a new ``containment-weighted-intensity`` weighting option to
+``StereoMeanCombiner``, which down-weights truncated (leaky) images via
+``(intensity * (1 - width / length))**2 * (1 - leakage_intensity_width_2)**4``.
+This is the most robust option at high energies, where image truncation
+dominates the angular-resolution degradation of the disp reconstruction.

--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -67,10 +67,20 @@ class StereoMeanCombiner(StereoCombiner):
     """
 
     weights = CaselessStrEnum(
-        ["none", "intensity", "aspect-weighted-intensity"],
+        [
+            "none",
+            "intensity",
+            "aspect-weighted-intensity",
+            "containment-weighted-intensity",
+        ],
         default_value="none",
         help=(
-            "What kind of weights to use. Options: ``none``, ``intensity``, ``aspect-weighted-intensity``."
+            "What kind of weights to use. Options: ``none``, ``intensity``,"
+            " ``aspect-weighted-intensity``, ``containment-weighted-intensity``."
+            " ``containment-weighted-intensity`` down-weights truncated (leaky)"
+            " images via ``(intensity * (1 - width / length))**2 *"
+            " (1 - leakage_intensity_width_2)**4`` and is the most robust option"
+            " at high energies where image truncation dominates."
         ),
     ).tag(config=True)
 
@@ -100,6 +110,11 @@ class StereoMeanCombiner(StereoCombiner):
             if self.weights == "aspect-weighted-intensity":
                 return data.hillas.intensity * data.hillas.length / data.hillas.width
 
+            if self.weights == "containment-weighted-intensity":
+                elongation = 1 - data.hillas.width / data.hillas.length
+                containment = 1 - data.leakage.intensity_width_2
+                return (data.hillas.intensity * elongation) ** 2 * containment**4
+
             return 1
 
         if isinstance(data, Table):
@@ -112,6 +127,11 @@ class StereoMeanCombiner(StereoCombiner):
                     * data["hillas_length"]
                     / data["hillas_width"]
                 )
+
+            if self.weights == "containment-weighted-intensity":
+                elongation = 1 - data["hillas_width"] / data["hillas_length"]
+                containment = 1 - data["leakage_intensity_width_2"]
+                return (data["hillas_intensity"] * elongation) ** 2 * containment**4
 
             return np.ones(len(data))
 

--- a/src/ctapipe/reco/tests/test_stereo_combination.py
+++ b/src/ctapipe/reco/tests/test_stereo_combination.py
@@ -260,10 +260,23 @@ def test_mean_prediction_single_event(weights):
         assert u.isclose(event.dl2.stereo.energy["dummy"].energy, 30 * u.GeV)
         assert u.isclose(event.dl2.stereo.geometry["dummy"].alt, 60.9748605 * u.deg)
         assert u.isclose(event.dl2.stereo.geometry["dummy"].az, 316.0365515 * u.deg)
+    # For none/intensity/aspect the weighted mean of [1.0, 0.0, 0.8] coincidentally
+    # equals 0.6 because the test intensities (100, 200, 400) and equal aspect ratios
+    # cancel out.  containment-weighted-intensity breaks that coincidence because
+    # (1 - leakage)**4 differs per telescope (leakage = 0.0, 0.1, 0.2), so the
+    # containment weight is a general image-quality weight that affects all prediction
+    # types, not just geometry.
     if weights == "containment-weighted-intensity":
-        # weight = (intensity * (1 - width / length))**2 * (1 - leakage)**4
+        w = np.array(
+            [
+                (100 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.0) ** 4,  # tel 25
+                (200 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.1) ** 4,  # tel 125
+                (400 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.2) ** 4,  # tel 130
+            ]
+        )
+        expected = np.average([1.0, 0.0, 0.8], weights=w)
         assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(
-            0.6133700137551582
+            expected
         )
     else:
         assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(0.6)

--- a/src/ctapipe/reco/tests/test_stereo_combination.py
+++ b/src/ctapipe/reco/tests/test_stereo_combination.py
@@ -8,6 +8,7 @@ from ctapipe.containers import (
     ArrayEventContainer,
     HillasParametersContainer,
     ImageParametersContainer,
+    LeakageContainer,
     ParticleClassificationContainer,
     ReconstructedContainer,
     ReconstructedEnergyContainer,
@@ -31,6 +32,7 @@ def mono_table():
             "hillas_intensity": [1, 2, 0, 1, 5, 9],
             "hillas_width": [0.1, 0.2, 0.1, 0.1, 0.2, 0.1] * u.deg,
             "hillas_length": 3 * ([0.1, 0.2, 0.1, 0.1, 0.2, 0.1] * u.deg),
+            "leakage_intensity_width_2": [0.0, 0.1, 0.0, 0.2, 0.05, 0.3],
             "dummy_tel_energy": [1, 10, 4, 0.5, 0.7, 1] * u.TeV,
             "dummy_tel_is_valid": [
                 True,
@@ -63,7 +65,15 @@ def mono_table():
     )
 
 
-@pytest.mark.parametrize("weights", ["aspect-weighted-intensity", "intensity", "none"])
+@pytest.mark.parametrize(
+    "weights",
+    [
+        "aspect-weighted-intensity",
+        "containment-weighted-intensity",
+        "intensity",
+        "none",
+    ],
+)
 def test_predict_mean_energy(weights, mono_table):
     combine = StereoMeanCombiner(
         prefix="dummy",
@@ -160,17 +170,28 @@ def test_predict_mean_disp(mono_table):
     assert_array_equal(tel_ids[2], [1])
 
 
-@pytest.mark.parametrize("weights", ["aspect-weighted-intensity", "intensity", "none"])
+@pytest.mark.parametrize(
+    "weights",
+    [
+        "aspect-weighted-intensity",
+        "containment-weighted-intensity",
+        "intensity",
+        "none",
+    ],
+)
 def test_mean_prediction_single_event(weights):
     event = ArrayEventContainer()
 
-    for tel_id, intensity in zip((25, 125, 130), (100, 200, 400)):
+    for tel_id, intensity, leakage in zip(
+        (25, 125, 130), (100, 200, 400), (0.0, 0.1, 0.2)
+    ):
         event.dl1.tel[tel_id].parameters = ImageParametersContainer(
             hillas=HillasParametersContainer(
                 intensity=intensity,
                 width=0.1 * u.deg,
                 length=0.3 * u.deg,
-            )
+            ),
+            leakage=LeakageContainer(intensity_width_2=leakage),
         )
 
     event.dl2.tel[25] = ReconstructedContainer(
@@ -239,7 +260,13 @@ def test_mean_prediction_single_event(weights):
         assert u.isclose(event.dl2.stereo.energy["dummy"].energy, 30 * u.GeV)
         assert u.isclose(event.dl2.stereo.geometry["dummy"].alt, 60.9748605 * u.deg)
         assert u.isclose(event.dl2.stereo.geometry["dummy"].az, 316.0365515 * u.deg)
-    assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(0.6)
+    if weights == "containment-weighted-intensity":
+        # weight = (intensity * (1 - width / length))**2 * (1 - leakage)**4
+        assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(
+            0.6133700137551582
+        )
+    else:
+        assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(0.6)
 
 
 def test_reconstructed_container_warning():

--- a/src/ctapipe/reco/tests/test_stereo_combination.py
+++ b/src/ctapipe/reco/tests/test_stereo_combination.py
@@ -170,16 +170,31 @@ def test_predict_mean_disp(mono_table):
     assert_array_equal(tel_ids[2], [1])
 
 
+def _containment_particle_expected():
+    # (1 - leakage)**4 differs per telescope (leakage = 0.0, 0.1, 0.2), so the
+    # containment weight is a general image-quality weight affecting all prediction
+    # types.  The other three schemes coincidentally give 0.6 because the test
+    # intensities (100, 200, 400) and equal aspect ratios happen to cancel out.
+    w = np.array(
+        [
+            (100 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.0) ** 4,  # tel 25
+            (200 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.1) ** 4,  # tel 125
+            (400 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.2) ** 4,  # tel 130
+        ]
+    )
+    return float(np.average([1.0, 0.0, 0.8], weights=w))
+
+
 @pytest.mark.parametrize(
-    "weights",
+    ("weights", "expected_particle_prediction"),
     [
-        "aspect-weighted-intensity",
-        "containment-weighted-intensity",
-        "intensity",
-        "none",
+        ("aspect-weighted-intensity", 0.6),
+        ("containment-weighted-intensity", _containment_particle_expected()),
+        ("intensity", 0.6),
+        ("none", 0.6),
     ],
 )
-def test_mean_prediction_single_event(weights):
+def test_mean_prediction_single_event(weights, expected_particle_prediction):
     event = ArrayEventContainer()
 
     for tel_id, intensity, leakage in zip(
@@ -264,22 +279,11 @@ def test_mean_prediction_single_event(weights):
     # equals 0.6 because the test intensities (100, 200, 400) and equal aspect ratios
     # cancel out.  containment-weighted-intensity breaks that coincidence because
     # (1 - leakage)**4 differs per telescope (leakage = 0.0, 0.1, 0.2), so the
-    # containment weight is a general image-quality weight that affects all prediction
+    # containment weight is a general image-quality weight affecting all prediction
     # types, not just geometry.
-    if weights == "containment-weighted-intensity":
-        w = np.array(
-            [
-                (100 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.0) ** 4,  # tel 25
-                (200 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.1) ** 4,  # tel 125
-                (400 * (1 - 0.1 / 0.3)) ** 2 * (1 - 0.2) ** 4,  # tel 130
-            ]
-        )
-        expected = np.average([1.0, 0.0, 0.8], weights=w)
-        assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(
-            expected
-        )
-    else:
-        assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(0.6)
+    assert event.dl2.stereo.particle_type["dummy"].prediction == pytest.approx(
+        expected_particle_prediction
+    )
 
 
 def test_reconstructed_container_warning():


### PR DESCRIPTION
## What

Adds a new `weights` option, `containment-weighted-intensity`, to `StereoMeanCombiner._calculate_weights` (shared by energy, geometry and particle-type combination).

The weight reproduces EventDisplay's geometric disp weight:

```
w = (intensity * (1 - width / length))**2 * (1 - leakage_intensity_width_2)**4
```

i.e. it combines image brightness, elongation, and a strong **containment** term `(1 - leakage)**4` that down-weights truncated (leaky) images.

## Why

High-energy angular resolution in the disp reconstruction is dominated by **image truncation (leakage)**: bright, leaky images have large along-axis `|disp|` scatter but are currently *over*-weighted (intensity correlates positively with leakage). None of the existing weighting schemes (`none`, `intensity`, `aspect-weighted-intensity`) account for containment.

In a benchmark on stereo test events (68% containment angular resolution, degrees), the containment weight was the single most robust option across all energies and matched or beat EventDisplay's disp-error weighting at the highest energies:

## Notes

- The new option is purely additive; the default (`none`) and existing options are unchanged.
- Uses only parameters already available at combination time (`hillas.intensity/width/length`, `leakage.intensity_width_2`).
- Complementary to PR #2731 (`StereoDispCombiner`), which improves head/tail **sign** handling but reuses the same three pre-existing weight options — this PR fills the containment-weighting gap. Because the weight lives in the shared `_calculate_weights`, #2731 would inherit it automatically.

## Tests

Extended `test_stereo_combination.py` to exercise the new scheme in both the table- and container-based paths.

Draft: opening for discussion / benchmarking on the full IRF pipeline.