### PR TITLE
Make time_tolerance of HDF5MonitoringSource configurable, set default to 1s

### DIFF
--- a/docs/changes/3092.bugfix.rst
+++ b/docs/changes/3092.bugfix.rst
@@ -1,0 +1,4 @@
+The ``timestamp_tolerance`` of the ``HDF5MonitoringSource`` is now configurable
+and set to 1 s by default. This fixes reading and applying of camera calibration
+coefficients for the usual case where the first physics event arrives before the
+first calibration event within one OB.

--- a/src/ctapipe/io/hdf5monitoringsource.py
+++ b/src/ctapipe/io/hdf5monitoringsource.py
@@ -6,12 +6,12 @@ import logging
 import warnings
 from contextlib import ExitStack
 
-import astropy
 import astropy.units as u
 import numpy as np
 import tables
 from astropy.coordinates import AltAz, SkyCoord
-from astropy.table import Row
+from astropy.table import Row, Table
+from astropy.time import Time
 from astropy.utils.decorators import lazyproperty
 
 from ..containers import (
@@ -23,7 +23,7 @@ from ..containers import (
     TelescopePointingContainer,
 )
 from ..core import Provenance
-from ..core.traits import List, Path
+from ..core.traits import AstroQuantity, List, Path
 from ..exceptions import InputMissing
 from ..instrument import SubarrayDescription
 from .astropy_helpers import read_table
@@ -150,6 +150,11 @@ class HDF5MonitoringSource(MonitoringSource):
         Path(exists=True, directory_ok=False),
         default_value=[],
         help="List of paths to the HDF5 input files containing monitoring data",
+    ).tag(config=True)
+
+    timestamp_tolerance = AstroQuantity(
+        default_value=1.0 * u.s,
+        help="Tolerance for timestamps outside monitoring validity ranges",
     ).tag(config=True)
 
     def __init__(self, subarray=None, config=None, parent=None, **kwargs):
@@ -436,7 +441,7 @@ class HDF5MonitoringSource(MonitoringSource):
     def _get_telescope_pointing_values(
         self,
         tel_id: int,
-        time: astropy.time.Time,
+        time: Time,
     ):
         """
         Get telescope pointing values for a given telescope and time.
@@ -464,12 +469,7 @@ class HDF5MonitoringSource(MonitoringSource):
             frame=AltAz(obstime=time, location=location),
         )
 
-    def _get_camera_coefficients_values(
-        self,
-        tel_id: int,
-        time: astropy.time.Time,
-        timestamp_tolerance: u.Quantity,
-    ) -> dict:
+    def _get_camera_coefficients_values(self, tel_id: int, time: Time) -> dict:
         """
         Get camera coefficients values for a given telescope and time.
 
@@ -479,8 +479,6 @@ class HDF5MonitoringSource(MonitoringSource):
             Telescope ID
         time : astropy.time.Time
             Target timestamp
-        timestamp_tolerance : astropy.units.Quantity
-            Time difference to consider two timestamps equal
 
         Returns
         -------
@@ -493,16 +491,13 @@ class HDF5MonitoringSource(MonitoringSource):
         if self.is_simulation and time is None:
             first_row = self._camera_coefficients[tel_id][0]
             return dict(zip(first_row.colnames, first_row))
