### PR TITLE
Muon charge extractor or waveform-based cleaning algorithm

### DIFF
--- a/src/ctapipe/conftest.py
+++ b/src/ctapipe/conftest.py
@@ -213,8 +213,11 @@ def calibpipe_camcalib_obslike_different_chunks():
 
 
 @pytest.fixture(scope="session")
-def ctapipe_ref_pules()
-    return get_dataset_path("calibpipe_camcalib_single_chunk_i0.1.0.dl1.h5")
+def ctapipe_ref_pules():
+    return read_table(
+        get_dataset_path("calibpipe_camcalib_single_chunk_i0.1.0.dl1.h5"),
+        "/configuration/instrument/telescope/camera/readout_0/",
+    )
 
 
 @pytest.fixture(scope="session")

--- a/src/ctapipe/conftest.py
+++ b/src/ctapipe/conftest.py
@@ -213,6 +213,11 @@ def calibpipe_camcalib_obslike_different_chunks():
 
 
 @pytest.fixture(scope="session")
+def ctapipe_ref_pules()
+    return get_dataset_path("calibpipe_camcalib_single_chunk_i0.1.0.dl1.h5")
+
+
+@pytest.fixture(scope="session")
 def prod5_lst(subarray_prod5_paranal):
     return subarray_prod5_paranal.tel[1]
 

--- a/src/ctapipe/image/tests/test_extractor.py
+++ b/src/ctapipe/image/tests/test_extractor.py
@@ -1,5 +1,8 @@
 from copy import deepcopy
 
+from sklearn.cluster import DBSCAN
+from sklearn.cluster import KMeans
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -944,8 +947,172 @@ def test_flashcam_extractor(toymodel_mst_fc, prod5_gamma_simtel_path):
                 )
 
 
-def test_global_peak_window_sum_muons(ctapipe_ref_pules):
-    from ctapipe.image.extractor import GlobalPeakWindowSum
+def test_global_peak_window_sum_muons(ctapipe_ref_pules,subarray):
+    from ctapipe.instrument.camera.readout import CameraReadout
+    from ctapipe.image.extractor import ImageExtractor
+    import matplotlib.pyplot as plt
+    #from ctapipe.image.extractor import GlobalPeakWindowSum
     print("test_global_peak_window_sum_muons")
