### PR TITLE
Reduce log level to DEBUG for skipping columns in hdf5 reader/writer

### DIFF
--- a/src/ctapipe/io/hdf5tableio.py
+++ b/src/ctapipe/io/hdf5tableio.py
@@ -402,7 +402,7 @@ class HDF5TableWriter(TableWriter):
                         value=value,
                     )
                 except ValueError:
-                    self.log.warning(
+                    self.log.debug(
                         f"Column {col_name}"
                         f" with value {value!r} of type {type(value)} "
                         f" of container {container.__class__.__name__} in"
@@ -612,7 +612,7 @@ class HDF5TableReader(TableReader):
 
                 elif col_name is None or col_name not in column_attrs:
                     missing.append(field_name)
-                    self.log.warning(
+                    self.log.debug(
                         f"Table {table_name} is missing column {col_name} for field {field_name}"
                         f" of container {container}. It will be skipped."
                     )


### PR DESCRIPTION
We now have a lot of optional columns in several stages that we intentionally skip writing/reading if they are not present.

Thus, the log level of WARNING is not appropriate, these are entirely expected messages in most cases.