-        return self._get_table_rows(
-            self._camera_coefficients[tel_id], time, timestamp_tolerance
-        )
+        return self._get_table_rows(self._camera_coefficients[tel_id], time)
 
     def _get_pixel_statistics_values(
         self,
         tel_id: int,
-        time: astropy.time.Time,
-        subtype: str,
-        timestamp_tolerance: u.Quantity,
+        time: Time,
+        subtype: str | None,
     ) -> dict:
         """
         Get pixel statistics values for a given telescope and time.
@@ -515,8 +510,6 @@ class HDF5MonitoringSource(MonitoringSource):
             Target timestamp
         subtype : str
             Subtype of pixel statistics (e.g., 'pedestal_image', 'flatfield_image')
-        timestamp_tolerance : astropy.units.Quantity
-            Time difference to consider two timestamps equal
 
         Returns
         -------
@@ -537,23 +530,19 @@ class HDF5MonitoringSource(MonitoringSource):
         interpolator = self.pixel_stats_dict[subtype]
         # For simulation, use first entry if time is None
         if self.is_simulation and time is None:
-            from astropy.time import Time
-
             time = Time(
                 self._pixel_statistics[tel_id][subtype]["time_start"][0],
                 format="mjd",
             )
-        return interpolator(tel_id, time, timestamp_tolerance)
+        return interpolator(tel_id, time, self.timestamp_tolerance)
 
     def get_values(
         self,
         monitoring_type: MonitoringType,
-        time: astropy.time.Time,
+        time: Time,
         tel_id: int | None = None,
         **kwargs,
     ):
-        import astropy.units as u
-
         if monitoring_type not in self.monitoring_types:
             raise KeyError(
                 f"Monitoring type {monitoring_type} not available in this source. "
@@ -565,19 +554,13 @@ class HDF5MonitoringSource(MonitoringSource):
                 f"tel_id is required for {monitoring_type.name} monitoring type"
             )
 
-        timestamp_tolerance = kwargs.get("timestamp_tolerance", 0.0 * u.s)
-
         if monitoring_type == MonitoringType.TELESCOPE_POINTINGS:
             return self._get_telescope_pointing_values(tel_id, time)
         elif monitoring_type == MonitoringType.CAMERA_COEFFICIENTS:
-            return self._get_camera_coefficients_values(
-                tel_id, time, timestamp_tolerance
-            )
+            return self._get_camera_coefficients_values(tel_id, time)
         elif monitoring_type == MonitoringType.PIXEL_STATISTICS:
             subtype = kwargs.get("subtype")
-            return self._get_pixel_statistics_values(
-                tel_id, time, subtype, timestamp_tolerance
-            )
+            return self._get_pixel_statistics_values(tel_id, time, subtype)
 
     def fill_monitoring_container(self, event: ArrayEventContainer):
         """
@@ -604,7 +587,7 @@ class HDF5MonitoringSource(MonitoringSource):
                 )
 
     def get_telescope_pointing_container(
-        self, tel_id: int, time: astropy.time.Time
+        self, tel_id: int, time: Time
     ) -> TelescopePointingContainer:
         """
         Get the telescope pointing container for a given telescope ID and time.
@@ -629,8 +612,7 @@ class HDF5MonitoringSource(MonitoringSource):
     def get_camera_monitoring_container(
         self,
         tel_id: int,
-        time: astropy.time.Time = None,
-        timestamp_tolerance: u.Quantity = 0.0 * u.s,
+        time: Time = None,
     ) -> CameraMonitoringContainer:
         """
         Retrieve the camera monitoring container with interpolated data.
@@ -644,8 +626,6 @@ class HDF5MonitoringSource(MonitoringSource):
             timestamp(s) are required to interpolate the monitoring data of observation.
             For monitoring data of simulation, the first entry of the monitoring data is typically
             used if no timestamp is provided.
-        timestamp_tolerance : astropy.units.Quantity
-            Time difference to consider two timestamps equal. Default is 0 seconds.
 
         Returns
         -------
@@ -676,7 +656,6 @@ class HDF5MonitoringSource(MonitoringSource):
                     time=time,
                     tel_id=tel_id,
                     subtype=name,
-                    timestamp_tolerance=timestamp_tolerance,
                 )
                 # Map any pedestal name to the container field name (unique for pedestal)
                 container_name = "pedestal_image" if "pedestal_image" in name else name
@@ -691,7 +670,6 @@ class HDF5MonitoringSource(MonitoringSource):
                 MonitoringType.CAMERA_COEFFICIENTS,
                 time=time,
                 tel_id=tel_id,