-    print(ctapipe_ref_pules)
+    #print(ctapipe_ref_pules)
+    #print(type(ctapipe_ref_pules))
+    #print(ctapipe_ref_pules.colnames)
+    
+    reference_pulse_shape = np.array(
+        [ctapipe_ref_pules["reference_pulse_shape_channel0"]]
+    )
+    reference_pulse_sample_width = (
+        ctapipe_ref_pules["reference_pulse_sample_time"][1] -
+        ctapipe_ref_pules["reference_pulse_sample_time"][0]
+    ) * u.ns
+    
+    sampling_rate = 1 * u.GHz
+    readout = CameraReadout(
+        name="TestCam",
+        sampling_rate=sampling_rate,
+        reference_pulse_shape=reference_pulse_shape,
+        reference_pulse_sample_width=reference_pulse_sample_width,
+        n_channels=1,
+        n_pixels=1,
+        n_samples=40,
+    )
+
+    model = WaveformModel.from_camera_readout(readout)
+    proton_a = np.random.normal(loc=10, scale=3, size=10000)
+    proton_t = np.random.normal(loc=22, scale=1, size=10000)
+    mu_a = np.random.normal(loc=40, scale=5, size=10000)
+    mu_t = np.random.normal(loc=20, scale=0.1, size=10000)
+    wf = model.get_waveform(np.concatenate([proton_a, mu_a]),
+                            np.concatenate([proton_t, mu_t]),
+                            n_samples=40)
+
+    print(wf.shape)
+    
+
+
+
+
+    print("sum proton_a = ",np.sum(proton_a))
+    print("sum mu_a = ",np.sum(mu_a))
+    
+
+    plt.figure()
+    plt.step(ctapipe_ref_pules["reference_pulse_sample_time"],
+             ctapipe_ref_pules["reference_pulse_shape_channel0"],
+             label="interpolated pulse")
+    plt.show()
+    
+
+    #reference_pulse.shape[-2]
+
+    plt.figure()
+    plt.step(np.arange(40),
+             wf[0,0,:],
+             label="interpolated pulse")
+    plt.step(np.arange(40),
+             wf[0,10010,:],
+             label="interpolated pulse")
+
+    extractor = ImageExtractor.from_name("LocalPeakWindowSum", subarray=subarray)
+    n_channels, n_pixels, _ = wf.shape
+    broken_pixels = np.zeros((n_channels, n_pixels), dtype=bool)
+    dl1 = extractor(wf, 1, 0, broken_pixels)
+
+
+    
+    # DBSCAN
+    #db = DBSCAN(eps=0.1, min_samples=1000)
+    kmeans = KMeans(n_clusters=2, random_state=42, n_init=10)
+    #kmeans = KMeans(n_clusters=3)
+    
+    #labels = db.fit_predict(dl1["peak_time"].reshape(-1, 1), sample_weight=dl1["image"])
+    #labels = db.fit_predict(dl1["peak_time"].reshape(-1, 1))
+    labels = kmeans.fit_predict(dl1["peak_time"].reshape(-1, 1), sample_weight=np.abs(dl1["image"]))
+
+    print(labels)
+    print(labels.shape)
+
+    print("unique", np.unique(labels))
+
+    plt.figure()
+    for label in np.unique(labels):
+        mask = labels == label
+
+        plt.hist(
+            dl1["peak_time"][mask],
+            bins=np.linspace(9,12,35),
+            alpha=0.5,
+            label=f"Cluster {label}"
+        )
+
+        print("np.mean ",np.mean(dl1["peak_time"][mask]))
+        print("np.std  ",np.std(dl1["peak_time"][mask]))
+        print("np.sum  ",np.sum(dl1["peak_time"][mask]))
+        
+
+    plt.show()
+    
+    #extractor = LocalPeakWindowSum(ImageExtractor(subarray))
+    print(dl1["image"])
+
+    
+    #plt.step(ctapipe_ref_pules["reference_pulse_sample_time"],
+    #         ctapipe_ref_pules["reference_pulse_shape_channel1"],
+    #         label="interpolated pulse")
+    #plt.xlabel("time (ns)")
+    #plt.ylabel("amplitude")
+    #plt.title("Simple reference pulse shape")
+    #plt.legend()
+    #plt.tight_layout()
+    #plt.show()
+
+    #waveform_model = WaveformModel.from_camera_readout(subarray_1_lst.tel[1].camera.readout)
+
+    #print(waveform_model)
+
+    #waveform = waveform_model.get_waveform(np.array([100,10]), np.array([20,10]), 40)
+
+    #print(waveform)
+    #print(waveform.shape)
+
+    #plt.figure()
+    #plt.step(np.arange(len(waveform[0,0,:])),
+    #         waveform[1,0,:],
+    #         label="pulse")
+    #plt.step(ctapipe_ref_pules["reference_pulse_sample_time"],
+    #         ctapipe_ref_pules["reference_pulse_shape_channel1"],
+    #         label="interpolated pulse")
+    #plt.xlabel("time (ns)")
+    #plt.ylabel("amplitude")
+    #plt.title("Simple reference pulse shape")
+    #plt.legend()
+    #plt.tight_layout()
+    plt.show()
+
+    plt.figure()
+    plt.hist(dl1['peak_time'][0:10000],bins=np.linspace(9,12,35),alpha=0.5)
+    plt.hist(dl1['peak_time'][10000::],bins=np.linspace(9,12,35),alpha=0.5)
+    plt.show()
+
+    plt.figure()
+    plt.hist(dl1["image"][0:10000], bins=np.linspace(0.0,200,100),alpha=0.5)
+    plt.hist(dl1['image'][10000::], bins=np.linspace(0.0,200,100),alpha=0.5)
+    plt.show()
+
+    
+    plt.figure()
+    plt.hist(dl1["image"][10000::],bins=np.linspace(0.0,200,100),alpha=0.5)
+    plt.hist(dl1['image'][dl1['peak_time']<9.75], bins=np.linspace(0.0,200,100),alpha=0.5)
+    #plt.hist(dl1["image"][10000::],bins=np.linspace(0.0,200,100),alpha=0.5)
+    plt.show()
+
+    #print(np.sum())
+    #print(np.sum(dl1["image"][0:10000]))
+    
+    
+    #print
+    
+    #wf = WaveformModel(reference_pulse=np.array([ctapipe_ref_pules["reference_pulse_shape_channel0"]]),
+    #    reference_pulse_sample_width = np.array(ctapipe_ref_pules["reference_pulse_sample_time"]),
+    #    sample_width = 1.0)
+    
     assert 1

--- a/src/ctapipe/image/tests/test_extractor.py
+++ b/src/ctapipe/image/tests/test_extractor.py
@@ -942,3 +942,10 @@ def test_flashcam_extractor(toymodel_mst_fc, prod5_gamma_simtel_path):
                 assert_allclose(
                     dl1.image[bright_pixels], true_charge[bright_pixels], rtol=0.35
                 )
