### PR TITLE
Ignore numpy deprecation warning from joblib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,8 @@ filterwarnings = [
     "ignore:'unquoteResults':DeprecationWarning:matplotlib",
     "ignore:'enablePackrat':DeprecationWarning:matplotlib",
     "ignore:'parseAll':DeprecationWarning:pyparsing",
+    # only ignore from joblib, should raise if its in our code directly
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning:joblib",
 ]
 norecursedirs = [
     ".git",


### PR DESCRIPTION
Yesterday, numba 0.67 was release with support for numpy 2.5, which is why we are getting it now in CI.

This triggered a DeprecationWarning in joblib (fixed upstream but not yet released) failing CI.