-                timestamp_tolerance=timestamp_tolerance,
             )
             cam_mon_container["coefficients"] = CameraCalibrationContainer(
                 time=table_rows["time"],
@@ -703,12 +681,7 @@ class HDF5MonitoringSource(MonitoringSource):
             )
         return cam_mon_container
 
-    def _get_table_rows(
-        self,
-        table: astropy.table.Table,
-        time: astropy.time.Time,
-        timestamp_tolerance: u.Quantity = 0.0 * u.s,
-    ) -> dict:
+    def _get_table_rows(self, table: Table, time: Time) -> dict:
         """
         Retrieve the rows of the table that corresponds to the target time.
 
@@ -718,8 +691,6 @@ class HDF5MonitoringSource(MonitoringSource):
             Target timestamp(s) to find the interval.
         table : astropy.table.Table
             Table containing ordered timestamp data.
-        timestamp_tolerance : astropy.units.Quantity
-            Time difference in seconds to consider two timestamps equal. Default is 0s.
 
         Returns
         -------
@@ -732,7 +703,7 @@ class HDF5MonitoringSource(MonitoringSource):
         mjd_times = np.atleast_1d(time.to_value("mjd"))
         table_times = table["time"]
         # Convert timestamp tolerance to MJD days
-        tolerance_mjd = timestamp_tolerance.to_value("day")
+        tolerance_mjd = self.timestamp_tolerance.to_value("day")
         # Find the index of the closest preceding start time
         preceding_indices = np.searchsorted(table_times, mjd_times, side="right") - 1
 
@@ -746,7 +717,7 @@ class HDF5MonitoringSource(MonitoringSource):
                         f"Out of bounds: Requested timestamp '{mjd} MJD' is before the "
                         f"validity start '{table['time'][0]} MJD' (first entry in the table). "
                         f"Please provide a timestamp within the validity range or increase "
-                        f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
+                        f"the 'timestamp_tolerance' (currently set to '{self.timestamp_tolerance}')."
                     )
                 else:
                     # Use the first chunk since it's within tolerance

--- a/src/ctapipe/io/monitoringsource.py
+++ b/src/ctapipe/io/monitoringsource.py
@@ -121,7 +121,7 @@ class MonitoringSource(TelescopeComponent):
         tel_id : int, optional
             Telescope ID for telescope-level monitoring. None for array-level.
         **kwargs
-            Implementation-specific parameters (e.g., timestamp_tolerance, query_method).
+            Implementation-specific parameters
 
         Returns
         -------

--- a/src/ctapipe/io/tests/test_hdf5monitoringsource.py
+++ b/src/ctapipe/io/tests/test_hdf5monitoringsource.py
@@ -356,6 +356,8 @@ def test_camcalib_obs(prod6_gamma_simtel_path, calibpipe_camcalib_obslike_same_c
         f"{DL1_CAMERA_COEFFICIENTS_GROUP}/tel_{tel_id:03d}",
     )
     # Define some usual trigger times
+    # before, but within tolerance
+    trigger_time_before = camcalib_coefficients["time"][0] - 0.5 * u.s
     # Inside of the validity range should work smoothly
     # and values should match to the fifth entry
     trigger_time_middle = camcalib_coefficients["time"][5] + 0.5 * u.s
@@ -363,42 +365,45 @@ def test_camcalib_obs(prod6_gamma_simtel_path, calibpipe_camcalib_obslike_same_c
     # and match the last entry.
     trigger_time_after = camcalib_coefficients["time"][-1] + 0.5 * u.s
     allowed_tels = {tel_id}
+
+    expected_bins = {
+        trigger_time_before: 0,
+        trigger_time_middle: 5,
+        trigger_time_after: len(camcalib_coefficients) - 1,
+    }
+
     with EventSource(
         input_url=prod6_gamma_simtel_path, allowed_tels=allowed_tels, max_events=1
     ) as source:
-        monitoring_source = HDF5MonitoringSource(
-            subarray=source.subarray,
-            input_files=[calibpipe_camcalib_obslike_same_chunks],
-        )
-        assert not monitoring_source.is_simulation
-        assert monitoring_source.pixel_statistics
-        assert monitoring_source.camera_coefficients
-        assert not monitoring_source.telescope_pointings
-        # Check that the camcalib_coefficients match the event calibration data
-        for e in source:
-            for chunk_bin, trigger_time in {
-                5: trigger_time_middle,
-                -1: trigger_time_after,
-            }.items():
-                # Set the trigger time to the pointing time
-                e.trigger.time = trigger_time
-                # Fill the monitoring container for the event
-                monitoring_source.fill_monitoring_container(e)
-                # Check that the values match after filling the container
-                for column in [
-                    "factor",
-                    "pedestal_offset",
-                    "time_shift",
-                    "outlier_mask",
-                ]:
-                    np.testing.assert_array_equal(
-                        e.monitoring.tel[tel_id].camera.coefficients[column],
-                        camcalib_coefficients[column][chunk_bin],
-                        err_msg=(
-                            f"'{column}' do not match after reading the monitoring file "
-                            "through the HDF5MonitoringSource."
-                        ),
-                    )
+        event = next(iter(source))
+
+    monitoring_source = HDF5MonitoringSource(
+        subarray=source.subarray,
+        input_files=[calibpipe_camcalib_obslike_same_chunks],
+    )
+    assert not monitoring_source.is_simulation
+    assert monitoring_source.pixel_statistics
+    assert monitoring_source.camera_coefficients
+    assert not monitoring_source.telescope_pointings
+
+    # Check that the camcalib_coefficients match the event calibration data
+    for trigger_time, expected_bin in expected_bins.items():
+        # test with our three dummy times as event times
+        event.trigger.time = trigger_time
+        monitoring_source.fill_monitoring_container(event)
+        coefficients = event.monitoring.tel[tel_id].camera.coefficients
+
+        # Check that the values match after filling the container
+        columns_to_check = ["factor", "pedestal_offset", "time_shift", "outlier_mask"]
+        for column in columns_to_check:
+            np.testing.assert_array_equal(
+                coefficients[column],
+                camcalib_coefficients[column][expected_bin],
+                err_msg=(
+                    f"'{column}' do not match after reading the monitoring file "
+                    "through the HDF5MonitoringSource."
+                ),
+            )
 
 
 def test_hdf5_monitoring_source_multi_files_loading(

--- a/src/ctapipe/io/tests/test_hdf5monitoringsource.py
+++ b/src/ctapipe/io/tests/test_hdf5monitoringsource.py
@@ -188,6 +188,7 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
     with HDF5MonitoringSource(
         subarray=None,
         input_files=[calibpipe_camcalib_obslike_same_chunks],
+        timestamp_tolerance=0.25 * u.s,
     ) as monitoring_source:
         with pytest.raises(
             ValueError,
@@ -196,26 +197,15 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
             monitoring_source.get_camera_monitoring_container(
                 tel_id,
             )
+        ff_image_table = monitoring_source.pixel_statistics[tel_id]["flatfield_image"]
         # Read start and end times from the flatfield image container
-        t_start = monitoring_source.pixel_statistics[tel_id]["flatfield_image"][
-            "time_start"
-        ][0]
-        t_end = monitoring_source.pixel_statistics[tel_id]["flatfield_image"][
-            "time_end"
-        ][-1]
-        # Set the unique timestamp
-        unique_timestamp = t_start - 0.2 * u.s
-        # Test exception of interpolating outside the valid range
-        with pytest.raises(
-            ValueError,
-            match="Out of bounds: Requested timestamp",
-        ):
-            monitoring_source.get_camera_monitoring_container(
-                tel_id, unique_timestamp, timestamp_tolerance=0.1 * u.s
-            )
-        # Get the camera monitoring container for the given unique timestamps
+        t_start = ff_image_table["time_start"][0]
+        t_end = ff_image_table["time_end"][-1]
+        timestamp = t_start - 0.2 * u.s
+
+        # Get the camera monitoring container for the given timestamp
         camera_mon_con = monitoring_source.get_camera_monitoring_container(
-            tel_id, unique_timestamp, timestamp_tolerance=0.25 * u.s
+            tel_id, timestamp
         )
         # Validate the returned container
         camera_mon_con.validate()
@@ -250,7 +240,7 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
         unique_timestamps = Time([t_start + 0.2 * u.s, t_end + 0.2 * u.s])
         # Get the camera monitoring container for the given unique timestamps
         camera_mon_con = monitoring_source.get_camera_monitoring_container(
-            tel_id, unique_timestamps, timestamp_tolerance=0.25 * u.s
+            tel_id, unique_timestamps
         )
         # Validate the returned container
         camera_mon_con.validate()
@@ -285,6 +275,33 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
                     "through the HDF5MonitoringSource for the camera calibration."
                 ),
             )
+
+
+def test_get_camera_monitoring_container_obs_invalid(
+    calibpipe_camcalib_obslike_same_chunks,
+):
+    """test the get_camera_monitoring_container method with the monitoring source of observation"""
+
+    tel_id = 1
+    with HDF5MonitoringSource(
+        subarray=None,
+        input_files=[calibpipe_camcalib_obslike_same_chunks],
+        timestamp_tolerance=0.1 * u.s,
+    ) as monitoring_source:
+        with pytest.raises(
+            ValueError,
+            match="Function argument 'time' must be provided for monitoring data from real observations.",
+        ):
+            monitoring_source.get_camera_monitoring_container(tel_id)
+
+        # Read start and end times from the flatfield image container
+        pixel_stats = monitoring_source.pixel_statistics[tel_id]
+        t_start = pixel_stats["flatfield_image"]["time_start"][0]
+        invalid_timestamp = t_start - 0.2 * u.s
+
+        # Test exception of interpolating outside the valid range
+        with pytest.raises(ValueError, match="Out of bounds: Requested timestamp"):
+            monitoring_source.get_camera_monitoring_container(tel_id, invalid_timestamp)
 
 
 def test_tel_pointing_filling(prod6_gamma_simtel_path, dl1_merged_monitoring_file_obs):
@@ -339,8 +356,6 @@ def test_camcalib_obs(prod6_gamma_simtel_path, calibpipe_camcalib_obslike_same_c
         f"{DL1_CAMERA_COEFFICIENTS_GROUP}/tel_{tel_id:03d}",
     )
     # Define some usual trigger times
-    # Before the validity range should raise an exception
-    trigger_time_before = camcalib_coefficients["time"][0] - 0.5 * u.s
     # Inside of the validity range should work smoothly
     # and values should match to the fifth entry
     trigger_time_middle = camcalib_coefficients["time"][5] + 0.5 * u.s
@@ -361,11 +376,6 @@ def test_camcalib_obs(prod6_gamma_simtel_path, calibpipe_camcalib_obslike_same_c
         assert not monitoring_source.telescope_pointings
         # Check that the camcalib_coefficients match the event calibration data
         for e in source:
-            # Test exception of interpolating outside the valid range
-            with pytest.raises(ValueError, match="Out of bounds: Requested timestamp"):
-                e.trigger.time = trigger_time_before
-                monitoring_source.fill_monitoring_container(e)
-
             for chunk_bin, trigger_time in {
                 5: trigger_time_middle,
                 -1: trigger_time_after,


### PR DESCRIPTION
Fixes case where `HDF5MonitoringSource` rejects the expected case of a physics event arriving before the first calibration event