+
+
+def test_global_peak_window_sum_muons(ctapipe_ref_pules):
+    from ctapipe.image.extractor import GlobalPeakWindowSum
+    print("test_global_peak_window_sum_muons")
+    print(ctapipe_ref_pules)
+    assert 1

--- a/src/ctapipe/image/tests/test_short_my.py
+++ b/src/ctapipe/image/tests/test_short_my.py
@@ -1,0 +1,79 @@
+import numpy as np
+import astropy.units as u
+
+from ctapipe.image.toymodel import WaveformModel
+from ctapipe.instrument.camera.readout import CameraReadout
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+
+
+def make_simple_camera_readout():
+    reference_pulse_shape = np.array([[0.0, 0.4, 1.0, 0.5, 0.1]])
+    reference_pulse_sample_width = 1 * u.ns
+    sampling_rate = 1 * u.GHz
+    return CameraReadout(
+        name="TestCam",
+        sampling_rate=sampling_rate,
+        reference_pulse_shape=reference_pulse_shape,
+        reference_pulse_sample_width=reference_pulse_sample_width,
+        n_channels=1,
+        n_pixels=1,
+        n_samples=10,
+    )
+
+
+def test_simple_ref_pulse_shape_from_camera_readout():
+    readout = make_simple_camera_readout()
+    model = WaveformModel.from_camera_readout(readout)
+
+    assert model.n_channels == 1
+    assert model.ref_interp_y.shape[0] == 1
+    assert np.isclose((model.ref_interp_y.sum(-1) * model.ref_width_ns)[0], 1.0)
+
+    waveform = model.get_waveform(np.array([5.0]), np.array([4.0]), n_samples=10)
+    assert waveform.shape == (1, 1, 10)
+    assert np.all(waveform >= 0)
+
+
+def plot_reference_pulse():
+    import matplotlib.pyplot as plt
+
+    #readout = make_simple_camera_readout()
+    model = WaveformModel(readout)
+
+    reference_pulse_shape = readout.reference_pulse_shape
+    reference_pulse_sample_width = readout.reference_pulse_sample_width
+    x_raw = np.arange(reference_pulse_shape.shape[-1]) * reference_pulse_sample_width.to_value(u.ns)
+    y_raw = reference_pulse_shape[0]
+    x_interp = model.ref_interp_x
+    y_interp = model.ref_interp_y[0]
+
+    plt.figure()
+    plt.step(x_raw, y_raw, where="mid", marker="o", label="raw reference pulse")
+    plt.plot(x_interp, y_interp, label="interpolated pulse")
+    plt.xlabel("time (ns)")
+    plt.ylabel("amplitude")
+    plt.title("Simple reference pulse shape")
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+    return model
+
+
+if __name__ == "__main__":
+    #plot_reference_pulse()
+    # One feature
+    x = np.array([1.0, 1.1, 1.2, 1.3, 5.0, 5.1, 5.2, 10.0])
+    
+    # Weight of each point
+    weights = np.array([1, 2, 1, 3, 1, 2, 1, 10])
+    
+    # DBSCAN
+    db = DBSCAN(eps=0.3, min_samples=4)
+    
+    labels = db.fit_predict(x.reshape(-1, 1), sample_weight=weights)
+    
+    print(labels)

--- a/src/ctapipe/image/toymodel.py
+++ b/src/ctapipe/image/toymodel.py
@@ -109,6 +109,10 @@ class WaveformModel:
             Sample width of the waveform
 
         """
+        print("class WaveformModel")
+        print("type                      = ", type(reference_pulse))
+        print("reference_pulse.shape[-2] = ", reference_pulse.shape[-2])
+        print("reference_pulse.shape     = ", reference_pulse.shape)
         self.n_channels = reference_pulse.shape[-2]
         self.upsampling = 10
         reference_pulse_sample_width = reference_pulse_sample_width.to_value(u.ns)


### PR DESCRIPTION
The LST hardware stereo trigger preferentially selects muons whose parent air shower, or part of it, falls within the same camera field of view (these events are classified as stereo muon events). This is because the density of the muon light pool decreases with the square of the distance from the muon's impact point, consequently, an isolated muon (i.e., a muon significantly deflected from its parent shower) cannot, in general, trigger two telescopes simultaneously. Therefore, a waveform-based cleaning algorithm needs to be used for LST muon reconstruction. The cleaning is applied at the waveform level, as the Cherenkov light from the muon arrives within a very short time window (about hundreds of picoseconds), slightly ahead of time from the rest of the shower light, and geometrically concentrated in a ring.