### PR TITLE
Fix: Add missing tools to sphinx documentation

### DIFF
--- a/docs/ctapipe_api/tools/index.rst
+++ b/docs/ctapipe_api/tools/index.rst
@@ -1,0 +1,32 @@
+.. _tools:
+
+*****
+Tools
+*****
+
+.. currentmodule:: ctapipe.tools
+
+Command-line Tools
+==================
+
+.. autosummary::
+   :toctree: ../generated/
+   :template: class.rst
+   :nosignatures:
+
+   ProcessTool
+   Stage1Tool
+   MergeTool
+   ApplyModelsExtraImagesTool
+   DL1ABMergeTool
+   DL1Concat
+   DL2Concat
+   DL3Concat
+   DumpInstrumentTool
+   DumpTriggerTool
+   FileInfoTool
+   QuickStartTool
+   SpectrumFitTool
+   TrainDispReconstructor
+   TrainEnergyRegressor
+   TrainParticleClassifier


### PR DESCRIPTION
Closes #1786

This PR adds all the missing tool classes to the sphinx documentation by explicitly listing them in `docs/ctapipe_api/tools/index.rst`. 

The tools are not imported in `ctapipe/tools/__init__.py` to reduce import times, which means they need to be manually added to the documentation index to appear in the generated API documentation and to be referenceable from other parts of the documentation.

Added the following tools:
- Stage1Tool
- MergeTool
- ApplyModelsExtraImagesTool
- DL1ABMergeTool
- DL1Concat
- DL2Concat
- DL3Concat
- DumpInstrumentTool
- DumpTriggerTool
- FileInfoTool
- QuickStartTool
- SpectrumFitTool
- TrainDispReconstructor
- TrainEnergyRegressor
- TrainParticleClassifier
