### PR TITLE
Validity time range for camera calibration based on pointing timestamps

### DIFF
--- a/src/ctapipe/io/hdf5monitoringsource.py
+++ b/src/ctapipe/io/hdf5monitoringsource.py
@@ -494,7 +494,7 @@ class HDF5MonitoringSource(MonitoringSource):
             first_row = self._camera_coefficients[tel_id][0]
             return dict(zip(first_row.colnames, first_row))
         return self._get_table_rows(
-            self._camera_coefficients[tel_id], time, timestamp_tolerance
+            self._camera_coefficients[tel_id], tel_id, time, timestamp_tolerance
         )
 
     def _get_pixel_statistics_values(
@@ -706,6 +706,7 @@ class HDF5MonitoringSource(MonitoringSource):
     def _get_table_rows(
         self,
         table: astropy.table.Table,
+        tel_id: int,
         time: astropy.time.Time,
         timestamp_tolerance: u.Quantity = 0.0 * u.s,
     ) -> dict:
@@ -720,6 +721,8 @@ class HDF5MonitoringSource(MonitoringSource):
             Table containing ordered timestamp data.
         timestamp_tolerance : astropy.units.Quantity
             Time difference in seconds to consider two timestamps equal. Default is 0s.
+        tel_id : int
+            Telescope ID.
 
         Returns
         -------
@@ -736,25 +739,45 @@ class HDF5MonitoringSource(MonitoringSource):
         # Find the index of the closest preceding start time
         preceding_indices = np.searchsorted(table_times, mjd_times, side="right") - 1
 
+        pointing_table = self._telescope_pointings.get(tel_id)
+
+        if pointing_table is not None:
+            pointing_times = pointing_table["time"]
+            pointing_times = pointing_times.to_value("mjd")
+            validity_start = pointing_times.min()
+            validity_end = pointing_times.max()
+        else:
+            validity_start = None
+            validity_end = None
+
         time_idx = []
         for mjd, preceding_index in zip(mjd_times, preceding_indices):
-            # Check if the requested time is before the first chunk
-            if preceding_index < 0:
-                # If the time is before the first chunk and not within tolerance, break
-                if (table_times[0] - tolerance_mjd) > mjd:
+            # Check if the requested time is before the first chunk or after the last
+            # If yes, break
+            if validity_start is not None:
+                if (validity_start - tolerance_mjd) > mjd:
                     raise ValueError(
                         f"Out of bounds: Requested timestamp '{mjd} MJD' is before the "
-                        f"validity start '{table['time'][0]} MJD' (first entry in the table). "
+                        f"validity start '{validity_start} MJD' (first entry in the table). "
                         f"Please provide a timestamp within the validity range or increase "
                         f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
                     )
-                else:
-                    # Use the first chunk since it's within tolerance
-                    preceding_index = 0
-            # Check upper bounds when requested timestamp is after the last entry
+
+                if (validity_end + tolerance_mjd) < mjd:
+                    raise ValueError(
+                        f"Out of bounds: Requested timestamp '{mjd} MJD' is after the "
+                        f"validity start '{validity_end} MJD' (first entry in the table). "
+                        f"Please provide a timestamp within the validity range or increase "
+                        f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
+                    )
+
+            if preceding_index < 0:
+                preceding_index = 0
+
             if preceding_index >= len(table) - 1:
                 time_idx.append(table["time"][-1])
                 continue
+
             time_idx.append(table["time"][preceding_index])
         # Get table row(s) and convert to dictionary
         table_rows = table.loc[time_idx]

--- a/src/ctapipe/io/hdf5monitoringsource.py
+++ b/src/ctapipe/io/hdf5monitoringsource.py
@@ -713,6 +713,18 @@ class HDF5MonitoringSource(MonitoringSource):
         """
         Retrieve the rows of the table that corresponds to the target time.
 
+        Retrieve table rows corresponding to the requested timestamp(s). For
+        each requested timestamp, the row with the closest preceding table
+        timestamp is selected. If the requested timestamp precedes the first
+        table entry but is still within the validity range, the first table
+        row is returned. Similarly, the last table row remains applicable after
+        its timestamp as long as the requested time is within the validity range.
+        When telescope pointing information is available, its temporal coverage
+        defines the validity range. Otherwise, the first table timestamp defines
+        the start of the validity range and the last table row is considered valid
+        for all later timestamps. ``timestamp_tolerance`` extends the validity
+        boundaries by the specified amount.
+
         Parameters
         ----------
 

--- a/src/ctapipe/io/hdf5monitoringsource.py
+++ b/src/ctapipe/io/hdf5monitoringsource.py
@@ -715,14 +715,16 @@ class HDF5MonitoringSource(MonitoringSource):
 
         Parameters
         ----------
-        time : astropy.time.Time
-            Target timestamp(s) to find the interval.
+
         table : astropy.table.Table
             Table containing ordered timestamp data.
-        timestamp_tolerance : astropy.units.Quantity
-            Time difference in seconds to consider two timestamps equal. Default is 0s.
         tel_id : int
             Telescope ID.
+        time : astropy.time.Time
+            Target timestamp(s) to find the interval.
+        timestamp_tolerance : astropy.units.Quantity
+            Time difference in seconds to consider two timestamps equal. Default is 0s.
+
 
         Returns
         -------
@@ -742,34 +744,37 @@ class HDF5MonitoringSource(MonitoringSource):
         pointing_table = self._telescope_pointings.get(tel_id)
 
         if pointing_table is not None:
+            # The telescope pointing defines the validity range of the observation
             pointing_times = pointing_table["time"]
             pointing_times = pointing_times.to_value("mjd")
             validity_start = pointing_times.min()
             validity_end = pointing_times.max()
         else:
-            validity_start = None
+            # Without pointing information, fall back to the bounds of the table
+            # itself: the validity range starts with the first chunk and the last
+            # chunk stays valid for all later timestamps.
+            validity_start = table_times[0]
             validity_end = None
 
         time_idx = []
         for mjd, preceding_index in zip(mjd_times, preceding_indices):
-            # Check if the requested time is before the first chunk or after the last
-            # If yes, break
-            if validity_start is not None:
-                if (validity_start - tolerance_mjd) > mjd:
-                    raise ValueError(
-                        f"Out of bounds: Requested timestamp '{mjd} MJD' is before the "
-                        f"validity start '{validity_start} MJD' (first entry in the table). "
-                        f"Please provide a timestamp within the validity range or increase "
-                        f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
-                    )
+            # Check if the requested time is before the start of the validity range
+            # or after its end, and raise if it is outside of the tolerance
+            if (validity_start - tolerance_mjd) > mjd:
+                raise ValueError(
+                    f"Out of bounds: Requested timestamp '{mjd} MJD' is before the "
+                    f"validity start '{validity_start} MJD' (first entry in the table). "
+                    f"Please provide a timestamp within the validity range or increase "
+                    f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
+                )
 
-                if (validity_end + tolerance_mjd) < mjd:
-                    raise ValueError(
-                        f"Out of bounds: Requested timestamp '{mjd} MJD' is after the "
-                        f"validity start '{validity_end} MJD' (first entry in the table). "
-                        f"Please provide a timestamp within the validity range or increase "
-                        f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
-                    )
+            if validity_end is not None and (validity_end + tolerance_mjd) < mjd:
+                raise ValueError(
+                    f"Out of bounds: Requested timestamp '{mjd} MJD' is after the "
+                    f"validity end '{validity_end} MJD' (first entry in the table). "
+                    f"Please provide a timestamp within the validity range or increase "
+                    f"the 'timestamp_tolerance' (currently set to '{timestamp_tolerance}')."
+                )
 
             if preceding_index < 0:
                 preceding_index = 0

--- a/src/ctapipe/io/tests/test_hdf5monitoringsource.py
+++ b/src/ctapipe/io/tests/test_hdf5monitoringsource.py
@@ -309,6 +309,71 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
             )
 
 
+def test_validity_range_without_pointings(calibpipe_camcalib_obslike_same_chunks):
+    """test that the validity range falls back to the table when no pointings exist"""
+
+    tel_id = 1
+    camcalib_coefficients = read_table(
+        calibpipe_camcalib_obslike_same_chunks,
+        f"{DL1_CAMERA_COEFFICIENTS_GROUP}/tel_{tel_id:03d}",
+    )
+    validity_start = Time(camcalib_coefficients["time"][0], format="mjd")
+
+    with HDF5MonitoringSource(
+        subarray=None,
+        input_files=[calibpipe_camcalib_obslike_same_chunks],
+    ) as monitoring_source:
+        # This file has no telescope pointings, so the first entry of the
+        # camera coefficients defines the start of the validity range.
+        assert not monitoring_source.telescope_pointings
+
+        # Timestamps before the first entry and outside of the tolerance
+        # are out of bounds and must raise.
+        with pytest.raises(
+            ValueError,
+            match="Out of bounds: Requested timestamp",
+        ):
+            monitoring_source.get_values(
+                MonitoringType.CAMERA_COEFFICIENTS,
+                time=validity_start - 0.2 * u.s,
+                tel_id=tel_id,
+                timestamp_tolerance=0.1 * u.s,
+            )
+
+        # The same timestamp within the tolerance returns the first entry.
+        coefficients = monitoring_source.get_values(
+            MonitoringType.CAMERA_COEFFICIENTS,
+            time=validity_start - 0.2 * u.s,
+            tel_id=tel_id,
+            timestamp_tolerance=0.25 * u.s,
+        )
+        for column in ["factor", "pedestal_offset", "time_shift", "outlier_mask"]:
+            np.testing.assert_array_equal(
+                coefficients[column],
+                camcalib_coefficients[column][0],
+                err_msg=(
+                    f"'{column}' do not match after reading the monitoring file "
+                    "through the HDF5MonitoringSource for the camera calibration."
+                ),
+            )
+
+        # Without pointings there is no upper bound: the last chunk stays valid.
+        coefficients = monitoring_source.get_values(
+            MonitoringType.CAMERA_COEFFICIENTS,
+            time=Time(camcalib_coefficients["time"][-1], format="mjd") + 1 * u.d,
+            tel_id=tel_id,
+        )
+        for column in ["factor", "pedestal_offset", "time_shift", "outlier_mask"]:
+            np.testing.assert_array_equal(
+                coefficients[column],
+                camcalib_coefficients[column][-1],
+                err_msg=(
+                    f"'{column}' do not match after reading the monitoring file "
+                    "through the HDF5MonitoringSource for the camera calibration."
+                ),
+            )
+
+
 def test_tel_pointing_filling(prod6_gamma_simtel_path, dl1_merged_monitoring_file_obs):
     """test the monitoring filling for the telescope pointings"""
 

--- a/src/ctapipe/io/tests/test_hdf5monitoringsource.py
+++ b/src/ctapipe/io/tests/test_hdf5monitoringsource.py
@@ -1,6 +1,7 @@
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.table import Table
 from astropy.time import Time
 
 from ctapipe.exceptions import InputMissing
@@ -14,7 +15,6 @@ from ctapipe.io import (
 from ctapipe.io.hdf5dataformat import (
     DL0_TEL_POINTING_GROUP,
     DL1_CAMERA_COEFFICIENTS_GROUP,
-    DL1_FLATFIELD_PEAK_TIME_GROUP,
     DL1_SKY_PEDESTAL_IMAGE_GROUP,
 )
 from ctapipe.utils import get_dataset_path
@@ -181,10 +181,7 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
         calibpipe_camcalib_obslike_same_chunks,
         f"{DL1_CAMERA_COEFFICIENTS_GROUP}/tel_{tel_id:03d}",
     )
-    flatfield_peak_time = read_table(
-        calibpipe_camcalib_obslike_same_chunks,
-        f"{DL1_FLATFIELD_PEAK_TIME_GROUP}/tel_{tel_id:03d}",
-    )
+
     with HDF5MonitoringSource(
         subarray=None,
         input_files=[calibpipe_camcalib_obslike_same_chunks],
@@ -196,6 +193,7 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
             monitoring_source.get_camera_monitoring_container(
                 tel_id,
             )
+
         # Read start and end times from the flatfield image container
         t_start = monitoring_source.pixel_statistics[tel_id]["flatfield_image"][
             "time_start"
@@ -203,22 +201,40 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
         t_end = monitoring_source.pixel_statistics[tel_id]["flatfield_image"][
             "time_end"
         ][-1]
-        # Set the unique timestamp
-        unique_timestamp = t_start - 0.2 * u.s
-        # Test exception of interpolating outside the valid range
+
+        # Telescope pointing defines the validity range
+        monitoring_source._telescope_pointings[tel_id] = Table(
+            {
+                "time": Time(
+                    [
+                        t_start - 1 * u.s,
+                        t_end + 1 * u.s,
+                    ]
+                )
+            }
+        )
+        pointing_start = monitoring_source._telescope_pointings[tel_id]["time"][0]
+
+        unique_timestamp = pointing_start - 0.2 * u.s
+
         with pytest.raises(
             ValueError,
             match="Out of bounds: Requested timestamp",
         ):
-            monitoring_source.get_camera_monitoring_container(
-                tel_id, unique_timestamp, timestamp_tolerance=0.1 * u.s
+            monitoring_source.get_values(
+                MonitoringType.CAMERA_COEFFICIENTS,
+                time=unique_timestamp,
+                tel_id=tel_id,
+                timestamp_tolerance=0.1 * u.s,
             )
-        # Get the camera monitoring container for the given unique timestamps
-        camera_mon_con = monitoring_source.get_camera_monitoring_container(
-            tel_id, unique_timestamp, timestamp_tolerance=0.25 * u.s
+
+        coefficients = monitoring_source.get_values(
+            MonitoringType.CAMERA_COEFFICIENTS,
+            time=unique_timestamp,
+            tel_id=tel_id,
+            timestamp_tolerance=0.25 * u.s,
         )
-        # Validate the returned container
-        camera_mon_con.validate()
+
         for column in [
             "factor",
             "pedestal_offset",
@@ -226,26 +242,32 @@ def test_get_camera_monitoring_container_obs(calibpipe_camcalib_obslike_same_chu
             "outlier_mask",
         ]:
             np.testing.assert_array_equal(
-                camera_mon_con.coefficients[column],
+                coefficients[column],
                 camcalib_coefficients[column][0],
-                err_msg=(
-                    f"'{column}' do not match after reading the monitoring file "
-                    "through the HDF5MonitoringSource for the camera calibration."
-                ),
             )
+
+        # Timestamp before the first camera-coefficient entry,
+        # but still within the telescope-pointing validity range.
+        coefficient_start = Time(camcalib_coefficients["time"][0], format="mjd")
+        unique_timestamp = coefficient_start - 0.2 * u.s
+
+        coefficients = monitoring_source.get_values(
+            MonitoringType.CAMERA_COEFFICIENTS,
+            time=unique_timestamp,
+            tel_id=tel_id,
+        )
+
         for column in [
-            "mean",
-            "median",
-            "std",
+            "factor",
+            "pedestal_offset",
+            "time_shift",
+            "outlier_mask",
         ]:
             np.testing.assert_array_equal(
-                camera_mon_con.pixel_statistics.flatfield_peak_time[column],
-                flatfield_peak_time[column][0],
-                err_msg=(
-                    f"'{column}' do not match after reading the monitoring file "
-                    "through the HDF5MonitoringSource for the flatfield peak time."
-                ),
+                coefficients[column],
+                camcalib_coefficients[column][0],
             )
+
         # Set the unique timestamps within the validity range
         unique_timestamps = Time([t_start + 0.2 * u.s, t_end + 0.2 * u.s])
         # Get the camera monitoring container for the given unique timestamps
@@ -338,15 +360,7 @@ def test_camcalib_obs(prod6_gamma_simtel_path, calibpipe_camcalib_obslike_same_c
         calibpipe_camcalib_obslike_same_chunks,
         f"{DL1_CAMERA_COEFFICIENTS_GROUP}/tel_{tel_id:03d}",
     )
-    # Define some usual trigger times
-    # Before the validity range should raise an exception
-    trigger_time_before = camcalib_coefficients["time"][0] - 0.5 * u.s
-    # Inside of the validity range should work smoothly
-    # and values should match to the fifth entry
-    trigger_time_middle = camcalib_coefficients["time"][5] + 0.5 * u.s
-    # After the last validity start of a chunk should also work
-    # and match the last entry.
-    trigger_time_after = camcalib_coefficients["time"][-1] + 0.5 * u.s
+
     allowed_tels = {tel_id}
     with EventSource(
         input_url=prod6_gamma_simtel_path, allowed_tels=allowed_tels, max_events=1
@@ -355,10 +369,40 @@ def test_camcalib_obs(prod6_gamma_simtel_path, calibpipe_camcalib_obslike_same_c
             subarray=source.subarray,
             input_files=[calibpipe_camcalib_obslike_same_chunks],
         )
+
+        # Read start and end times from the flatfield image container
+        t_start = monitoring_source.pixel_statistics[tel_id]["flatfield_image"][
+            "time_start"
+        ][0]
+        t_end = monitoring_source.pixel_statistics[tel_id]["flatfield_image"][
+            "time_end"
+        ][-1]
+        # Telescope pointing defines the validity range
+        monitoring_source._telescope_pointings[tel_id] = Table(
+            {
+                "time": Time(
+                    [
+                        t_start,
+                        t_end + 1 * u.s,
+                    ]
+                )
+            }
+        )
+
+        # Define some usual trigger times
+        # Before the validity range should raise an exception
+        trigger_time_before = t_start - 0.5 * u.s
+        # Inside of the validity range should work smoothly
+        # and values should match to the fifth entry
+        trigger_time_middle = camcalib_coefficients["time"][5] + 0.5 * u.s
+        # After the last validity start of a chunk should also work
+        # and match the last entry.
+        trigger_time_after = camcalib_coefficients["time"][-1] + 0.5 * u.s
+
         assert not monitoring_source.is_simulation
         assert monitoring_source.pixel_statistics
         assert monitoring_source.camera_coefficients
-        assert not monitoring_source.telescope_pointings
+        assert monitoring_source.telescope_pointings
         # Check that the camcalib_coefficients match the event calibration data
         for e in source:
             # Test exception of interpolating outside the valid range


### PR DESCRIPTION
An alternative approach to https://github.com/cta-observatory/ctapipe/pull/3092/changes that is based on the assumption that telescope pointing monitoring data should cover the whole OB.