### PR TITLE
Fixed bug in get_cache_path

### DIFF
--- a/docs/changes/3078.bugfix.rst
+++ b/docs/changes/3078.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed bug in ``utilities.get_cache_path`` where the ``env_override`` parameter
+was ignored, using the hard-coded "CTAPIPE_CACHE" even if the user specified a
+different one. This did not affect anything inside ctapipe, only external
+packages that use this method with a non-default cache location.

--- a/src/ctapipe/utils/download.py
+++ b/src/ctapipe/utils/download.py
@@ -72,7 +72,7 @@ def download_file(url, path, auth=None, chunk_size=10240, progress=False):
 
 def get_cache_path(url, cache_name="ctapipe", env_override="CTAPIPE_CACHE"):
     if os.getenv(env_override):
-        base = Path(os.environ["CTAPIPE_CACHE"])
+        base = Path(os.environ[env_override])
     else:
         base = Path.home() / ".cache" / cache_name
 


### PR DESCRIPTION
The `env_override` variable was not used for the actual environment name, and instead it used the hard-coded "CTAPIPE_CACHE" even if the user specified a different variable.  This did not affect anything inside ctapipe, only external packages that use this method.