### PR TITLE
StereoDispCombiner: Add Transformation to Nominalframe so divergent pointing is supported

### DIFF
--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -878,16 +878,17 @@ class StereoDispCombiner(StereoCombiner):
         valid = mono_predictions[f"{prefix_tel}_is_valid"].copy()
         self._require_disp_column(mono_predictions, prefix_tel)
 
-        fov_lon_values, fov_lat_values = calc_fov_lon_lat(
-            mono_predictions, prefix_tel
-        )
+        fov_lon_values, fov_lat_values = calc_fov_lon_lat(mono_predictions, prefix_tel)
         fov_lon_values, fov_lat_values = self._transform_to_nominal(
             mono_predictions, fov_lon_values, fov_lat_values
         )
-        hillas_psis = np.arctan2(
-            np.diff(fov_lat_values, axis=1),
-            np.diff(fov_lon_values, axis=1),
-        )[:, 0] * u.rad
+        hillas_psis = (
+            np.arctan2(
+                np.diff(fov_lat_values, axis=1),
+                np.diff(fov_lon_values, axis=1),
+            )[:, 0]
+            * u.rad
+        )
 
         obs_ids, event_ids, _, tel_to_array_indices = get_subarray_index(
             mono_predictions

--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -2,11 +2,17 @@ from abc import abstractmethod
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import AltAz, CartesianRepresentation, SphericalRepresentation
+from astropy.coordinates import (
+    AltAz,
+    CartesianRepresentation,
+    SkyCoord,
+    SphericalRepresentation,
+)
 from astropy.table import Table
 from traitlets import UseEnum
 
 from ctapipe.containers import ImageParametersContainer
+from ctapipe.coordinates import NominalFrame, TelescopeFrame
 from ctapipe.core import Component, Container
 from ctapipe.core.traits import (
     Bool,
@@ -756,6 +762,13 @@ class StereoDispCombiner(StereoCombiner):
         weights = []
 
         signs = np.array([-1, 1])
+        # Use the array pointing as the common frame for all telescopes.
+        array_pointing = SkyCoord(
+            alt=event.monitoring.pointing.array_altitude,
+            az=event.monitoring.pointing.array_azimuth,
+            frame=AltAz(),
+        )
+        nominal_frame = NominalFrame(origin=array_pointing)
 
         for tel_id, dl2 in event.dl2.tel.items():
             if not dl2.geometry[self.prefix].is_valid:
@@ -781,6 +794,21 @@ class StereoDispCombiner(StereoCombiner):
 
             fov_lons = hillas_fov_lon + signs * disp * np.cos(hillas_psi)
             fov_lats = hillas_fov_lat + signs * disp * np.sin(hillas_psi)
+
+            # Transform both DISP candidates and their axis to the common frame.
+            telescope_pointing = SkyCoord(
+                alt=event.monitoring.tel[tel_id].pointing.altitude,
+                az=event.monitoring.tel[tel_id].pointing.azimuth,
+                frame=AltAz(),
+            )
+            candidates = SkyCoord(
+                fov_lon=fov_lons * u.deg,
+                fov_lat=fov_lats * u.deg,
+                frame=TelescopeFrame(telescope_pointing=telescope_pointing),
+            ).transform_to(nominal_frame)
+            fov_lons = candidates.fov_lon.to_value(u.deg)
+            fov_lats = candidates.fov_lat.to_value(u.deg)
+            hillas_psi = np.arctan2(np.diff(fov_lats), np.diff(fov_lons))[0] * u.rad
 
             fov_lon_values.append(fov_lons)
             fov_lat_values.append(fov_lats)
@@ -850,15 +878,26 @@ class StereoDispCombiner(StereoCombiner):
         valid = mono_predictions[f"{prefix_tel}_is_valid"].copy()
         self._require_disp_column(mono_predictions, prefix_tel)
 
+        fov_lon_values, fov_lat_values = calc_fov_lon_lat(
+            mono_predictions, prefix_tel
+        )
+        fov_lon_values, fov_lat_values = self._transform_to_nominal(
+            mono_predictions, fov_lon_values, fov_lat_values
+        )
+        hillas_psis = np.arctan2(
+            np.diff(fov_lat_values, axis=1),
+            np.diff(fov_lon_values, axis=1),
+        )[:, 0] * u.rad
+
         obs_ids, event_ids, _, tel_to_array_indices = get_subarray_index(
             mono_predictions
         )
         n_array_events = len(obs_ids)
 
         valid = self._apply_min_ang_diff_cut(
-            mono_predictions=mono_predictions,
             valid=valid,
             tel_to_array_indices=tel_to_array_indices,
+            hillas_psis=hillas_psis,
         )
         valid = self._apply_n_best_tels_cut(
             mono_predictions=mono_predictions,
@@ -873,6 +912,8 @@ class StereoDispCombiner(StereoCombiner):
             tel_to_array_indices=tel_to_array_indices,
             n_array_events=n_array_events,
             prefix_tel=prefix_tel,
+            fov_lon_values=fov_lon_values[valid],
+            fov_lat_values=fov_lat_values[valid],
         )
 
         stereo_table[f"{self.prefix}_alt"] = alt
@@ -907,9 +948,9 @@ class StereoDispCombiner(StereoCombiner):
 
     def _apply_min_ang_diff_cut(
         self,
-        mono_predictions: Table,
         valid: np.ndarray,
         tel_to_array_indices: np.ndarray,
+        hillas_psis: u.Quantity,
     ) -> np.ndarray:
         if self.min_ang_diff is None:
             return valid
@@ -921,7 +962,7 @@ class StereoDispCombiner(StereoCombiner):
 
         valid_idx = np.flatnonzero(valid)
         pairs_in_valid = np.flatnonzero(mask_multi2_tels).reshape(-1, 2)
-        valid_psis = mono_predictions["hillas_psi"][valid]
+        valid_psis = hillas_psis[valid]
 
         keep_pairs = check_ang_diff(
             self.min_ang_diff,
@@ -984,6 +1025,8 @@ class StereoDispCombiner(StereoCombiner):
         tel_to_array_indices: np.ndarray,
         n_array_events: int,
         prefix_tel: str,
+        fov_lon_values: np.ndarray,
+        fov_lat_values: np.ndarray,
     ):
         if np.count_nonzero(valid) == 0:
             nan = u.Quantity(
@@ -993,10 +1036,6 @@ class StereoDispCombiner(StereoCombiner):
 
         weights = self._calculate_weights(mono_predictions[valid])
         _, _, valid_multiplicity, _ = get_subarray_index(mono_predictions[valid])
-
-        fov_lon_values, fov_lat_values = calc_fov_lon_lat(
-            mono_predictions[valid], prefix_tel
-        )
 
         combs_array, combs_to_multi_indices = create_combs_array(
             valid_multiplicity.max(), self.n_tel_combinations
@@ -1082,6 +1121,29 @@ class StereoDispCombiner(StereoCombiner):
             ]
 
         return alt, az
+
+    @staticmethod
+    def _transform_to_nominal(mono_predictions, fov_lons, fov_lats):
+        """Transform telescope-frame DISP candidates to the shared nominal frame."""
+        telescope_pointing = SkyCoord(
+            alt=mono_predictions["telescope_pointing_altitude"].quantity[:, None],
+            az=mono_predictions["telescope_pointing_azimuth"].quantity[:, None],
+            frame=AltAz(),
+        )
+        array_pointing = SkyCoord(
+            alt=mono_predictions["subarray_pointing_lat"].quantity[:, None],
+            az=mono_predictions["subarray_pointing_lon"].quantity[:, None],
+            frame=AltAz(),
+        )
+        candidates = SkyCoord(
+            fov_lon=fov_lons * u.deg,
+            fov_lat=fov_lats * u.deg,
+            frame=TelescopeFrame(telescope_pointing=telescope_pointing),
+        ).transform_to(NominalFrame(origin=array_pointing))
+        return (
+            candidates.fov_lon.to_value(u.deg),
+            candidates.fov_lat.to_value(u.deg),
+        )
 
     def _collect_telescopes_per_event(
         self,

--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -1146,13 +1146,13 @@ class StereoDispCombiner(StereoCombiner):
 
     @staticmethod
     def _transform_to_nominal(
-        tel_pointing_alt,
-        tel_pointing_az,
-        subarray_pointing_alt,
-        subarray_pointing_az,
-        fov_lons,
-        fov_lats,
-    ):
+        tel_pointing_alt: u.Quantity,
+        tel_pointing_az: u.Quantity,
+        subarray_pointing_alt: u.Quantity,
+        subarray_pointing_az: u.Quantity,
+        fov_lons: np.ndarray | u.Quantity,
+        fov_lats: np.ndarray | u.Quantity,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Transform DISP candidates from telescope frames to a shared nominal frame.
 

--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -740,8 +740,8 @@ class StereoDispCombiner(StereoCombiner):
 
         if valid:
             alt, az = telescope_to_horizontal(
-                lon=stereo_fov_lon * u.deg,
-                lat=stereo_fov_lat * u.deg,
+                lon=u.Quantity(stereo_fov_lon, u.deg, copy=COPY_IF_NEEDED),
+                lat=u.Quantity(stereo_fov_lat, u.deg, copy=COPY_IF_NEEDED),
                 pointing_alt=event.monitoring.pointing.array_altitude,
                 pointing_az=event.monitoring.pointing.array_azimuth,
             )
@@ -762,13 +762,10 @@ class StereoDispCombiner(StereoCombiner):
         weights = []
 
         signs = np.array([-1, 1])
-        # Use the array pointing as the common frame for all telescopes.
-        array_pointing = SkyCoord(
-            alt=event.monitoring.pointing.array_altitude,
-            az=event.monitoring.pointing.array_azimuth,
-            frame=AltAz(),
-        )
-        nominal_frame = NominalFrame(origin=array_pointing)
+
+        # Gather the subarray pointing information for the transformation to the nominal frame
+        subarray_pointing_alt = event.monitoring.pointing.array_altitude
+        subarray_pointing_az = event.monitoring.pointing.array_azimuth
 
         for tel_id, dl2 in event.dl2.tel.items():
             if not dl2.geometry[self.prefix].is_valid:
@@ -795,20 +792,27 @@ class StereoDispCombiner(StereoCombiner):
             fov_lons = hillas_fov_lon + signs * disp * np.cos(hillas_psi)
             fov_lats = hillas_fov_lat + signs * disp * np.sin(hillas_psi)
 
-            # Transform both DISP candidates and their axis to the common frame.
-            telescope_pointing = SkyCoord(
-                alt=event.monitoring.tel[tel_id].pointing.altitude,
-                az=event.monitoring.tel[tel_id].pointing.azimuth,
-                frame=AltAz(),
+            # Convert to quantity to ensure the helper functions can handle the inputs correctly
+            fov_lons = u.Quantity(fov_lons, u.deg, copy=COPY_IF_NEEDED)
+            fov_lats = u.Quantity(fov_lats, u.deg, copy=COPY_IF_NEEDED)
+
+            # Gather the telescope pointing information for the transformation to the nominal frame
+            tel_pointing_alt = event.monitoring.tel[tel_id].pointing.altitude
+            tel_pointing_az = event.monitoring.tel[tel_id].pointing.azimuth
+
+            fov_lons, fov_lats = self._transform_to_nominal(
+                tel_pointing_alt,
+                tel_pointing_az,
+                subarray_pointing_alt,
+                subarray_pointing_az,
+                fov_lons,
+                fov_lats,
             )
-            candidates = SkyCoord(
-                fov_lon=fov_lons * u.deg,
-                fov_lat=fov_lats * u.deg,
-                frame=TelescopeFrame(telescope_pointing=telescope_pointing),
-            ).transform_to(nominal_frame)
-            fov_lons = candidates.fov_lon.to_value(u.deg)
-            fov_lats = candidates.fov_lat.to_value(u.deg)
-            hillas_psi = np.arctan2(np.diff(fov_lats), np.diff(fov_lons))[0] * u.rad
+            hillas_psi = u.Quantity(
+                np.arctan2(np.diff(fov_lats), np.diff(fov_lons))[0],
+                u.rad,
+                copy=COPY_IF_NEEDED,
+            )
 
             fov_lon_values.append(fov_lons)
             fov_lat_values.append(fov_lats)
@@ -878,16 +882,40 @@ class StereoDispCombiner(StereoCombiner):
         valid = mono_predictions[f"{prefix_tel}_is_valid"].copy()
         self._require_disp_column(mono_predictions, prefix_tel)
 
+        # Returns values as to_value(u.deg)
         fov_lon_values, fov_lat_values = calc_fov_lon_lat(mono_predictions, prefix_tel)
+
+        # Convert to radians for the angular difference calculation
+        fov_lon_values = u.Quantity(fov_lon_values, u.deg, copy=COPY_IF_NEEDED)
+        fov_lat_values = u.Quantity(fov_lat_values, u.deg, copy=COPY_IF_NEEDED)
+        tel_pointing_alt = mono_predictions["telescope_pointing_altitude"].quantity[
+            :, None
+        ]
+        tel_pointing_az = mono_predictions["telescope_pointing_azimuth"].quantity[
+            :, None
+        ]
+        subarray_pointing_alt = mono_predictions["subarray_pointing_altitude"].quantity[
+            :, None
+        ]
+        subarray_pointing_az = mono_predictions["subarray_pointing_azimuth"].quantity[
+            :, None
+        ]
+
         fov_lon_values, fov_lat_values = self._transform_to_nominal(
-            mono_predictions, fov_lon_values, fov_lat_values
+            tel_pointing_alt,
+            tel_pointing_az,
+            subarray_pointing_alt,
+            subarray_pointing_az,
+            fov_lon_values,
+            fov_lat_values,
         )
-        hillas_psis = (
+        hillas_psis = u.Quantity(
             np.arctan2(
                 np.diff(fov_lat_values, axis=1),
                 np.diff(fov_lon_values, axis=1),
-            )[:, 0]
-            * u.rad
+            )[:, 0],
+            u.rad,
+            copy=COPY_IF_NEEDED,
         )
 
         obs_ids, event_ids, _, tel_to_array_indices = get_subarray_index(
@@ -1124,21 +1152,46 @@ class StereoDispCombiner(StereoCombiner):
         return alt, az
 
     @staticmethod
-    def _transform_to_nominal(mono_predictions, fov_lons, fov_lats):
-        """Transform telescope-frame DISP candidates to the shared nominal frame."""
+    def _transform_to_nominal(
+        tel_pointing_alt,
+        tel_pointing_az,
+        subarray_pointing_alt,
+        subarray_pointing_az,
+        fov_lons,
+        fov_lats,
+    ):
+        """
+        Transform DISP candidates from telescope frames to a shared nominal frame.
+
+        Parameters
+        ----------
+        tel_pointing_alt, tel_pointing_az : astropy.units.Quantity
+            Scalar or array-valued telescope pointings defining the input frames.
+        subarray_pointing_alt, subarray_pointing_az : astropy.units.Quantity
+            Scalar or array-valued subarray pointings defining the nominal frames.
+        fov_lons, fov_lats : astropy.units.Quantity
+            Array-valued DISP candidate coordinates with angular units. The shape
+            is ``(2,)`` for one telescope event or ``(n_events, 2)`` for a table.
+
+        Returns
+        -------
+        nominal_lons, nominal_lats : tuple[numpy.ndarray, numpy.ndarray]
+            Candidate coordinates in the nominal frames, in degrees and with the
+            same shape as ``fov_lons`` and ``fov_lats``.
+        """
         telescope_pointing = SkyCoord(
-            alt=mono_predictions["telescope_pointing_altitude"].quantity[:, None],
-            az=mono_predictions["telescope_pointing_azimuth"].quantity[:, None],
+            alt=tel_pointing_alt,
+            az=tel_pointing_az,
             frame=AltAz(),
         )
         array_pointing = SkyCoord(
-            alt=mono_predictions["subarray_pointing_lat"].quantity[:, None],
-            az=mono_predictions["subarray_pointing_lon"].quantity[:, None],
+            alt=subarray_pointing_alt,
+            az=subarray_pointing_az,
             frame=AltAz(),
         )
         candidates = SkyCoord(
-            fov_lon=fov_lons * u.deg,
-            fov_lat=fov_lats * u.deg,
+            fov_lon=fov_lons,
+            fov_lat=fov_lats,
             frame=TelescopeFrame(telescope_pointing=telescope_pointing),
         ).transform_to(NominalFrame(origin=array_pointing))
         return (

--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -792,10 +792,6 @@ class StereoDispCombiner(StereoCombiner):
             fov_lons = hillas_fov_lon + signs * disp * np.cos(hillas_psi)
             fov_lats = hillas_fov_lat + signs * disp * np.sin(hillas_psi)
 
-            # Convert to quantity to ensure the helper functions can handle the inputs correctly
-            fov_lons = u.Quantity(fov_lons, u.deg, copy=COPY_IF_NEEDED)
-            fov_lats = u.Quantity(fov_lats, u.deg, copy=COPY_IF_NEEDED)
-
             # Gather the telescope pointing information for the transformation to the nominal frame
             tel_pointing_alt = event.monitoring.tel[tel_id].pointing.altitude
             tel_pointing_az = event.monitoring.tel[tel_id].pointing.azimuth
@@ -882,12 +878,9 @@ class StereoDispCombiner(StereoCombiner):
         valid = mono_predictions[f"{prefix_tel}_is_valid"].copy()
         self._require_disp_column(mono_predictions, prefix_tel)
 
-        # Returns values as to_value(u.deg)
+        # Returns the FoV coordinates in deg as a ndarray
         fov_lon_values, fov_lat_values = calc_fov_lon_lat(mono_predictions, prefix_tel)
 
-        # Convert to radians for the angular difference calculation
-        fov_lon_values = u.Quantity(fov_lon_values, u.deg, copy=COPY_IF_NEEDED)
-        fov_lat_values = u.Quantity(fov_lat_values, u.deg, copy=COPY_IF_NEEDED)
         tel_pointing_alt = mono_predictions["telescope_pointing_altitude"].quantity[
             :, None
         ]
@@ -1169,9 +1162,9 @@ class StereoDispCombiner(StereoCombiner):
             Scalar or array-valued telescope pointings defining the input frames.
         subarray_pointing_alt, subarray_pointing_az : astropy.units.Quantity
             Scalar or array-valued subarray pointings defining the nominal frames.
-        fov_lons, fov_lats : astropy.units.Quantity
-            Array-valued DISP candidate coordinates with angular units. The shape
-            is ``(2,)`` for one telescope event or ``(n_events, 2)`` for a table.
+        fov_lons, fov_lats : numpy.ndarray | astropy.units.Quantity
+            DISP candidate coordinates in degrees. The shape is ``(2,)`` for one
+            telescope event or ``(n_events, 2)`` for a table.
 
         Returns
         -------
@@ -1179,6 +1172,9 @@ class StereoDispCombiner(StereoCombiner):
             Candidate coordinates in the nominal frames, in degrees and with the
             same shape as ``fov_lons`` and ``fov_lats``.
         """
+        fov_lons = u.Quantity(fov_lons, u.deg, copy=COPY_IF_NEEDED)
+        fov_lats = u.Quantity(fov_lats, u.deg, copy=COPY_IF_NEEDED)
+
         telescope_pointing = SkyCoord(
             alt=tel_pointing_alt,
             az=tel_pointing_az,

--- a/src/ctapipe/reco/stereo_combination.py
+++ b/src/ctapipe/reco/stereo_combination.py
@@ -786,7 +786,7 @@ class StereoDispCombiner(StereoCombiner):
 
             hillas_fov_lon = dl1.hillas.fov_lon.to_value(u.deg)
             hillas_fov_lat = dl1.hillas.fov_lat.to_value(u.deg)
-            hillas_psi = dl1.hillas.psi
+            hillas_psi = dl1.hillas.psi.to_value(u.rad)
             disp = disp_reco.parameter.to_value(u.deg)
 
             fov_lons = hillas_fov_lon + signs * disp * np.cos(hillas_psi)
@@ -894,10 +894,10 @@ class StereoDispCombiner(StereoCombiner):
         tel_pointing_az = mono_predictions["telescope_pointing_azimuth"].quantity[
             :, None
         ]
-        subarray_pointing_alt = mono_predictions["subarray_pointing_altitude"].quantity[
+        subarray_pointing_alt = mono_predictions["subarray_pointing_lat"].quantity[
             :, None
         ]
-        subarray_pointing_az = mono_predictions["subarray_pointing_azimuth"].quantity[
+        subarray_pointing_az = mono_predictions["subarray_pointing_lon"].quantity[
             :, None
         ]
 

--- a/src/ctapipe/reco/tests/test_stereo_combination.py
+++ b/src/ctapipe/reco/tests/test_stereo_combination.py
@@ -1,6 +1,7 @@
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.coordinates import AltAz, SkyCoord
 from astropy.table import Table
 from numpy.testing import assert_allclose, assert_array_equal
 
@@ -18,6 +19,7 @@ from ctapipe.containers import (
     ReconstructedGeometryContainer,
     TelescopeReconstructedContainer,
 )
+from ctapipe.coordinates import TelescopeFrame
 from ctapipe.core.traits import TraitError
 from ctapipe.reco.reconstructor import ReconstructionProperty
 from ctapipe.reco.stereo_combination import StereoDispCombiner, StereoMeanCombiner
@@ -445,6 +447,89 @@ def test_disp_combiner_single_event(weights):
     elif weights == "none":
         assert u.isclose(event.dl2.stereo.geometry["dummy"].alt, 70.75451665 * u.deg)
         assert u.isclose(event.dl2.stereo.geometry["dummy"].az, 0.05821327 * u.deg)
+
+
+def _make_divergent_disp_data():
+    source_position = SkyCoord(alt=70.2 * u.deg, az=0.1 * u.deg, frame=AltAz())
+    telescope_pointings = [
+        SkyCoord(alt=69.5 * u.deg, az=-1 * u.deg, frame=AltAz()),
+        SkyCoord(alt=70.5 * u.deg, az=1 * u.deg, frame=AltAz()),
+    ]
+    source_in_telescope_frames = [
+        source_position.transform_to(TelescopeFrame(telescope_pointing=pointing))
+        for pointing in telescope_pointings
+    ]
+
+    hillas_psis = [20, 100] * u.deg
+    disp_parameters = [0.7, 0.8] * u.deg
+    source_fov_lons = u.Quantity(
+        [coordinate.fov_lon for coordinate in source_in_telescope_frames]
+    )
+    source_fov_lats = u.Quantity(
+        [coordinate.fov_lat for coordinate in source_in_telescope_frames]
+    )
+
+    # Shift each source backwards along its Hillas axis by the DISP distance.
+    # Assumes that disp predictions are 100% correct
+    hillas_centroid_fov_lons = source_fov_lons - disp_parameters * np.cos(hillas_psis)
+    hillas_centroid_fov_lats = source_fov_lats - disp_parameters * np.sin(hillas_psis)
+
+    event_data = {
+        "tel_id": [1, 2],
+        "hillas_intensity": [100, 200],
+        "hillas_width": [0.1, 0.1] * u.deg,
+        "hillas_length": [0.3, 0.3] * u.deg,
+        "hillas_fov_lon": hillas_centroid_fov_lons,
+        "hillas_fov_lat": hillas_centroid_fov_lats,
+        "hillas_psi": hillas_psis,
+        # Mono directions are not combined directly. Just use the known source here.
+        "disp_tel_alt": u.Quantity([source_position.alt, source_position.alt]),
+        "disp_tel_az": u.Quantity([source_position.az, source_position.az]),
+        "disp_tel_parameter": disp_parameters,
+        "disp_tel_sign_score": [1, 1],
+        "disp_tel_is_valid": [True, True],
+    }
+    return source_position, telescope_pointings, event_data
+
+
+def test_disp_combiner_single_event_divergent_pointing():
+    source_position, telescope_pointings, event_data = _make_divergent_disp_data()
+    event = _make_disp_event(event_data)
+    for tel_id, pointing in zip(event_data["tel_id"], telescope_pointings):
+        event.monitoring.tel[tel_id].pointing.altitude = pointing.alt
+        event.monitoring.tel[tel_id].pointing.azimuth = pointing.az
+
+    StereoDispCombiner(prefix="dummy")(event)
+
+    reconstructed_geometry = event.dl2.stereo.geometry["dummy"]
+    assert reconstructed_geometry.is_valid
+    assert u.isclose(reconstructed_geometry.alt, source_position.alt)
+    assert u.isclose(reconstructed_geometry.az, source_position.az)
+
+
+def test_predict_disp_combiner_divergent_pointing():
+    source_position, telescope_pointings, event_data = _make_divergent_disp_data()
+    mono_predictions = Table(
+        {
+            "obs_id": [1, 1],
+            "event_id": [1, 1],
+            **event_data,
+            "subarray_pointing_lat": [70, 70] * u.deg,
+            "subarray_pointing_lon": [0, 0] * u.deg,
+            "telescope_pointing_altitude": u.Quantity(
+                [pointing.alt for pointing in telescope_pointings]
+            ),
+            "telescope_pointing_azimuth": u.Quantity(
+                [pointing.az for pointing in telescope_pointings]
+            ),
+        }
+    )
+
+    stereo = StereoDispCombiner(prefix="disp").predict_table(mono_predictions)
+
+    assert stereo["disp_is_valid"][0]
+    assert u.isclose(stereo["disp_alt"].quantity[0], source_position.alt)
+    assert u.isclose(stereo["disp_az"].quantity[0], source_position.az)
 
 
 def test_disp_combiner_single_event_disp_parameter():

--- a/src/ctapipe/reco/tests/test_stereo_combination.py
+++ b/src/ctapipe/reco/tests/test_stereo_combination.py
@@ -110,6 +110,8 @@ def mono_table():
             ],
             "subarray_pointing_lat": 10 * [70] * u.deg,
             "subarray_pointing_lon": 10 * [0] * u.deg,
+            "telescope_pointing_altitude": 10 * [70] * u.deg,
+            "telescope_pointing_azimuth": 10 * [0] * u.deg,
         }
     )
 
@@ -392,6 +394,9 @@ def _make_disp_event(event_dict, prefix="dummy"):
                 )
             },
         )
+        pointing = event.monitoring.tel[event_dict["tel_id"][i]].pointing
+        pointing.azimuth = 0 * u.deg
+        pointing.altitude = 70 * u.deg
 
     event.monitoring.pointing = ArrayPointingContainer(
         array_azimuth=0 * u.deg, array_altitude=70 * u.deg


### PR DESCRIPTION
This introduces support for divergent pointing for the StereoDispCombiner. Since the StereoDispCombiner PR is not finished yet this PR targets the corresponding branch instead of main. 